### PR TITLE
Confirmations value in block is NaN - Close #3688

### DIFF
--- a/framework/src/modules/chain/logic/block.js
+++ b/framework/src/modules/chain/logic/block.js
@@ -518,7 +518,7 @@ Block.prototype.dbRead = function(raw) {
 		generatorPublicKey: raw.b_generatorPublicKey,
 		generatorId: __private.getAddressByPublicKey(raw.b_generatorPublicKey),
 		blockSignature: raw.b_blockSignature,
-		confirmations: raw.b_confirmations ? parseInt(raw.b_confirmations) : 0,
+		confirmations: parseInt(raw.b_confirmations) ? parseInt(raw.b_confirmations) : 0,
 	};
 	block.totalForged = block.totalFee.plus(block.reward).toString();
 	return block;
@@ -550,7 +550,7 @@ Block.prototype.storageRead = function(raw) {
 		generatorPublicKey: raw.generatorPublicKey,
 		generatorId: __private.getAddressByPublicKey(raw.generatorPublicKey),
 		blockSignature: raw.blockSignature,
-		confirmations: raw.confirmations ? parseInt(raw.confirmations) : 0,
+		confirmations: parseInt(raw.confirmations) ? parseInt(raw.confirmations) : 0,
 	};
 
 	if (raw.transactions) {

--- a/framework/src/modules/chain/logic/block.js
+++ b/framework/src/modules/chain/logic/block.js
@@ -518,7 +518,7 @@ Block.prototype.dbRead = function(raw) {
 		generatorPublicKey: raw.b_generatorPublicKey,
 		generatorId: __private.getAddressByPublicKey(raw.b_generatorPublicKey),
 		blockSignature: raw.b_blockSignature,
-		confirmations: parseInt(raw.b_confirmations),
+		confirmations: raw.b_confirmations ? parseInt(raw.b_confirmations) : 0,
 	};
 	block.totalForged = block.totalFee.plus(block.reward).toString();
 	return block;
@@ -550,7 +550,7 @@ Block.prototype.storageRead = function(raw) {
 		generatorPublicKey: raw.generatorPublicKey,
 		generatorId: __private.getAddressByPublicKey(raw.generatorPublicKey),
 		blockSignature: raw.blockSignature,
-		confirmations: parseInt(raw.confirmations),
+		confirmations: raw.confirmations ? parseInt(raw.confirmations) : 0,
 	};
 
 	if (raw.transactions) {
@@ -560,7 +560,6 @@ Block.prototype.storageRead = function(raw) {
 	}
 
 	block.totalForged = block.totalFee.plus(block.reward).toString();
-
 	return block;
 };
 

--- a/framework/src/modules/chain/logic/block.js
+++ b/framework/src/modules/chain/logic/block.js
@@ -503,6 +503,9 @@ Block.prototype.dbRead = function(raw) {
 	if (!raw.b_id) {
 		return null;
 	}
+
+	const confirmations = parseInt(raw.b_confirmations);
+
 	const block = {
 		id: raw.b_id,
 		version: parseInt(raw.b_version),
@@ -518,7 +521,7 @@ Block.prototype.dbRead = function(raw) {
 		generatorPublicKey: raw.b_generatorPublicKey,
 		generatorId: __private.getAddressByPublicKey(raw.b_generatorPublicKey),
 		blockSignature: raw.b_blockSignature,
-		confirmations: parseInt(raw.b_confirmations) ? parseInt(raw.b_confirmations) : 0,
+		confirmations: !Number.isNaN(confirmations) ? confirmations : 0,
 	};
 	block.totalForged = block.totalFee.plus(block.reward).toString();
 	return block;
@@ -535,6 +538,8 @@ Block.prototype.storageRead = function(raw) {
 		return null;
 	}
 
+	const confirmations = parseInt(raw.confirmations);
+
 	const block = {
 		id: raw.id,
 		version: parseInt(raw.version),
@@ -550,7 +555,7 @@ Block.prototype.storageRead = function(raw) {
 		generatorPublicKey: raw.generatorPublicKey,
 		generatorId: __private.getAddressByPublicKey(raw.generatorPublicKey),
 		blockSignature: raw.blockSignature,
-		confirmations: parseInt(raw.confirmations) ? parseInt(raw.confirmations) : 0,
+		confirmations: !Number.isNaN(confirmations) ? confirmations : 0,
 	};
 
 	if (raw.transactions) {


### PR DESCRIPTION
### What was the problem?

- confirmations was showing NAN

### How did I fix it?

- By setting a default when the property `confirmations` is not present in the blocks when calling `dbRead` or `storageRead` when receiving blocks

### How to test it?

- Build should be green
- Run two nodes, one forging, one not
- Look for the message `chain:blocks:change` confirmations should not be `NaN`

### Review checklist

* The PR resolves #3688
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
