### PR TITLE
P2P should not connect to itself - Closes #3364

### DIFF
--- a/elements/lisk-p2p/src/disconnect_status_codes.ts
+++ b/elements/lisk-p2p/src/disconnect_status_codes.ts
@@ -6,6 +6,9 @@ export const INVALID_CONNECTION_QUERY_CODE = 4502;
 export const INVALID_CONNECTION_QUERY_REASON =
 	'Peer did not provide valid query parameters as part of the WebSocket connection';
 
+export const INVALID_CONNECTION_SELF_CODE = 4101;
+export const INVALID_CONNECTION_SELF_REASON = 'Peer cannot connect to itself';
+
 export const INCOMPATIBLE_NETWORK_CODE = 4102;
 export const INCOMPATIBLE_NETWORK_REASON = 'Peer nethash did not match our own';
 

--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -34,6 +34,19 @@ export class PeerInboundHandshakeError extends VError {
 	}
 }
 
+export class PeerOutboundConnectionError extends VError {
+	public statusCode?: number;
+
+	public constructor(
+		message: string,
+		statusCode?: number,
+	) {
+		super(message);
+		this.name = 'PeerOutboundConnectError';
+		this.statusCode = statusCode;
+	}
+}
+
 export class NotEnoughPeersError extends VError {
 	public constructor(message: string) {
 		super(message);

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -35,6 +35,8 @@ import {
 	INCOMPATIBLE_PEER_UNKNOWN_REASON,
 	INVALID_CONNECTION_QUERY_CODE,
 	INVALID_CONNECTION_QUERY_REASON,
+	INVALID_CONNECTION_SELF_CODE,
+	INVALID_CONNECTION_SELF_REASON,
 	INVALID_CONNECTION_URL_CODE,
 	INVALID_CONNECTION_URL_REASON,
 } from './disconnect_status_codes';
@@ -248,7 +250,7 @@ export class P2P extends EventEmitter {
 		this._bindHandlersToPeerPool(this._peerPool);
 
 		this._nodeInfo = config.nodeInfo;
-		this._peerPool.applyNodeInfo(this._nodeInfo);
+		this.applyNodeInfo(this._nodeInfo);
 
 		this._discoveryInterval = config.discoveryInterval
 			? config.discoveryInterval
@@ -275,7 +277,6 @@ export class P2P extends EventEmitter {
 		this._nodeInfo = {
 			...nodeInfo,
 		};
-
 		this._peerPool.applyNodeInfo(this._nodeInfo);
 	}
 
@@ -337,6 +338,16 @@ export class P2P extends EventEmitter {
 					return;
 				}
 				const queryObject = url.parse(socket.request.url, true).query;
+
+				if (queryObject.nonce === this._nodeInfo.nonce) {
+					this._disconnectSocketDueToFailedHandshake(
+						socket,
+						INVALID_CONNECTION_SELF_CODE,
+						INVALID_CONNECTION_SELF_REASON,
+					);
+
+					return;
+				}
 
 				if (
 					typeof queryObject.wsPort !== 'string' ||

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -638,6 +638,7 @@ export const connectAndRequest = async (
 
 			const outboundSocket = socketClusterClient.create(clientOptions);
 			// Bind an error handler immediately after creating the socket; otherwise errors may crash the process
+			// tslint:disable-next-line no-empty
 			outboundSocket.on('error', () => {});
 
 			// Attaching handlers for various events that could be used future for logging or any other application

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -655,7 +655,6 @@ export const connectAndRequest = async (
 			};
 			outboundSocket.once('close', closeHandler);
 
-
 			// Attaching handlers for various events that could be used future for logging or any other application
 			outboundSocket.emit(
 				REMOTE_EVENT_RPC_REQUEST,

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -40,7 +40,7 @@ describe('Integration tests for P2P library', () => {
 						height: 0,
 						broadhash:
 							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-						nonce: 'O2wTkjqplHII5wPv',
+						nonce: `O2wTkjqplHII${nodePort}`,
 					},
 				});
 			});
@@ -91,6 +91,8 @@ describe('Integration tests for P2P library', () => {
 					},
 				];
 
+				const nodePort = NETWORK_START_PORT + index;
+
 				return new P2P({
 					blacklistedPeers: [],
 					seedPeers,
@@ -101,7 +103,7 @@ describe('Integration tests for P2P library', () => {
 					// Set a different discoveryInterval for each node; that way they don't keep trying to discover each other at the same time.
 					discoveryInterval: DISCOVERY_INTERVAL + index * 11,
 					nodeInfo: {
-						wsPort: NETWORK_START_PORT + index,
+						wsPort: nodePort,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 						minVersion: '1.0.1',
@@ -111,7 +113,7 @@ describe('Integration tests for P2P library', () => {
 						height: 0,
 						broadhash:
 							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-						nonce: 'O2wTkjqplHII5wPv',
+						nonce: `O2wTkjqplHII${nodePort}`,
 					},
 				});
 			});
@@ -142,7 +144,8 @@ describe('Integration tests for P2P library', () => {
 					const peerPorts = connectedPeers
 						.map(peerInfo => peerInfo.wsPort)
 						.sort();
-					const expectedPeerPorts = ALL_NODE_PORTS;
+					const expectedPeerPorts = ALL_NODE_PORTS
+						.filter(peerPort => peerPort !== p2p.nodeInfo.wsPort);
 
 					expect(peerPorts).to.be.eql(expectedPeerPorts);
 				});
@@ -329,6 +332,8 @@ describe('Integration tests for P2P library', () => {
 								},
 						  ];
 
+				const nodePort = NETWORK_START_PORT + index;
+
 				return new P2P({
 					blacklistedPeers: [],
 					connectTimeout: 5000,
@@ -336,7 +341,7 @@ describe('Integration tests for P2P library', () => {
 					seedPeers,
 					wsEngine: 'ws',
 					nodeInfo: {
-						wsPort: NETWORK_START_PORT + index,
+						wsPort: nodePort,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 						version: '1.0.1',
@@ -346,7 +351,7 @@ describe('Integration tests for P2P library', () => {
 						height: 0,
 						broadhash:
 							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-						nonce: 'O2wTkjqplHII5wPv',
+						nonce: `O2wTkjqplHII${nodePort}`,
 					},
 				});
 			});
@@ -377,18 +382,12 @@ describe('Integration tests for P2P library', () => {
 						.map(peerInfo => peerInfo.wsPort)
 						.sort();
 
-					// Right now we do not care whether the node includes itself in its own peer list.
-					// TODO later: Formalize the correct approach and assert it here.
-					const peerPortsExcludingSelf = peerPorts.filter(
-						wsPort => wsPort !== p2p.nodeInfo.wsPort,
-					);
-
 					// The current node should not be in its own peer list.
 					const expectedPeerPorts = ALL_NODE_PORTS.filter(port => {
 						return port !== p2p.nodeInfo.wsPort;
 					});
 
-					expect(peerPortsExcludingSelf).to.be.eql(expectedPeerPorts);
+					expect(peerPorts).to.be.eql(expectedPeerPorts);
 				});
 			});
 
@@ -408,18 +407,13 @@ describe('Integration tests for P2P library', () => {
 					const { triedPeers } = p2p.getNetworkStatus();
 
 					const peerPorts = triedPeers.map(peerInfo => peerInfo.wsPort).sort();
-					// Right now we do not care whether the node includes itself in its own peer list.
-					// TODO later: Formalize the correct approach and assert it here.
-					const peerPortsExcludingSelf = peerPorts.filter(
-						wsPort => wsPort !== p2p.nodeInfo.wsPort,
-					);
 
 					// The current node should not be in its own peer list.
 					const expectedPeerPorts = ALL_NODE_PORTS.filter(port => {
 						return port !== p2p.nodeInfo.wsPort;
 					});
 
-					expect(peerPortsExcludingSelf).to.be.eql(expectedPeerPorts);
+					expect(peerPorts).to.be.eql(expectedPeerPorts);
 				});
 			});
 		});
@@ -743,6 +737,8 @@ describe('Integration tests for P2P library', () => {
 								},
 						  ];
 
+				const nodePort = NETWORK_START_PORT + index;
+
 				return new P2P({
 					blacklistedPeers: [],
 					connectTimeout: 5000,
@@ -753,7 +749,7 @@ describe('Integration tests for P2P library', () => {
 					seedPeers,
 					wsEngine: 'ws',
 					nodeInfo: {
-						wsPort: NETWORK_START_PORT + index,
+						wsPort: nodePort,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 						version: '1.0.1',
@@ -762,7 +758,8 @@ describe('Integration tests for P2P library', () => {
 						height: 1000 + index,
 						broadhash:
 							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-						nonce: 'O2wTkjqplHII5wPv',
+						nonce: `O2wTkjqplHII${nodePort}`,
+						
 						modules: index % 2 === 0 ? ['fileTransfer'] : ['socialSite'],
 					},
 				});
@@ -901,6 +898,8 @@ describe('Integration tests for P2P library', () => {
 					},
 				];
 
+				const nodePort = NETWORK_START_PORT + index;
+
 				return new P2P({
 					blacklistedPeers: [],
 					seedPeers,
@@ -911,7 +910,7 @@ describe('Integration tests for P2P library', () => {
 					// Set a different discoveryInterval for each node; that way they don't keep trying to discover each other at the same time.
 					discoveryInterval: DISCOVERY_INTERVAL + index * 11,
 					nodeInfo: {
-						wsPort: NETWORK_START_PORT + index,
+						wsPort: nodePort,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 						version: '1.0.1',
@@ -921,7 +920,7 @@ describe('Integration tests for P2P library', () => {
 						height: 0,
 						broadhash:
 							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-						nonce: 'O2wTkjqplHII5wPv',
+						nonce: `O2wTkjqplHII${nodePort}`,
 						modules: {
 							names: ['test', 'crypto'],
 							active: true,


### PR DESCRIPTION
### What was the problem?

- The peer was allowed to connect to itself. This may be causing issues with current tests.
- Found a gap during which socket errors may not have been handled which could have lead to process crash.

### How did I fix it?

- Use the nonce to prevent the node from connecting to itself at the earliest possible stage (during the inbound handshake).
- Bound error handler on outbound socket as soon as it is created. The handler does not log socket errors, but this is not a problem because we should get any error from the callback which is passed to `outboundSocket.emit(...)` if anything goes wrong.

### How to test it?

In `lisk-p2p`, run `npm test`

### Review checklist

* The PR resolves #3364
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
