### PR TITLE
Support {} behavior for asset field accounts - Closes #3717

### DIFF
--- a/framework/src/modules/chain/components/storage/entities/account.js
+++ b/framework/src/modules/chain/components/storage/entities/account.js
@@ -37,6 +37,7 @@ const defaultCreateValues = {
 	nameExist: false,
 	multiMin: 0,
 	multiLifetime: 0,
+	asset: {},
 };
 
 const readOnlyFields = ['address'];
@@ -163,7 +164,7 @@ class ChainAccount extends AccountEntity {
 
 		accounts = accounts.map(account => {
 			const parsedAccount = _.defaults(account, defaultCreateValues);
-			parsedAccount.asset = parsedAccount.asset ? parsedAccount.asset : null;
+			// parsedAccount.asset = parsedAccount.asset ? parsedAccount.asset : null;
 
 			return parsedAccount;
 		});

--- a/framework/src/modules/chain/components/storage/entities/account.js
+++ b/framework/src/modules/chain/components/storage/entities/account.js
@@ -164,8 +164,6 @@ class ChainAccount extends AccountEntity {
 
 		accounts = accounts.map(account => {
 			const parsedAccount = _.defaults(account, defaultCreateValues);
-			// parsedAccount.asset = parsedAccount.asset ? parsedAccount.asset : null;
-
 			return parsedAccount;
 		});
 

--- a/framework/src/modules/chain/components/storage/sql/migrations/updates/20190410112400_add_asset_field_mem_accounts.sql
+++ b/framework/src/modules/chain/components/storage/sql/migrations/updates/20190410112400_add_asset_field_mem_accounts.sql
@@ -19,7 +19,7 @@
 */
 
  -- Add asset column to trs table as jsonb
-ALTER TABLE "mem_accounts" ADD COLUMN IF NOT EXISTS "asset" jsonb;
+ALTER TABLE "mem_accounts" ADD COLUMN IF NOT EXISTS "asset" jsonb NOT NULL DEFAULT '{}'::jsonb;
 
 -- Create index for asset field. Using `gin` index as it's more efficient for keys or key/value search.
 CREATE INDEX IF NOT EXISTS "mem_accounts_asset" ON "mem_accounts" USING gin ("asset");

--- a/framework/src/modules/chain/components/storage/sql/migrations/updates/20190524120600_add_default_value_asset_mem_account.sql
+++ b/framework/src/modules/chain/components/storage/sql/migrations/updates/20190524120600_add_default_value_asset_mem_account.sql
@@ -19,4 +19,4 @@
 */
 
  -- Alter asset field to empty JSON
-UPDATE mem_accounts SET asset = '{}'::json;
+UPDATE mem_accounts SET asset = '{}'::json WHERE asset IS NULL;

--- a/framework/src/modules/chain/components/storage/sql/migrations/updates/20190524120600_add_default_value_asset_mem_account.sql
+++ b/framework/src/modules/chain/components/storage/sql/migrations/updates/20190524120600_add_default_value_asset_mem_account.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Lisk Foundation
+ * Copyright © 2019 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -14,12 +14,9 @@
 
 
 /*
-   DESCRIPTION: Add asset field for mem_accounts column
+   DESCRIPTION: Alter null value to empty JSON object {} for asset field for mem_accounts column
    PARAMETERS: None
 */
 
- -- Add asset column to trs table as jsonb
-ALTER TABLE "mem_accounts" ADD COLUMN IF NOT EXISTS "asset" jsonb;
-
--- Create index for asset field. Using `gin` index as it's more efficient for keys or key/value search.
-CREATE INDEX IF NOT EXISTS "mem_accounts_asset" ON "mem_accounts" USING gin ("asset");
+ -- Alter asset field to empty JSON
+UPDATE mem_accounts SET asset = '{}'::json;

--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -32,6 +32,7 @@ const defaultAccount = {
 	nameExist: false,
 	multiMin: 0,
 	multiLifetime: 0,
+	asset: {},
 };
 
 class AccountStore {

--- a/framework/test/mocha/fixtures/accounts.js
+++ b/framework/test/mocha/fixtures/accounts.js
@@ -84,7 +84,7 @@ const Account = stampit({
 		votedDelegatesPublicKeys: null,
 		membersPublicKeys: null,
 		productivity: 0,
-		asset: null,
+		asset: {},
 	},
 	init({
 		isDelegate,
@@ -138,7 +138,7 @@ const dbAccount = stampit({
 		secondSignature: 0,
 		username: null,
 		vote: '0',
-		asset: null,
+		asset: {},
 	},
 	init({ address, balance }) {
 		this.address = address || this.address;

--- a/framework/test/mocha/functional/http/get/accounts/accounts.js
+++ b/framework/test/mocha/functional/http/get/accounts/accounts.js
@@ -449,6 +449,7 @@ describe('GET /accounts', () => {
 				delegate.vote,
 				constansts.supply
 			);
+
 			expect(delegate.approval).to.be.eql(calculatedApproval);
 		});
 

--- a/framework/test/mocha/unit/modules/chain/components/storage/entities/account.js
+++ b/framework/test/mocha/unit/modules/chain/components/storage/entities/account.js
@@ -160,7 +160,7 @@ describe('ChainAccount', () => {
 			await AccountEntity.create(account);
 
 			const mergedObject = Object.assign({}, defaultCreateValues, account);
-			mergedObject.asset = mergedObject.asset ? mergedObject.asset : null;
+			// mergedObject.asset = mergedObject.asset ? mergedObject.asset : null;
 
 			expect(AccountEntity.getValuesSet.firstCall.args[0]).to.be.eql([
 				mergedObject,
@@ -281,7 +281,7 @@ describe('ChainAccount', () => {
 				productivity: 0,
 				votedDelegatesPublicKeys: null,
 				membersPublicKeys: null,
-				asset: null,
+				asset: {},
 			};
 			expect(accountFromDB).to.be.eql(expectedObject);
 		});

--- a/framework/test/mocha/unit/modules/chain/components/storage/entities/account.js
+++ b/framework/test/mocha/unit/modules/chain/components/storage/entities/account.js
@@ -160,7 +160,6 @@ describe('ChainAccount', () => {
 			await AccountEntity.create(account);
 
 			const mergedObject = Object.assign({}, defaultCreateValues, account);
-			// mergedObject.asset = mergedObject.asset ? mergedObject.asset : null;
 
 			expect(AccountEntity.getValuesSet.firstCall.args[0]).to.be.eql([
 				mergedObject,

--- a/framework/test/mocha/unit/modules/chain/logic/account.js
+++ b/framework/test/mocha/unit/modules/chain/logic/account.js
@@ -45,7 +45,7 @@ const validAccount = {
 	productivity: 0,
 	membersPublicKeys: null,
 	votedDelegatesPublicKeys: null,
-	asset: null,
+	asset: {},
 };
 
 describe('account', () => {


### PR DESCRIPTION
### What was the problem?
Currently, the account field in `accounts` column holds `null` if we don't pass a JSON object for `asset` field.

### How did I fix it?
Modify behavior to store empty object `{}`.

### How to test it?
Run tests and check in DB if all accounts have `{}` under `asset` field.

### Review checklist

* The PR resolves #3717 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
