### PR TITLE
P2P does not consider broadcastLimit - Closes #3690

### DIFF
--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -43,13 +43,6 @@ export class PeerOutboundConnectionError extends Error {
 	}
 }
 
-export class NotEnoughPeersError extends Error {
-	public constructor(message: string) {
-		super(message);
-		this.name = 'NotEnoughPeersError';
-	}
-}
-
 export class RPCResponseError extends Error {
 	public peerIp: string;
 	public peerPort: number;

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -54,8 +54,6 @@ import {
 	P2PNetworkStatus,
 	P2PNodeInfo,
 	P2PPeerInfo,
-	P2PPeerSelectionForRequestFunction,
-	P2PPeerSelectionForSendFunction,
 	P2PPenalty,
 	P2PRequestPacket,
 	P2PResponsePacket,
@@ -280,7 +278,7 @@ export class P2P extends EventEmitter {
 			peerSelectionForConnection: config.peerSelectionForConnection
 				? config.peerSelectionForConnection
 				: selectForConnection,
-			peerSendLimit: config.peerSendLimit
+			sendPeerLimit: config.sendPeerLimit
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -108,6 +108,7 @@ export const EVENT_NEW_PEER = 'newPeer';
 
 export const NODE_HOST_IP = '0.0.0.0';
 export const DEFAULT_DISCOVERY_INTERVAL = 30000;
+export const DEFAULT_SEND_PEER_LIMIT = 25;
 
 const BASE_10_RADIX = 10;
 
@@ -278,7 +279,7 @@ export class P2P extends EventEmitter {
 			peerSelectionForConnection: config.peerSelectionForConnection
 				? config.peerSelectionForConnection
 				: selectPeersForConnection,
-			sendPeerLimit: config.sendPeerLimit
+			sendPeerLimit: config.sendPeerLimit === undefined ? DEFAULT_SEND_PEER_LIMIT : config.sendPeerLimit,
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -64,7 +64,7 @@ import {
 import { P2PRequest } from './p2p_request';
 export { P2PRequest };
 import {
-	selectForConnection,
+	selectPeersForConnection,
 	selectPeersForRequest,
 	selectPeersForSend,
 } from './peer_selection';
@@ -277,7 +277,7 @@ export class P2P extends EventEmitter {
 				: selectPeersForRequest,
 			peerSelectionForConnection: config.peerSelectionForConnection
 				? config.peerSelectionForConnection
-				: selectForConnection,
+				: selectPeersForConnection,
 			sendPeerLimit: config.sendPeerLimit
 		});
 

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -54,8 +54,8 @@ import {
 	P2PNetworkStatus,
 	P2PNodeInfo,
 	P2PPeerInfo,
-	P2PPeerSelectionForRequest,
-	P2PPeerSelectionForSend,
+	P2PPeerSelectionForRequestFunction,
+	P2PPeerSelectionForSendFunction,
 	P2PPenalty,
 	P2PRequestPacket,
 	P2PResponsePacket,
@@ -65,7 +65,11 @@ import {
 
 import { P2PRequest } from './p2p_request';
 export { P2PRequest };
-import { selectForConnection, selectPeers } from './peer_selection';
+import {
+	selectForConnection,
+	selectPeersForRequest,
+	selectPeersForSend,
+} from './peer_selection';
 
 import {
 	EVENT_CLOSE_OUTBOUND,
@@ -269,13 +273,14 @@ export class P2P extends EventEmitter {
 			ackTimeout: config.ackTimeout,
 			peerSelectionForSend: config.peerSelectionForSend
 				? config.peerSelectionForSend
-				: (selectPeers as P2PPeerSelectionForSend),
+				: selectPeersForSend,
 			peerSelectionForRequest: config.peerSelectionForRequest
 				? config.peerSelectionForRequest
-				: (selectPeers as P2PPeerSelectionForRequest),
+				: selectPeersForRequest,
 			peerSelectionForConnection: config.peerSelectionForConnection
 				? config.peerSelectionForConnection
 				: selectForConnection,
+			peerSendLimit: config.peerSendLimit
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -81,10 +81,11 @@ export interface P2PConfig {
 	readonly nodeInfo: P2PNodeInfo;
 	readonly wsEngine?: string;
 	readonly discoveryInterval?: number;
-	readonly peerSelectionForSend?: P2PPeerSelectionForSend;
-	readonly peerSelectionForRequest?: P2PPeerSelectionForRequest;
-	readonly peerSelectionForConnection?: P2PPeerSelectionForConnection;
+	readonly peerSelectionForSend?: P2PPeerSelectionForSendFunction;
+	readonly peerSelectionForRequest?: P2PPeerSelectionForRequestFunction;
+	readonly peerSelectionForConnection?: P2PPeerSelectionForConnectionFunction;
 	readonly peerHandshakeCheck?: P2PCheckPeerCompatibility;
+	readonly peerSendLimit?: number;
 }
 
 // Network info exposed by the P2P library.
@@ -109,29 +110,35 @@ export interface ProtocolNodeInfo {
 	readonly [key: string]: unknown;
 }
 
-export type P2PPeerSelectionForSendRequest = (
-	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
-	nodeInfo?: P2PNodeInfo,
-	numOfPeers?: number,
+export interface P2PPeerSelectionForSendInput {
+	readonly peers: ReadonlyArray<P2PDiscoveredPeerInfo>;
+	readonly nodeInfo?: P2PNodeInfo;
+	readonly peerLimit?: number;
+	readonly messagePacket?: P2PMessagePacket;
+}
+
+export type P2PPeerSelectionForSendFunction = (
+	input: P2PPeerSelectionForSendInput
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
-export type P2PPeerSelectionForSend = (
-	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
-	nodeInfo?: P2PNodeInfo,
-	numOfPeers?: number,
-	messagePacket?: P2PMessagePacket,
+export interface P2PPeerSelectionForRequestInput {
+	readonly peers: ReadonlyArray<P2PDiscoveredPeerInfo>;
+	readonly nodeInfo?: P2PNodeInfo;
+	readonly peerLimit?: number;
+	readonly requestPacket?: P2PRequestPacket;
+}
+
+export type P2PPeerSelectionForRequestFunction = (
+	input: P2PPeerSelectionForRequestInput
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
-export type P2PPeerSelectionForRequest = (
-	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
-	nodeInfo?: P2PNodeInfo,
-	numOfPeers?: number,
-	requestPacket?: P2PRequestPacket,
-) => ReadonlyArray<P2PDiscoveredPeerInfo>;
+export interface P2PPeerSelectionForConnectionInput {
+	readonly peers: ReadonlyArray<P2PDiscoveredPeerInfo>;
+	readonly nodeInfo?: P2PNodeInfo;
+}
 
-export type P2PPeerSelectionForConnection = (
-	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
-	nodeInfo?: P2PNodeInfo,
+export type P2PPeerSelectionForConnectionFunction = (
+	input: P2PPeerSelectionForConnectionInput
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
 export interface P2PCompatibilityCheckReturnType {

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -85,7 +85,7 @@ export interface P2PConfig {
 	readonly peerSelectionForRequest?: P2PPeerSelectionForRequestFunction;
 	readonly peerSelectionForConnection?: P2PPeerSelectionForConnectionFunction;
 	readonly peerHandshakeCheck?: P2PCheckPeerCompatibility;
-	readonly peerSendLimit?: number;
+	readonly sendPeerLimit?: number;
 }
 
 // Network info exposed by the P2P library.

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -58,7 +58,7 @@ import { discoverPeers } from './peer_discovery';
 export const EVENT_FAILED_TO_PUSH_NODE_INFO = 'failedToPushNodeInfo';
 export const EVENT_DISCOVERED_PEER = 'discoveredPeer';
 export const EVENT_FAILED_TO_FETCH_PEER_INFO = 'failedToFetchPeerInfo';
-export const DEFAULT_PEER_SEND_LIMIT = 25;
+export const DEFAULT_SEND_PEER_LIMIT = 25;
 
 export {
 	EVENT_CLOSE_OUTBOUND,
@@ -120,7 +120,7 @@ export class PeerPool extends EventEmitter {
 		this._peerSelectForSend = peerPoolConfig.peerSelectionForSend;
 		this._peerSelectForRequest = peerPoolConfig.peerSelectionForRequest;
 		this._peerSelectForConnection = peerPoolConfig.peerSelectionForConnection;
-		this._sendPeerLimit = peerPoolConfig.sendPeerLimit === undefined ? DEFAULT_PEER_SEND_LIMIT : peerPoolConfig.sendPeerLimit;
+		this._sendPeerLimit = peerPoolConfig.sendPeerLimit === undefined ? DEFAULT_SEND_PEER_LIMIT : peerPoolConfig.sendPeerLimit;
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerRPC = (request: P2PRequest) => {

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -78,7 +78,7 @@ interface PeerPoolConfig {
 	readonly peerSelectionForSend: P2PPeerSelectionForSendFunction;
 	readonly peerSelectionForRequest: P2PPeerSelectionForRequestFunction;
 	readonly peerSelectionForConnection: P2PPeerSelectionForConnectionFunction;
-	readonly peerSendLimit?: number;
+	readonly sendPeerLimit?: number;
 }
 
 export const MAX_PEER_LIST_BATCH_SIZE = 100;
@@ -111,7 +111,7 @@ export class PeerPool extends EventEmitter {
 	private readonly _peerSelectForSend: P2PPeerSelectionForSendFunction;
 	private readonly _peerSelectForRequest: P2PPeerSelectionForRequestFunction;
 	private readonly _peerSelectForConnection: P2PPeerSelectionForConnectionFunction;
-	private readonly _peerSendLimit: number;
+	private readonly _sendPeerLimit: number;
 
 	public constructor(peerPoolConfig: PeerPoolConfig) {
 		super();
@@ -120,7 +120,7 @@ export class PeerPool extends EventEmitter {
 		this._peerSelectForSend = peerPoolConfig.peerSelectionForSend;
 		this._peerSelectForRequest = peerPoolConfig.peerSelectionForRequest;
 		this._peerSelectForConnection = peerPoolConfig.peerSelectionForConnection;
-		this._peerSendLimit = peerPoolConfig.peerSendLimit === undefined ? DEFAULT_PEER_SEND_LIMIT : peerPoolConfig.peerSendLimit;
+		this._sendPeerLimit = peerPoolConfig.sendPeerLimit === undefined ? DEFAULT_PEER_SEND_LIMIT : peerPoolConfig.sendPeerLimit;
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerRPC = (request: P2PRequest) => {
@@ -243,7 +243,7 @@ export class PeerPool extends EventEmitter {
 		const selectedPeers = this._peerSelectForSend({
 			peers: listOfPeerInfo,
 			nodeInfo: this._nodeInfo,
-			peerLimit: this._peerSendLimit,
+			peerLimit: this._sendPeerLimit,
 			messagePacket: message,
 		});
 

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -223,15 +223,15 @@ export class PeerPool extends EventEmitter {
 		}
 
 		const selectedPeerId = constructPeerIdFromPeerInfo(selectedPeers[0]);
-		const peer = this._peerMap.get(selectedPeerId);
+		const selectedPeer = this._peerMap.get(selectedPeerId);
 
-		if (!peer) {
+		if (!selectedPeer) {
 			throw new RequestFailError(
 				`No such Peer exist in PeerPool with the selected peer with Id: ${selectedPeerId}`,
 			);
 		}
 
-		const response: P2PResponsePacket = await peer.request(packet);
+		const response: P2PResponsePacket = await selectedPeer.request(packet);
 
 		return response;
 	}

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -58,7 +58,6 @@ import { discoverPeers } from './peer_discovery';
 export const EVENT_FAILED_TO_PUSH_NODE_INFO = 'failedToPushNodeInfo';
 export const EVENT_DISCOVERED_PEER = 'discoveredPeer';
 export const EVENT_FAILED_TO_FETCH_PEER_INFO = 'failedToFetchPeerInfo';
-export const DEFAULT_SEND_PEER_LIMIT = 25;
 
 export {
 	EVENT_CLOSE_OUTBOUND,
@@ -78,7 +77,7 @@ interface PeerPoolConfig {
 	readonly peerSelectionForSend: P2PPeerSelectionForSendFunction;
 	readonly peerSelectionForRequest: P2PPeerSelectionForRequestFunction;
 	readonly peerSelectionForConnection: P2PPeerSelectionForConnectionFunction;
-	readonly sendPeerLimit?: number;
+	readonly sendPeerLimit: number;
 }
 
 export const MAX_PEER_LIST_BATCH_SIZE = 100;
@@ -120,7 +119,7 @@ export class PeerPool extends EventEmitter {
 		this._peerSelectForSend = peerPoolConfig.peerSelectionForSend;
 		this._peerSelectForRequest = peerPoolConfig.peerSelectionForRequest;
 		this._peerSelectForConnection = peerPoolConfig.peerSelectionForConnection;
-		this._sendPeerLimit = peerPoolConfig.sendPeerLimit === undefined ? DEFAULT_SEND_PEER_LIMIT : peerPoolConfig.sendPeerLimit;
+		this._sendPeerLimit = peerPoolConfig.sendPeerLimit;
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerRPC = (request: P2PRequest) => {

--- a/elements/lisk-p2p/src/peer_selection.ts
+++ b/elements/lisk-p2p/src/peer_selection.ts
@@ -96,6 +96,6 @@ export const selectPeersForSend = (
 ): ReadonlyArray<P2PDiscoveredPeerInfo> =>
 	shuffle(input.peers).slice(0, input.peerLimit);
 
-export const selectForConnection = (
+export const selectPeersForConnection = (
 	input: P2PPeerSelectionForConnectionInput,
 ) => input.peers;

--- a/elements/lisk-p2p/src/peer_selection.ts
+++ b/elements/lisk-p2p/src/peer_selection.ts
@@ -12,8 +12,14 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { NotEnoughPeersError } from './errors';
-import { P2PDiscoveredPeerInfo, P2PNodeInfo } from './p2p_types';
+import {
+	P2PDiscoveredPeerInfo,
+	P2PPeerSelectionForSendInput,
+	P2PPeerSelectionForRequestInput,
+	P2PPeerSelectionForConnectionInput,
+} from './p2p_types';
+import shuffle = require('lodash.shuffle');
+
 /* tslint:disable: readonly-keyword*/
 interface Histogram {
 	[key: number]: number;
@@ -25,11 +31,11 @@ interface HistogramValues {
 }
 
 /* tslint:enable: readonly-keyword */
-export const selectPeers = (
-	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
-	nodeInfo?: P2PNodeInfo,
-	numOfPeers: number = 0,
+export const selectPeersForRequest = (
+	input: P2PPeerSelectionForRequestInput,
 ): ReadonlyArray<P2PDiscoveredPeerInfo> => {
+	const {peers, nodeInfo} = input;
+	const peerLimit = input.peerLimit;
 	const nodeHeight = nodeInfo ? nodeInfo.height : 0;
 	const filteredPeers = peers.filter(
 		// Remove unreachable peers or heights below last block height
@@ -69,24 +75,11 @@ export const selectPeers = (
 				aggregation + 1,
 	);
 
-	if (numOfPeers <= 0) {
+	if (peerLimit === undefined) {
 		return processedPeers;
 	}
 
-	// Select n number of peers
-	if (numOfPeers > processedPeers.length) {
-		throw new NotEnoughPeersError(
-			`Requested number of peers: '${numOfPeers}' is more than the available number of good peers: '${
-				processedPeers.length
-			}'`,
-		);
-	}
-
-	if (numOfPeers === processedPeers.length) {
-		return processedPeers;
-	}
-
-	if (numOfPeers === 1) {
+	if (peerLimit === 1) {
 		const goodPeer: ReadonlyArray<P2PDiscoveredPeerInfo> = [
 			processedPeers[Math.floor(Math.random() * processedPeers.length)],
 		];
@@ -94,29 +87,15 @@ export const selectPeers = (
 		return goodPeer;
 	}
 
-	const { peerList } = new Array(numOfPeers).fill(0).reduce(
-		peerListObject => {
-			const index = Math.floor(
-				Math.random() * peerListObject.processedPeersArray.length,
-			);
-			const peer = peerListObject.processedPeersArray[index];
-			// This will ensure that the selected peer is not choosen again by the random function above
-			const tempProcessedPeers = peerListObject.processedPeersArray.filter(
-				(findPeer: P2PDiscoveredPeerInfo) => findPeer !== peer,
-			);
+	return shuffle(processedPeers).slice(0, peerLimit);
+};
 
-			return {
-				peerList: [...peerListObject.peerList, peer],
-				processedPeersArray: tempProcessedPeers,
-			};
-		},
-		{ peerList: [], processedPeersArray: processedPeers },
-	);
-
-	return peerList;
+export const selectPeersForSend = (
+	input: P2PPeerSelectionForSendInput,
+): ReadonlyArray<P2PDiscoveredPeerInfo> => {
+	return shuffle(input.peers).slice(0, input.peerLimit);
 };
 
 export const selectForConnection = (
-	peerInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>,
-	_nodeInfo?: P2PNodeInfo,
-) => peerInfoList;
+	input: P2PPeerSelectionForConnectionInput,
+) => input.peers;

--- a/elements/lisk-p2p/src/peer_selection.ts
+++ b/elements/lisk-p2p/src/peer_selection.ts
@@ -12,13 +12,14 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+// tslint:disable-next-line no-require-imports
+import shuffle = require('lodash.shuffle');
 import {
 	P2PDiscoveredPeerInfo,
-	P2PPeerSelectionForSendInput,
-	P2PPeerSelectionForRequestInput,
 	P2PPeerSelectionForConnectionInput,
+	P2PPeerSelectionForRequestInput,
+	P2PPeerSelectionForSendInput,
 } from './p2p_types';
-import shuffle = require('lodash.shuffle');
 
 /* tslint:disable: readonly-keyword*/
 interface Histogram {
@@ -92,9 +93,8 @@ export const selectPeersForRequest = (
 
 export const selectPeersForSend = (
 	input: P2PPeerSelectionForSendInput,
-): ReadonlyArray<P2PDiscoveredPeerInfo> => {
-	return shuffle(input.peers).slice(0, input.peerLimit);
-};
+): ReadonlyArray<P2PDiscoveredPeerInfo> =>
+	shuffle(input.peers).slice(0, input.peerLimit);
 
 export const selectForConnection = (
 	input: P2PPeerSelectionForConnectionInput,

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -3,12 +3,12 @@ import { P2P } from '../../src/index';
 import { wait } from '../utils/helpers';
 import { platform } from 'os';
 import {
-	P2PPeerSelectionForSendRequest,
-	P2PPeerSelectionForSend,
-	P2PPeerSelectionForRequest,
-	P2PNodeInfo,
-	P2PDiscoveredPeerInfo,
-	P2PPeerSelectionForConnection,
+	P2PPeerSelectionForSendFunction,
+	P2PPeerSelectionForRequestFunction,
+	P2PPeerSelectionForConnectionFunction,
+	P2PPeerSelectionForSendInput,
+	P2PPeerSelectionForRequestInput,
+	P2PPeerSelectionForConnectionInput,
 } from '../../src/p2p_types';
 
 describe('Integration tests for P2P library', () => {
@@ -685,11 +685,11 @@ describe('Integration tests for P2P library', () => {
 
 	describe('Connected network: User custom selection algorithm is passed to each node', () => {
 		// Custom selection function that finds peers having common values for modules field for example.
-		const peerSelectionForSendRequest: P2PPeerSelectionForSendRequest = (
-			peersList: ReadonlyArray<P2PDiscoveredPeerInfo>,
-			nodeInfo?: P2PNodeInfo,
-			_numOfPeer?: number,
+		const peerSelectionForSendRequest: P2PPeerSelectionForSendFunction | P2PPeerSelectionForRequestFunction = (
+			input: P2PPeerSelectionForSendInput | P2PPeerSelectionForRequestInput
 		) => {
+			const {peers: peersList, nodeInfo} = input;
+
 			const filteredPeers = peersList.filter(peer => {
 				if (nodeInfo && nodeInfo.height <= peer.height) {
 					const nodesModules = nodeInfo.modules
@@ -724,9 +724,9 @@ describe('Integration tests for P2P library', () => {
 			return filteredPeers;
 		};
 		// Custom Peer selection for connection that returns all the peers
-		const peerSelectionForConnection: P2PPeerSelectionForConnection = (
-			peersList: ReadonlyArray<P2PDiscoveredPeerInfo>,
-		) => peersList;
+		const peerSelectionForConnection: P2PPeerSelectionForConnectionFunction = (
+			input: P2PPeerSelectionForConnectionInput
+		) => input.peers;
 
 		beforeEach(async () => {
 			p2pNodeList = [...new Array(NETWORK_PEER_COUNT).keys()].map(index => {
@@ -748,8 +748,8 @@ describe('Integration tests for P2P library', () => {
 					blacklistedPeers: [],
 					connectTimeout: 5000,
 					ackTimeout: 5000,
-					peerSelectionForSend: peerSelectionForSendRequest as P2PPeerSelectionForSend,
-					peerSelectionForRequest: peerSelectionForSendRequest as P2PPeerSelectionForRequest,
+					peerSelectionForSend: peerSelectionForSendRequest as P2PPeerSelectionForSendFunction,
+					peerSelectionForRequest: peerSelectionForSendRequest as P2PPeerSelectionForRequestFunction,
 					peerSelectionForConnection,
 					seedPeers,
 					wsEngine: 'ws',

--- a/elements/lisk-p2p/test/unit/errors.ts
+++ b/elements/lisk-p2p/test/unit/errors.ts
@@ -15,7 +15,6 @@
 import { expect } from 'chai';
 import {
 	InvalidPeerError,
-	NotEnoughPeersError,
 	PeerInboundHandshakeError,
 	RPCResponseError,
 	InvalidRPCResponseError,
@@ -26,28 +25,6 @@ import {
 } from '../../src';
 
 describe('errors', () => {
-	describe('#NotEnoughPeersError', () => {
-		const defaultMessage =
-			'Requested number of peers is greater than available good peers';
-		let notEnoughPeersError: NotEnoughPeersError;
-
-		beforeEach(async () => {
-			notEnoughPeersError = new NotEnoughPeersError(defaultMessage);
-		});
-
-		it('should create a new instance of NotEnoughPeersError', async () => {
-			expect(notEnoughPeersError).to.be.instanceof(NotEnoughPeersError);
-		});
-
-		it('should set error name to `NotEnoughPeersError`', async () => {
-			expect(notEnoughPeersError.name).to.eql('NotEnoughPeersError');
-		});
-
-		it('should set error message when passed an argument', async () => {
-			expect(notEnoughPeersError.message).to.eql(defaultMessage);
-		});
-	});
-
 	describe('#PeerInboundHandshakeError', () => {
 		const remoteAddress = '127.0.0.1';
 		const statusCode = 4501;

--- a/elements/lisk-p2p/test/unit/peer_selection.ts
+++ b/elements/lisk-p2p/test/unit/peer_selection.ts
@@ -15,7 +15,7 @@
 import { expect } from 'chai';
 import { initializePeerInfoList } from '../utils/peers';
 import {
-	selectForConnection,
+	selectPeersForConnection,
 	selectPeersForRequest,
 } from '../../src/peer_selection';
 import { P2PNodeInfo } from '../../src/p2p_types';
@@ -97,13 +97,13 @@ describe('peer selector', () => {
 		});
 	});
 
-	describe('#selectForConnection', () => {
+	describe('#selectPeersForConnection', () => {
 		const peerList = initializePeerInfoList();
 		const numberOfPeers = peerList.length;
 
 		describe('get all the peers for selection', () => {
 			it('should return all the peers given as argument for connection', () => {
-				return expect(selectForConnection({peers: peerList}))
+				return expect(selectPeersForConnection({peers: peerList}))
 					.be.an('array')
 					.and.is.eql(peerList)
 					.of.length(numberOfPeers);

--- a/elements/lisk-p2p/test/unit/peer_selection.ts
+++ b/elements/lisk-p2p/test/unit/peer_selection.ts
@@ -14,11 +14,14 @@
  */
 import { expect } from 'chai';
 import { initializePeerInfoList } from '../utils/peers';
-import { selectForConnection, selectPeers } from '../../src/peer_selection';
+import {
+	selectForConnection,
+	selectPeersForRequest,
+} from '../../src/peer_selection';
 import { P2PNodeInfo } from '../../src/p2p_types';
 
 describe('peer selector', () => {
-	describe('#selectPeer', () => {
+	describe('#selectPeersForRequest', () => {
 		let peerList = initializePeerInfoList();
 		const nodeInfo: P2PNodeInfo = {
 			height: 545777,
@@ -34,62 +37,47 @@ describe('peer selector', () => {
 			});
 
 			it('should return an array without optional arguments', () => {
-				return expect(selectPeers(peerList)).to.be.an('array');
+				return expect(selectPeersForRequest({peers: peerList})).to.be.an('array');
 			});
 
 			it('should return an array', () => {
-				return expect(selectPeers(peerList, nodeInfo)).to.be.an('array');
+				return expect(selectPeersForRequest({peers: peerList, nodeInfo})).to.be.an('array');
 			});
 
 			it('returned array should contain good peers according to algorithm', () => {
-				return expect(selectPeers(peerList, nodeInfo))
+				return expect(selectPeersForRequest({peers: peerList, nodeInfo}))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('return empty peer list for no peers as an argument', () => {
-				return expect(selectPeers([], nodeInfo))
+				return expect(selectPeersForRequest({peers: [], nodeInfo}))
 					.and.be.an('array')
 					.and.to.be.eql([]);
 			});
 
 			it('should return an array having one good peer', () => {
-				return expect(selectPeers(peerList, nodeInfo, 1))
+				return expect(selectPeersForRequest({peers: peerList, nodeInfo, peerLimit: 1}))
 					.and.be.an('array')
 					.and.of.length(1);
 			});
 
 			it('should return an array having 2 good peers', () => {
-				return expect(selectPeers(peerList, nodeInfo, 2))
+				return expect(selectPeersForRequest({peers: peerList, nodeInfo, peerLimit: 2}))
 					.and.be.an('array')
 					.and.of.length(2);
 			});
 
 			it('should return an array having all good peers', () => {
-				return expect(selectPeers(peerList, nodeInfo, 0))
-					.and.be.an('array')
-					.and.of.length(3);
-			});
-
-			it('should return an array having all good peers ignoring requested negative number of peers', () => {
-				return expect(selectPeers(peerList, nodeInfo, -1))
+				return expect(selectPeersForRequest({peers: peerList, nodeInfo}))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('should return an array of equal length equal to requested number of peers', () => {
-				return expect(selectPeers(peerList, nodeInfo, 3))
+				return expect(selectPeersForRequest({peers: peerList, nodeInfo, peerLimit: 3}))
 					.and.be.an('array')
 					.and.of.length(3);
-			});
-
-			it('should throw an error when requested peers are greater than available good peers', () => {
-				return expect(selectPeers.bind(selectPeers, peerList, nodeInfo, 4))
-					.to.throw(
-						`Requested number of peers: '4' is more than the available number of good peers: '3'`,
-					)
-					.to.have.property('name')
-					.eql('NotEnoughPeersError');
 			});
 		});
 
@@ -102,7 +90,7 @@ describe('peer selector', () => {
 			);
 
 			it('should return an array with 0 good peers', () => {
-				return expect(selectPeers(lowHeightPeers, nodeInfo, 2))
+				return expect(selectPeersForRequest({peers: lowHeightPeers, nodeInfo, peerLimit: 2}))
 					.and.be.an('array')
 					.and.of.length(0);
 			});
@@ -115,7 +103,7 @@ describe('peer selector', () => {
 
 		describe('get all the peers for selection', () => {
 			it('should return all the peers given as argument for connection', () => {
-				return expect(selectForConnection(peerList))
+				return expect(selectForConnection({peers: peerList}))
 					.be.an('array')
 					.and.is.eql(peerList)
 					.of.length(numberOfPeers);

--- a/framework/src/modules/network/defaults/config.js
+++ b/framework/src/modules/network/defaults/config.js
@@ -79,6 +79,7 @@ const defaultConfig = {
 		ackTimeout: 20000,
 		connectTimeout: 5000,
 		wsEngine: 'ws',
+		emitPeerLimit: 25,
 	},
 };
 

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -129,6 +129,7 @@ module.exports = class Network {
 					...peerWithoutIp,
 				};
 			}),
+			sendPeerLimit: this.options.emitPeerLimit,
 		};
 
 		this.p2p = new P2P(p2pConfig);


### PR DESCRIPTION
### What was the problem?

- There was no default limit regarding the number of peers to send a packet to and it could not be configured.
- The same peer selection function was used for both request and send. The one needed for send does not need to account for height.
- The implementation of the peer selection function was overly complex.
- The peer selection functions (for send, request and also for connect) had a fixed set of arguments so were not future-proof in case we want to add new properties in the future.
- Added support for a new `emitPeerLimit` (integer) under the Network module config (this should be used instead of the top level `broadcastLimit`).

### How did I fix it?

- Made the sendPeerLimit configurable and specified a default in the library (`25`).
- Cleaned up interface names.
- Pass a single object to peer selection functions; that way the properties can be specified in any order; this is more future-proof.
- Use `lodash.shuffle` to randomize random selection since we already rely on it as part of discovery (instead of our inefficient solution).
- The peer limit passed to the selection functions is an upper bound; don't throw an error if there are fewer available peers than the limit. The network should be able to work with only a few peers.

### How to test it?

In `lisk-p2p` library:

`npm run test:integration`

### Review checklist

* The PR resolves #3690
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
