### PR TITLE
Remove redundant handler check in Bus - Closes #3669

### DIFF
--- a/framework/src/controller/bus.js
+++ b/framework/src/controller/bus.js
@@ -131,14 +131,6 @@ class Bus extends EventEmitter2 {
 
 		Object.keys(actions).forEach(actionName => {
 			const actionFullName = `${moduleAlias}:${actionName}`;
-			if (
-				typeof actions[actionName] !== 'object' ||
-				!actions[actionName].handler
-			) {
-				throw new Error(
-					`Action "${actionFullName}" should be object with handler property.`
-				);
-			}
 
 			if (this.actions[actionFullName]) {
 				throw new Error(

--- a/framework/src/controller/channels/child_process_channel.js
+++ b/framework/src/controller/channels/child_process_channel.js
@@ -149,10 +149,7 @@ class ChildProcessChannel extends BaseChannel {
 				? new Action(actionName, params, this.moduleAlias)
 				: actionName;
 
-		if (
-			action.module === this.moduleAlias &&
-			typeof this.actions[action.name].handler === 'function'
-		) {
+		if (action.module === this.moduleAlias) {
 			return this.actions[action.name].handler(action);
 		}
 
@@ -181,10 +178,7 @@ class ChildProcessChannel extends BaseChannel {
 				? new Action(actionName, params, this.moduleAlias)
 				: actionName;
 
-		if (
-			action.module === this.moduleAlias &&
-			typeof this.actions[action.name].handler === 'function'
-		) {
+		if (action.module === this.moduleAlias) {
 			if (!this.actions[action.name].isPublic) {
 				throw new Error(
 					`Action ${action.name} is not allowed because it's not public.`

--- a/framework/src/controller/channels/in_memory_channel.js
+++ b/framework/src/controller/channels/in_memory_channel.js
@@ -114,10 +114,7 @@ class InMemoryChannel extends BaseChannel {
 				? new Action(actionName, params, this.moduleAlias)
 				: actionName;
 
-		if (
-			action.module === this.moduleAlias &&
-			typeof this.actions[action.name].handler === 'function'
-		) {
+		if (action.module === this.moduleAlias) {
 			return this.actions[action.name].handler(action);
 		}
 
@@ -138,10 +135,7 @@ class InMemoryChannel extends BaseChannel {
 				? new Action(actionName, params, this.moduleAlias)
 				: actionName;
 
-		if (
-			action.module === this.moduleAlias &&
-			typeof this.actions[action.name].handler === 'function'
-		) {
+		if (action.module === this.moduleAlias) {
 			if (!this.actions[action.name].isPublic) {
 				throw new Error(
 					`Action ${action.name} is not allowed because it's not public.`

--- a/framework/test/jest/unit/specs/controller/bus.spec.js
+++ b/framework/test/jest/unit/specs/controller/bus.spec.js
@@ -118,38 +118,6 @@ describe('Bus', () => {
 			});
 		});
 
-		it('should throw error registering incorrect action (no handler).', async () => {
-			// Arrange
-			const moduleAlias = 'alias';
-			const actions = {
-				action1: {
-					isPublic: false,
-				},
-			};
-
-			// Act && Assert
-			await expect(
-				bus.registerChannel(moduleAlias, [], actions, channelOptions)
-			).rejects.toBeInstanceOf(Error);
-		});
-
-		it('should throw error registering incorrect action (no object).', async () => {
-			// Arrange
-			const moduleAlias = 'alias';
-			const actions = {
-				action1: 'not an object',
-			};
-
-			// Act && Assert
-			await expect(
-				bus.registerChannel(moduleAlias, [], actions, channelOptions)
-			).rejects.toEqual(
-				new Error(
-					'Action "alias:action1" should be object with handler property.'
-				)
-			);
-		});
-
 		it('should throw error when trying to register duplicate actions.', async () => {
 			// Arrange
 			const moduleAlias = 'alias';


### PR DESCRIPTION
### What was the problem?
Action handler checks in the bus was causing `childProcessChannel.registerToBus` method to fail.
### How did I fix it?
I removed the action handler checks.
### How to test it?

### Review checklist

* The PR resolves #3669 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
