### PR TITLE
Discovery is too reliant on seed peers - Closes #3643

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -552,17 +552,15 @@ export class P2P extends EventEmitter {
 		this._peerPool.selectPeersAndConnect([...this._newPeers.values()]);
 	}
 
-	private async _startDiscovery(
-		knownPeers: ReadonlyArray<P2PDiscoveredPeerInfo> = [],
-	): Promise<void> {
+	private async _startDiscovery(): Promise<void> {
 		if (this._discoveryIntervalId) {
 			throw new Error('Discovery is already running');
 		}
 		this._discoveryIntervalId = setInterval(async () => {
-			await this._discoverPeers(knownPeers);
+			await this._discoverPeers([...this._triedPeers.values()]);
 		}, this._discoveryInterval);
 
-		await this._discoverPeers(knownPeers);
+		await this._discoverPeers([...this._triedPeers.values()]);
 	}
 
 	private _stopDiscovery(): void {
@@ -643,7 +641,7 @@ export class P2P extends EventEmitter {
 			}
 		});
 
-		await this._startDiscovery(seedPeerInfos);
+		await this._startDiscovery();
 	}
 
 	public async stop(): Promise<void> {

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -136,7 +136,7 @@ describe('Integration tests for P2P library', () => {
 		describe('Peer discovery', () => {
 			it('should discover all peers in the network after a few cycles of discovery', async () => {
 				// Wait for a few cycles of discovery.
-				await wait(DISCOVERY_INTERVAL * 5);
+				await wait(DISCOVERY_INTERVAL * 7);
 
 				p2pNodeList.forEach(p2p => {
 					const { connectedPeers } = p2p.getNetworkStatus();


### PR DESCRIPTION
### What was the problem?

Discovery was only using seed peers to discover new peers.

### How did I fix it?

Each cycle, it takes a random sample from `triedPeers` and uses those to perform discovery.

### How to test it?

Run the p2p integration tests.

### Review checklist

* The PR resolves #3643
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
