### PR TITLE
confirmed transaction count not returned when cache is disabled - Close #3618

### DIFF
--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -642,7 +642,7 @@ Transactions.prototype.shared = {
 							});
 					}
 
-					return setImmediate(waterCb, null, null);
+					return setImmediate(waterCb, null, dbCount);
 				},
 
 				function getAllCount(confirmedTransactionCount, waterCb) {


### PR DESCRIPTION
### What was the problem?

Confirmed count not being shown when cache disabled

### How did I fix it?

By returning dbCount value when cache is disabled

### How to test it?

- Disable cache in the config
- Send some transactions and wait for confirmation
- GET api/node/status data.transactions.confirmed should show confirmed count 

### Review checklist

* The PR resolves #3618
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
