### PR TITLE
Change log level of relevant network events to debug - Closes #3623

### DIFF
--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -203,7 +203,7 @@ module.exports = class Network {
 		});
 
 		this.p2p.on(EVENT_REQUEST_RECEIVED, async request => {
-			this.logger.info(
+			this.logger.trace(
 				`Incoming request event: Received inbound request for procedure ${
 					request.procedure
 				}`

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -142,29 +142,33 @@ module.exports = class Network {
 
 		this.p2p.on(EVENT_CLOSE_OUTBOUND, closePacket => {
 			this.logger.debug(
-				`Outbound connection of peer ${closePacket.peerInfo.ipAddress}:${
-					closePacket.peerInfo.wsPort
-				} was closed with code ${closePacket.code} and reason: ${
-					closePacket.reason
-				}`
+				`Peer disconnect event: Outbound connection of peer ${
+					closePacket.peerInfo.ipAddress
+				}:${closePacket.peerInfo.wsPort} was closed with code ${
+					closePacket.code
+				} and reason: ${closePacket.reason}`
 			);
 		});
 
 		this.p2p.on(EVENT_CONNECT_OUTBOUND, peerInfo => {
 			this.logger.info(
-				`Connected to peer ${peerInfo.ipAddress}:${peerInfo.wsPort}`
+				`Peer connect event: Connected to peer ${peerInfo.ipAddress}:${
+					peerInfo.wsPort
+				}`
 			);
 		});
 
 		this.p2p.on(EVENT_DISCOVERED_PEER, peerInfo => {
 			this.logger.info(
-				`Discovered peer ${peerInfo.ipAddress}:${peerInfo.wsPort}`
+				`New peer found event: Discovered peer ${peerInfo.ipAddress}:${
+					peerInfo.wsPort
+				}`
 			);
 		});
 
 		this.p2p.on(EVENT_NEW_INBOUND_PEER, peerInfo => {
 			this.logger.debug(
-				`Connected from peer ${peerInfo.ipAddress}:${
+				`New inbound peer event: Connected from peer ${peerInfo.ipAddress}:${
 					peerInfo.wsPort
 				} ${JSON.stringify(peerInfo)}`
 			);
@@ -188,7 +192,7 @@ module.exports = class Network {
 
 		this.p2p.on(EVENT_UPDATED_PEER_INFO, peerInfo => {
 			this.logger.debug(
-				`Updated info of peer ${peerInfo.ipAddress}:${
+				`Peer update info event: Updated info of peer ${peerInfo.ipAddress}:${
 					peerInfo.wsPort
 				} to ${JSON.stringify(peerInfo)}`
 			);
@@ -200,7 +204,9 @@ module.exports = class Network {
 
 		this.p2p.on(EVENT_REQUEST_RECEIVED, async request => {
 			this.logger.info(
-				`Received inbound request for procedure ${request.procedure}`
+				`Incoming request event: Received inbound request for procedure ${
+					request.procedure
+				}`
 			);
 			// If the request has already been handled internally by the P2P library, we ignore.
 			if (request.wasResponseSent) {
@@ -216,11 +222,15 @@ module.exports = class Network {
 					sanitizedProcedure,
 					request.data
 				);
-				this.logger.debug(`Responsed to peer request ${request.procedure}`);
+				this.logger.debug(
+					`Peer request fulfilled event: Responsed to peer request ${
+						request.procedure
+					}`
+				);
 				request.end(result); // Send the response back to the peer.
 			} catch (error) {
 				this.logger.error(
-					`Could not respond to peer request ${
+					`Peer request not fulfilled event: Could not respond to peer request ${
 						request.procedure
 					} because of error: ${error.message || error}`
 				);
@@ -229,7 +239,11 @@ module.exports = class Network {
 		});
 
 		this.p2p.on(EVENT_MESSAGE_RECEIVED, async packet => {
-			this.logger.debug(`Received inbound message for event ${packet.event}`);
+			this.logger.debug(
+				`Message Received event: Received inbound message for event ${
+					packet.event
+				}`
+			);
 			this.channel.publish('network:event', packet);
 		});
 

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -187,7 +187,7 @@ module.exports = class Network {
 		});
 
 		this.p2p.on(EVENT_UPDATED_PEER_INFO, peerInfo => {
-			this.logger.info(
+			this.logger.debug(
 				`Updated info of peer ${peerInfo.ipAddress}:${
 					peerInfo.wsPort
 				} to ${JSON.stringify(peerInfo)}`
@@ -216,7 +216,7 @@ module.exports = class Network {
 					sanitizedProcedure,
 					request.data
 				);
-				this.logger.info(`Responsed to peer request ${request.procedure}`);
+				this.logger.debug(`Responsed to peer request ${request.procedure}`);
 				request.end(result); // Send the response back to the peer.
 			} catch (error) {
 				this.logger.error(
@@ -229,7 +229,7 @@ module.exports = class Network {
 		});
 
 		this.p2p.on(EVENT_MESSAGE_RECEIVED, async packet => {
-			this.logger.info(`Received inbound message for event ${packet.event}`);
+			this.logger.debug(`Received inbound message for event ${packet.event}`);
 			this.channel.publish('network:event', packet);
 		});
 

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -191,7 +191,7 @@ module.exports = class Network {
 		});
 
 		this.p2p.on(EVENT_UPDATED_PEER_INFO, peerInfo => {
-			this.logger.debug(
+			this.logger.trace(
 				`Peer update info event: Updated info of peer ${peerInfo.ipAddress}:${
 					peerInfo.wsPort
 				} to ${JSON.stringify(peerInfo)}`
@@ -222,8 +222,8 @@ module.exports = class Network {
 					sanitizedProcedure,
 					request.data
 				);
-				this.logger.debug(
-					`Peer request fulfilled event: Responsed to peer request ${
+				this.logger.trace(
+					`Peer request fulfilled event: Responded to peer request ${
 						request.procedure
 					}`
 				);
@@ -239,8 +239,8 @@ module.exports = class Network {
 		});
 
 		this.p2p.on(EVENT_MESSAGE_RECEIVED, async packet => {
-			this.logger.debug(
-				`Message Received event: Received inbound message for event ${
+			this.logger.trace(
+				`Message received event: Received inbound message for event ${
 					packet.event
 				}`
 			);


### PR DESCRIPTION
### What was the problem?

Too many logs coming from the network module's events that are more appropriate for the debug log level.

### How did I fix it?

Change the log level of these events to debug.

### How to test it?

Start the application and check the logs

### Review checklist

* The PR resolves #3623 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
