### PR TITLE
New network module receive connection id not match error alot - Closes #3417

### DIFF
--- a/framework/src/modules/chain/submodules/blocks/verify.js
+++ b/framework/src/modules/chain/submodules/blocks/verify.js
@@ -830,11 +830,11 @@ Verify.prototype.processBlock = function(block, broadcast, saveBlock, cb) {
 				// Also that function set new block as our last block
 				modules.blocks.chain.applyBlock(block, saveBlock, seriesCb);
 			},
-			// Perform next two steps only when 'broadcast' flag is set, it can be:
+			// Perform the next step only when 'broadcast' flag is set, it can be:
 			// 'true' if block comes from generation or receiving process
 			// 'false' if block comes from chain synchronization process
 			updateApplicationState(seriesCb) {
-				if (!library.config.loading.snapshotRound) {
+				if (!library.config.loading.snapshotRound && broadcast) {
 					return modules.blocks
 						.calculateNewBroadhash()
 						.then(({ broadhash, height }) => {


### PR DESCRIPTION
### What was the problem?

1. There was an issue with timing which was causing v1 nodes to receive the `updateMyself` from the new v2 node before it was inserted into the peerManager. This was causing a `Connection id does not match with corresponding peer` error to occur very frequently.
2. While debugging with two nodes (v1 and v2) on testnet (made up mostly of v1 nodes), there was an issue which caused every height increment to be broadcast to the network during synching. This caused a lot of messages to be sent out to the network.

### How did I fix it?

Fixing the second issue above solved both problems. The large number of messages from the new v2 node may have triggered some a race condition on the v1 nodes which caused the order of `updateMyself` and peer insertion to be mixed up.

The root problem was that the app state was being updated for every block during synching (the block verification logic was not checking the `broadcast` flag).

### How to test it?

Run tests, run new node on testnet and verify that the `Connection id does not match with corresponding peer` rarely comes up.

### Review checklist

* The PR resolves #3417
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
