### PR TITLE
Add script to start test app - Closes #3383

### DIFF
--- a/framework/package.json
+++ b/framework/package.json
@@ -26,6 +26,7 @@
 	"main": "src/index.js",
 	"scripts": {
 		"start": "node src/index.js",
+		"start:test:app": "node test/test_app",
 		"console": "node scripts/console.js",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",


### PR DESCRIPTION
### What was the problem?
There was no easy way to start the test application

### How did I fix it?
Add start up script for test app

### How to test it?
npm run start:test:app

### Review checklist

* The PR resolves #3383 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
