### PR TITLE
P2P errors while sync on testnet - Closes #3651

### DIFF
--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -84,9 +84,16 @@ export class InvalidPeerError extends Error {
 }
 
 export class RequestFailError extends Error {
-	public constructor(message: string) {
+	public peerId: string;
+	public peerVersion: string;
+	public constructor(message: string, peerId?: string, peerVersion?: string) {
 		super(message);
 		this.name = 'RequestFailError';
+		this.peerId = peerId || '';
+		this.peerVersion = peerVersion || '';
+		this.message = `${this.message}: PeerId: ${this.peerId}: Peer Version: ${
+			this.peerVersion
+		}`;
 	}
 }
 

--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -98,9 +98,11 @@ export class RequestFailError extends Error {
 		this.errorResponse = errorResponse || new Error(message);
 		this.peerId = peerId || '';
 		this.peerVersion = peerVersion || '';
-		this.message = `${this.message}: PeerId: ${this.peerId}: Peer Version: ${
-			this.peerVersion
-		}`;
+		this.message = peerId
+			? `${this.message}: PeerId: ${this.peerId}: Peer Version: ${
+					this.peerVersion
+			  }`
+			: message;
 	}
 }
 

--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -84,16 +84,17 @@ export class InvalidPeerError extends Error {
 export class RequestFailError extends Error {
 	public peerId: string;
 	public peerVersion: string;
-	public errorResponse: Error;
+	public response: Error;
 	public constructor(
 		message: string,
-		errorResponse?: Error,
+		response?: Error,
 		peerId?: string,
 		peerVersion?: string,
 	) {
 		super(message);
 		this.name = 'RequestFailError';
-		this.errorResponse = errorResponse || new Error(message);
+		// The request was made and the peer responded with error
+		this.response = response || new Error(message);
 		this.peerId = peerId || '';
 		this.peerVersion = peerVersion || '';
 		this.message = peerId

--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -44,14 +44,12 @@ export class PeerOutboundConnectionError extends Error {
 }
 
 export class RPCResponseError extends Error {
-	public peerIp: string;
-	public peerPort: number;
+	public peerId: string;
 
-	public constructor(message: string, peerIp: string, peerPort: number) {
+	public constructor(message: string, peerId: string) {
 		super(message);
 		this.name = 'RPCResponseError';
-		this.peerIp = peerIp;
-		this.peerPort = peerPort;
+		this.peerId = peerId;
 	}
 }
 
@@ -99,7 +97,7 @@ export class RequestFailError extends Error {
 		this.peerId = peerId || '';
 		this.peerVersion = peerVersion || '';
 		this.message = peerId
-			? `${this.message}: PeerId: ${this.peerId}: Peer Version: ${
+			? `${this.message}: Peer Id: ${this.peerId}: Peer Version: ${
 					this.peerVersion
 			  }`
 			: message;

--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -86,9 +86,16 @@ export class InvalidPeerError extends Error {
 export class RequestFailError extends Error {
 	public peerId: string;
 	public peerVersion: string;
-	public constructor(message: string, peerId?: string, peerVersion?: string) {
+	public errorResponse: Error;
+	public constructor(
+		message: string,
+		errorResponse?: Error,
+		peerId?: string,
+		peerVersion?: string,
+	) {
 		super(message);
 		this.name = 'RequestFailError';
+		this.errorResponse = errorResponse || new Error(message);
 		this.peerId = peerId || '';
 		this.peerVersion = peerVersion || '';
 		this.message = `${this.message}: PeerId: ${this.peerId}: Peer Version: ${

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -395,7 +395,7 @@ export class Peer extends EventEmitter {
 							// Wrap response error within the a new custom error and add peer id and version info
 							reject(
 								new RequestFailError(
-									err.message,
+									err instanceof Error ? err.message : err,
 									err,
 									constructPeerIdFromPeerInfo(this._peerInfo),
 									this._peerInfo.version,

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -392,9 +392,11 @@ export class Peer extends EventEmitter {
 					},
 					(err: Error | undefined, responseData: unknown) => {
 						if (err) {
+							// Wrap reponse error within the a new custom erro and attach peer id and version
 							reject(
 								new RequestFailError(
 									err.message,
+									err,
 									constructPeerIdFromPeerInfo(this._peerInfo),
 									this._peerInfo.version,
 								),

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -392,7 +392,7 @@ export class Peer extends EventEmitter {
 					},
 					(err: Error | undefined, responseData: unknown) => {
 						if (err) {
-							// Wrap reponse error within the a new custom erro and attach peer id and version
+							// Wrap response error within the a new custom error and add peer id and version info
 							reject(
 								new RequestFailError(
 									err.message,

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -18,6 +18,7 @@ import * as querystring from 'querystring';
 import {
 	FetchPeerStatusError,
 	PeerOutboundConnectionError,
+	RequestFailError,
 	RPCResponseError,
 } from './errors';
 
@@ -391,7 +392,13 @@ export class Peer extends EventEmitter {
 					},
 					(err: Error | undefined, responseData: unknown) => {
 						if (err) {
-							reject(err);
+							reject(
+								new RequestFailError(
+									err.message,
+									constructPeerIdFromPeerInfo(this._peerInfo),
+									this._peerInfo.version,
+								),
+							);
 
 							return;
 						}

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -414,8 +414,7 @@ export class Peer extends EventEmitter {
 						reject(
 							new RPCResponseError(
 								`Failed to handle response for procedure ${packet.procedure}`,
-								this.ipAddress,
-								this.wsPort,
+								constructPeerIdFromPeerInfo(this._peerInfo),
 							),
 						);
 					},
@@ -434,8 +433,7 @@ export class Peer extends EventEmitter {
 		} catch (error) {
 			throw new RPCResponseError(
 				'Failed to fetch peer list of peer',
-				this.ipAddress,
-				this.wsPort,
+				constructPeerIdFromPeerInfo(this._peerInfo),
 			);
 		}
 	}
@@ -452,8 +450,7 @@ export class Peer extends EventEmitter {
 
 			throw new RPCResponseError(
 				'Failed to fetch peer info of peer',
-				this.ipAddress,
-				this.wsPort,
+				constructPeerIdFromPeerInfo(this._peerInfo),
 			);
 		}
 
@@ -731,8 +728,7 @@ export const connectAndRequest = async (
 							`Failed to handle response for procedure ${
 								requestPacket.procedure
 							}`,
-							basicPeerInfo.ipAddress,
-							basicPeerInfo.wsPort,
+							constructPeerIdFromPeerInfo(basicPeerInfo),
 						),
 					);
 				},

--- a/elements/lisk-p2p/test/unit/errors.ts
+++ b/elements/lisk-p2p/test/unit/errors.ts
@@ -53,17 +53,12 @@ describe('errors', () => {
 	});
 
 	describe('#RPCResponseError', () => {
-		const peerIp = '127.0.0.1:5001';
-		const peerPort = 5001;
-		const defaultMessage = `Error when fetching peerlist of peer with peer ip ${peerIp} and port ${peerPort}`;
+		const peerId = '127.0.0.1:5001';
+		const defaultMessage = `Error when fetching peerlist of peer with peer Id ${peerId}`;
 		let rpcGetPeersFailed: RPCResponseError;
 
 		beforeEach(async () => {
-			rpcGetPeersFailed = new RPCResponseError(
-				defaultMessage,
-				peerIp,
-				peerPort,
-			);
+			rpcGetPeersFailed = new RPCResponseError(defaultMessage, peerId);
 		});
 
 		it('should create a new instance of RPCResponseError', async () => {
@@ -74,16 +69,10 @@ describe('errors', () => {
 			expect(rpcGetPeersFailed.name).to.eql('RPCResponseError');
 		});
 
-		it('should set error property peer ip when passed as an argument', async () => {
+		it('should set error property peer Id when passed as an argument', async () => {
 			expect(rpcGetPeersFailed)
-				.and.to.have.property('peerIp')
-				.which.is.eql(peerIp);
-		});
-
-		it('should set error property peer port when passed as an argument', async () => {
-			expect(rpcGetPeersFailed)
-				.and.to.have.property('peerPort')
-				.which.is.eql(peerPort);
+				.and.to.have.property('peerId')
+				.which.is.eql(peerId);
 		});
 	});
 
@@ -233,7 +222,7 @@ describe('errors', () => {
 
 		it('should set error message when passed an argument', async () => {
 			expect(requestFailError.message).to.eql(
-				`${defaultMessage}: PeerId: ${peerId}: Peer Version: ${peerVersion}`,
+				`${defaultMessage}: Peer Id: ${peerId}: Peer Version: ${peerVersion}`,
 			);
 		});
 

--- a/elements/lisk-p2p/test/unit/errors.ts
+++ b/elements/lisk-p2p/test/unit/errors.ts
@@ -207,10 +207,17 @@ describe('errors', () => {
 	describe('#RequestFailError', () => {
 		const defaultMessage =
 			'Request failed due to no peers found in peer selection';
+		const peerId = '127.0.0.1:4000';
+		const peerVersion = '1.5.0';
+
 		let requestFailError: RequestFailError;
 
 		beforeEach(async () => {
-			requestFailError = new RequestFailError(defaultMessage);
+			requestFailError = new RequestFailError(
+				defaultMessage,
+				peerId,
+				peerVersion,
+			);
 		});
 
 		it('should create a new instance of RequestFailError', async () => {
@@ -222,7 +229,9 @@ describe('errors', () => {
 		});
 
 		it('should set error message when passed an argument', async () => {
-			expect(requestFailError.message).to.eql(defaultMessage);
+			expect(requestFailError.message).to.eql(
+				`${defaultMessage}: PeerId: ${peerId}: Peer Version: ${peerVersion}`,
+			);
 		});
 	});
 });

--- a/elements/lisk-p2p/test/unit/errors.ts
+++ b/elements/lisk-p2p/test/unit/errors.ts
@@ -197,7 +197,7 @@ describe('errors', () => {
 		const defaultMessage =
 			'Request failed due to no peers found in peer selection';
 		const errorResponseMessage = 'Invalid block id';
-		const errorResponse = new Error(errorResponseMessage);
+		const response = new Error(errorResponseMessage);
 		const peerId = '127.0.0.1:4000';
 		const peerVersion = '1.5.0';
 
@@ -206,7 +206,7 @@ describe('errors', () => {
 		beforeEach(async () => {
 			requestFailError = new RequestFailError(
 				defaultMessage,
-				errorResponse,
+				response,
 				peerId,
 				peerVersion,
 			);
@@ -226,9 +226,9 @@ describe('errors', () => {
 			);
 		});
 
-		it('should set errorResponse object within this custom error', async () => {
-			expect(requestFailError.errorResponse)
-				.to.eql(errorResponse)
+		it('should set response object within this custom error', async () => {
+			expect(requestFailError.response)
+				.to.eql(response)
 				.to.have.property('message')
 				.eql(errorResponseMessage);
 		});

--- a/elements/lisk-p2p/test/unit/errors.ts
+++ b/elements/lisk-p2p/test/unit/errors.ts
@@ -207,6 +207,8 @@ describe('errors', () => {
 	describe('#RequestFailError', () => {
 		const defaultMessage =
 			'Request failed due to no peers found in peer selection';
+		const errorResponseMessage = 'Invalid block id';
+		const errorResponse = new Error(errorResponseMessage);
 		const peerId = '127.0.0.1:4000';
 		const peerVersion = '1.5.0';
 
@@ -215,6 +217,7 @@ describe('errors', () => {
 		beforeEach(async () => {
 			requestFailError = new RequestFailError(
 				defaultMessage,
+				errorResponse,
 				peerId,
 				peerVersion,
 			);
@@ -232,6 +235,13 @@ describe('errors', () => {
 			expect(requestFailError.message).to.eql(
 				`${defaultMessage}: PeerId: ${peerId}: Peer Version: ${peerVersion}`,
 			);
+		});
+
+		it('should set errorResponse object within this custom error', async () => {
+			expect(requestFailError.errorResponse)
+				.to.eql(errorResponse)
+				.to.have.property('message')
+				.eql(errorResponseMessage);
 		});
 	});
 });

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -180,7 +180,7 @@ module.exports = class Network {
 		});
 
 		this.p2p.on(EVENT_FAILED_TO_PUSH_NODE_INFO, error => {
-			this.logger.error(error.message || error);
+			this.logger.trace(error.message || error);
 		});
 
 		this.p2p.on(EVENT_OUTBOUND_SOCKET_ERROR, error => {

--- a/framework/test/mocha/functional/ws/transport/blocks.js
+++ b/framework/test/mocha/functional/ws/transport/blocks.js
@@ -162,12 +162,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err.errorResponse),
+					JSON.stringify(err.response),
 					JSON.stringify(res)
 				);
-				expect(err.errorResponse).to.equal(
-					'Missing required property: ids: #/'
-				);
+				expect(err.response).to.equal('Missing required property: ids: #/');
 				expect(res).to.be.undefined;
 			}
 		});
@@ -182,10 +180,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err.errorResponse),
+					JSON.stringify(err.response),
 					JSON.stringify(res)
 				);
-				expect(err.errorResponse).to.equal('Invalid block id sequence');
+				expect(err.response).to.equal('Invalid block id sequence');
 			}
 		});
 
@@ -199,10 +197,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err.errorResponse),
+					JSON.stringify(err.response),
 					JSON.stringify(res)
 				);
-				expect(err.errorResponse).to.equal('Invalid block id sequence');
+				expect(err.response).to.equal('Invalid block id sequence');
 			}
 		});
 
@@ -216,10 +214,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err.errorResponse),
+					JSON.stringify(err.response),
 					JSON.stringify(res)
 				);
-				expect(err.errorResponse).to.equal('Invalid block id sequence');
+				expect(err.response).to.equal('Invalid block id sequence');
 			}
 		});
 
@@ -233,10 +231,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err.errorResponse),
+					JSON.stringify(err.response),
 					JSON.stringify(res)
 				);
-				expect(err.errorResponse).to.equal('Invalid block id sequence');
+				expect(err.response).to.equal('Invalid block id sequence');
 			}
 		});
 

--- a/framework/test/mocha/functional/ws/transport/blocks.js
+++ b/framework/test/mocha/functional/ws/transport/blocks.js
@@ -162,10 +162,12 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err),
+					JSON.stringify(err.errorResponse),
 					JSON.stringify(res)
 				);
-				expect(err).to.equal('Missing required property: ids: #/');
+				expect(err.errorResponse).to.equal(
+					'Missing required property: ids: #/'
+				);
 				expect(res).to.be.undefined;
 			}
 		});
@@ -180,10 +182,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err),
+					JSON.stringify(err.errorResponse),
 					JSON.stringify(res)
 				);
-				expect(err).to.equal('Invalid block id sequence');
+				expect(err.errorResponse).to.equal('Invalid block id sequence');
 			}
 		});
 
@@ -197,10 +199,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err),
+					JSON.stringify(err.errorResponse),
 					JSON.stringify(res)
 				);
-				expect(err).to.equal('Invalid block id sequence');
+				expect(err.errorResponse).to.equal('Invalid block id sequence');
 			}
 		});
 
@@ -214,10 +216,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err),
+					JSON.stringify(err.errorResponse),
 					JSON.stringify(res)
 				);
-				expect(err).to.equal('Invalid block id sequence');
+				expect(err.errorResponse).to.equal('Invalid block id sequence');
 			}
 		});
 
@@ -231,10 +233,10 @@ describe('WS transport blocks', () => {
 			} catch (err) {
 				__testContext.debug(
 					'> Error / Response:'.grey,
-					JSON.stringify(err),
+					JSON.stringify(err.errorResponse),
 					JSON.stringify(res)
 				);
-				expect(err).to.equal('Invalid block id sequence');
+				expect(err.errorResponse).to.equal('Invalid block id sequence');
 			}
 		});
 


### PR DESCRIPTION
### What was the problem?

There are a lot of error messages from P2P while syncing in testnet.

### How did I fix it?

I found that this event is mostly happening when we call `applyNodeInfo` in P2P library whenever a node wants to apply its `nodeInfo` to its peers. Some peers from the old version have this issue and also the peers that are disconnected.

Below are the errors are commonly seen in the corresponding version of peers,

```
Error: Unable to match an address to the peer

Version of connected peer: '1.6.0-rc.3' and also some older version


Error: Connection id does not match with the corresponding peer

Verison of connected peer: '1.6.0-rc.4' 
```

Lower the log level of `EVENT_FAILED_TO_PUSH_NODE_INFO` from `error` to `trace`.

### How to test it?

Run the application and check the logs

### Review checklist

* The PR resolves #3651
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
