### PR TITLE
Fix insufficient balance log - Closes #3578

### DIFF
--- a/elements/lisk-transactions/src/5_dapp_transaction.ts
+++ b/elements/lisk-transactions/src/5_dapp_transaction.ts
@@ -228,7 +228,7 @@ export class DappTransaction extends BaseTransaction {
 		if (!this.amount.eq(0)) {
 			errors.push(
 				new TransactionError(
-					'Amount must be zero for vote transaction',
+					'Amount must be zero for dapp transaction',
 					this.id,
 					'.amount',
 					this.amount.toString(),

--- a/elements/lisk-transactions/src/utils/verify.ts
+++ b/elements/lisk-transactions/src/utils/verify.ts
@@ -64,8 +64,6 @@ export const verifyBalance = (
 				}, balance: ${convertBeddowsToLSK(account.balance.toString())}`,
 				id,
 				'.balance',
-				account.balance,
-				convertBeddowsToLSK(account.balance.toString()),
 		  )
 		: undefined;
 


### PR DESCRIPTION
### What was the problem?

For insufficient balance error, `actual` and `expected` fields were both 0. These fields are not necessary for this error log as the actual balance is already listed in the message. 

### How did I fix it?

Remove `actual` and `expected` fields from insufficient balance error. 

### How to test it?

Send any transaction with insufficient balance account. 

### Review checklist

* The PR resolves #3578 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
