### PR TITLE
NewRelic does not show the proper network name - Closes #3435

### DIFF
--- a/lisk/src/helpers/config.js
+++ b/lisk/src/helpers/config.js
@@ -1,4 +1,3 @@
-
 const path = require('path');
 const {
 	helpers: { configurator },
@@ -50,8 +49,16 @@ configurator.loadConfig(appConfig);
 
 const { NETWORK, CUSTOM_CONFIG_FILE } = configurator.getConfig();
 
-configurator.loadConfigFile(path.resolve(__dirname, `../../config/${NETWORK}/config`));
-configurator.loadConfigFile(path.resolve(__dirname, `../../config/${NETWORK}/exceptions`), 'modules.chain.exceptions');
+// Variable is used to identify different networks on NewRelic
+process.env.LISK_NETWORK = NETWORK;
+
+configurator.loadConfigFile(
+	path.resolve(__dirname, `../../config/${NETWORK}/config`)
+);
+configurator.loadConfigFile(
+	path.resolve(__dirname, `../../config/${NETWORK}/exceptions`),
+	'modules.chain.exceptions'
+);
 
 if (CUSTOM_CONFIG_FILE) {
 	configurator.loadConfigFile(path.resolve(CUSTOM_CONFIG_FILE));


### PR DESCRIPTION
### What was the problem?

The environment variable need to be explicitly set to identify network. 

### How did I fix it?

Explicitly set the environment variable for the network. 

### How to test it?

```
cd lisk
node src/index.js
```

### Review checklist

* The PR resolves #3435
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated