### PR TITLE
API returns incorrect error for postTransactions - Closes #3586

### DIFF
--- a/framework/src/modules/chain/submodules/transport.js
+++ b/framework/src/modules/chain/submodules/transport.js
@@ -709,7 +709,7 @@ Transport.prototype.shared = {
 				if (err) {
 					return setImmediate(cb, null, {
 						success: false,
-						message: 'Invalid transaction body',
+						message: err.message || 'Invalid transaction body',
 						errors: err,
 					});
 				}

--- a/framework/test/mocha/unit/modules/chain/submodules/transport.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/transport.js
@@ -1731,6 +1731,31 @@ describe('transport', () => {
 								.which.is.equal(receiveTransactionError);
 						});
 					});
+
+					describe('when __private.receiveTransaction fails with "Transaction pool is full"', () => {
+						const receiveTransactionError = 'Transaction pool is full';
+
+						beforeEach(done => {
+							__private.receiveTransaction = sinonSandbox
+								.stub()
+								.callsArgWith(3, receiveTransactionError);
+							transportInstance.shared.postTransaction(query, (err, res) => {
+								error = err;
+								result = res;
+								done();
+							});
+						});
+
+						it('should invoke callback with object { success: false, message: err }', async () => {
+							expect(error).to.equal(null);
+							expect(result)
+								.to.have.property('success')
+								.which.is.equal(false);
+							return expect(result)
+								.to.have.property('errors')
+								.which.is.equal(receiveTransactionError);
+						});
+					});
 				});
 
 				describe('postTransactions', () => {


### PR DESCRIPTION
### What was the problem?

`submodules/transport.js` was always returning `Invalid transaction body`  as error message

### How did I fix it?

Returning original `err` which was passed to the method

### How to test it?

- Build should be green
- Send additional transactions when the transaction pool is ull

### Review checklist

* The PR resolves #3586
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
