### PR TITLE
Expose `validateTransferAmount` and `validateNonTransferAmount` from elements - Closes #3640

### DIFF
--- a/elements/lisk-transactions/src/index.ts
+++ b/elements/lisk-transactions/src/index.ts
@@ -53,9 +53,11 @@ import {
 	validateAddress,
 	validateFee,
 	validateKeysgroup,
+	validateNonTransferAmount,
 	validatePublicKey,
 	validatePublicKeys,
 	validateTransaction,
+	validateTransferAmount,
 	validator,
 	verifyAmountBalance,
 	verifyTransaction,
@@ -76,6 +78,8 @@ const exposedUtils = {
 	validatePublicKey,
 	validatePublicKeys,
 	verifyAmountBalance,
+	validateNonTransferAmount,
+	validateTransferAmount,
 
 	// TODO: Deprecated
 	signTransaction,


### PR DESCRIPTION
### What was the problem?
`validateTransferAmount` and `validateNonTransferAmount` were not exposed from lisk-transactions
### How did I fix it?
Exposed these functions from src/index.ts file.
### How to test it?
Run the tests.
### Review checklist

* The PR resolves #3640 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
