### PR TITLE
Multi-signature registration - Create member accounts - Closes #3313

### DIFF
--- a/elements/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/4_multisignature_transaction.ts
@@ -13,6 +13,7 @@
  *
  */
 import * as BigNum from '@liskhq/bignum';
+import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import {
 	BaseTransaction,
 	MultisignatureStatus,
@@ -65,6 +66,21 @@ export const multisignatureAssetFormatSchema = {
 	},
 };
 
+const setMemberAccounts = (
+	store: StateStore,
+	membersPublicKeys: ReadonlyArray<string>,
+) => {
+	membersPublicKeys.map(memberPublicKey => {
+		const address = getAddressFromPublicKey(memberPublicKey);
+		const memberAccount = { ...store.account.getOrDefault(address) };
+		memberAccount.publicKey = memberAccount.publicKey || memberPublicKey;
+		store.account.set(memberAccount.address, memberAccount);
+	});
+};
+
+const extractPublicKeysFromAsset = (assetPublicKeys: ReadonlyArray<string>) =>
+	assetPublicKeys.map(key => key.substring(1));
+
 export interface MultiSignatureAsset {
 	readonly multisignature: {
 		readonly keysgroup: ReadonlyArray<string>;
@@ -101,10 +117,15 @@ export class MultisignatureTransaction extends BaseTransaction {
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {
+		const membersAddresses = extractPublicKeysFromAsset(
+			this.asset.multisignature.keysgroup,
+		).map(publicKey => ({ address: getAddressFromPublicKey(publicKey) }));
+
 		await store.account.cache([
 			{
 				address: this.senderId,
 			},
+			...membersAddresses,
 		]);
 	}
 
@@ -281,13 +302,15 @@ export class MultisignatureTransaction extends BaseTransaction {
 
 		const updatedSender = {
 			...sender,
-			membersPublicKeys: this.asset.multisignature.keysgroup.map(key =>
-				key.substring(1),
+			membersPublicKeys: extractPublicKeysFromAsset(
+				this.asset.multisignature.keysgroup,
 			),
 			multiMin: this.asset.multisignature.min,
 			multiLifetime: this.asset.multisignature.lifetime,
 		};
 		store.account.set(updatedSender.address, updatedSender);
+
+		setMemberAccounts(store, updatedSender.membersPublicKeys);
 
 		return errors;
 	}

--- a/elements/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/4_multisignature_transaction.ts
@@ -70,11 +70,14 @@ const setMemberAccounts = (
 	store: StateStore,
 	membersPublicKeys: ReadonlyArray<string>,
 ) => {
-	membersPublicKeys.map(memberPublicKey => {
+	membersPublicKeys.forEach(memberPublicKey => {
 		const address = getAddressFromPublicKey(memberPublicKey);
-		const memberAccount = { ...store.account.getOrDefault(address) };
-		memberAccount.publicKey = memberAccount.publicKey || memberPublicKey;
-		store.account.set(memberAccount.address, memberAccount);
+		const memberAccount = store.account.getOrDefault(address);
+		const memberAccountWithPublicKey = {
+			...memberAccount,
+			publicKey: memberAccount.publicKey || memberPublicKey,
+		};
+		store.account.set(memberAccount.address, memberAccountWithPublicKey);
 	});
 };
 

--- a/elements/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/elements/lisk-transactions/test/4_multisignature_transaction.ts
@@ -13,6 +13,7 @@
  *
  */
 import { expect } from 'chai';
+import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import { MULTISIGNATURE_FEE } from '../src/constants';
 import { SignatureObject } from '../src/create_signature_object';
 import { MultisignatureTransaction } from '../src/4_multisignature_transaction';
@@ -174,10 +175,15 @@ describe('Multisignature transaction class', () => {
 	});
 
 	describe('#prepare', async () => {
-		it('should call state store', async () => {
+		it('should call state store with correct params', async () => {
 			await validTestTransaction.prepare(store);
+			// Derive addresses from public keys
+			const membersAddresses = validTestTransaction.asset.multisignature.keysgroup
+				.map(key => key.substring(1))
+				.map(aKey => ({ address: getAddressFromPublicKey(aKey) }));
 			expect(storeAccountCacheStub).to.have.been.calledWithExactly([
 				{ address: validTestTransaction.senderId },
+				...membersAddresses,
 			]);
 		});
 	});

--- a/framework/test/mocha/functional/http/get/accounts/multisignatures.js
+++ b/framework/test/mocha/functional/http/get/accounts/multisignatures.js
@@ -72,8 +72,7 @@ describe('GET /api/accounts', () => {
 		);
 
 		describe('address', () => {
-			// eslint-disable-next-line
-			it.skip('[feature/improve_transactions_processing_efficiency] using known address should respond with its multisignature_group', async () => {
+			it('using known address should respond with its multisignature_group', async () => {
 				return multisigGroupsEndpoint
 					.makeRequest({ address: account.address }, 200)
 					.then(res => {
@@ -140,8 +139,7 @@ describe('GET /api/accounts', () => {
 						expect(res.body.data).to.have.length(0);
 					});
 			});
-			// eslint-disable-next-line
-			it.skip('[feature/improve_transactions_processing_efficiency] using known member address should respond with its multisignature memberships', async () => {
+			it('using known member address should respond with its multisignature memberships', async () => {
 				return multisigMembersEndpoint
 					.makeRequest({ address: scenario.members[0].address }, 200)
 					.then(res => {
@@ -155,8 +153,7 @@ describe('GET /api/accounts', () => {
 						);
 					});
 			});
-			// eslint-disable-next-line
-			it.skip('[feature/improve_transactions_processing_efficiency] using known other member address should respond with its multisignature memberships', async () => {
+			it('using known other member address should respond with its multisignature memberships', async () => {
 				return multisigMembersEndpoint
 					.makeRequest({ address: scenario.members[1].address }, 200)
 					.then(res => {

--- a/framework/test/mocha/functional/http/get/accounts/multisignatures.js
+++ b/framework/test/mocha/functional/http/get/accounts/multisignatures.js
@@ -72,7 +72,7 @@ describe('GET /api/accounts', () => {
 		);
 
 		describe('address', () => {
-			it('using known address should respond with its multisignature_group', async () => {
+			it('it should respond with its multisignature group when using known address', async () => {
 				return multisigGroupsEndpoint
 					.makeRequest({ address: account.address }, 200)
 					.then(res => {

--- a/framework/test/mocha/functional/http/post/4.multisignature.accounts.js
+++ b/framework/test/mocha/functional/http/post/4.multisignature.accounts.js
@@ -1,0 +1,264 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+require('../../functional');
+
+const { transfer } = require('@liskhq/lisk-transactions');
+const Scenarios = require('../../../common/scenarios');
+const waitFor = require('../../../common/utils/wait_for');
+const apiHelpers = require('../../../common/helpers/api');
+const SwaggerEndpoint = require('../../../common/swagger_spec');
+const accountFixtures = require('../../../fixtures/accounts');
+
+const signatureEndpoint = new SwaggerEndpoint('POST /signatures');
+const accountsEndpoint = new SwaggerEndpoint('GET /accounts');
+
+const { NORMALIZER } = global.constants;
+const amount = `${10 * NORMALIZER}`;
+
+describe('POST /api/transactions (type 4) register multisignature', () => {
+	const scenarios = {
+		no_members_exists: new Scenarios.Multisig({ members: 3 }),
+		some_members_exists: new Scenarios.Multisig({ members: 3 }),
+		all_members_exists: new Scenarios.Multisig({ members: 3 }),
+	};
+
+	before(async () => {
+		const transactions = [];
+
+		// Credit main account for each scenario
+		Object.keys(scenarios).forEach(type =>
+			transactions.push(scenarios[type].creditTransaction)
+		);
+		const responses = await apiHelpers.sendTransactionsPromise(transactions);
+
+		responses.forEach(res => {
+			return expect(res.statusCode).to.be.equal(200);
+		});
+		// Wait for confirmation of credits
+		const transactionsToWaitFor = transactions.map(
+			transaction => transaction.id
+		);
+		await waitFor.confirmations(transactionsToWaitFor);
+	});
+
+	it('When members do not exist in blockchain should be created', async () => {
+		const membersPublicKeysByAddress = {};
+		// Send registration
+		const resgisterMultisignature =
+			scenarios.no_members_exists.multiSigTransaction;
+		const response = await apiHelpers.sendTransactionPromise(
+			resgisterMultisignature
+		);
+		expect(response.statusCode).to.be.equal(200);
+		// Generate signatures
+		const signatureRequests = scenarios.no_members_exists.members.map(
+			member => {
+				membersPublicKeysByAddress[member.address] = member.publicKey;
+				return {
+					signature: apiHelpers.createSignatureObject(
+						resgisterMultisignature,
+						member
+					),
+				};
+			}
+		);
+		const sendSignatures = await signatureEndpoint.makeRequests(
+			signatureRequests,
+			200
+		);
+
+		sendSignatures.forEach(res => {
+			return expect(res.statusCode).to.be.equal(200);
+		});
+
+		// Wait for multi-signature registration to succeed
+		await waitFor.confirmations([resgisterMultisignature.id]);
+
+		// Check mem_accounts
+		const membersAccounts = await Promise.all(
+			Object.keys(membersPublicKeysByAddress).map(aMemberAddress =>
+				accountsEndpoint.makeRequest({ address: aMemberAddress }, 200)
+			)
+		);
+		// mem_accounts records should contain accounts
+		membersAccounts.forEach(aMember => {
+			const aMembersData = aMember.body.data[0];
+			const memberAddress = aMembersData.address;
+			const memberPublicKey = aMembersData.publicKey;
+			expect(membersPublicKeysByAddress[memberAddress]).to.be.eql(
+				memberPublicKey
+			);
+		});
+	});
+
+	it('When some members exists its account balance should not be modified ', async () => {
+		const membersPublicKeysByAddress = {};
+		// Send registration
+		const resgisterMultisignature =
+			scenarios.some_members_exists.multiSigTransaction;
+		const response = await apiHelpers.sendTransactionPromise(
+			resgisterMultisignature
+		);
+		expect(response.statusCode).to.be.equal(200);
+		// Generate signatures
+		const signatureRequests = scenarios.some_members_exists.members.map(
+			member => {
+				membersPublicKeysByAddress[member.address] = member.publicKey;
+				return {
+					signature: apiHelpers.createSignatureObject(
+						resgisterMultisignature,
+						member
+					),
+				};
+			}
+		);
+
+		// Send credit to first member
+		const creditMemberTransfer = transfer({
+			amount: `${10 * NORMALIZER}`,
+			passphrase: accountFixtures.genesis.passphrase,
+			recipientId: scenarios.some_members_exists.members[0].address,
+		});
+
+		const creditMemberOne = await apiHelpers.sendTransactionPromise(
+			creditMemberTransfer
+		);
+		expect(creditMemberOne.statusCode).to.be.equal(200);
+		await waitFor.confirmations([creditMemberTransfer.id]);
+		const memberOne = await accountsEndpoint.makeRequest(
+			{ address: scenarios.some_members_exists.members[0].address },
+			200
+		);
+
+		const memberOneBeforeRegistration = memberOne.body.data[0];
+
+		// Send signatures
+		const sendSignatures = await signatureEndpoint.makeRequests(
+			signatureRequests,
+			200
+		);
+
+		sendSignatures.forEach(res => {
+			return expect(res.statusCode).to.be.equal(200);
+		});
+
+		// Wait for multi-signature registration to succeed
+		await waitFor.confirmations([resgisterMultisignature.id]);
+
+		// Check mem_accounts
+		const membersAccounts = await Promise.all(
+			Object.keys(membersPublicKeysByAddress).map(aMemberAddress =>
+				accountsEndpoint.makeRequest({ address: aMemberAddress }, 200)
+			)
+		);
+
+		let memberOneAfterRegistration = null;
+		// mem_accounts records should contain accounts
+		membersAccounts.forEach(aMember => {
+			const aMembersData = aMember.body.data[0];
+			const memberAddress = aMembersData.address;
+			const memberPublicKey = aMembersData.publicKey;
+			expect(membersPublicKeysByAddress[memberAddress]).to.be.eql(
+				memberPublicKey
+			);
+			aMembersData.address === memberOneBeforeRegistration.address
+				? (memberOneAfterRegistration = aMembersData)
+				: null;
+		});
+		// Balance from existing member one shouldn't have changed, i.e. the account was not overwritten!
+		expect(memberOneAfterRegistration.balance).to.be.equal(
+			memberOneBeforeRegistration.balance
+		);
+	});
+
+	it('When all members exist its account balances should not be modified ', async () => {
+		const membersPublicKeysByAddress = {};
+		// Send registration
+		const resgisterMultisignature =
+			scenarios.all_members_exists.multiSigTransaction;
+		const response = await apiHelpers.sendTransactionPromise(
+			resgisterMultisignature
+		);
+		expect(response.statusCode).to.be.equal(200);
+		// Generate signatures
+		const signatureRequests = scenarios.all_members_exists.members.map(
+			member => {
+				membersPublicKeysByAddress[member.address] = member.publicKey;
+				return {
+					signature: apiHelpers.createSignatureObject(
+						resgisterMultisignature,
+						member
+					),
+				};
+			}
+		);
+
+		// Credit all members
+		const members = scenarios.all_members_exists.members;
+
+		const creditTransactionsIds = [];
+		const creditTransactions = members.map(aMember => {
+			const aTransfer = transfer({
+				amount,
+				passphrase: accountFixtures.genesis.passphrase,
+				recipientId: aMember.address,
+			});
+			creditTransactionsIds.push(aTransfer.id);
+			return aTransfer;
+		});
+
+		await Promise.all(
+			creditTransactions.map(aCredit =>
+				apiHelpers.sendTransactionPromise(aCredit, 200)
+			)
+		);
+		await waitFor.confirmations(creditTransactionsIds);
+
+		// Send signatures
+		const sendSignatures = await signatureEndpoint.makeRequests(
+			signatureRequests,
+			200
+		);
+
+		sendSignatures.forEach(res => {
+			return expect(res.statusCode).to.be.equal(200);
+		});
+
+		// Wait for multi-signature registration to succeed
+		await waitFor.confirmations([resgisterMultisignature.id]);
+
+		// Check mem_accounts
+		const membersAccounts = await Promise.all(
+			Object.keys(membersPublicKeysByAddress).map(aMemberAddress =>
+				accountsEndpoint.makeRequest({ address: aMemberAddress }, 200)
+			)
+		);
+
+		// mem_accounts records should contain accounts and correct balance
+		membersAccounts.forEach(aMember => {
+			const aMembersData = aMember.body.data[0];
+			const memberAddress = aMembersData.address;
+			const memberPublicKey = aMembersData.publicKey;
+			expect(membersPublicKeysByAddress[memberAddress]).to.be.eql(
+				memberPublicKey
+			);
+			expect(aMembersData.balance).to.be.equal(amount);
+		});
+		// Balance from existing member one shouldn't have changed, i.e. the account was not overwritten!
+		// expect(memberOneAfterRegistration.balance).to.be.equal(memberOneBeforeRegistration.balance);
+	});
+});

--- a/framework/test/mocha/functional/http/post/4.multisignature.accounts.js
+++ b/framework/test/mocha/functional/http/post/4.multisignature.accounts.js
@@ -258,7 +258,5 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 			);
 			expect(aMembersData.balance).to.be.equal(amount);
 		});
-		// Balance from existing member one shouldn't have changed, i.e. the account was not overwritten!
-		// expect(memberOneAfterRegistration.balance).to.be.equal(memberOneBeforeRegistration.balance);
 	});
 });


### PR DESCRIPTION
### What was the problem?

Group member accounts were not being created when registering a multi-signature transaction

### How did I fix it?

By adding methods to fetch/create the group member accounts

### How to test it?

- Register a multi-signature with two members and the two members should have accounts created
- Credit two accounts, register multi-signature for the first one and use the second one and another one as members. Registration should succeed and second account should have same balance

### Review checklist

* The PR resolves #3313
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
