### PR TITLE
Reuse wsPort of Peer to validate its incoming status - Closes#3666

### DIFF
--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -555,7 +555,7 @@ export class Peer extends EventEmitter {
 		inboundSocket: SCServerSocketUpdated,
 	): void {
 		inboundSocket.on('error', this._handleInboundSocketError);
-		
+
 		// Bind RPC and remote event handlers
 		inboundSocket.on(REMOTE_EVENT_RPC_REQUEST, this._handleRawRPC);
 		inboundSocket.on(REMOTE_EVENT_MESSAGE, this._handleRawMessage);
@@ -589,7 +589,11 @@ export class Peer extends EventEmitter {
 	}
 
 	private _updateFromProtocolPeerInfo(rawPeerInfo: unknown): void {
-		const protocolPeerInfo = { ...rawPeerInfo, ip: this._ipAddress };
+		const protocolPeerInfo = {
+			...rawPeerInfo,
+			ip: this._ipAddress,
+			wsPort: this._wsPort,
+		};
 		const newPeerInfo = validatePeerInfo(protocolPeerInfo);
 		this.updatePeerInfo(newPeerInfo);
 	}


### PR DESCRIPTION
### What was the problem?

whenever we try to fetch status or if the peer updates itself, sometimes it doesn't have `wsPort` value and it fails at the `validatePeerInfo` step.

### How did I fix it?

Reused peer `wsPort` while updating itself so that it doesn't fail at `validatePeerAddress`

![image](https://user-images.githubusercontent.com/9600691/57943192-b3b61d00-78d3-11e9-9b55-06c5bda93326.png)

### How to test it?

Start the application and check the logs

### Review checklist

* The PR resolves #3666
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
