### PR TITLE
Fix application warnings - Closes #3704

### DIFF
--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -1202,14 +1202,6 @@ parameters:
     description: Ending unix timestamp
     type: integer
     minimum: 1
-  data:
-    name: data
-    in: query
-    description: Additional data field to query
-    type: string
-    format: additionalData
-    minLength: 1
-    maxLength: 64
 
 definitions:
   Meta:
@@ -1912,83 +1904,6 @@ definitions:
           Total amount of LSK that have been forged in this Block.
           Consists of fees and the reward.
 
-  ReducedBlock:
-    type: object
-    required:
-      - id
-      - height
-      - timestamp
-      - generatorPublicKey
-    properties:
-      id:
-        type: string
-        format: id
-        minLength: 1
-        maxLength: 20
-        example: '6258354802676165798'
-      version:
-        type: integer
-        example: 0
-        minimum: 0
-      height:
-        type: integer
-        example: 123
-        minimum: 1
-      timestamp:
-        description: Unix Timestamp
-        type: integer
-        example: 28227090
-      generatorAddress:
-        type: string
-        format: address
-        example: 12668885769632475474L
-      generatorPublicKey:
-        type: string
-        format: publicKey
-        example: 968ba2fa993ea9dc27ed740da0daf49eddd740dbd7cb1cb4fc5db3a20baf341b
-      payloadLength:
-        type: integer
-        example: 117
-        minimum: 0
-      payloadHash:
-        type: string
-        format: hex
-        example: 4e4d91be041e09a2e54bb7dd38f1f2a02ee7432ec9f169ba63cd1f193a733dd2
-      blockSignature:
-        type: string
-        format: signature
-        example: a3733254aad600fa787d6223002278c3400be5e8ed4763ae27f9a15b80e20c22ac9259dc926f4f4cabdf0e4f8cec49308fa8296d71c288f56b9d1e11dfe81e07
-      confirmations:
-        type: integer
-        example: 200
-      previousBlockId:
-        type: string
-        format: id
-        example: '15918760246746894806'
-
-  CommonBlock:
-    x-private: true
-    type: object
-    required:
-      - id
-      - height
-      - previousBlock
-    properties:
-      id:
-        type: string
-        format: id
-        minLength: 1
-        maxLength: 20
-        example: '6258354802676165798'
-      height:
-        type: integer
-        example: 123
-        minimum: 1
-      previousBlock:
-        type: string
-        format: id
-        example: '15918760246746894806'
-
   ForgingStatus:
     type: object
     required:
@@ -2225,17 +2140,6 @@ definitions:
           Unique Identifier for the peer.
           Random string.
 
-  PeersList:
-    x-private: true
-    type: object
-    required:
-      - peers
-    properties:
-      peers:
-        type: array
-        items:
-          $ref: '#/definitions/Peer'
-
   Fees:
     type: object
     required:
@@ -2432,14 +2336,14 @@ definitions:
             type: integer
             example: 5
             description: Number of confirmed Transactions known to the node.
-          validated: 
+          validated:
             type: integer
             example: 5
             description: Number of validated Transactions known to the node.
-          received: 
+          received:
             type: integer
             example: 5
-            description: Number of received Transactions known to the node. 
+            description: Number of received Transactions known to the node.
           total:
             type: integer
             example: 15


### PR DESCRIPTION
### What was the problem?

There were unused definitions in the swagger schema file. 

### How did I fix it?

Removed the unused definitions.  

### Review checklist

* The PR resolves #3704
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
