### PR TITLE
Node doesn't sync with the network - Closes #3577

### DIFF
--- a/framework/src/modules/chain/submodules/blocks/process.js
+++ b/framework/src/modules/chain/submodules/blocks/process.js
@@ -371,7 +371,9 @@ Process.prototype.loadBlocksFromNetwork = function(cb) {
 			throw new Error('Received an invalid blocks response from the network');
 		}
 		// Check for strict equality for backwards compatibility reasons.
-		if (data.success === false) {
+		// The misspelled data.sucess is required to support v1 nodes.
+		// TODO: Remove the misspelled data.sucess === false condition once enough nodes have migrated to v2.
+		if (data.success === false || data.sucess === false) {
 			throw new Error(
 				`Peer did not have a matching lastBlockId. ${data.message}`
 			);

--- a/framework/src/modules/chain/submodules/transport.js
+++ b/framework/src/modules/chain/submodules/transport.js
@@ -533,7 +533,7 @@ Transport.prototype.shared = {
 					return setImmediate(cb, null, {
 						blocks: [],
 						message: err,
-						sucess: false,
+						success: false,
 					});
 				}
 


### PR DESCRIPTION
### What was the problem?

During synching, if a node forks, it should try to rollback until it's back on the main chain. Right now, nodes in the network are not correctly reporting the absence of a common block through the `blocks` RPC and so it causes the node to get stuck at the height where it forked.

### How did I fix it?

Added support for the existing format which has a typo in one of the properties sent in the response.

### How to test it?

Run on alphanet as a small network for 10 nodes and check that nodes are able to recover from forks during synching.

### Review checklist

* The PR resolves #3577
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
