### PR TITLE
Add validated queue count to api/node/status

### DIFF
--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -49,7 +49,7 @@ const wrapAddTransactionResponseInCb = (
 	return cb();
 };
 
-const receivedQueue = 'recieved';
+const receivedQueue = 'received';
 // TODO: Need to decide which queue will include transactions in the validated queue
 const pendingQueue = 'pending';
 const verifiedQueue = 'verified';

--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -55,6 +55,7 @@ const receivedQueue = 'recieved';
 const pendingQueue = 'pending';
 const verifiedQueue = 'verified';
 const readyQueue = 'ready';
+const validatedQueue = 'validated';
 
 /**
  * Transaction pool logic. Initializes variables,
@@ -222,6 +223,17 @@ class TransactionPool {
 	 */
 	getQueuedTransactionList(reverse, limit) {
 		return this.getTransactionsList(verifiedQueue, reverse, limit);
+	}
+
+	/**
+	 * Gets validated transactions based on limit and reverse option.
+	 *
+	 * @param {boolean} reverse - Reverse order of results
+	 * @param {number} limit - Limit applied to results
+	 * @returns {Object[]} Of bundled transactions
+	 */
+	getValidatedTransactionList(reverse, limit) {
+		return this.getTransactionsList(validatedQueue, reverse, limit);
 	}
 
 	/**

--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -51,7 +51,6 @@ const wrapAddTransactionResponseInCb = (
 
 const receivedQueue = 'recieved';
 // TODO: Need to decide which queue will include transactions in the validated queue
-// const validatedQueue = 'validated';
 const pendingQueue = 'pending';
 const verifiedQueue = 'verified';
 const readyQueue = 'ready';

--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -236,6 +236,17 @@ class TransactionPool {
 	}
 
 	/**
+	 * Gets received transactions based on limit and reverse option.
+	 *
+	 * @param {boolean} reverse - Reverse order of results
+	 * @param {number} limit - Limit applied to results
+	 * @returns {Object[]} Of bundled transactions
+	 */
+	getReceivedTransactionList(reverse, limit) {
+		return this.getTransactionsList(receivedQueue, reverse, limit);
+	}
+
+	/**
 	 * Gets multisignature transactions based on limit and reverse option.
 	 *
 	 * @param {boolean} reverse - Reverse order of results

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -653,6 +653,8 @@ Transactions.prototype.shared = {
 						unprocessed:
 							__private.transactionPool.getCountByQueue('verified') || 0,
 						unsigned: __private.transactionPool.getCountByQueue('pending') || 0,
+						validated:
+							__private.transactionPool.getCountByQueue('validated') || 0,
 					});
 				},
 			],
@@ -666,6 +668,7 @@ Transactions.prototype.shared = {
 					result.confirmed +
 					result.unconfirmed +
 					result.unprocessed +
+					result.validated +
 					result.unsigned;
 
 				return setImmediate(cb, null, result);

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -696,10 +696,10 @@ Transactions.prototype.shared = {
 	 */
 	getTransactionsFromPool(type, filters, cb) {
 		const typeMap = {
-			unprocessed: 'getQueuedTransactionList',
-			unconfirmed: 'getUnconfirmedTransactionList',
-			unsigned: 'getMultisignatureTransactionList',
+			pending: 'getMultisignatureTransactionList',
+			ready: 'getUnconfirmedTransactionList',
 			validated: 'getValidatedTransactionList',
+			verified: 'getQueuedTransactionList',
 		};
 
 		return __private.getPooledTransactions(typeMap[type], filters, cb);

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -660,11 +660,10 @@ Transactions.prototype.shared = {
 				function getAllCount(confirmedTransactionCount, waterCb) {
 					setImmediate(waterCb, null, {
 						confirmed: confirmedTransactionCount,
-						unconfirmed:
-							__private.transactionPool.getCountByQueue('ready') || 0,
-						unprocessed:
+						ready: __private.transactionPool.getCountByQueue('ready') || 0,
+						verified:
 							__private.transactionPool.getCountByQueue('verified') || 0,
-						unsigned: __private.transactionPool.getCountByQueue('pending') || 0,
+						pending: __private.transactionPool.getCountByQueue('pending') || 0,
 						validated:
 							__private.transactionPool.getCountByQueue('validated') || 0,
 					});
@@ -678,10 +677,10 @@ Transactions.prototype.shared = {
 
 				result.total =
 					result.confirmed +
-					result.unconfirmed +
-					result.unprocessed +
+					result.ready +
+					result.verified +
 					result.validated +
-					result.unsigned;
+					result.pending;
 
 				return setImmediate(cb, null, result);
 			}

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -466,6 +466,18 @@ Transactions.prototype.getValidatedTransactionList = function(reverse, limit) {
 };
 
 /**
+ * Gets validated transactions based on limit and reverse option.
+ *
+ * @param {boolean} reverse - Reverse order of results
+ * @param {number} limit - Limit applied to results
+ * @returns {function} Calls transactionPool.getQueuedTransactionList
+ * @todo Add description for the params
+ */
+Transactions.prototype.getReceivedTransactionList = function(reverse, limit) {
+	return __private.transactionPool.getReceivedTransactionList(reverse, limit);
+};
+
+/**
  * Search transactions based on the query parameter passed.
  *
  * @param {Object} filters - Filters applied to results
@@ -666,6 +678,8 @@ Transactions.prototype.shared = {
 						pending: __private.transactionPool.getCountByQueue('pending') || 0,
 						validated:
 							__private.transactionPool.getCountByQueue('validated') || 0,
+						received:
+							__private.transactionPool.getCountByQueue('received') || 0,
 					});
 				},
 			],
@@ -680,7 +694,8 @@ Transactions.prototype.shared = {
 					result.ready +
 					result.verified +
 					result.validated +
-					result.pending;
+					result.pending +
+					result.received;
 
 				return setImmediate(cb, null, result);
 			}
@@ -698,6 +713,7 @@ Transactions.prototype.shared = {
 		const typeMap = {
 			pending: 'getMultisignatureTransactionList',
 			ready: 'getUnconfirmedTransactionList',
+			received: 'getReceivedTransactionList',
 			validated: 'getValidatedTransactionList',
 			verified: 'getQueuedTransactionList',
 		};

--- a/framework/src/modules/chain/submodules/transactions.js
+++ b/framework/src/modules/chain/submodules/transactions.js
@@ -454,6 +454,18 @@ Transactions.prototype.getMergedTransactionList = function(reverse, limit) {
 };
 
 /**
+ * Gets validated transactions based on limit and reverse option.
+ *
+ * @param {boolean} reverse - Reverse order of results
+ * @param {number} limit - Limit applied to results
+ * @returns {function} Calls transactionPool.getQueuedTransactionList
+ * @todo Add description for the params
+ */
+Transactions.prototype.getValidatedTransactionList = function(reverse, limit) {
+	return __private.transactionPool.getValidatedTransactionList(reverse, limit);
+};
+
+/**
  * Search transactions based on the query parameter passed.
  *
  * @param {Object} filters - Filters applied to results
@@ -688,6 +700,7 @@ Transactions.prototype.shared = {
 			unprocessed: 'getQueuedTransactionList',
 			unconfirmed: 'getUnconfirmedTransactionList',
 			unsigned: 'getMultisignatureTransactionList',
+			validated: 'getValidatedTransactionList',
 		};
 
 		return __private.getPooledTransactions(typeMap[type], filters, cb);

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -492,11 +492,11 @@ paths:
           required: true
           type: string
           enum:
-            - unprocessed
-            - unconfirmed
-            - unsigned
+            - pending
+            - ready
             - validated
-          default: unprocessed
+            - verified
+          default: verified
         - $ref: '#/parameters/transactionId'
         - $ref: '#/parameters/recipientId'
         - $ref: '#/parameters/recipientPublicKey'

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -494,6 +494,7 @@ paths:
           enum:
             - pending
             - ready
+            - received
             - validated
             - verified
           default: verified
@@ -2411,6 +2412,7 @@ definitions:
           - verified
           - confirmed
           - validated
+          - received
           - total
         description: Transactions known to the node.
         properties:
@@ -2434,6 +2436,10 @@ definitions:
             type: integer
             example: 5
             description: Number of validated Transactions known to the node.
+          received: 
+            type: integer
+            example: 5
+            description: Number of received Transactions known to the node. 
           total:
             type: integer
             example: 15

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -2409,6 +2409,7 @@ definitions:
           - unsigned
           - unprocessed
           - confirmed
+          - validated
           - total
         description: Transactions known to the node.
         properties:
@@ -2428,6 +2429,10 @@ definitions:
             type: integer
             example: 5
             description: Number of confirmed Transactions known to the node.
+          validated: 
+            type: integer
+            example: 5
+            description: Number of validated Transactions known to the node.
           total:
             type: integer
             example: 15

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -495,6 +495,7 @@ paths:
             - unprocessed
             - unconfirmed
             - unsigned
+            - validated
           default: unprocessed
         - $ref: '#/parameters/transactionId'
         - $ref: '#/parameters/recipientId'

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -2406,26 +2406,26 @@ definitions:
       transactions:
         type: object
         required:
-          - unconfirmed
-          - unsigned
-          - unprocessed
+          - ready
+          - pending
+          - verified
           - confirmed
           - validated
           - total
         description: Transactions known to the node.
         properties:
-          unconfirmed:
+          ready:
             type: integer
             example: 5
             description: Number of unconfirmed Transactions known to the node.
-          unsigned:
+          pending:
             type: integer
             example: 2
-            description: Number of unsigned Transactions known to the node.
-          unprocessed:
+            description: Number of pending Transactions known to the node.
+          verified:
             type: integer
             example: 3
-            description: Number of unprocessed Transactions known to the node.
+            description: Number of verified Transactions known to the node.
           confirmed:
             type: integer
             example: 5

--- a/framework/test/mocha/common/helpers/api.js
+++ b/framework/test/mocha/common/helpers/api.js
@@ -163,14 +163,14 @@ function getUnconfirmedTransactions(cb) {
 
 function getQueuedTransaction(transaction, cb) {
 	http.get(
-		`/api/node/transactions/ready?id=${transaction}`,
+		`/api/node/transactions/verified?id=${transaction}`,
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }
 
 function getQueuedTransactions(cb) {
 	http.get(
-		'/api/node/transactions/ready',
+		'/api/node/transactions/verified',
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }

--- a/framework/test/mocha/common/helpers/api.js
+++ b/framework/test/mocha/common/helpers/api.js
@@ -149,48 +149,48 @@ function getTransactions(params, cb) {
 
 function getUnconfirmedTransaction(transaction, cb) {
 	http.get(
-		`/api/node/transactions/unconfirmed?id=${transaction}`,
+		`/api/node/transactions/ready?id=${transaction}`,
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }
 
 function getUnconfirmedTransactions(cb) {
 	http.get(
-		'/api/node/transactions/unconfirmed',
+		'/api/node/transactions/ready',
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }
 
 function getQueuedTransaction(transaction, cb) {
 	http.get(
-		`/api/node/transactions/unprocessed?id=${transaction}`,
+		`/api/node/transactions/ready?id=${transaction}`,
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }
 
 function getQueuedTransactions(cb) {
 	http.get(
-		'/api/node/transactions/unprocessed',
+		'/api/node/transactions/ready',
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }
 
 function getMultisignaturesTransaction(transaction, cb) {
 	http.get(
-		`/api/node/transactions/unsigned?id=${transaction}`,
+		`/api/node/transactions/pending?id=${transaction}`,
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }
 
 function getMultisignaturesTransactions(cb) {
 	http.get(
-		'/api/node/transactions/unsigned',
+		'/api/node/transactions/pending',
 		httpResponseCallbackHelper.bind(null, cb)
 	);
 }
 
 function getPendingMultisignatures(params, cb) {
-	let url = '/api/node/transactions/unsigned';
+	let url = '/api/node/transactions/pending';
 	url = paramsHelper(url, params);
 
 	http.get(url, httpResponseCallbackHelper.bind(null, cb));

--- a/framework/test/mocha/functional/http/get/node/transactions_ready.js
+++ b/framework/test/mocha/functional/http/get/node/transactions_ready.js
@@ -28,10 +28,10 @@ const sendTransactionPromise = apiHelpers.sendTransactionPromise;
 
 describe('GET /api/node', () => {
 	describe('/transactions', () => {
-		describe('/unconfirmed', () => {
-			const UnconfirmedEndpoint = new SwaggerEndpoint(
+		describe('/ready', () => {
+			const ReadyEndpoint = new SwaggerEndpoint(
 				'GET /node/transactions/{state}'
-			).addParameters({ state: 'unconfirmed' });
+			).addParameters({ state: 'ready' });
 
 			const account = randomUtil.account();
 			const transactionList = [];
@@ -65,7 +65,7 @@ describe('GET /api/node', () => {
 
 			describe('with wrong input', () => {
 				it('using invalid field name should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{
 							whatever: accountFixtures.genesis.address,
 						},
@@ -76,7 +76,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using empty parameter should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{
 							recipientPublicKey: '',
 						},
@@ -87,7 +87,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using completely invalid fields should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{
 							senderId: 'invalid',
 							recipientId: 'invalid',
@@ -106,7 +106,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using partially invalid fields should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{
 							senderId: 'invalid',
 							recipientId: account.address,
@@ -125,22 +125,20 @@ describe('GET /api/node', () => {
 			});
 
 			it('using no params should be ok', async () => {
-				return UnconfirmedEndpoint.makeRequest({}, 200).then(res => {
+				return ReadyEndpoint.makeRequest({}, 200).then(res => {
 					expect(res.body.meta.count).to.be.at.least(0);
 				});
 			});
 
 			describe('id', () => {
 				it('using invalid id should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest({ id: '79fjdfd' }, 400).then(
-						res => {
-							expectSwaggerParamError(res, 'id');
-						}
-					);
+					return ReadyEndpoint.makeRequest({ id: '79fjdfd' }, 400).then(res => {
+						expectSwaggerParamError(res, 'id');
+					});
 				});
 
 				it('using valid but unknown id should be ok', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{ id: '1111111111111111' },
 						200
 					).then(res => {
@@ -151,26 +149,23 @@ describe('GET /api/node', () => {
 
 			describe('type', () => {
 				it('using invalid type should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest({ type: 'a' }, 400).then(
-						res => {
-							expectSwaggerParamError(res, 'type');
-						}
-					);
+					return ReadyEndpoint.makeRequest({ type: 'a' }, 400).then(res => {
+						expectSwaggerParamError(res, 'type');
+					});
 				});
 			});
 
 			describe('senderId', () => {
 				it('using invalid senderId should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
-						{ senderId: '79fjdfd' },
-						400
-					).then(res => {
-						expectSwaggerParamError(res, 'senderId');
-					});
+					return ReadyEndpoint.makeRequest({ senderId: '79fjdfd' }, 400).then(
+						res => {
+							expectSwaggerParamError(res, 'senderId');
+						}
+					);
 				});
 
 				it('using valid but unknown senderId should be ok', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{ senderId: '1631373961111634666L' },
 						200
 					).then(res => {
@@ -181,7 +176,7 @@ describe('GET /api/node', () => {
 
 			describe('senderPublicKey', () => {
 				it('using invalid senderPublicKey should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{ senderPublicKey: '79fjdfd' },
 						400
 					).then(res => {
@@ -190,7 +185,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid but unknown senderPublicKey should be ok', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{
 							senderPublicKey:
 								'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f',
@@ -204,7 +199,7 @@ describe('GET /api/node', () => {
 
 			describe('recipientId', () => {
 				it('using invalid recipientId should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{ recipientId: '79fjdfd' },
 						400
 					).then(res => {
@@ -213,7 +208,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid but unknown recipientId should be ok', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{ recipientId: '1631373961111634666L' },
 						200
 					).then(res => {
@@ -224,7 +219,7 @@ describe('GET /api/node', () => {
 
 			describe('recipientPublicKey', () => {
 				it('using invalid recipientPublicKey should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{ recipientPublicKey: '79fjdfd' },
 						400
 					).then(res => {
@@ -233,7 +228,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid but unknown recipientPublicKey should be ok', async () => {
-					return UnconfirmedEndpoint.makeRequest(
+					return ReadyEndpoint.makeRequest(
 						{
 							recipientPublicKey:
 								'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f',
@@ -247,113 +242,98 @@ describe('GET /api/node', () => {
 
 			describe('limit', () => {
 				it('using limit < 0 should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest({ limit: -1 }, 400).then(
-						res => {
-							expectSwaggerParamError(res, 'limit');
-						}
-					);
+					return ReadyEndpoint.makeRequest({ limit: -1 }, 400).then(res => {
+						expectSwaggerParamError(res, 'limit');
+					});
 				});
 
 				it('using limit > 100 should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest({ limit: 101 }, 400).then(
-						res => {
-							expectSwaggerParamError(res, 'limit');
-						}
-					);
+					return ReadyEndpoint.makeRequest({ limit: 101 }, 400).then(res => {
+						expectSwaggerParamError(res, 'limit');
+					});
 				});
 
 				it('using limit = 10 should be ok', async () => {
-					return UnconfirmedEndpoint.makeRequest({ limit: 10 }, 200).then(
-						res => {
-							expect(res.body).to.not.be.empty;
-						}
-					);
+					return ReadyEndpoint.makeRequest({ limit: 10 }, 200).then(res => {
+						expect(res.body).to.not.be.empty;
+					});
 				});
 			});
 
 			describe('offset', () => {
 				it('using offset="one" should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest({ offset: 'one' }, 400).then(
-						res => {
-							expectSwaggerParamError(res, 'offset');
-						}
-					);
+					return ReadyEndpoint.makeRequest({ offset: 'one' }, 400).then(res => {
+						expectSwaggerParamError(res, 'offset');
+					});
 				});
 
 				it('using offset=1 should be ok', async () => {
-					return UnconfirmedEndpoint.makeRequest(
-						{ offset: 0, limit: 2 },
-						200
-					).then(res => {
-						expect(res.body).to.not.be.empty;
-					});
+					return ReadyEndpoint.makeRequest({ offset: 0, limit: 2 }, 200).then(
+						res => {
+							expect(res.body).to.not.be.empty;
+						}
+					);
 				});
 			});
 
 			describe('sort', () => {
 				describe('amount', () => {
 					it('sorted by amount:asc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
-							{ sort: 'amount:asc' },
-							200
-						).then(res => {
-							expect(res.body).to.not.be.empty;
-						});
+						return ReadyEndpoint.makeRequest({ sort: 'amount:asc' }, 200).then(
+							res => {
+								expect(res.body).to.not.be.empty;
+							}
+						);
 					});
 
 					it('sorted by amount:desc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
-							{ sort: 'amount:desc' },
-							200
-						).then(res => {
-							expect(res.body).to.not.be.empty;
-						});
+						return ReadyEndpoint.makeRequest({ sort: 'amount:desc' }, 200).then(
+							res => {
+								expect(res.body).to.not.be.empty;
+							}
+						);
 					});
 				});
 
 				describe('fee', () => {
 					it('sorted by fee:asc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
-							{ sort: 'fee:asc' },
-							200
-						).then(res => {
-							expect(res.body).to.not.be.empty;
-						});
+						return ReadyEndpoint.makeRequest({ sort: 'fee:asc' }, 200).then(
+							res => {
+								expect(res.body).to.not.be.empty;
+							}
+						);
 					});
 
 					it('sorted by fee:desc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
-							{ sort: 'fee:desc' },
-							200
-						).then(res => {
-							expect(res.body).to.not.be.empty;
-						});
+						return ReadyEndpoint.makeRequest({ sort: 'fee:desc' }, 200).then(
+							res => {
+								expect(res.body).to.not.be.empty;
+							}
+						);
 					});
 				});
 
 				describe('type', () => {
 					it('sorted by fee:asc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
-							{ sort: 'type:asc' },
-							200
-						).then(res => {
-							expect(res.body).to.not.be.empty;
-						});
+						return ReadyEndpoint.makeRequest({ sort: 'type:asc' }, 200).then(
+							res => {
+								expect(res.body).to.not.be.empty;
+							}
+						);
 					});
 
 					it('sorted by fee:desc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
-							{ sort: 'type:desc' },
-							200
-						).then(res => {
-							expect(res.body).to.not.be.empty;
-						});
+						return ReadyEndpoint.makeRequest({ sort: 'type:desc' }, 200).then(
+							res => {
+								expect(res.body).to.not.be.empty;
+							}
+						);
 					});
 				});
 
 				describe('timestamp', () => {
 					it('sorted by timestamp:asc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
+						return ReadyEndpoint.makeRequest(
 							{ sort: 'timestamp:asc' },
 							200
 						).then(res => {
@@ -362,7 +342,7 @@ describe('GET /api/node', () => {
 					});
 
 					it('sorted by timestamp:desc should be ok', async () => {
-						return UnconfirmedEndpoint.makeRequest(
+						return ReadyEndpoint.makeRequest(
 							{ sort: 'timestamp:desc' },
 							200
 						).then(res => {
@@ -372,7 +352,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using any other sort field should fail', async () => {
-					return UnconfirmedEndpoint.makeRequest({ sort: 'id:asc' }, 400).then(
+					return ReadyEndpoint.makeRequest({ sort: 'id:asc' }, 400).then(
 						res => {
 							expectSwaggerParamError(res, 'sort');
 						}

--- a/framework/test/mocha/functional/http/get/node/transactions_verified.js
+++ b/framework/test/mocha/functional/http/get/node/transactions_verified.js
@@ -16,128 +16,56 @@
 
 require('../../../functional');
 const Promise = require('bluebird');
-const {
-	transfer,
-	registerSecondPassphrase,
-	registerMultisignature,
-} = require('@liskhq/lisk-transactions');
+const { transfer } = require('@liskhq/lisk-transactions');
 const apiHelpers = require('../../../../common/helpers/api');
 const randomUtil = require('../../../../common/utils/random');
 const SwaggerEndpoint = require('../../../../common/swagger_spec');
 const accountFixtures = require('../../../../fixtures/accounts');
-const waitFor = require('../../../../common/utils/wait_for');
 
-const { NORMALIZER } = global.__testContext.config;
 const expectSwaggerParamError = apiHelpers.expectSwaggerParamError;
 const sendTransactionPromise = apiHelpers.sendTransactionPromise;
 
 describe('GET /api/node', () => {
 	describe('/transactions', () => {
-		describe('/unsigned', () => {
-			const UnsignedEndpoint = new SwaggerEndpoint(
+		// eslint-disable-next-line
+		describe('/verified', () => {
+			const VerifiedEndpoint = new SwaggerEndpoint(
 				'GET /node/transactions/{state}'
-			).addParameters({ state: 'unsigned' });
-			const signatureEndpoint = new SwaggerEndpoint('POST /signatures');
+			).addParameters({ state: 'verified' });
 
-			const senderAccount = randomUtil.account();
-			const recipientAccount = randomUtil.account();
-
+			const account = randomUtil.account();
 			const transactionList = [];
-			const numOfTransactions = 5;
-			let transaction = null;
-
-			const randomMember = randomUtil.account();
+			const numOfTransactions = 100;
 
 			before(() => {
-				// Credit account with some funds
-				transaction = transfer({
-					amount: (1000 * NORMALIZER).toString(),
-					passphrase: accountFixtures.genesis.passphrase,
-					recipientId: senderAccount.address,
-				});
+				const data = 'extra information';
 
-				return sendTransactionPromise(transaction)
-					.then(res => {
-						expect(res.body.data.message).to.be.equal(
+				// Create numOfTransactions transactions
+				for (let i = 0; i < numOfTransactions; i++) {
+					transactionList.push(
+						transfer({
+							amount: randomUtil.number(100000000, 1000000000).toString(),
+							passphrase: accountFixtures.genesis.passphrase,
+							recipientId: account.address,
+							data,
+						})
+					);
+				}
+
+				return Promise.map(transactionList, transaction => {
+					return sendTransactionPromise(transaction);
+				}).then(responses => {
+					responses.map(res => {
+						return expect(res.body.data.message).to.be.equal(
 							'Transaction(s) accepted'
 						);
-
-						return waitFor.confirmations([transaction.id]);
-					})
-					.then(() => {
-						// Create Second Signature for sender account
-						transaction = registerSecondPassphrase({
-							passphrase: senderAccount.passphrase,
-							secondPassphrase: senderAccount.secondPassphrase,
-						});
-
-						return sendTransactionPromise(transaction);
-					})
-					.then(res => {
-						expect(res.body.data.message).to.be.equal(
-							'Transaction(s) accepted'
-						);
-
-						return waitFor.confirmations([transaction.id]);
-					})
-					.then(() => {
-						// Convert account to multisig account
-						transaction = registerMultisignature({
-							passphrase: senderAccount.passphrase,
-							secondPassphrase: senderAccount.secondPassphrase,
-							keysgroup: [`${randomMember.publicKey}`],
-							lifetime: 1,
-							minimum: 1,
-						});
-
-						return sendTransactionPromise(transaction);
-					})
-					.then(res => {
-						expect(res.body.data.message).to.be.equal(
-							'Transaction(s) accepted'
-						);
-
-						const signature = apiHelpers.createSignatureObject(
-							transaction,
-							randomMember
-						);
-
-						return signatureEndpoint.makeRequest({ signature }, 200);
-					})
-					.then(res => {
-						expect(res.body.data.message).to.be.equal('Signature Accepted');
-
-						return waitFor.confirmations([transaction.id]);
-					})
-					.then(() => {
-						// Create numOfTransactions transactions
-						for (let i = 0; i < numOfTransactions; i++) {
-							transactionList.push(
-								transfer({
-									amount: ((i + 1) * NORMALIZER).toString(),
-									passphrase: senderAccount.passphrase,
-									secondPassphrase: senderAccount.secondPassphrase,
-									recipientId: recipientAccount.address,
-								})
-							);
-						}
-
-						return Promise.map(transactionList, mapTransaction => {
-							return sendTransactionPromise(mapTransaction);
-						});
-					})
-					.then(responses => {
-						responses.map(res => {
-							return expect(res.body.data.message).to.be.equal(
-								'Transaction(s) accepted'
-							);
-						});
 					});
+				});
 			});
 
 			describe('with wrong input', () => {
 				it('using invalid field name should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{
 							whatever: accountFixtures.genesis.address,
 						},
@@ -148,7 +76,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using empty parameter should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{
 							recipientPublicKey: '',
 						},
@@ -159,7 +87,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using completely invalid fields should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{
 							senderId: 'invalid',
 							recipientId: 'invalid',
@@ -178,10 +106,10 @@ describe('GET /api/node', () => {
 				});
 
 				it('using partially invalid fields should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{
 							senderId: 'invalid',
-							recipientId: senderAccount.address,
+							recipientId: account.address,
 							limit: 'invalid',
 							offset: 'invalid',
 							sort: 'invalid',
@@ -197,14 +125,14 @@ describe('GET /api/node', () => {
 			});
 
 			it('using no params should be ok', async () => {
-				return UnsignedEndpoint.makeRequest({}, 200).then(res => {
-					expect(res.body.meta.count).to.be.at.least(numOfTransactions);
+				return VerifiedEndpoint.makeRequest({}, 200).then(res => {
+					expect(res.body.meta.count).to.be.at.least(1);
 				});
 			});
 
 			describe('id', () => {
 				it('using invalid id should fail', async () => {
-					return UnsignedEndpoint.makeRequest({ id: '79fjdfd' }, 400).then(
+					return VerifiedEndpoint.makeRequest({ id: '79fjdfd' }, 400).then(
 						res => {
 							expectSwaggerParamError(res, 'id');
 						}
@@ -212,9 +140,10 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid id should be ok', async () => {
-					const transactionInCheck = transactionList[0];
+					const transactionInCheck =
+						transactionList[transactionList.length - 1];
 
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ id: transactionInCheck.id },
 						200
 					).then(res => {
@@ -225,7 +154,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid but unknown id should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ id: '1111111111111111' },
 						200
 					).then(res => {
@@ -236,22 +165,22 @@ describe('GET /api/node', () => {
 
 			describe('type', () => {
 				it('using invalid type should fail', async () => {
-					return UnsignedEndpoint.makeRequest({ type: 'a' }, 400).then(res => {
+					return VerifiedEndpoint.makeRequest({ type: 'a' }, 400).then(res => {
 						expectSwaggerParamError(res, 'type');
 					});
 				});
 
-				it('using valid type should be ok', async () => {
+				it('using valid type should be ok @unstable', async () => {
 					const transactionInCheck = transactionList[0];
 
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ type: transactionInCheck.type },
 						200
 					).then(res => {
 						expect(res.body.data).to.not.empty;
-						expect(res.body.data.length).to.be.at.least(numOfTransactions);
-						res.body.data.map(mapTransaction => {
-							return expect(mapTransaction.type).to.be.equal(
+						expect(res.body.data.length).to.be.at.least(1);
+						res.body.data.map(transaction => {
+							return expect(transaction.type).to.be.equal(
 								transactionInCheck.type
 							);
 						});
@@ -261,7 +190,7 @@ describe('GET /api/node', () => {
 
 			describe('senderId', () => {
 				it('using invalid senderId should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ senderId: '79fjdfd' },
 						400
 					).then(res => {
@@ -270,22 +199,22 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid senderId should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
-						{ senderId: senderAccount.address },
+					return VerifiedEndpoint.makeRequest(
+						{ senderId: accountFixtures.genesis.address },
 						200
 					).then(res => {
 						expect(res.body.data).to.not.empty;
-						expect(res.body.data.length).to.be.at.least(numOfTransactions);
-						res.body.data.map(mapTransaction => {
-							return expect(mapTransaction.senderId).to.be.equal(
-								senderAccount.address
+						expect(res.body.data.length).to.be.at.least(1);
+						res.body.data.map(transaction => {
+							return expect(transaction.senderId).to.be.equal(
+								accountFixtures.genesis.address
 							);
 						});
 					});
 				});
 
 				it('using valid but unknown senderId should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ senderId: '1631373961111634666L' },
 						200
 					).then(res => {
@@ -296,7 +225,7 @@ describe('GET /api/node', () => {
 
 			describe('senderPublicKey', () => {
 				it('using invalid senderPublicKey should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ senderPublicKey: '79fjdfd' },
 						400
 					).then(res => {
@@ -305,22 +234,22 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid senderPublicKey should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
-						{ senderPublicKey: senderAccount.publicKey },
+					return VerifiedEndpoint.makeRequest(
+						{ senderPublicKey: accountFixtures.genesis.publicKey },
 						200
 					).then(res => {
 						expect(res.body.data).to.not.empty;
-						expect(res.body.data.length).to.be.at.least(numOfTransactions);
-						res.body.data.map(mapTransaction => {
-							return expect(mapTransaction.senderPublicKey).to.be.equal(
-								senderAccount.publicKey
+						expect(res.body.data.length).to.be.at.least(1);
+						res.body.data.map(transaction => {
+							return expect(transaction.senderPublicKey).to.be.equal(
+								accountFixtures.genesis.publicKey
 							);
 						});
 					});
 				});
 
 				it('using valid but unknown senderPublicKey should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{
 							senderPublicKey:
 								'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f',
@@ -334,7 +263,7 @@ describe('GET /api/node', () => {
 
 			describe('recipientId', () => {
 				it('using invalid recipientId should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ recipientId: '79fjdfd' },
 						400
 					).then(res => {
@@ -343,22 +272,22 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid recipientId should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
-						{ recipientId: recipientAccount.address },
+					return VerifiedEndpoint.makeRequest(
+						{ recipientId: account.address },
 						200
 					).then(res => {
 						expect(res.body.data).to.not.empty;
-						expect(res.body.data.length).to.be.at.least(numOfTransactions);
-						res.body.data.map(mapTransaction => {
-							return expect(mapTransaction.recipientId).to.be.equal(
-								recipientAccount.address
+						expect(res.body.data.length).to.be.at.least(1);
+						res.body.data.map(transaction => {
+							return expect(transaction.recipientId).to.be.equal(
+								account.address
 							);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientId should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ recipientId: '1631373961111634666L' },
 						200
 					).then(res => {
@@ -369,7 +298,7 @@ describe('GET /api/node', () => {
 
 			describe('recipientPublicKey', () => {
 				it('using invalid recipientPublicKey should fail', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{ recipientPublicKey: '79fjdfd' },
 						400
 					).then(res => {
@@ -378,22 +307,22 @@ describe('GET /api/node', () => {
 				});
 
 				it('using valid recipientPublicKey should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
-						{ recipientPublicKey: recipientAccount.publicKey },
+					return VerifiedEndpoint.makeRequest(
+						{ recipientPublicKey: account.publicKey },
 						200
 					).then(res => {
 						expect(res.body.data).to.not.empty;
-						expect(res.body.data.length).to.be.at.least(numOfTransactions);
-						res.body.data.map(mapTransaction => {
-							return expect(mapTransaction.recipientId).to.be.equal(
-								recipientAccount.address
+						expect(res.body.data.length).to.be.at.least(1);
+						res.body.data.map(transaction => {
+							return expect(transaction.recipientId).to.be.equal(
+								account.address
 							);
 						});
 					});
 				});
 
 				it('using valid but unknown recipientPublicKey should be ok', async () => {
-					return UnsignedEndpoint.makeRequest(
+					return VerifiedEndpoint.makeRequest(
 						{
 							recipientPublicKey:
 								'c094ebee7ec0c50ebeeaaaa8655e089f6e1a604b83bcaa760293c61e0f18ab6f',
@@ -407,28 +336,28 @@ describe('GET /api/node', () => {
 
 			describe('limit', () => {
 				it('using limit < 0 should fail', async () => {
-					return UnsignedEndpoint.makeRequest({ limit: -1 }, 400).then(res => {
+					return VerifiedEndpoint.makeRequest({ limit: -1 }, 400).then(res => {
 						expectSwaggerParamError(res, 'limit');
 					});
 				});
 
 				it('using limit > 100 should fail', async () => {
-					return UnsignedEndpoint.makeRequest({ limit: 101 }, 400).then(res => {
+					return VerifiedEndpoint.makeRequest({ limit: 101 }, 400).then(res => {
 						expectSwaggerParamError(res, 'limit');
 					});
 				});
 
 				it('using limit = 2 should return 2 transactions', async () => {
-					return UnsignedEndpoint.makeRequest({ limit: 2 }, 200).then(res => {
+					return VerifiedEndpoint.makeRequest({ limit: 2 }, 200).then(res => {
 						expect(res.body.data).to.not.be.empty;
 						expect(res.body.data.length).to.be.at.most(2);
 					});
 				});
 			});
 
-			describe('offset', () => {
+			describe('offset @unstable', () => {
 				it('using offset="one" should fail', async () => {
-					return UnsignedEndpoint.makeRequest({ offset: 'one' }, 400).then(
+					return VerifiedEndpoint.makeRequest({ offset: 'one' }, 400).then(
 						res => {
 							expectSwaggerParamError(res, 'offset');
 						}
@@ -438,15 +367,15 @@ describe('GET /api/node', () => {
 				it('using offset=1 should be ok', async () => {
 					let firstTransaction = null;
 
-					return UnsignedEndpoint.makeRequest({ offset: 0, limit: 2 }, 200)
+					return VerifiedEndpoint.makeRequest({ offset: 0, limit: 2 }, 200)
 						.then(res => {
 							firstTransaction = res.body.data[0];
 
-							return UnsignedEndpoint.makeRequest({ offset: 1, limit: 2 }, 200);
+							return VerifiedEndpoint.makeRequest({ offset: 1, limit: 2 }, 200);
 						})
 						.then(res => {
-							res.body.data.forEach(mapTransaction => {
-								expect(mapTransaction.id).to.not.equal(firstTransaction.id);
+							res.body.data.forEach(transaction => {
+								expect(transaction.id).to.not.equal(firstTransaction.id);
 							});
 						});
 				});
@@ -455,7 +384,7 @@ describe('GET /api/node', () => {
 			describe('sort', () => {
 				describe('amount', () => {
 					it('sorted by amount:asc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest(
+						return VerifiedEndpoint.makeRequest(
 							{ sort: 'amount:asc' },
 							200
 						).then(res => {
@@ -470,7 +399,7 @@ describe('GET /api/node', () => {
 					});
 
 					it('sorted by amount:desc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest(
+						return VerifiedEndpoint.makeRequest(
 							{ sort: 'amount:desc' },
 							200
 						).then(res => {
@@ -487,7 +416,7 @@ describe('GET /api/node', () => {
 
 				describe('fee', () => {
 					it('sorted by fee:asc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest({ sort: 'fee:asc' }, 200).then(
+						return VerifiedEndpoint.makeRequest({ sort: 'fee:asc' }, 200).then(
 							res => {
 								expect(res.body.data).to.not.be.empty;
 
@@ -501,7 +430,7 @@ describe('GET /api/node', () => {
 					});
 
 					it('sorted by fee:desc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest({ sort: 'fee:desc' }, 200).then(
+						return VerifiedEndpoint.makeRequest({ sort: 'fee:desc' }, 200).then(
 							res => {
 								expect(res.body.data).to.not.be.empty;
 
@@ -519,7 +448,7 @@ describe('GET /api/node', () => {
 
 				describe('type', () => {
 					it('sorted by fee:asc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest({ sort: 'type:asc' }, 200).then(
+						return VerifiedEndpoint.makeRequest({ sort: 'type:asc' }, 200).then(
 							res => {
 								expect(res.body.data).to.not.be.empty;
 
@@ -533,7 +462,7 @@ describe('GET /api/node', () => {
 					});
 
 					it('sorted by fee:desc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest(
+						return VerifiedEndpoint.makeRequest(
 							{ sort: 'type:desc' },
 							200
 						).then(res => {
@@ -550,7 +479,7 @@ describe('GET /api/node', () => {
 
 				describe('timestamp', () => {
 					it('sorted by timestamp:asc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest(
+						return VerifiedEndpoint.makeRequest(
 							{ sort: 'timestamp:asc' },
 							200
 						).then(res => {
@@ -565,7 +494,7 @@ describe('GET /api/node', () => {
 					});
 
 					it('sorted by timestamp:desc should be ok', async () => {
-						return UnsignedEndpoint.makeRequest(
+						return VerifiedEndpoint.makeRequest(
 							{ sort: 'timestamp:desc' },
 							200
 						).then(res => {
@@ -581,7 +510,7 @@ describe('GET /api/node', () => {
 				});
 
 				it('using any other sort field should fail', async () => {
-					return UnsignedEndpoint.makeRequest({ sort: 'id:asc' }, 400).then(
+					return VerifiedEndpoint.makeRequest({ sort: 'id:asc' }, 400).then(
 						res => {
 							expectSwaggerParamError(res, 'sort');
 						}

--- a/framework/test/mocha/integration/common.js
+++ b/framework/test/mocha/integration/common.js
@@ -272,7 +272,7 @@ function getTransactionFromModule(library, filter, cb) {
 
 function getUnconfirmedTransactionFromModule(library, filter, cb) {
 	library.modules.transactions.shared.getTransactionsFromPool(
-		'unconfirmed',
+		'ready',
 		filter,
 		(err, res) => {
 			cb(err, res);
@@ -282,7 +282,7 @@ function getUnconfirmedTransactionFromModule(library, filter, cb) {
 
 function getMultisignatureTransactions(library, filter, cb) {
 	library.modules.transactions.shared.getTransactionsFromPool(
-		'unsigned',
+		'pending',
 		filter,
 		(err, res) => {
 			cb(err, res);

--- a/framework/test/mocha/unit/modules/chain/logic/transaction_pool.js
+++ b/framework/test/mocha/unit/modules/chain/logic/transaction_pool.js
@@ -189,7 +189,7 @@ describe('transactionPool', () => {
 			const limit = 10;
 			transactionPool.getBundledTransactionList(reverse, limit);
 			expect(getTransactionsListStub).to.be.calledWithExactly(
-				'recieved',
+				'received',
 				reverse,
 				limit
 			);


### PR DESCRIPTION
### What was the problem?

- One queue from the transaction pool was not exposed in `api/node/status`

### How did I fix it?

- By exposing the `validated` queue size and add it to the total
- By exposing the `validated` queue in `api/node/transactions/validated`

### How to test it?

- Send a thousand migrations to an endpoint and `GET api/node/status` a new key `data.transactions.validated` is going to be shown.
- GET `api/node/transactions/validated` and transactions should be shown

### Review checklist

* The PR resolves #3609
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
