### PR TITLE
Add README for new lisk node commands - Closes #3314

### DIFF
--- a/commander/README.md
+++ b/commander/README.md
@@ -34,6 +34,7 @@ COMMANDS
   account      Commands relating to Lisk accounts.
   block        Commands relating to Lisk blocks.
   config       Manages Lisk Commander configuration.
+  core         Install and Manages Lisk Core instances.
   copyright    Displays copyright notice.
   delegate     Commands relating to Lisk delegates.
   help         Displays help.


### PR DESCRIPTION
### What was the problem?
Missing `core` command readme
### How did I fix it?
Added `core` command readme
### How to test it?
`lisk core --help`
### Review checklist

* The PR resolves #3314
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
