### PR TITLE
Move the type check from validateAsset to validate as a static field - Closes #3726

### DIFF
--- a/elements/lisk-transactions/src/0_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/0_transfer_transaction.ts
@@ -30,8 +30,6 @@ import {
 	verifyBalance,
 } from './utils';
 
-const TRANSACTION_TRANSFER_TYPE = 0;
-
 export interface TransferAsset {
 	readonly data: string;
 }
@@ -49,6 +47,7 @@ export const transferAssetFormatSchema = {
 
 export class TransferTransaction extends BaseTransaction {
 	public readonly asset: TransferAsset;
+	protected static TYPE = 0;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -93,17 +92,6 @@ export class TransferTransaction extends BaseTransaction {
 			this.id,
 			validator.errors,
 		) as TransactionError[];
-		if (this.type !== TRANSACTION_TRANSFER_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_TRANSFER_TYPE,
-				),
-			);
-		}
 
 		if (!validateTransferAmount(this.amount.toString())) {
 			errors.push(

--- a/elements/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/elements/lisk-transactions/src/1_second_signature_transaction.ts
@@ -23,8 +23,6 @@ import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import { getId, validator } from './utils';
 
-const TRANSACTION_SIGNATURE_TYPE = 1;
-
 export interface SecondSignatureAsset {
 	readonly signature: {
 		readonly publicKey: string;
@@ -50,6 +48,8 @@ export const secondSignatureAssetFormatSchema = {
 
 export class SecondSignatureTransaction extends BaseTransaction {
 	public readonly asset: SecondSignatureAsset;
+	protected static TYPE = 1;
+
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
 		const tx = (typeof rawTransaction === 'object' && rawTransaction !== null
@@ -103,18 +103,6 @@ export class SecondSignatureTransaction extends BaseTransaction {
 			this.id,
 			validator.errors,
 		) as TransactionError[];
-
-		if (this.type !== TRANSACTION_SIGNATURE_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_SIGNATURE_TYPE,
-				),
-			);
-		}
 
 		if (!this.amount.eq(0)) {
 			errors.push(

--- a/elements/lisk-transactions/src/2_delegate_transaction.ts
+++ b/elements/lisk-transactions/src/2_delegate_transaction.ts
@@ -22,8 +22,6 @@ import { convertToAssetError, TransactionError } from './errors';
 import { Account, TransactionJSON } from './transaction_types';
 import { validator } from './utils';
 
-const TRANSACTION_DELEGATE_TYPE = 2;
-
 export interface DelegateAsset {
 	readonly delegate: {
 		readonly username: string;
@@ -52,6 +50,7 @@ export const delegateAssetFormatSchema = {
 export class DelegateTransaction extends BaseTransaction {
 	public readonly asset: DelegateAsset;
 	public readonly containsUniqueData: boolean;
+	protected static TYPE = 2;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -109,18 +108,6 @@ export class DelegateTransaction extends BaseTransaction {
 			this.id,
 			validator.errors,
 		) as TransactionError[];
-
-		if (this.type !== TRANSACTION_DELEGATE_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_DELEGATE_TYPE,
-				),
-			);
-		}
 
 		if (!this.amount.eq(0)) {
 			errors.push(

--- a/elements/lisk-transactions/src/3_vote_transaction.ts
+++ b/elements/lisk-transactions/src/3_vote_transaction.ts
@@ -30,7 +30,6 @@ const PREFIX_UNVOTE = '-';
 const MAX_VOTE_PER_ACCOUNT = 101;
 const MIN_VOTE_PER_TX = 1;
 const MAX_VOTE_PER_TX = 33;
-const TRANSACTION_VOTE_TYPE = 3;
 
 export interface VoteAsset {
 	readonly votes: ReadonlyArray<string>;
@@ -63,6 +62,7 @@ export const voteAssetFormatSchema = {
 export class VoteTransaction extends BaseTransaction {
 	public readonly containsUniqueData: boolean;
 	public readonly asset: VoteAsset;
+	protected static TYPE = 3;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -147,18 +147,6 @@ export class VoteTransaction extends BaseTransaction {
 					'.amount',
 					this.amount.toString(),
 					'0',
-				),
-			);
-		}
-
-		if (this.type !== TRANSACTION_VOTE_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_VOTE_TYPE,
 				),
 			);
 		}

--- a/elements/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/4_multisignature_transaction.ts
@@ -31,8 +31,6 @@ import { createResponse, Status, TransactionResponse } from './response';
 import { TransactionJSON } from './transaction_types';
 import { validateMultisignatures, validateSignature, validator } from './utils';
 
-const TRANSACTION_MULTISIGNATURE_TYPE = 4;
-
 export const multisignatureAssetFormatSchema = {
 	type: 'object',
 	required: ['multisignature'],
@@ -94,8 +92,10 @@ export interface MultiSignatureAsset {
 
 export class MultisignatureTransaction extends BaseTransaction {
 	public readonly asset: MultiSignatureAsset;
+	protected static TYPE = 4;
 	protected _multisignatureStatus: MultisignatureStatus =
 		MultisignatureStatus.PENDING;
+
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
 		const tx = (typeof rawTransaction === 'object' && rawTransaction !== null
@@ -158,18 +158,6 @@ export class MultisignatureTransaction extends BaseTransaction {
 			this.id,
 			validator.errors,
 		) as TransactionError[];
-
-		if (this.type !== TRANSACTION_MULTISIGNATURE_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_MULTISIGNATURE_TYPE,
-				),
-			);
-		}
 
 		if (!this.amount.eq(0)) {
 			errors.push(

--- a/elements/lisk-transactions/src/5_dapp_transaction.ts
+++ b/elements/lisk-transactions/src/5_dapp_transaction.ts
@@ -22,8 +22,6 @@ import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import { stringEndsWith, validator } from './utils/validation';
 
-const TRANSACTION_DAPP_TYPE = 5;
-
 export interface DappAsset {
 	readonly dapp: {
 		readonly category: number;
@@ -92,6 +90,7 @@ export const dappAssetFormatSchema = {
 export class DappTransaction extends BaseTransaction {
 	public readonly containsUniqueData: boolean;
 	public readonly asset: DappAsset;
+	protected static TYPE = 5;
 
 	public constructor(rawTransaction: unknown) {
 		super(rawTransaction);
@@ -213,18 +212,6 @@ export class DappTransaction extends BaseTransaction {
 			validator.errors,
 		) as TransactionError[];
 
-		if (this.type !== TRANSACTION_DAPP_TYPE) {
-			errors.push(
-				new TransactionError(
-					'Invalid type',
-					this.id,
-					'.type',
-					this.type,
-					TRANSACTION_DAPP_TYPE,
-				),
-			);
-		}
-
 		if (!this.amount.eq(0)) {
 			errors.push(
 				new TransactionError(
@@ -317,7 +304,7 @@ export class DappTransaction extends BaseTransaction {
 		const errors: TransactionError[] = [];
 		const nameExists = store.transaction.find(
 			(transaction: TransactionJSON) =>
-				transaction.type === TRANSACTION_DAPP_TYPE &&
+				transaction.type === DappTransaction.TYPE &&
 				transaction.id !== this.id &&
 				(transaction.asset as DappAsset).dapp &&
 				(transaction.asset as DappAsset).dapp.name === this.asset.dapp.name,
@@ -335,7 +322,7 @@ export class DappTransaction extends BaseTransaction {
 
 		const linkExists = store.transaction.find(
 			(transaction: TransactionJSON) =>
-				transaction.type === TRANSACTION_DAPP_TYPE &&
+				transaction.type === DappTransaction.TYPE &&
 				transaction.id !== this.id &&
 				(transaction.asset as DappAsset).dapp &&
 				(transaction.asset as DappAsset).dapp.link === this.asset.dapp.link,

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -114,6 +114,8 @@ export abstract class BaseTransaction {
 	public readonly fee: BigNum;
 	public receivedAt?: Date;
 
+	protected static TYPE: number;
+
 	protected _id?: string;
 	protected _signature?: string;
 	protected _signSignature?: string;
@@ -263,6 +265,20 @@ export abstract class BaseTransaction {
 		if (idError) {
 			errors.push(idError);
 		}
+
+		/* tslint:disable */
+		if (this.type !== (<typeof BaseTransaction>this.constructor).TYPE) {
+			errors.push(
+				new TransactionError(
+					`Invalid type`,
+					this.id,
+					'.type',
+					this.type,
+					(<typeof BaseTransaction>this.constructor).TYPE,
+				),
+			);
+		}
+		/* tslint:enable */
 
 		return createResponse(this.id, errors);
 	}

--- a/elements/lisk-transactions/test/helpers/test_transaction_class.ts
+++ b/elements/lisk-transactions/test/helpers/test_transaction_class.ts
@@ -17,6 +17,8 @@ import { TransactionJSON } from '../../src/transaction_types';
 import { TransactionError } from '../../src/errors';
 
 export class TestTransaction extends BaseTransaction {
+	protected static TYPE = 0;
+
 	public assetToJSON(): object {
 		return {};
 	}


### PR DESCRIPTION
### What was the problem?
Transaction type check was implemented in `validateAsset` function while not being part of the asset. I moved it to `validate` in BaseTransaction.

Valid transaction type needs to be assigned as a static field instead of a private constant.

### Review checklist

* The PR resolves #3726
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
