### PR TITLE
Unprocessed transactions were not added to empty or non full blocks - Closes #3624

### DIFF
--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -172,6 +172,7 @@ export abstract class BaseTransaction {
 		this.blockId = tx.blockId;
 		this.height = tx.height;
 		this.receivedAt = tx.receivedAt ? new Date(tx.receivedAt) : undefined;
+		this.relays = typeof tx.relays === 'number' ? tx.relays : undefined;
 	}
 
 	public get id(): string {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -52,6 +52,7 @@ export interface TransactionJSON {
 	readonly timestamp: number;
 	readonly type: number;
 	readonly receivedAt?: string;
+	readonly relays?: number;
 }
 
 export interface IsValidResponse {


### PR DESCRIPTION
### What was the problem?
The relays property for the transaction was not transmitted between peers correctly. In turn, the nodes kept broadcasting it expecting that it is the first time the network has seen this transaction until the transaction was confirmed in the database. 
### How did I fix it?
Initialized the relay property for transactions in the constructor.
### How to test it?
Run stress tests in network and count the number of times one transaction is received from different peers before it gets confirmed.
### Review checklist

* The PR resolves #3624  
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
