### PR TITLE
Remove redundant .eslintrc.test.json - Closes #3380

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,5 @@
 {
 	"extends": ["lisk-base"],
-	"plugins": ["chai-expect"],
 	"rules": {
 		"implicit-arrow-linebreak": "off",
 		"no-mixed-spaces-and-tabs": "off",

--- a/.eslintrc.test.json
+++ b/.eslintrc.test.json
@@ -1,9 +1,0 @@
-{
-	"globals": {
-		"expect": true
-	},
-	"rules": {
-		"arrow-body-style": "off",
-		"no-unused-expressions": "off"
-	}
-}

--- a/framework/.eslintrc.json
+++ b/framework/.eslintrc.json
@@ -2,8 +2,6 @@
 	"extends": ["../.eslintrc.json"],
 	"rules": {
 		"camelcase": "off",
-		"chai-expect/missing-assertion": "error",
-		"chai-expect/no-inner-compare": "error",
 		"comma-dangle": [
 			"error",
 			{
@@ -43,7 +41,6 @@
 			"error",
 			{
 				"devDependencies": [
-					"test/**",
 					"src/modules/chain/tasks/**",
 					"src/modules/chain/scripts/**"
 				]

--- a/framework/test/jest/.eslintrc.json
+++ b/framework/test/jest/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["../../../.eslintrc.test.json", "plugin:jest/recommended"],
+	"extends": ["plugin:jest/recommended"],
 	"plugins": ["jest"],
 	"env": {
 		"jest/globals": true

--- a/framework/test/mocha/.eslintrc.json
+++ b/framework/test/mocha/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-	"extends": ["../../../.eslintrc.test.json"],
 	"plugins": ["chai-expect"],
 	"env": {
 		"mocha": true
@@ -12,6 +11,14 @@
 		"sinonSandbox": true
 	},
 	"rules": {
-		"arrow-body-style": "off"
+		"arrow-body-style": "off",
+		"chai-expect/missing-assertion": "error",
+		"chai-expect/no-inner-compare": "error",
+		"import/no-extraneous-dependencies": [
+			"error",
+			{
+				"devDependencies": ["./**"]
+			}
+		]
 	}
 }

--- a/lisk/.eslintrc.json
+++ b/lisk/.eslintrc.json
@@ -2,8 +2,6 @@
 	"extends": ["../.eslintrc.json"],
 	"rules": {
 		"camelcase": "off",
-		"chai-expect/missing-assertion": "error",
-		"chai-expect/no-inner-compare": "error",
 		"comma-dangle": [
 			"error",
 			{

--- a/lisk/test/.eslintrc.json
+++ b/lisk/test/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-	"extends": ["../../.eslintrc.test.json"],
 	"plugins": ["chai-expect"],
 	"env": {
 		"mocha": true
@@ -12,6 +11,8 @@
 		"sinonSandbox": true
 	},
 	"rules": {
-		"arrow-body-style": "off"
+		"arrow-body-style": "off",
+		"chai-expect/missing-assertion": "error",
+		"chai-expect/no-inner-compare": "error"
 	}
 }


### PR DESCRIPTION
### What was the problem?
.eslintrc.json files had irrevelant configuration, 
- test configs were mixed with source code configs.
- We had redundant .eslintrc.test.json
- IDEs were not able to resolve eslint configs properly.

### How did I fix it?
I reorganised .eslintrc files.

### How to test it?

### Review checklist

* The PR resolves #3380 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
