### PR TITLE
Node fail to sync when block contains multisignature transaction - Closes #3612

### DIFF
--- a/framework/src/modules/chain/submodules/blocks/utils.js
+++ b/framework/src/modules/chain/submodules/blocks/utils.js
@@ -510,7 +510,10 @@ Utils.prototype._parseStorageObjToLegacyObj = function(block) {
 			v_votes: t.asset && t.asset.votes ? t.asset.votes.join(',') : null,
 			m_min: _.get(t, 'asset.multisignature.min', null),
 			m_lifetime: _.get(t, 'asset.multisignature.lifetime', null),
-			m_keysgroup: _.get(t, 'asset.multisignature.keysgroup', null),
+			m_keysgroup:
+				t.asset && t.asset.multisignature && t.asset.multisignature.keysgroup
+					? t.asset.multisignature.keysgroup.join(',')
+					: null,
 			dapp_name: _.get(t, 'asset.dapp.name', null),
 			dapp_description: _.get(t, 'asset.dapp.description', null),
 			dapp_tags: _.get(t, 'asset.dapp.tags', null),


### PR DESCRIPTION
### What was the problem?
The node did not return the block with the correct type for multisignature keys group property. Previously, it was a comma-separated list of public keys with + sign. Whereas now, it was returning an array of publicKey with + sign.
### How did I fix it?
Fixed the mapper to match the correct property type.
### How to test it?
Sync with the node.
### Review checklist

* The PR resolves #3612 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
