### PR TITLE
Provide default application parameters - Closes #3660

### DIFF
--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -206,6 +206,10 @@ module.exports = {
 	additionalProperties: false,
 	default: {
 		app: {
+			label: 'alpha-sdk-app',
+			version: '0.0.0',
+			minVersion: '0.0.0',
+			protocolVersion: '0.0.0',
 			ipc: {
 				enabled: false,
 			},

--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -209,7 +209,7 @@ module.exports = {
 			label: 'alpha-sdk-app',
 			version: '0.0.0',
 			minVersion: '0.0.0',
-			protocolVersion: '0.0.0',
+			protocolVersion: '0.0',
 			ipc: {
 				enabled: false,
 			},

--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -209,7 +209,7 @@ module.exports = {
 			label: 'alpha-sdk-app',
 			version: '0.0.0',
 			minVersion: '0.0.0',
-			protocolVersion: '0.0',
+			protocolVersion: '1.5',
 			ipc: {
 				enabled: false,
 			},

--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -209,7 +209,7 @@ module.exports = {
 			label: 'alpha-sdk-app',
 			version: '0.0.0',
 			minVersion: '0.0.0',
-			protocolVersion: '1.5',
+			protocolVersion: '1.1',
 			ipc: {
 				enabled: false,
 			},

--- a/framework/src/errors.js
+++ b/framework/src/errors.js
@@ -37,6 +37,7 @@ class SchemaValidationError extends FrameworkError {
 	 */
 	constructor(errors) {
 		super('Schema validation error');
+		this.message = JSON.stringify(errors, null, 2);
 		this.errors = errors;
 	}
 }


### PR DESCRIPTION
### What was the problem?
A need for specifying the label and versions parameters while running an Alpha SDK application doesn't follow the documented example.

### How did I fix it?
There are defaults for application parameters. 

Also, the schema validation errors were not shown, so I populated them in the error's message.
### How to test it?

### Review checklist

* The PR resolves #3660 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
