### PR TITLE
API returns incorrect error for postTransactions - Closes #3586

### DIFF
--- a/framework/src/modules/chain/submodules/transport.js
+++ b/framework/src/modules/chain/submodules/transport.js
@@ -144,10 +144,7 @@ __private.receiveSignature = function(signature, cb) {
  * @param {Array} transactions - Array of transactions
  * @param {string} extraLogMessage - Extra log message
  */
-__private.receiveTransactions = function(
-	transactions = [],
-	extraLogMessage
-) {
+__private.receiveTransactions = function(transactions = [], extraLogMessage) {
 	transactions.forEach(transaction => {
 		if (transaction) {
 			transaction.bundled = true;
@@ -208,9 +205,7 @@ __private.receiveTransaction = async function(
 	}
 
 	return library.balancesSequence.add(balancesSequenceCb => {
-		library.logger.debug(
-			`Received transaction ${transaction.id}`
-		);
+		library.logger.debug(`Received transaction ${transaction.id}`);
 
 		modules.transactions.processUnconfirmedTransaction(
 			transaction,
@@ -698,7 +693,7 @@ Transport.prototype.shared = {
 				if (err) {
 					return setImmediate(cb, null, {
 						success: false,
-						message: err.message || 'Invalid transaction body',
+						message: err.message || 'Transaction was rejected with errors',
 						errors: err,
 					});
 				}

--- a/framework/test/mocha/functional/http/post/0.transfer.js
+++ b/framework/test/mocha/functional/http/post/0.transfer.js
@@ -80,7 +80,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Failed to validate signature ${transaction.signature}`
@@ -97,7 +99,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.eql('Invalid transaction body');
+				expect(res.body.message).to.eql('Transaction was rejected with errors');
 				expect(res.body.code).to.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors).to.not.be.empty;
 				badTransactions.push(transaction);
@@ -121,7 +123,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'Amount must be a valid number in string format.'
@@ -141,7 +145,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Account does not have enough LSK: ${account.address}, balance: 0`
@@ -161,7 +167,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.include(
 					'Account does not have enough LSK: 16313739661670634666L, balance: '
@@ -190,7 +198,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				signedTransactionFromGenesis,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.include(
 					'Account does not have enough LSK: 1085993630748340485L, balance: -'
@@ -211,7 +221,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				goodTransaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Transaction is already processed: ${goodTransaction.id}`
@@ -226,7 +238,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				cloneGoodTransaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[1].message).to.be.equal(
 					'Invalid transaction id'
@@ -241,7 +255,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				cloneGoodTransaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Transaction is already processed: ${cloneGoodTransaction.id}`
@@ -276,7 +292,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'Invalid transaction timestamp. Timestamp is in the future'
@@ -304,7 +322,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 							transaction,
 							apiCodes.PROCESSING_ERROR
 						).then(res => {
-							expect(res.body.message).to.be.equal('Invalid transaction body');
+							expect(res.body.message).to.be.equal(
+								'Transaction was rejected with errors'
+							);
 							expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 							expect(res.body.errors[0].message).to.not.be.empty;
 							badTransactions.push(transaction);
@@ -389,7 +409,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						transaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.be.eql('Invalid transaction body');
+						expect(res.body.message).to.be.eql(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.be.equal(
 							'\'.data\' should match format "transferData"'
@@ -412,7 +434,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						transaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.be.eql('Invalid transaction body');
+						expect(res.body.message).to.be.eql(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.be.equal(
 							'\'.data\' should match format "transferData"'
@@ -435,7 +459,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						transaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.be.eql('Invalid transaction body');
+						expect(res.body.message).to.be.eql(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.be.equal(
 							'\'.data\' should match format "transferData"'
@@ -458,7 +484,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 						transaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.be.eql('Invalid transaction body');
+						expect(res.body.message).to.be.eql(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.be.equal(
 							'\'.data\' should match format "transferData"'
@@ -480,7 +508,9 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 				goodTransaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.eql('Invalid transaction body');
+				expect(res.body.message).to.be.eql(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Transaction is already confirmed: ${goodTransaction.id}`

--- a/framework/test/mocha/functional/http/post/2.delegate.js
+++ b/framework/test/mocha/functional/http/post/2.delegate.js
@@ -112,7 +112,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Account does not have enough LSK: ${
@@ -155,7 +157,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					"'.delegate.username' should NOT be shorter than 1 characters"
@@ -175,7 +179,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.delegate.username\' should match format "username"'
@@ -195,7 +201,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.delegate.username\' should match format "username"'
@@ -215,7 +223,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.delegate.username\' should match format "username"'
@@ -235,7 +245,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.delegate.username\' should match format "username"'
@@ -255,7 +267,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.delegate.username\' should match format "username"'
@@ -275,7 +289,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.delegate.username\' should match format "username"'
@@ -305,7 +321,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					"'.delegate.username' should NOT be longer than 20 characters"
@@ -324,7 +342,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.delegate.username\' should match format "username"'
@@ -361,7 +381,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'Username is not unique.'
@@ -380,7 +402,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'Username is not unique.'
@@ -399,7 +423,9 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'Account is already a delegate'

--- a/framework/test/mocha/functional/http/post/3.votes.js
+++ b/framework/test/mocha/functional/http/post/3.votes.js
@@ -269,7 +269,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.votes[0]\' should match format "signedPublicKey"'
@@ -295,7 +297,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.votes[0]\' should match format "signedPublicKey"'
@@ -319,7 +323,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.votes[0]\' should match format "signedPublicKey"'
@@ -343,7 +349,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'\'.votes[0]\' should match format "signedPublicKey"'
@@ -367,7 +375,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					"'.votes[0]' should be string"
@@ -387,7 +397,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Account does not have enough LSK: ${
@@ -408,7 +420,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`${accountMinimalFunds.publicKey} is not a delegate.`
@@ -439,7 +453,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`${accountFixtures.existingDelegate.publicKey} is not voted.`
@@ -501,7 +517,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					"'.votes' should NOT have more than 33 items"
@@ -571,7 +589,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`${accountFixtures.existingDelegate.publicKey} is already voted.`
@@ -614,7 +634,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					'Vote cannot exceed 101 but has 102.'
@@ -650,7 +672,9 @@ describe('POST /api/transactions (type 3) votes', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					"'.votes' should NOT have more than 33 items"

--- a/framework/test/mocha/functional/http/post/4.multisignature.advanced.js
+++ b/framework/test/mocha/functional/http/post/4.multisignature.advanced.js
@@ -186,7 +186,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 						scenario.multiSigTransaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.eql('Invalid transaction body');
+						expect(res.body.message).to.eql(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.be.equal(
 							'\'.signatures[0]\' should match format "signature"'
@@ -246,7 +248,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 						scenario.multiSigTransaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.be.equal('Invalid transaction body');
+						expect(res.body.message).to.be.equal(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.be.equal(
 							`Failed to validate signature ${signatureFromunknown.signature}`
@@ -272,7 +276,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 						scenario.multiSigTransaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.be.equal('Invalid transaction body');
+						expect(res.body.message).to.be.equal(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.eql(
 							"'.signatures' should NOT have duplicate items (items ## 1 and 0 are identical)"
@@ -305,7 +311,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 						scenario.multiSigTransaction,
 						apiCodes.PROCESSING_ERROR
 					).then(res => {
-						expect(res.body.message).to.be.equal('Invalid transaction body');
+						expect(res.body.message).to.be.equal(
+							'Transaction was rejected with errors'
+						);
 						expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 						expect(res.body.errors[0].message).to.eql(
 							"'.signatures' should NOT have duplicate items (items ## 2 and 0 are identical)"

--- a/framework/test/mocha/functional/http/post/4.multisignature.js
+++ b/framework/test/mocha/functional/http/post/4.multisignature.js
@@ -106,7 +106,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.keysgroup' should NOT have fewer than 1 items"
@@ -139,7 +141,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.keysgroup[3]' should be string"
@@ -165,7 +169,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[1].message).to.be.equal(
 						'Invalid multisignature keysgroup. Can not contain sender'
@@ -200,7 +206,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.keysgroup' should NOT have duplicate items (items ## 1 and 0 are identical)"
@@ -235,7 +243,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.multisignature.keysgroup[1]\' should match format "additionPublicKey"'
@@ -271,7 +281,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.multisignature.keysgroup[0]\' should match format "additionPublicKey"'
@@ -303,7 +315,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.multisignature.keysgroup[0]\' should match format "additionPublicKey"'
@@ -339,7 +353,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.multisignature.keysgroup[0]\' should match format "additionPublicKey"'
@@ -375,7 +391,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.multisignature.keysgroup[0]\' should match format "additionPublicKey"'
@@ -398,7 +416,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.keysgroup' should NOT have more than 15 items"
@@ -422,7 +442,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'Invalid multisignature min. Must be less than or equal to keysgroup size'
@@ -446,7 +468,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.min' should be <= 15"
@@ -470,7 +494,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.min' should be >= 1"
@@ -496,7 +522,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.lifetime' should be <= 72"
@@ -520,7 +548,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.eql('Invalid transaction body');
+					expect(res.body.message).to.be.eql(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.multisignature.lifetime' should be >= 1"
@@ -539,7 +569,9 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 				scenario.multiSigTransaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Account does not have enough LSK: ${

--- a/framework/test/mocha/functional/http/post/5.dapps.js
+++ b/framework/test/mocha/functional/http/post/5.dapps.js
@@ -111,7 +111,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp' should have required property 'category'"
@@ -131,7 +133,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.category' should be integer"
@@ -151,7 +155,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.category' should be >= 0"
@@ -171,7 +177,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.category' should be <= 8"
@@ -220,7 +228,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors).to.not.be.empty;
 					badTransactions.push(transaction);
@@ -256,7 +266,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.description' should NOT be longer than 160 characters"
@@ -293,7 +305,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.description\' should match format "noNullByte"'
@@ -315,7 +329,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.description\' should match format "noNullByte"'
@@ -337,7 +353,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.description\' should match format "noNullByte"'
@@ -359,7 +377,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.description\' should match format "noNullByte"'
@@ -396,7 +416,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors).to.not.be.empty;
 					badTransactions.push(transaction);
@@ -416,7 +438,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.icon\' should match format "uri"'
@@ -438,7 +462,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'Dapp icon must have suffix of one of .png,.jpeg,.jpg'
@@ -462,7 +488,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.link\' should match format "uri"'
@@ -482,7 +510,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.link' should be string"
@@ -504,7 +534,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'Dapp icon must have suffix .zip'
@@ -526,7 +558,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp' should have required property 'name'"
@@ -546,7 +580,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.name' should be string"
@@ -566,7 +602,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.name' should NOT be shorter than 1 characters"
@@ -589,7 +627,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.name' should NOT be longer than 32 characters"
@@ -627,7 +667,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.name\' should match format "noNullByte"'
@@ -649,7 +691,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.name\' should match format "noNullByte"'
@@ -671,7 +715,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.name\' should match format "noNullByte"'
@@ -693,7 +739,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.name\' should match format "noNullByte"'
@@ -730,7 +778,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors).to.not.be.empty;
 					badTransactions.push(transaction);
@@ -766,7 +816,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.tags' should NOT be longer than 160 characters"
@@ -804,7 +856,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'Dapp tags must have unique set'
@@ -841,7 +895,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.tags\' should match format "noNullByte"'
@@ -863,7 +919,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.tags\' should match format "noNullByte"'
@@ -885,7 +943,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.tags\' should match format "noNullByte"'
@@ -907,7 +967,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						'\'.dapp.tags\' should match format "noNullByte"'
@@ -929,7 +991,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp' should have required property 'type'"
@@ -949,7 +1013,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.type' should be >= 0"
@@ -969,7 +1035,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.type' should be >= 0"
@@ -990,7 +1058,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 					transaction,
 					apiCodes.PROCESSING_ERROR
 				).then(res => {
-					expect(res.body.message).to.be.equal('Invalid transaction body');
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors'
+					);
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.be.equal(
 						"'.dapp.type' should be <= 1"
@@ -1014,7 +1084,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Application name already exists: ${randomUtil.guestbookDapp.name}`
@@ -1035,7 +1107,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Application link already exists: ${randomUtil.guestbookDapp.link}`
@@ -1054,7 +1128,9 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.equal('Invalid transaction body');
+				expect(res.body.message).to.be.equal(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Account does not have enough LSK: ${

--- a/framework/test/mocha/functional/http/post/transactions.js
+++ b/framework/test/mocha/functional/http/post/transactions.js
@@ -70,7 +70,9 @@ describe('POST /api/transactions (general)', () => {
 				transaction,
 				apiCodes.PROCESSING_ERROR
 			).then(res => {
-				expect(res.body.message).to.be.eql('Invalid transaction body');
+				expect(res.body.message).to.be.eql(
+					'Transaction was rejected with errors'
+				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
 					`Transaction is already confirmed: ${transaction.id}`


### PR DESCRIPTION
### What was the problem?

The error being used in postTransactions was not generic enough (as the detailed errors are always in the `errors` array )

### How did I fix it?

By changing the previous error to a more generic one

### How to test it?

- Build should be green

### Review checklist

* The PR resolves #3586
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
