### PR TITLE
Fire `chain:blocks:change` event on block deletion - Closes #3525

### DIFF
--- a/framework/src/modules/chain/submodules/blocks.js
+++ b/framework/src/modules/chain/submodules/blocks.js
@@ -179,7 +179,7 @@ class Blocks {
 		const { transactions } = block;
 		if (transactions.length) {
 			library.channel.publish(
-				'chain:confirmed_transactions:update',
+				'chain:transactions:confirmed:change',
 				transactions
 			);
 		}

--- a/framework/src/modules/chain/submodules/blocks.js
+++ b/framework/src/modules/chain/submodules/blocks.js
@@ -174,6 +174,18 @@ class Blocks {
 		return library.channel.publish('chain:blocks:change', block);
 	}
 
+	// eslint-disable-next-line class-methods-use-this
+	async onDeleteBlock(block) {
+		const { transactions } = block;
+		if (transactions.length) {
+			library.channel.publish(
+				'chain:confirmed_transactions:update',
+				transactions
+			);
+		}
+		return library.channel.publish('chain:blocks:change', block);
+	}
+
 	/**
 	 * Handle node shutdown request.
 	 *

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -739,7 +739,7 @@ __private.popLastBlock = function(oldLastBlock, cb) {
 			.then(() => __private.deleteBlockStep(oldLastBlock, tx))
 	)
 		.then(() => {
-			library.channel.publish('chain:blocks:change', oldLastBlock);
+			library.bus.message('deleteBlock', oldLastBlock);
 			return setImmediate(cb, null, secondLastBlock);
 		})
 		.catch(err => setImmediate(cb, err));

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -738,7 +738,10 @@ __private.popLastBlock = function(oldLastBlock, cb) {
 			.then(() => __private.backwardTickStep(oldLastBlock, secondLastBlock, tx))
 			.then(() => __private.deleteBlockStep(oldLastBlock, tx))
 	)
-		.then(() => setImmediate(cb, null, secondLastBlock))
+		.then(() => {
+			library.channel.publish('chain:blocks:change', oldLastBlock);
+			return setImmediate(cb, null, secondLastBlock);
+		})
 		.catch(err => setImmediate(cb, err));
 };
 

--- a/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
@@ -986,7 +986,7 @@ describe('blocks/chain', () => {
 
 			it('should call a callback', done => {
 				__private.popLastBlock(blockWithTransactions, err => {
-					expect(library.channel.publish.callCount).to.be.eql(1);
+					expect(library.bus.message.callCount).to.be.eql(1);
 					expect(err).to.be.null;
 					done();
 				});

--- a/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
@@ -135,6 +135,7 @@ describe('blocks/chain', () => {
 				.stub()
 				.withArgs('app:state:updated')
 				.callsArg(1),
+			publish: sinonSandbox.stub(),
 		};
 
 		blocksChainModule = new BlocksChain(
@@ -985,6 +986,7 @@ describe('blocks/chain', () => {
 
 			it('should call a callback', done => {
 				__private.popLastBlock(blockWithTransactions, err => {
+					expect(library.channel.publish.callCount).to.be.eql(1);
 					expect(err).to.be.null;
 					done();
 				});


### PR DESCRIPTION
### What was the problem?

The event `chain:blocks:change` was not being fired on block deletion.

### How did I fix it?

By firing `chain:blocks:change` in `popLastBlock()`

### How to test it?

- Build should be green
- npm run mocha:unit test/mocha/unit/modules/chain/submodules/blocks/chain.js
- NOTE: this PR has to be merged after #3522 for it to be useful

### Review checklist

* The PR resolves #3525
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
