### PR TITLE
Fix bug sorting API /delegates/forgers - Closes #3304

### DIFF
--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -172,7 +172,7 @@ async function _getDelegates(filters, options) {
 	const supply = lastBlock.height
 		? await channel.invoke('chain:calculateSupply', {
 				height: lastBlock.height,
-			})
+		  })
 		: 0;
 
 	return delegates.map(delegate => delegateFormatter(supply, delegate));
@@ -226,7 +226,7 @@ async function _getForgers(filters) {
 			publicKey,
 			nextSlot: forgerKeys.indexOf(publicKey) + currentSlot + 1,
 		}))
-		.sort((prev, next) => prev.nextSlot > next.nextSlot);
+		.sort((prev, next) => (prev.nextSlot > next.nextSlot ? 1 : -1));
 
 	return {
 		data: forgers,

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -171,8 +171,8 @@ async function _getDelegates(filters, options) {
 
 	const supply = lastBlock.height
 		? await channel.invoke('chain:calculateSupply', {
-				height: lastBlock.height,
-		  })
+			height: lastBlock.height,
+		})
 		: 0;
 
 	return delegates.map(delegate => delegateFormatter(supply, delegate));

--- a/framework/test/mocha/functional/http/get/delegates.js
+++ b/framework/test/mocha/functional/http/get/delegates.js
@@ -642,12 +642,10 @@ describe('GET /delegates', () => {
 
 		it('using limit=101 should sort forgers ascending using nextSlot', async () => {
 			return forgersEndpoint.makeRequest({ limit: 101 }, 200).then(res => {
-				const forgers = _.clone(res.body.data);
-				expect(
-					forgers
-						.reverse()
-						.sort((prev, next) => (prev.nextSlot > next.nextSlot ? 1 : -1))
-				).to.be.eql(res.body.data);
+				const nextSlots = _(res.body.data)
+					.map('nextSlot')
+					.value();
+				expect(_.clone(nextSlots).sort()).to.be.eql(nextSlots);
 			});
 		});
 

--- a/framework/test/mocha/functional/http/get/delegates.js
+++ b/framework/test/mocha/functional/http/get/delegates.js
@@ -640,6 +640,17 @@ describe('GET /delegates', () => {
 			});
 		});
 
+		it('using limit=101 should sort forgers ascending using nextSlot', async () => {
+			return forgersEndpoint.makeRequest({ limit: 101 }, 200).then(res => {
+				const forgers = _.clone(res.body.data);
+				expect(
+					forgers
+						.reverse()
+						.sort((prev, next) => (prev.nextSlot > next.nextSlot ? 1 : -1))
+				).to.be.eql(res.body.data);
+			});
+		});
+
 		it('using offset=100 should be ok', async () => {
 			return forgersEndpoint.makeRequest({ offset: 100 }, 200).then(res => {
 				expect(res.body.data).to.have.length(1);


### PR DESCRIPTION
### What was the problem?
Custom sorting passed was not correct for `/delegates/forgers` and returned inconsistent results when trying: `/delegates/forgers?limit=101`. 

### How did I fix it?
`.sort((prev, next) => (prev.nextSlot > next.nextSlot ? 1 : -1));`

### How to test it?
Run func tests for `http_api/controllers/delegates.js`.

### Review checklist

* The PR resolves #3304 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
