### PR TITLE
Fix typo in the string of the `receivedQueue` constant

### DIFF
--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -49,7 +49,7 @@ const wrapAddTransactionResponseInCb = (
 	return cb();
 };
 
-const receivedQueue = 'recieved';
+const receivedQueue = 'received';
 // TODO: Need to decide which queue will include transactions in the validated queue
 // const validatedQueue = 'validated';
 const pendingQueue = 'pending';

--- a/framework/test/mocha/unit/modules/chain/logic/transaction_pool.js
+++ b/framework/test/mocha/unit/modules/chain/logic/transaction_pool.js
@@ -189,7 +189,7 @@ describe('transactionPool', () => {
 			const limit = 10;
 			transactionPool.getBundledTransactionList(reverse, limit);
 			expect(getTransactionsListStub).to.be.calledWithExactly(
-				'recieved',
+				'received',
 				reverse,
 				limit
 			);
@@ -338,7 +338,7 @@ describe('transactionPool', () => {
 		it('should call this.pool.addTransaction with tranasction as parameter', done => {
 			const addTransactionStub = sinonSandbox
 				.stub(transactionPool.pool, 'addTransaction')
-				.returns({ isFull: false, exists: false, queueName: 'recieved' });
+				.returns({ isFull: false, exists: false, queueName: 'received' });
 			transactionPool.addBundledTransaction(dummyTransactions[0], err => {
 				expect(err).to.not.exist;
 				expect(addTransactionStub).to.be.calledWithExactly(


### PR DESCRIPTION
### What was the problem?
The spellings of the received queue were incorrect.
### How did I fix it?
Corrected the spellings.
### Review checklist

* The PR resolves #3576 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
