### PR TITLE
Invalid monitoring logs for bus activity - Closes #3545

### DIFF
--- a/framework/src/controller/controller.js
+++ b/framework/src/controller/controller.js
@@ -181,10 +181,7 @@ class Controller {
 		// If log level is greater than info
 		if (this.logger.level && this.logger.level() < 30) {
 			this.bus.onAny((name, event) => {
-				this.logger.debug(
-					`MONITOR: ${event.source} -> ${event.module}:${event.name}`,
-					event.data
-				);
+				this.logger.debug(`MONITOR: ${event.module}:${event.name}`, event.data);
 			});
 		}
 	}

--- a/framework/src/controller/controller.js
+++ b/framework/src/controller/controller.js
@@ -181,7 +181,7 @@ class Controller {
 		// If log level is greater than info
 		if (this.logger.level && this.logger.level() < 30) {
 			this.bus.onAny((name, event) => {
-				this.logger.debug(`MONITOR: ${event.module}:${event.name}`, event.data);
+				this.logger.trace(`MONITOR: ${event.module}:${event.name}`, event.data);
 			});
 		}
 	}


### PR DESCRIPTION
### What was the problem?

- event.source was being used in controller for logs but source is no longer a valid property of events

### How did I fix it?

- by removing event.source

### How to test it?

- Build should be green
- When an event is emitted `undefined` should not be shown in the logs

### Review checklist

* The PR resolves #3545
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
