### PR TITLE
Unstable broadhash due to stale info about peers in `getNetworkStatus()`

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -194,11 +194,12 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handlePeerConnectAbort = (peerInfo: P2PPeerInfo) => {
-			// Re-emit the message to allow it to bubble up the class hierarchy.
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
 			if (this._triedPeers.has(peerId)) {
 				this._triedPeers.delete(peerId);
 			}
+
+			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CONNECT_ABORT_OUTBOUND, peerInfo);
 		};
 

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -451,7 +451,7 @@ export class P2P extends EventEmitter {
 					!(
 						['127.0.0.1', '0.0.0.0', 'localhost'].includes(
 							incomingPeerInfo.ipAddress,
-						) && incomingPeerInfo.wsPort !== this.nodeInfo.wsPort
+						) && incomingPeerInfo.wsPort === this.nodeInfo.wsPort
 					)
 				) {
 					this._newPeers.set(peerId, incomingPeerInfo);
@@ -522,7 +522,7 @@ export class P2P extends EventEmitter {
 				!this._newPeers.has(peerId) &&
 				!(
 					['127.0.0.1', '0.0.0.0', 'localhost'].includes(peerInfo.ipAddress) &&
-					peerInfo.wsPort !== this.nodeInfo.wsPort
+					peerInfo.wsPort === this.nodeInfo.wsPort
 				)
 			) {
 				this._newPeers.set(peerId, peerInfo);

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -191,8 +191,20 @@ export class P2P extends EventEmitter {
 			this.emit(EVENT_CLOSE_OUTBOUND, closePacket);
 		};
 
-		this._handlePeerInfoUpdate = (peerInfo: P2PPeerInfo) => {
+		this._handlePeerInfoUpdate = (peerInfo: P2PDiscoveredPeerInfo) => {
 			// Re-emit the message to allow it to bubble up the class hierarchy.
+			const peerId = constructPeerIdFromPeerInfo(peerInfo);
+			const foundTriedPeer = this._triedPeers.get(peerId);
+
+			if (foundTriedPeer) {
+				const updatedPeerInfo = {
+					...peerInfo,
+					ipAddress: foundTriedPeer.ipAddress,
+					wsPort: foundTriedPeer.wsPort,
+				};
+				this._triedPeers.set(peerId, updatedPeerInfo);
+			}
+
 			this.emit(EVENT_UPDATED_PEER_INFO, peerInfo);
 		};
 

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -103,7 +103,6 @@ export const EVENT_FAILED_TO_ADD_INBOUND_PEER = 'failedToAddInboundPeer';
 export const EVENT_NEW_PEER = 'newPeer';
 
 export const NODE_HOST_IP = '0.0.0.0';
-export const NODE_HOST_IP_LIST = ['127.0.0.1', '0.0.0.0', 'localhost'];
 export const DEFAULT_DISCOVERY_INTERVAL = 30000;
 
 const BASE_10_RADIX = 10;
@@ -446,14 +445,7 @@ export class P2P extends EventEmitter {
 					this.emit(EVENT_NEW_PEER, incomingPeerInfo);
 				}
 
-				if (
-					!this._newPeers.has(peerId) &&
-					!this._triedPeers.has(peerId) &&
-					!(
-						NODE_HOST_IP_LIST.includes(incomingPeerInfo.ipAddress) &&
-						incomingPeerInfo.wsPort === this.nodeInfo.wsPort
-					)
-				) {
+				if (!this._newPeers.has(peerId) && !this._triedPeers.has(peerId)) {
 					this._newPeers.set(peerId, incomingPeerInfo);
 				}
 			},
@@ -517,14 +509,7 @@ export class P2P extends EventEmitter {
 
 		discoveredPeers.forEach((peerInfo: P2PDiscoveredPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
-			if (
-				!this._triedPeers.has(peerId) &&
-				!this._newPeers.has(peerId) &&
-				!(
-					NODE_HOST_IP_LIST.includes(peerInfo.ipAddress) &&
-					peerInfo.wsPort === this.nodeInfo.wsPort
-				)
-			) {
+			if (!this._triedPeers.has(peerId) && !this._newPeers.has(peerId)) {
 				this._newPeers.set(peerId, peerInfo);
 			}
 		});

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -433,7 +433,15 @@ export class P2P extends EventEmitter {
 					this.emit(EVENT_NEW_PEER, incomingPeerInfo);
 				}
 
-				if (!this._newPeers.has(peerId) && !this._triedPeers.has(peerId)) {
+				if (
+					!this._newPeers.has(peerId) &&
+					!this._triedPeers.has(peerId) &&
+					!(
+						['127.0.0.1', '0.0.0.0', 'localhost'].includes(
+							incomingPeerInfo.ipAddress,
+						) && incomingPeerInfo.wsPort !== this.nodeInfo.wsPort
+					)
+				) {
 					this._newPeers.set(peerId, incomingPeerInfo);
 				}
 			},
@@ -497,7 +505,14 @@ export class P2P extends EventEmitter {
 
 		discoveredPeers.forEach((peerInfo: P2PDiscoveredPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
-			if (!this._triedPeers.has(peerId) && !this._newPeers.has(peerId)) {
+			if (
+				!this._triedPeers.has(peerId) &&
+				!this._newPeers.has(peerId) &&
+				!(
+					['127.0.0.1', '0.0.0.0', 'localhost'].includes(peerInfo.ipAddress) &&
+					peerInfo.wsPort !== this.nodeInfo.wsPort
+				)
+			) {
 				this._newPeers.set(peerId, peerInfo);
 			}
 		});

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -103,6 +103,7 @@ export const EVENT_FAILED_TO_ADD_INBOUND_PEER = 'failedToAddInboundPeer';
 export const EVENT_NEW_PEER = 'newPeer';
 
 export const NODE_HOST_IP = '0.0.0.0';
+export const NODE_HOST_IP_LIST = ['127.0.0.1', '0.0.0.0', 'localhost'];
 export const DEFAULT_DISCOVERY_INTERVAL = 30000;
 
 const BASE_10_RADIX = 10;
@@ -449,9 +450,8 @@ export class P2P extends EventEmitter {
 					!this._newPeers.has(peerId) &&
 					!this._triedPeers.has(peerId) &&
 					!(
-						['127.0.0.1', '0.0.0.0', 'localhost'].includes(
-							incomingPeerInfo.ipAddress,
-						) && incomingPeerInfo.wsPort === this.nodeInfo.wsPort
+						NODE_HOST_IP_LIST.includes(incomingPeerInfo.ipAddress) &&
+						incomingPeerInfo.wsPort === this.nodeInfo.wsPort
 					)
 				) {
 					this._newPeers.set(peerId, incomingPeerInfo);
@@ -521,7 +521,7 @@ export class P2P extends EventEmitter {
 				!this._triedPeers.has(peerId) &&
 				!this._newPeers.has(peerId) &&
 				!(
-					['127.0.0.1', '0.0.0.0', 'localhost'].includes(peerInfo.ipAddress) &&
+					NODE_HOST_IP_LIST.includes(peerInfo.ipAddress) &&
 					peerInfo.wsPort === this.nodeInfo.wsPort
 				)
 			) {

--- a/framework/src/modules/network/filter_peers.js
+++ b/framework/src/modules/network/filter_peers.js
@@ -192,7 +192,7 @@ const getConsolidatedPeersList = networkStatus => {
 				...peerWithoutIp
 			} = peer;
 
-			return { ip: ipAddress, ...peerWithoutIp, state: 0 };
+			return { ip: ipAddress, ...peerWithoutIp, state: 1 };
 		});
 
 	return [...connectedList, ...disconnectedList];

--- a/framework/src/modules/network/filter_peers.js
+++ b/framework/src/modules/network/filter_peers.js
@@ -168,18 +168,22 @@ const getCountByFilter = (peers, filter) => {
  */
 const getConsolidatedPeersList = networkStatus => {
 	const { connectedPeers, newPeers, triedPeers } = networkStatus;
+	// Assign state 2 to the connected peers
+	const connectedList = connectedPeers.map(peer => {
+		const { ipAddress, options, minVersion, nethash, ...peerWithoutIp } = peer;
 
-	const uniquerPeersList = [
-		...connectedPeers,
-		...newPeers,
-		...triedPeers,
-	].reduce((uniquePeers, peer) => {
-		const found = uniquePeers.find(
-			findPeer =>
-				findPeer.ip === peer.ipAddress && findPeer.wsPort === peer.wsPort
-		);
-
-		if (!found) {
+		return { ip: ipAddress, ...peerWithoutIp, state: 2 };
+	});
+	// For the peers that are not present in connectedList should be assigned state 0
+	const disconnectedList = [...newPeers, ...triedPeers]
+		.filter(peer => {
+			const found = connectedList.find(
+				findPeer =>
+					findPeer.ip === peer.ipAddress && findPeer.wsPort === peer.wsPort
+			);
+			return !found;
+		})
+		.map(peer => {
 			const {
 				ipAddress,
 				options,
@@ -188,12 +192,10 @@ const getConsolidatedPeersList = networkStatus => {
 				...peerWithoutIp
 			} = peer;
 
-			return [...uniquePeers, { ip: ipAddress, ...peerWithoutIp }];
-		}
-		return uniquePeers;
-	}, []);
+			return { ip: ipAddress, ...peerWithoutIp, state: 0 };
+		});
 
-	return uniquerPeersList;
+	return [...connectedList, ...disconnectedList];
 };
 
 module.exports = {


### PR DESCRIPTION
### What was the problem?

Broadhash consensus is unstable which leads to missed blocks. #3574 

`networkHeight` is incorrect (for about 1 second) when API called just after forging a block. #3533 

### How did I fix it?

- Assigning correct `state` information (`0` for `disconnected` and `2` for `connected`) for `connectedPeers` and `triedPeers` which are not connected.
- Update `triedPeers` info on update status event on p2p-lib
- Don't let the node to add itself in its `newPeers` list

### How to test it?

Test on network with 10 peers, observe logs.

### Review checklist

* The PR resolves #3574 #3533
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
