### PR TITLE
Remove unused config - Closes #3710

### DIFF
--- a/framework/src/modules/chain/defaults/config.js
+++ b/framework/src/modules/chain/defaults/config.js
@@ -28,16 +28,6 @@ const defaultConfig = {
 					minimum: 1000,
 					maximum: 60000,
 				},
-				broadcastLimit: {
-					type: 'integer',
-					minimum: 1,
-					maximum: 100,
-				},
-				parallelLimit: {
-					type: 'integer',
-					minimum: 1,
-					maximum: 100,
-				},
 				releaseLimit: {
 					type: 'integer',
 					minimum: 1,
@@ -49,13 +39,7 @@ const defaultConfig = {
 					maximum: 100,
 				},
 			},
-			required: [
-				'broadcastInterval',
-				'broadcastLimit',
-				'parallelLimit',
-				'releaseLimit',
-				'relayLimit',
-			],
+			required: ['broadcastInterval', 'releaseLimit', 'relayLimit'],
 		},
 		transactions: {
 			type: 'object',
@@ -262,9 +246,7 @@ const defaultConfig = {
 	default: {
 		broadcasts: {
 			active: true,
-			broadcastInterval: 5000,
-			broadcastLimit: 25,
-			parallelLimit: 20,
+			broadcastinterval: 5000,
 			releaseLimit: 25,
 			relayLimit: 3,
 		},

--- a/framework/src/modules/chain/defaults/config.js
+++ b/framework/src/modules/chain/defaults/config.js
@@ -246,7 +246,7 @@ const defaultConfig = {
 	default: {
 		broadcasts: {
 			active: true,
-			broadcastinterval: 5000,
+			broadcastInterval: 5000,
 			releaseLimit: 25,
 			relayLimit: 3,
 		},

--- a/framework/src/modules/network/defaults/config.js
+++ b/framework/src/modules/network/defaults/config.js
@@ -68,6 +68,11 @@ const defaultConfig = {
 		ackTimeout: {
 			type: 'integer',
 		},
+		emitPeerLimit: {
+			type: 'integer',
+			minimum: 1,
+			maximum: 100,
+		},
 	},
 	required: ['wsPort', 'seedPeers'],
 	default: {


### PR DESCRIPTION
### What was the problem?
broadcastLimit was moved to network module config, and parallelLimit was not used.

### How did I fix it?
Remove the unused properties

### How to test it?
Grep the usage in framework/modules/chain, and see the usage doesn't exsit

### Review checklist

* The PR resolves #3710 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
