### PR TITLE
"Error writing cache count for transactions - Cache Disabled" when /api/node/status is called - Closes #2482

### DIFF
--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -867,7 +867,7 @@ __private.loadBlocksFromNetwork = function(cb) {
  */
 __private.sync = function(cb) {
 	library.logger.info('Starting sync');
-	if (components.cache.cacheReady) {
+	if (components.cache.options.enabled && components.cache.cacheReady) {
 		components.cache.disable();
 	}
 
@@ -915,7 +915,7 @@ __private.sync = function(cb) {
 			__private.blocksToSync = 0;
 
 			library.logger.info('Finished sync');
-			if (!components.cache.cacheReady) {
+			if (components.cache.options.enabled && !components.cache.cacheReady) {
 				components.cache.enable();
 			}
 			return setImmediate(cb, err);

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -867,7 +867,7 @@ __private.loadBlocksFromNetwork = function(cb) {
  */
 __private.sync = function(cb) {
 	library.logger.info('Starting sync');
-	if (components.cache.options.enabled && components.cache.cacheReady) {
+	if (components.cache.options.enabled) {
 		components.cache.disable();
 	}
 
@@ -915,7 +915,7 @@ __private.sync = function(cb) {
 			__private.blocksToSync = 0;
 
 			library.logger.info('Finished sync');
-			if (components.cache.options.enabled && !components.cache.cacheReady) {
+			if (components.cache.options.enabled) {
 				components.cache.enable();
 			}
 			return setImmediate(cb, err);


### PR DESCRIPTION
### What was the problem?

- loader.js was enabling/disabling cache regardless of the cache being enabled/disabled

### How did I fix it?

- By adding extra checks in loader.js

### How to test it?

- Sync a node until loader tries to enable the cache and the cache config is off (or redis is turned off)
- `GET api/node/status` and you shouldn't see the error message in the console attempting to write/read from the cache

### Review checklist

* The PR resolves #2482
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
