### PR TITLE
Inconsistent cache behavior - error when cache enabled - Closes #3600

### DIFF
--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -867,7 +867,7 @@ __private.loadBlocksFromNetwork = function(cb) {
  */
 __private.sync = function(cb) {
 	library.logger.info('Starting sync');
-	if (components.cache) {
+	if (components.cache.cacheReady) {
 		components.cache.disable();
 	}
 
@@ -915,7 +915,7 @@ __private.sync = function(cb) {
 			__private.blocksToSync = 0;
 
 			library.logger.info('Finished sync');
-			if (components.cache) {
+			if (!components.cache.cacheReady) {
 				components.cache.enable();
 			}
 			return setImmediate(cb, err);

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -599,7 +599,7 @@ Transactions.prototype.shared = {
 		async.waterfall(
 			[
 				function getConfirmedCountFromCache(waterCb) {
-					if (components.cache.cacheReady && components.cache.options.enabled) {
+					if (components.cache.cacheReady) {
 						return components.cache
 							.getJsonForKey(CACHE_KEYS_TRANSACTION_COUNT)
 							.then(data => {
@@ -630,7 +630,7 @@ Transactions.prototype.shared = {
 						// Cache already persisted, no need to set cache again
 						return setImmediate(waterCb, null, cachedCount);
 					}
-					if (components.cache.cacheReady && components.cache.options.enabled) {
+					if (components.cache.cacheReady) {
 						return components.cache
 							.setJsonForKey(CACHE_KEYS_TRANSACTION_COUNT, {
 								confirmed: dbCount,

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -599,7 +599,7 @@ Transactions.prototype.shared = {
 		async.waterfall(
 			[
 				function getConfirmedCountFromCache(waterCb) {
-					if (components.cache) {
+					if (components.cache.cacheReady && components.cache.options.enabled) {
 						return components.cache
 							.getJsonForKey(CACHE_KEYS_TRANSACTION_COUNT)
 							.then(data => {
@@ -630,7 +630,7 @@ Transactions.prototype.shared = {
 						// Cache already persisted, no need to set cache again
 						return setImmediate(waterCb, null, cachedCount);
 					}
-					if (components.cache) {
+					if (components.cache.cacheReady && components.cache.options.enabled) {
 						return components.cache
 							.setJsonForKey(CACHE_KEYS_TRANSACTION_COUNT, {
 								confirmed: dbCount,


### PR DESCRIPTION
### What was the problem?

Incorrect property was being used for checking if cache was enabled

### How did I fix it?

By using the correct properties to check if cache is enabled

### How to test it?

- build should be green
- Disable cache from the config and `GET http://localhost:4000/api/node/status` no messages about cache should be shown.

### Review checklist

* The PR resolves #3600
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
