### PR TITLE
Remove nonce from WSBlocksBroadcast schema definition - Closes #3687

### DIFF
--- a/framework/src/modules/chain/schema/definitions.js
+++ b/framework/src/modules/chain/schema/definitions.js
@@ -163,14 +163,8 @@ module.exports = {
 	WSBlocksBroadcast: {
 		id: 'WSBlocksBroadcast',
 		type: 'object',
-		required: ['block', 'nonce'],
+		required: ['block'],
 		properties: {
-			nonce: {
-				type: 'string',
-				example: 'sYHEDBKcScaAAAYg',
-				minLength: 16,
-				maxLength: 16,
-			},
 			block: {
 				type: 'object',
 				required: ['id', 'height', 'timestamp', 'generatorPublicKey'],


### PR DESCRIPTION
### What was the problem?

Nonce was an unintended property of the blocks validation schema definition received via websockets.

### How did I fix it?

Removing the unintended property from the validation schema definition.

### How to test it?

`NODE_ENV=test npm run mocha:functional:ws`

### Review checklist

* The PR resolves #3687
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
