### PR TITLE
Fix unstable broadhash consensus - Closes#3574

### DIFF
--- a/framework/src/controller/schema/constants_schema.js
+++ b/framework/src/controller/schema/constants_schema.js
@@ -26,6 +26,7 @@ module.exports = {
 		'MAX_SHARED_TRANSACTIONS',
 		'MAX_VOTES_PER_ACCOUNT',
 		'MIN_BROADHASH_CONSENSUS',
+		'MAX_PEERS',
 		'TOTAL_AMOUNT',
 		'TRANSACTION_TYPES',
 		'UNCONFIRMED_TRANSACTION_TIMEOUT',
@@ -146,6 +147,13 @@ module.exports = {
 			description:
 				'Minimum broadhash consensus(%) among connected {MAX_PEERS} peers',
 		},
+		MAX_PEERS: {
+			type: 'integer',
+			min: 1,
+			const: 100,
+			description:
+				'Maximum number of peers for calculating broadhash consensus',
+		},
 		TOTAL_AMOUNT: {
 			type: 'string',
 			format: 'amount',
@@ -234,6 +242,7 @@ module.exports = {
 		MAX_SHARED_TRANSACTIONS: 100,
 		MAX_VOTES_PER_ACCOUNT: 101,
 		MIN_BROADHASH_CONSENSUS: 51,
+		MAX_PEERS: 100,
 		// WARNING: When changing totalAmount you also need to change getBlockRewards(int) SQL function!
 		TOTAL_AMOUNT: '10000000000000000',
 		TRANSACTION_TYPES: {

--- a/framework/src/controller/schema/constants_schema.js
+++ b/framework/src/controller/schema/constants_schema.js
@@ -26,7 +26,6 @@ module.exports = {
 		'MAX_SHARED_TRANSACTIONS',
 		'MAX_VOTES_PER_ACCOUNT',
 		'MIN_BROADHASH_CONSENSUS',
-		'MAX_PEERS',
 		'TOTAL_AMOUNT',
 		'TRANSACTION_TYPES',
 		'UNCONFIRMED_TRANSACTION_TIMEOUT',
@@ -147,13 +146,6 @@ module.exports = {
 			description:
 				'Minimum broadhash consensus(%) among connected {MAX_PEERS} peers',
 		},
-		MAX_PEERS: {
-			type: 'integer',
-			min: 1,
-			const: 100,
-			description:
-				'Maximum number of peers for calculating broadhash consensus',
-		},
 		TOTAL_AMOUNT: {
 			type: 'string',
 			format: 'amount',
@@ -242,7 +234,6 @@ module.exports = {
 		MAX_SHARED_TRANSACTIONS: 100,
 		MAX_VOTES_PER_ACCOUNT: 101,
 		MIN_BROADHASH_CONSENSUS: 51,
-		MAX_PEERS: 100,
 		// WARNING: When changing totalAmount you also need to change getBlockRewards(int) SQL function!
 		TOTAL_AMOUNT: '10000000000000000',
 		TRANSACTION_TYPES: {

--- a/framework/src/modules/chain/submodules/peers.js
+++ b/framework/src/modules/chain/submodules/peers.js
@@ -22,6 +22,7 @@ let self;
 const { MIN_BROADHASH_CONSENSUS } = global.constants;
 
 const PEER_STATE_CONNECTED = 2;
+const MAX_PEERS = 100;
 
 /**
  * Main peers methods. Initializes library with scope content.
@@ -82,14 +83,21 @@ Peers.prototype.getLastConsensus = function() {
  */
 Peers.prototype.calculateConsensus = async function() {
 	const { broadhash } = library.applicationState;
-	const activeCount = await library.channel.invoke(
-		'network:getPeersCountByFilter',
-		{ state: PEER_STATE_CONNECTED }
+	const activeCount = Math.min(
+		await library.channel.invoke('network:getPeersCountByFilter', {
+			state: PEER_STATE_CONNECTED,
+		}),
+		MAX_PEERS
 	);
-	const matchedCount = await library.channel.invoke(
-		'network:getPeersCountByFilter',
-		{ broadhash }
+
+	const matchedCount = Math.min(
+		await library.channel.invoke('network:getPeersCountByFilter', {
+			broadhash,
+			state: PEER_STATE_CONNECTED,
+		}),
+		MAX_PEERS
 	);
+
 	const consensus = +((matchedCount / activeCount) * 100).toPrecision(2);
 	self.consensus = Number.isNaN(consensus) ? 0 : consensus;
 	return self.consensus;

--- a/framework/src/modules/network/filter_peers.js
+++ b/framework/src/modules/network/filter_peers.js
@@ -13,6 +13,8 @@
  */
 const { shuffle } = require('lodash');
 
+const PEER_STATE_CONNECTED = 2;
+const PEER_STATE_DISCONNECTED = 1;
 /**
  * Sorts peers.
  *
@@ -172,9 +174,9 @@ const getConsolidatedPeersList = networkStatus => {
 	const connectedList = connectedPeers.map(peer => {
 		const { ipAddress, options, minVersion, nethash, ...peerWithoutIp } = peer;
 
-		return { ip: ipAddress, ...peerWithoutIp, state: 2 };
+		return { ip: ipAddress, ...peerWithoutIp, state: PEER_STATE_CONNECTED };
 	});
-	// For the peers that are not present in connectedList should be assigned state 0
+	// For the peers that are not present in connectedList should be assigned state 1 which is a DISCONNECTED state.
 	const disconnectedList = [...newPeers, ...triedPeers]
 		.filter(peer => {
 			const found = connectedList.find(
@@ -192,7 +194,11 @@ const getConsolidatedPeersList = networkStatus => {
 				...peerWithoutIp
 			} = peer;
 
-			return { ip: ipAddress, ...peerWithoutIp, state: 1 };
+			return {
+				ip: ipAddress,
+				...peerWithoutIp,
+				state: PEER_STATE_DISCONNECTED,
+			};
 		});
 
 	return [...connectedList, ...disconnectedList];

--- a/framework/test/mocha/unit/modules/chain/submodules/peers.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/peers.js
@@ -157,6 +157,7 @@ describe('peers', () => {
 				channelMock.invoke
 					.withArgs('network:getPeersCountByFilter', {
 						broadhash: prefixedPeer.broadhash,
+						state: PEER_STATE_CONNECTED,
 					})
 					.returns(2);
 			});
@@ -181,7 +182,7 @@ describe('peers', () => {
 				expect(
 					channelMock.invoke.calledWithExactly(
 						'network:getPeersCountByFilter',
-						{ broadhash: prefixedPeer.broadhash }
+						{ broadhash: prefixedPeer.broadhash, state: PEER_STATE_CONNECTED }
 					)
 				).to.be.true);
 
@@ -202,6 +203,7 @@ describe('peers', () => {
 				channelMock.invoke
 					.withArgs('network:getPeersCountByFilter', {
 						broadhash: prefixedPeer.broadhash,
+						state: PEER_STATE_CONNECTED,
 					})
 					.returns(1);
 			});


### PR DESCRIPTION
### What was the problem?

Broadhash consensus is too good and reaches `110%`.

### How did I fix it?

Matched count for broadhash value is incorrect because it takes disconnected peers as well into the count.

### How to test it?

`npm start`

### Review checklist

* The PR resolves #3574 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
