### PR TITLE
Create data structure to store block headers for BFT - Closes #3691

### DIFF
--- a/framework/src/modules/chain/logic/bft.js
+++ b/framework/src/modules/chain/logic/bft.js
@@ -16,28 +16,28 @@
 
 const assert = require('assert');
 
-const __private = {
-	items: new WeakMap(),
-	size: new WeakMap(),
-};
-
 class HeadersList {
 	constructor({ size }) {
 		assert(size, 'Must provide size of the queue');
-		__private.size.set(this, size);
-		__private.items.set(this, []);
+		this.__items = [];
+		this.__size = size;
 	}
 
 	get items() {
-		return __private.items.get(this);
+		return this.__items;
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	set items(value) {
+		throw new Error('You can\'t set the items directly use "list.add"');
 	}
 
 	get length() {
-		return __private.items.get(this).length;
+		return this.items.length;
 	}
 
 	get size() {
-		return __private.size.get(this);
+		return this.__size;
 	}
 
 	set size(newSize) {
@@ -46,7 +46,7 @@ class HeadersList {
 			this.items.splice(0, currentSize - newSize);
 		}
 
-		__private.size.set(this, newSize);
+		this.__size = newSize;
 	}
 
 	get first() {
@@ -58,11 +58,10 @@ class HeadersList {
 	}
 
 	add(blockHeader) {
-		const items = this.items;
 		const first = this.first;
 		const last = this.last;
 
-		if (items.length) {
+		if (this.items.length) {
 			assert(
 				blockHeader.height === last.height + 1 ||
 					blockHeader.height === first.height - 1,
@@ -73,18 +72,16 @@ class HeadersList {
 
 		if (first && blockHeader.height === last.height + 1) {
 			// Add to the end
-			items.push(blockHeader);
+			this.items.push(blockHeader);
 		} else {
 			// Add to the start
-			items.unshift(blockHeader);
+			this.items.unshift(blockHeader);
 		}
 
 		// If the list size is already full remove one item
-		if (items.length > this.size) {
-			items.shift();
+		if (this.items.length > this.size) {
+			this.items.shift();
 		}
-
-		__private.items.set(this, items);
 
 		return this;
 	}
@@ -94,26 +91,21 @@ class HeadersList {
 			beforeHeight = this.last.height - 1;
 		}
 
-		const items = this.items;
 		const removeItemsCount = this.last.height - beforeHeight;
-		let itemsToReturn;
 
-		if (removeItemsCount < 0 || removeItemsCount >= items.length) {
-			itemsToReturn = items.splice(0, items.length);
-		} else {
-			itemsToReturn = items.splice(
-				items.length - removeItemsCount,
-				removeItemsCount
-			);
+		if (removeItemsCount < 0 || removeItemsCount >= this.items.length) {
+			return this.items.splice(0, this.items.length);
 		}
 
-		__private.items.set(this, items);
-		return itemsToReturn;
+		return this.items.splice(
+			this.items.length - removeItemsCount,
+			removeItemsCount
+		);
 	}
 
 	empty() {
 		const items = [...this.items];
-		__private.items.set(this, []);
+		this.__items = [];
 		return items;
 	}
 }

--- a/framework/src/modules/chain/logic/bft.js
+++ b/framework/src/modules/chain/logic/bft.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const assert = require('assert');
+
+const __private = {
+	items: new WeakMap(),
+};
+
+class HeadersList {
+	constructor({ size }) {
+		assert(size, 'Must provide size of the queue');
+		this.size = size;
+		__private.items.set(this, []);
+	}
+
+	get items() {
+		return __private.items.get(this);
+	}
+
+	get length() {
+		return __private.items.get(this).length;
+	}
+
+	get first() {
+		return this.items[0];
+	}
+
+	get last() {
+		return this.items[this.length - 1];
+	}
+
+	add(blockHeader) {
+		const items = this.items;
+		const first = this.first;
+		const last = this.last;
+
+		if (items.length) {
+			assert(
+				blockHeader.height === last.height + 1 ||
+					blockHeader.height === first.height - 1,
+				`Block header with height ${last.height + 1} or ${first.height -
+					1} can be added at the moment`
+			);
+		}
+
+		if (first && blockHeader.height === last.height + 1) {
+			// Add to the end
+			items.push(blockHeader);
+		} else {
+			// Add to the start
+			items.unshift(blockHeader);
+		}
+
+		// If the list size is already full remove one item
+		if (items.length > this.size) {
+			items.shift();
+		}
+
+		__private.items.set(this, items);
+
+		return this;
+	}
+}
+
+module.exports = { HeadersList };

--- a/framework/src/modules/chain/logic/bft.js
+++ b/framework/src/modules/chain/logic/bft.js
@@ -19,12 +19,12 @@ const assert = require('assert');
 class HeadersList {
 	constructor({ size }) {
 		assert(size, 'Must provide size of the queue');
-		this.__items = [];
-		this.__size = size;
+		this._items = [];
+		this._size = size;
 	}
 
 	get items() {
-		return this.__items;
+		return this._items;
 	}
 
 	// eslint-disable-next-line class-methods-use-this
@@ -37,7 +37,7 @@ class HeadersList {
 	}
 
 	get size() {
-		return this.__size;
+		return this._size;
 	}
 
 	set size(newSize) {
@@ -46,7 +46,7 @@ class HeadersList {
 			this.items.splice(0, currentSize - newSize);
 		}
 
-		this.__size = newSize;
+		this._size = newSize;
 	}
 
 	get first() {
@@ -105,7 +105,7 @@ class HeadersList {
 
 	empty() {
 		const items = [...this.items];
-		this.__items = [];
+		this._items = [];
 		return items;
 	}
 }

--- a/framework/src/modules/chain/logic/bft.js
+++ b/framework/src/modules/chain/logic/bft.js
@@ -86,12 +86,12 @@ class HeadersList {
 		return this;
 	}
 
-	remove({ beforeHeight } = {}) {
-		if (!beforeHeight) {
-			beforeHeight = this.last.height - 1;
+	remove({ aboveHeight } = {}) {
+		if (!aboveHeight) {
+			aboveHeight = this.last.height - 1;
 		}
 
-		const removeItemsCount = this.last.height - beforeHeight;
+		const removeItemsCount = this.last.height - aboveHeight;
 
 		if (removeItemsCount < 0 || removeItemsCount >= this.items.length) {
 			return this.items.splice(0, this.items.length);

--- a/framework/src/modules/chain/logic/bft.js
+++ b/framework/src/modules/chain/logic/bft.js
@@ -96,6 +96,12 @@ class HeadersList {
 		__private.items.set(this, items);
 		return itemsToReturn;
 	}
+
+	empty() {
+		const items = [...this.items];
+		__private.items.set(this, []);
+		return items;
+	}
 }
 
 module.exports = { HeadersList };

--- a/framework/src/modules/chain/logic/bft.js
+++ b/framework/src/modules/chain/logic/bft.js
@@ -18,12 +18,13 @@ const assert = require('assert');
 
 const __private = {
 	items: new WeakMap(),
+	size: new WeakMap(),
 };
 
 class HeadersList {
 	constructor({ size }) {
 		assert(size, 'Must provide size of the queue');
-		this.size = size;
+		__private.size.set(this, size);
 		__private.items.set(this, []);
 	}
 
@@ -33,6 +34,19 @@ class HeadersList {
 
 	get length() {
 		return __private.items.get(this).length;
+	}
+
+	get size() {
+		return __private.size.get(this);
+	}
+
+	set size(newSize) {
+		const currentSize = this.size;
+		if (currentSize > newSize) {
+			this.items.splice(0, currentSize - newSize);
+		}
+
+		__private.size.set(this, newSize);
 	}
 
 	get first() {

--- a/framework/src/modules/chain/logic/bft.js
+++ b/framework/src/modules/chain/logic/bft.js
@@ -74,6 +74,28 @@ class HeadersList {
 
 		return this;
 	}
+
+	remove({ beforeHeight } = {}) {
+		if (!beforeHeight) {
+			beforeHeight = this.last.height - 1;
+		}
+
+		const items = this.items;
+		const removeItemsCount = this.last.height - beforeHeight;
+		let itemsToReturn;
+
+		if (removeItemsCount < 0 || removeItemsCount >= items.length) {
+			itemsToReturn = items.splice(0, items.length);
+		} else {
+			itemsToReturn = items.splice(
+				items.length - removeItemsCount,
+				removeItemsCount
+			);
+		}
+
+		__private.items.set(this, items);
+		return itemsToReturn;
+	}
 }
 
 module.exports = { HeadersList };

--- a/framework/test/mocha/fixtures/blocks.js
+++ b/framework/test/mocha/fixtures/blocks.js
@@ -74,7 +74,26 @@ const GenesisBlock = stampit(Block, {
 	},
 });
 
+const BlockHeader = stampit({
+	props: {
+		blockId: '',
+		height: 0,
+		maxHeightPreviouslyForged: 0,
+		prevotedConfirmedUptoHeight: 0,
+		activeSinceRound: 3,
+		delegatePublicKey: '',
+	},
+	init({ height }) {
+		this.blockId = randomstring.generate({ charset: 'numeric', length: 20 });
+		this.height = height || Math.floor(Math.random() * Math.floor(5000));
+		this.delegatePublicKey = randomstring
+			.generate({ charset: '0123456789ABCDE', length: 32 })
+			.toLowerCase();
+	},
+});
+
 module.exports = {
 	Block,
 	GenesisBlock,
+	BlockHeader,
 };

--- a/framework/test/mocha/unit/modules/chain/logic/bft.js
+++ b/framework/test/mocha/unit/modules/chain/logic/bft.js
@@ -168,8 +168,8 @@ describe('bft', () => {
 				list.remove();
 				expect(list.items).to.be.eql([header1, header2, header3, header4]);
 			});
-			it('should remove all items upto and including the provided height', async () => {
-				list.remove({ beforeHeight: 2 });
+			it('should remove all items above provided aboveHeight', async () => {
+				list.remove({ aboveHeight: 2 });
 				expect(list.items).to.be.eql([header1, header2]);
 			});
 			it('should return removed items if removed one', async () => {
@@ -178,7 +178,7 @@ describe('bft', () => {
 				expect(removedItems).to.be.eql([header5]);
 			});
 			it('should return removed items if removed multiple', async () => {
-				const removedItems = list.remove({ beforeHeight: 2 });
+				const removedItems = list.remove({ aboveHeight: 2 });
 
 				expect(removedItems).to.be.eql([header3, header4, header5]);
 			});
@@ -213,7 +213,7 @@ describe('bft', () => {
 					.add(header3)
 					.add(header4)
 					.add(header5);
-				myList.remove({ beforeHeight: 1 });
+				myList.remove({ aboveHeight: 1 });
 
 				expect(myList.items).to.be.eql([]);
 			});

--- a/framework/test/mocha/unit/modules/chain/logic/bft.js
+++ b/framework/test/mocha/unit/modules/chain/logic/bft.js
@@ -133,5 +133,90 @@ describe('bft', () => {
 				]);
 			});
 		});
+
+		describe('remove()', () => {
+			let header1;
+			let header2;
+			let header3;
+			let header4;
+			let header5;
+
+			beforeEach(async () => {
+				header1 = blockHeaderFixture({ height: 1 });
+				header2 = blockHeaderFixture({ height: 2 });
+				header3 = blockHeaderFixture({ height: 3 });
+				header4 = blockHeaderFixture({ height: 4 });
+				header5 = blockHeaderFixture({ height: 5 });
+
+				list
+					.add(header1)
+					.add(header2)
+					.add(header3)
+					.add(header4)
+					.add(header5);
+
+				expect(list.items).to.be.eql([
+					header1,
+					header2,
+					header3,
+					header4,
+					header5,
+				]);
+			});
+
+			it('should remove last item from the list if passed without height', async () => {
+				list.remove();
+				expect(list.items).to.be.eql([header1, header2, header3, header4]);
+			});
+			it('should remove all items upto and including the provided height', async () => {
+				list.remove({ beforeHeight: 2 });
+				expect(list.items).to.be.eql([header1, header2]);
+			});
+			it('should return removed items if removed one', async () => {
+				const removedItems = list.remove();
+
+				expect(removedItems).to.be.eql([header5]);
+			});
+			it('should return removed items if removed multiple', async () => {
+				const removedItems = list.remove({ beforeHeight: 2 });
+
+				expect(removedItems).to.be.eql([header3, header4, header5]);
+			});
+
+			it('should empty the list if remove is called number of items item in the list', async () => {
+				list.remove();
+				list.remove();
+				list.remove();
+				list.remove();
+				list.remove();
+
+				expect(list.items).to.be.eql([]);
+			});
+
+			it('should not throw any error if called on empty list', async () => {
+				list.remove();
+				list.remove();
+				list.remove();
+				list.remove();
+				list.remove();
+
+				expect(list.items).to.be.eql([]);
+
+				expect(() => {
+					list.remove();
+				}).to.not.throw;
+			});
+
+			it('should empty the list if provided height is less than the first item height', async () => {
+				const myList = new HeadersList({ size: SIZE });
+				myList
+					.add(header3)
+					.add(header4)
+					.add(header5);
+				myList.remove({ beforeHeight: 1 });
+
+				expect(myList.items).to.be.eql([]);
+			});
+		});
 	});
 });

--- a/framework/test/mocha/unit/modules/chain/logic/bft.js
+++ b/framework/test/mocha/unit/modules/chain/logic/bft.js
@@ -219,6 +219,59 @@ describe('bft', () => {
 			});
 		});
 
+		describe('size', () => {
+			let header1;
+			let header2;
+			let header3;
+			let header4;
+			let header5;
+
+			beforeEach(async () => {
+				header1 = blockHeaderFixture({ height: 1 });
+				header2 = blockHeaderFixture({ height: 2 });
+				header3 = blockHeaderFixture({ height: 3 });
+				header4 = blockHeaderFixture({ height: 4 });
+				header5 = blockHeaderFixture({ height: 5 });
+
+				list
+					.add(header1)
+					.add(header2)
+					.add(header3)
+					.add(header4)
+					.add(header5);
+
+				expect(list.items).to.be.eql([
+					header1,
+					header2,
+					header3,
+					header4,
+					header5,
+				]);
+			});
+
+			it('should return the current size of the list', async () => {
+				expect(list.size).to.be.eql(SIZE);
+			});
+
+			it('should increase the size without effecting list', async () => {
+				list.size = 10;
+				expect(list.size).to.be.eql(10);
+				expect(list.items).to.be.eql([
+					header1,
+					header2,
+					header3,
+					header4,
+					header5,
+				]);
+			});
+
+			it('should decrease the  size by chopping the headers with lowest height', async () => {
+				list.size = 2;
+				expect(list.size).to.be.eql(2);
+				expect(list.items).to.be.eql([header4, header5]);
+			});
+		});
+
 		describe('reset()', () => {
 			let header1;
 			let header2;

--- a/framework/test/mocha/unit/modules/chain/logic/bft.js
+++ b/framework/test/mocha/unit/modules/chain/logic/bft.js
@@ -32,8 +32,8 @@ describe('bft', () => {
 
 		describe('constructor()', () => {
 			it('should set set the object attributes', async () => {
-				expect(list.size).to.eql(SIZE);
-				expect(list.items).to.eql([]);
+				expect(list._size).to.eql(SIZE);
+				expect(list._items).to.eql([]);
 			});
 		});
 

--- a/framework/test/mocha/unit/modules/chain/logic/bft.js
+++ b/framework/test/mocha/unit/modules/chain/logic/bft.js
@@ -218,5 +218,53 @@ describe('bft', () => {
 				expect(myList.items).to.be.eql([]);
 			});
 		});
+
+		describe('reset()', () => {
+			let header1;
+			let header2;
+			let header3;
+			let header4;
+			let header5;
+
+			beforeEach(async () => {
+				header1 = blockHeaderFixture({ height: 1 });
+				header2 = blockHeaderFixture({ height: 2 });
+				header3 = blockHeaderFixture({ height: 3 });
+				header4 = blockHeaderFixture({ height: 4 });
+				header5 = blockHeaderFixture({ height: 5 });
+
+				list
+					.add(header1)
+					.add(header2)
+					.add(header3)
+					.add(header4)
+					.add(header5);
+
+				expect(list.items).to.be.eql([
+					header1,
+					header2,
+					header3,
+					header4,
+					header5,
+				]);
+			});
+
+			it('should empty the list', async () => {
+				list.empty();
+
+				expect(list.items).to.be.eql([]);
+			});
+			it('should return all items when empty the list', async () => {
+				const returnValue = list.empty();
+
+				expect(returnValue).to.be.eql([
+					header1,
+					header2,
+					header3,
+					header4,
+					header5,
+				]);
+			});
+		});
 	});
 });

--- a/framework/test/mocha/unit/modules/chain/logic/bft.js
+++ b/framework/test/mocha/unit/modules/chain/logic/bft.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const {
+	HeadersList,
+} = require('../../../../../../src/modules/chain/logic/bft');
+const {
+	BlockHeader: blockHeaderFixture,
+} = require('../../../../fixtures/blocks');
+
+describe('bft', () => {
+	describe('HeadersQueue', () => {
+		let list;
+		const SIZE = 5;
+
+		beforeEach(async () => {
+			list = new HeadersList({ size: SIZE });
+		});
+
+		describe('constructor()', () => {
+			it('should set set the object attributes', async () => {
+				expect(list.size).to.eql(SIZE);
+				expect(list.items).to.eql([]);
+			});
+		});
+
+		describe('add()', () => {
+			it('should return the list object after push to chain', async () => {
+				const header = blockHeaderFixture();
+				const returnValue = list.add(header);
+
+				expect(returnValue).to.be.eql(list);
+			});
+
+			it('should add the block header to items', async () => {
+				const header = blockHeaderFixture();
+				list.add(header);
+
+				expect(list.items).to.be.eql([header]);
+			});
+
+			it('should add the block header to items in higher order', async () => {
+				const header1 = blockHeaderFixture({ height: 10 });
+				const header2 = blockHeaderFixture({ height: 11 });
+
+				list.add(header1).add(header2);
+				expect(list.items).to.be.eql([header1, header2]);
+			});
+
+			it('should add the block header to items in lower order', async () => {
+				const header1 = blockHeaderFixture({ height: 10 });
+				const header2 = blockHeaderFixture({ height: 11 });
+
+				list.add(header2).add(header1);
+				expect(list.items).to.be.eql([header1, header2]);
+			});
+
+			it('should throw error if block header added is not one step higher than last item', async () => {
+				const header1 = blockHeaderFixture({ height: 10 });
+				const header2 = blockHeaderFixture({ height: 11 });
+				const header3 = blockHeaderFixture({ height: 13 });
+
+				list.add(header1).add(header2);
+
+				expect(() => {
+					list.add(header3);
+				}).to.throw(
+					'Block header with height 12 or 9 can be added at the moment'
+				);
+			});
+
+			it('should throw error if block header added is not one step less than first item', async () => {
+				const header1 = blockHeaderFixture({ height: 10 });
+				const header2 = blockHeaderFixture({ height: 9 });
+				const header3 = blockHeaderFixture({ height: 7 });
+
+				list.add(header1).add(header2);
+
+				expect(() => {
+					list.add(header3);
+				}).to.throw(
+					'Block header with height 11 or 8 can be added at the moment'
+				);
+			});
+
+			it('should keep headers pushed in sequence', async () => {
+				const header1 = blockHeaderFixture({ height: 10 });
+				const header2 = blockHeaderFixture({ height: 11 });
+				const header3 = blockHeaderFixture({ height: 12 });
+
+				list.add(header1);
+				list.add(header2);
+				list.add(header3);
+
+				expect(list.items).to.eql([header1, header2, header3]);
+			});
+
+			it('should remove the first header if list size increased', async () => {
+				const header1 = blockHeaderFixture({ height: 1 });
+				const header2 = blockHeaderFixture({ height: 2 });
+				const header3 = blockHeaderFixture({ height: 3 });
+				const header4 = blockHeaderFixture({ height: 4 });
+				const header5 = blockHeaderFixture({ height: 5 });
+				const header6 = blockHeaderFixture({ height: 6 });
+
+				list
+					.add(header1)
+					.add(header2)
+					.add(header3)
+					.add(header4)
+					.add(header5)
+					.add(header6);
+
+				expect(list.items).to.be.eql([
+					header2,
+					header3,
+					header4,
+					header5,
+					header6,
+				]);
+			});
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?
There was a need to store block headers in-memory with certain order. 

### How did I fix it?
Created a data structure specifically for the use case. 

### How to test it?

Run unit tests 

### Review checklist

* The PR resolves #3691
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
