### PR TITLE
Add identifier for ambiguous column reference asset - Closes #3639

### DIFF
--- a/framework/src/components/storage/entities/transaction.js
+++ b/framework/src/components/storage/entities/transaction.js
@@ -403,7 +403,10 @@ class Transaction extends BaseEntity {
 
 		// TODO: improve this logic
 		parsedSort = parsedSort.replace('"rowId"', 'trs."rowId"');
-		parsedSort = parsedSort.replace('"dapp_name"', "asset->'dapp'->>'name'");
+		parsedSort = parsedSort.replace(
+			'"dapp_name"',
+			"trs.asset->'dapp'->>'name'"
+		);
 
 		const params = {
 			limit: parsedOptions.limit,


### PR DESCRIPTION
### What was the problem?
Order clause for SQL query didn't have a column identifier.

### How did I fix it?
Add `trs.` identifier.

### How to test it?
Run Docker instance and monitor PSQL logs.

### Review checklist

* The PR resolves #3639 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
