### PR TITLE
Disable network test - Closes #3296

### DIFF
--- a/framework/test/mocha/network/index.js
+++ b/framework/test/mocha/network/index.js
@@ -29,7 +29,8 @@ _.range(TOTAL_PEERS).map(index => {
 	return WSPORTS.push(5000 + index);
 });
 
-describe(`Start a network of ${TOTAL_PEERS} nodes with address "127.0.0.1", WS ports 500[0-9] and HTTP ports 400[0-9] using separate databases`, () => {
+// eslint-disable-next-line
+describe.skip(`Start a network of ${TOTAL_PEERS} nodes with address "127.0.0.1", WS ports 500[0-9] and HTTP ports 400[0-9] using separate databases`, () => {
 	const configurations = setup.config.generateLiskConfigs(TOTAL_PEERS);
 	const network = new Network(configurations);
 	const suiteFolder = 'test/mocha/network/scenarios/';


### PR DESCRIPTION
### What was the problem?
Current protocol does not support the way we created the network test, so temporally disabling.

### Review checklist

* The PR resolves #3296 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
