### PR TITLE
Propagate inbound socket close event on Peer to the top level P2P class - Closes #3602

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -66,6 +66,7 @@ export { P2PRequest };
 import { selectForConnection, selectPeers } from './peer_selection';
 
 import {
+	EVENT_CLOSE_INBOUND,
 	EVENT_CLOSE_OUTBOUND,
 	EVENT_CONNECT_ABORT_OUTBOUND,
 	EVENT_CONNECT_OUTBOUND,
@@ -84,6 +85,7 @@ import {
 import { checkPeerCompatibility } from './validation';
 
 export {
+	EVENT_CLOSE_INBOUND,
 	EVENT_CLOSE_OUTBOUND,
 	EVENT_CONNECT_ABORT_OUTBOUND,
 	EVENT_CONNECT_OUTBOUND,
@@ -138,7 +140,8 @@ export class P2P extends EventEmitter {
 	private readonly _handlePeerConnectAbort: (
 		peerInfo: P2PDiscoveredPeerInfo,
 	) => void;
-	private readonly _handlePeerClose: (closePacket: P2PClosePacket) => void;
+	private readonly _handlePeerCloseOutbound: (closePacket: P2PClosePacket) => void;
+	private readonly _handlePeerCloseInbound: (closePacket: P2PClosePacket) => void;
 	private readonly _handlePeerInfoUpdate: (
 		peerInfo: P2PDiscoveredPeerInfo,
 	) => void;
@@ -186,9 +189,14 @@ export class P2P extends EventEmitter {
 			this.emit(EVENT_CONNECT_ABORT_OUTBOUND, peerInfo);
 		};
 
-		this._handlePeerClose = (closePacket: P2PClosePacket) => {
+		this._handlePeerCloseOutbound = (closePacket: P2PClosePacket) => {
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CLOSE_OUTBOUND, closePacket);
+		};
+
+		this._handlePeerCloseInbound = (closePacket: P2PClosePacket) => {
+			// Re-emit the message to allow it to bubble up the class hierarchy.
+			this.emit(EVENT_CLOSE_INBOUND, closePacket);
 		};
 
 		this._handlePeerInfoUpdate = (peerInfo: P2PPeerInfo) => {
@@ -613,7 +621,8 @@ export class P2P extends EventEmitter {
 		peerPool.on(EVENT_MESSAGE_RECEIVED, this._handlePeerPoolMessage);
 		peerPool.on(EVENT_CONNECT_OUTBOUND, this._handlePeerConnect);
 		peerPool.on(EVENT_CONNECT_ABORT_OUTBOUND, this._handlePeerConnectAbort);
-		peerPool.on(EVENT_CLOSE_OUTBOUND, this._handlePeerClose);
+		peerPool.on(EVENT_CLOSE_INBOUND, this._handlePeerCloseInbound);
+		peerPool.on(EVENT_CLOSE_OUTBOUND, this._handlePeerCloseOutbound);
 		peerPool.on(EVENT_UPDATED_PEER_INFO, this._handlePeerInfoUpdate);
 		peerPool.on(
 			EVENT_FAILED_PEER_INFO_UPDATE,

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -89,9 +89,9 @@ type SCServerSocketUpdated = {
 } & SCServerSocket;
 
 export enum ConnectionState {
-	CONNECTING = 0,
-	CONNECTED = 1,
-	DISCONNECTED = 2,
+	CONNECTING = 'connecting',
+	OPEN = 'open',
+	CLOSED = 'closed',
 }
 
 export interface PeerConnectionState {
@@ -301,14 +301,14 @@ export class Peer extends EventEmitter {
 	public get state(): PeerConnectionState {
 		const inbound = this._inboundSocket
 			? this._inboundSocket.state === this._inboundSocket.OPEN
-				? ConnectionState.CONNECTED
-				: ConnectionState.DISCONNECTED
-			: ConnectionState.DISCONNECTED;
+				? ConnectionState.OPEN
+				: ConnectionState.CLOSED
+			: ConnectionState.CLOSED;
 		const outbound = this._outboundSocket
 			? this._outboundSocket.state === this._outboundSocket.OPEN
-				? ConnectionState.CONNECTED
-				: ConnectionState.DISCONNECTED
-			: ConnectionState.DISCONNECTED;
+				? ConnectionState.OPEN
+				: ConnectionState.CLOSED
+			: ConnectionState.CLOSED;
 
 		return {
 			inbound,

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -164,14 +164,14 @@ export class PeerPool extends EventEmitter {
 			this.emit(EVENT_CONNECT_ABORT_OUTBOUND, peerInfo);
 		};
 		this._handlePeerCloseOutbound = (closePacket: P2PClosePacket) => {
-			// If we disconnect from a peer outbound, we should remove them to conserve our resources (especially in case of a malicious peer).
-			// A peer which was removed may added back later during the next round of discovery.
 			const peerId = constructPeerIdFromPeerInfo(closePacket.peerInfo);
-			this.removePeer(peerId);
+			this._removePeerIfFullyDisconnected(peerId);
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CLOSE_OUTBOUND, closePacket);
 		};
 		this._handlePeerCloseInbound = (closePacket: P2PClosePacket) => {
+			const peerId = constructPeerIdFromPeerInfo(closePacket.peerInfo);
+			this._removePeerIfFullyDisconnected(peerId);
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CLOSE_INBOUND, closePacket);
 		};
@@ -507,6 +507,17 @@ export class PeerPool extends EventEmitter {
 		}
 
 		return this._peerMap.delete(peerId);
+	}
+
+	private _removePeerIfFullyDisconnected(peerId: string): void {
+		const peer = this.getPeer(peerId);
+		if (
+			peer &&
+			peer.state.inbound === ConnectionState.CLOSED &&
+			peer.state.outbound === ConnectionState.CLOSED
+		) {
+			this.removePeer(peerId);
+		}
 	}
 
 	private _applyNodeInfoOnPeer(peer: Peer, nodeInfo: P2PNodeInfo): void {

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -429,7 +429,7 @@ export class PeerPool extends EventEmitter {
 		if (existingPeer) {
 			// Update the peerInfo from the latest inbound socket.
 			existingPeer.updatePeerInfo(peerInfo);
-			if (existingPeer.state.inbound === ConnectionState.DISCONNECTED) {
+			if (existingPeer.state.inbound === ConnectionState.CLOSED) {
 				existingPeer.inboundSocket = socket;
 
 				return false;
@@ -453,7 +453,7 @@ export class PeerPool extends EventEmitter {
 		if (existingPeer) {
 			// Update the peerInfo from the latest inbound socket.
 			existingPeer.updatePeerInfo(peerInfo);
-			if (existingPeer.state.outbound === ConnectionState.DISCONNECTED) {
+			if (existingPeer.state.outbound === ConnectionState.CLOSED) {
 				existingPeer.outboundSocket = socket;
 
 				return false;

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -41,6 +41,7 @@ import {
 	connectAndFetchPeerInfo,
 	ConnectionState,
 	constructPeerIdFromPeerInfo,
+	EVENT_CLOSE_INBOUND,
 	EVENT_CLOSE_OUTBOUND,
 	EVENT_CONNECT_ABORT_OUTBOUND,
 	EVENT_CONNECT_OUTBOUND,
@@ -60,6 +61,7 @@ export const EVENT_DISCOVERED_PEER = 'discoveredPeer';
 export const EVENT_FAILED_TO_FETCH_PEER_INFO = 'failedToFetchPeerInfo';
 
 export {
+	EVENT_CLOSE_INBOUND,
 	EVENT_CLOSE_OUTBOUND,
 	EVENT_CONNECT_OUTBOUND,
 	EVENT_CONNECT_ABORT_OUTBOUND,
@@ -98,7 +100,8 @@ export class PeerPool extends EventEmitter {
 	private readonly _handlePeerConnectAbort: (
 		peerInfo: P2PDiscoveredPeerInfo,
 	) => void;
-	private readonly _handlePeerClose: (closePacket: P2PClosePacket) => void;
+	private readonly _handlePeerCloseOutbound: (closePacket: P2PClosePacket) => void;
+	private readonly _handlePeerCloseInbound: (closePacket: P2PClosePacket) => void;
 	private readonly _handlePeerOutboundSocketError: (error: Error) => void;
 	private readonly _handlePeerInboundSocketError: (error: Error) => void;
 	private readonly _handlePeerInfoUpdate: (
@@ -160,13 +163,17 @@ export class PeerPool extends EventEmitter {
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CONNECT_ABORT_OUTBOUND, peerInfo);
 		};
-		this._handlePeerClose = (closePacket: P2PClosePacket) => {
+		this._handlePeerCloseOutbound = (closePacket: P2PClosePacket) => {
 			// If we disconnect from a peer outbound, we should remove them to conserve our resources (especially in case of a malicious peer).
 			// A peer which was removed may added back later during the next round of discovery.
 			const peerId = constructPeerIdFromPeerInfo(closePacket.peerInfo);
 			this.removePeer(peerId);
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CLOSE_OUTBOUND, closePacket);
+		};
+		this._handlePeerCloseInbound = (closePacket: P2PClosePacket) => {
+			// Re-emit the message to allow it to bubble up the class hierarchy.
+			this.emit(EVENT_CLOSE_INBOUND, closePacket);
 		};
 		this._handlePeerOutboundSocketError = (error: Error) => {
 			// Re-emit the error to allow it to bubble up the class hierarchy.
@@ -518,7 +525,8 @@ export class PeerPool extends EventEmitter {
 		peer.on(EVENT_MESSAGE_RECEIVED, this._handlePeerMessage);
 		peer.on(EVENT_CONNECT_OUTBOUND, this._handlePeerConnect);
 		peer.on(EVENT_CONNECT_ABORT_OUTBOUND, this._handlePeerConnectAbort);
-		peer.on(EVENT_CLOSE_OUTBOUND, this._handlePeerClose);
+		peer.on(EVENT_CLOSE_OUTBOUND, this._handlePeerCloseOutbound);
+		peer.on(EVENT_CLOSE_INBOUND, this._handlePeerCloseInbound);
 		peer.on(EVENT_OUTBOUND_SOCKET_ERROR, this._handlePeerOutboundSocketError);
 		peer.on(EVENT_INBOUND_SOCKET_ERROR, this._handlePeerInboundSocketError);
 		peer.on(EVENT_UPDATED_PEER_INFO, this._handlePeerInfoUpdate);
@@ -533,7 +541,8 @@ export class PeerPool extends EventEmitter {
 			EVENT_CONNECT_ABORT_OUTBOUND,
 			this._handlePeerConnectAbort,
 		);
-		peer.removeListener(EVENT_CLOSE_OUTBOUND, this._handlePeerClose);
+		peer.removeListener(EVENT_CLOSE_OUTBOUND, this._handlePeerCloseOutbound);
+		peer.removeListener(EVENT_CLOSE_INBOUND, this._handlePeerCloseInbound);
 		peer.removeListener(EVENT_UPDATED_PEER_INFO, this._handlePeerInfoUpdate);
 		peer.removeListener(
 			EVENT_FAILED_PEER_INFO_UPDATE,


### PR DESCRIPTION
### What was the problem?

- The inbound socket close event was not being emitted on top level P2P class.
- We were removing the peer from the peer pool if the outbound socket was disconnected; this is fine for v2.0 but not suitable for v2.1 LIP protocol version since peers will no longer always be both inbound and outbound.

### How did I fix it?

- Propagated 'close' event to P2P class.
- For connections state, use constants that are consistent with WebSocket connection states.
- Used strings as enums for connection states for ease of debugging.
- Only remove a peer from the PeerPool if it is disconnected both inbound and outbound.

### How to test it?

Run `lisk-p2p` tests.

### Review checklist

* The PR resolves #3602
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
