### PR TITLE
Loader module does not have processTransactions module - Closes #3583

### DIFF
--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -1026,6 +1026,7 @@ Loader.prototype.onBind = function(scope) {
 		peers: scope.modules.peers,
 		rounds: scope.modules.rounds,
 		multisignatures: scope.modules.multisignatures,
+		processTransactions: scope.modules.processTransactions,
 	};
 
 	__private.loadBlockChain();


### PR DESCRIPTION
### What was the problem?

- processTransactions was not assigned to the modules variable

### How did I fix it?

- by adding processTransactions to the modules variable

### How to test it?

- Build should be green

### Review checklist

* The PR resolves #3583
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
