### PR TITLE
Add defualt create value for asset field - Closes #3715

### DIFF
--- a/framework/src/modules/chain/components/storage/entities/account.js
+++ b/framework/src/modules/chain/components/storage/entities/account.js
@@ -37,6 +37,7 @@ const defaultCreateValues = {
 	nameExist: false,
 	multiMin: 0,
 	multiLifetime: 0,
+	asset: null,
 };
 
 const readOnlyFields = ['address'];

--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -32,6 +32,7 @@ const defaultAccount = {
 	nameExist: false,
 	multiMin: 0,
 	multiLifetime: 0,
+	asset: null,
 };
 
 class AccountStore {


### PR DESCRIPTION
### What was the problem?
No default create values.

### How did I fix it?
Add default for state_store for account.

### How to test it?
Run tests.

### Review checklist

* The PR resolves #3715 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
