### PR TITLE
Too many self connect errors from P2P

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -154,10 +154,7 @@ export class P2P extends EventEmitter {
 
 	public constructor(config: P2PConfig) {
 		super();
-		this._config = {
-			...config,
-			blacklistedPeers: config.blacklistedPeers ? config.blacklistedPeers : [],
-		};
+		this._config = config;
 		this._isActive = false;
 		this._newPeers = new Map();
 		this._triedPeers = new Map();

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -72,8 +72,7 @@ export interface P2PClosePacket {
 }
 
 export interface P2PConfig {
-	// tslint:disable-next-line:readonly-keyword
-	blacklistedPeers: P2PPeerInfo[];
+	readonly blacklistedPeers?: ReadonlyArray<P2PPeerInfo>;
 	readonly connectTimeout?: number;
 	readonly ackTimeout?: number;
 	readonly hostAddress?: string;

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -72,7 +72,8 @@ export interface P2PClosePacket {
 }
 
 export interface P2PConfig {
-	readonly blacklistedPeers?: ReadonlyArray<P2PPeerInfo>;
+	// tslint:disable-next-line:readonly-keyword
+	blacklistedPeers: P2PPeerInfo[];
 	readonly connectTimeout?: number;
 	readonly ackTimeout?: number;
 	readonly hostAddress?: string;
@@ -118,7 +119,7 @@ export interface P2PPeerSelectionForSendInput {
 }
 
 export type P2PPeerSelectionForSendFunction = (
-	input: P2PPeerSelectionForSendInput
+	input: P2PPeerSelectionForSendInput,
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
 export interface P2PPeerSelectionForRequestInput {
@@ -129,7 +130,7 @@ export interface P2PPeerSelectionForRequestInput {
 }
 
 export type P2PPeerSelectionForRequestFunction = (
-	input: P2PPeerSelectionForRequestInput
+	input: P2PPeerSelectionForRequestInput,
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
 export interface P2PPeerSelectionForConnectionInput {
@@ -138,7 +139,7 @@ export interface P2PPeerSelectionForConnectionInput {
 }
 
 export type P2PPeerSelectionForConnectionFunction = (
-	input: P2PPeerSelectionForConnectionInput
+	input: P2PPeerSelectionForConnectionInput,
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
 export interface P2PCompatibilityCheckReturnType {

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -462,14 +462,13 @@ describe('Integration tests for P2P library', () => {
 				});
 			});
 
-			it('should discover all peers and add them to the newPeers list within each node', () => {
+			it('should discover all peers and connect to all the peers so there should be no peer in newPeers list', () => {
 				p2pNodeList.forEach(p2p => {
 					const { newPeers } = p2p.getNetworkStatus();
 
 					const peerPorts = newPeers.map(peerInfo => peerInfo.wsPort).sort();
 
-					// TODO ASAP: Make better assertions.
-					expect(peerPorts).to.be.an.instanceOf(Array);
+					expect(peerPorts).to.be.eql([]);
 				});
 			});
 
@@ -485,6 +484,30 @@ describe('Integration tests for P2P library', () => {
 					});
 
 					expect(peerPorts).to.be.eql(expectedPeerPorts);
+				});
+			});
+
+			it('should not contain itself in any of its peer list', async () => {
+				p2pNodeList.forEach(p2p => {
+					const {
+						triedPeers,
+						connectedPeers,
+						newPeers,
+					} = p2p.getNetworkStatus();
+
+					const triedPeerPorts = triedPeers
+						.map(peerInfo => peerInfo.wsPort)
+						.sort();
+					const newPeerPorts = newPeers.map(peerInfo => peerInfo.wsPort).sort();
+					const connectedPeerPorts = connectedPeers
+						.map(peerInfo => peerInfo.wsPort)
+						.sort();
+
+					expect([
+						...triedPeerPorts,
+						...newPeerPorts,
+						...connectedPeerPorts,
+					]).to.not.contain.members([p2p.nodeInfo.wsPort]);
 				});
 			});
 		});

--- a/framework/test/mocha/functional/http/get/peers.js
+++ b/framework/test/mocha/functional/http/get/peers.js
@@ -293,4 +293,16 @@ describe('GET /peers', () => {
 			expect(res.body.data).to.not.empty;
 		});
 	});
+
+	describe('node does not connect to itself', () => {
+		it('should not contain itself in its peer list', async () => {
+			return peersEndpoint.makeRequest({}, 200).then(res => {
+				expect(res.body.data).is.an('array');
+
+				res.body.data.forEach(peer => {
+					expect(peer.wsPort).to.be.eql(p2p1.nodeInfo.wsPort);
+				});
+			});
+		});
+	});
 });

--- a/framework/test/mocha/functional/http/get/peers.js
+++ b/framework/test/mocha/functional/http/get/peers.js
@@ -297,10 +297,14 @@ describe('GET /peers', () => {
 	describe('node does not connect to itself', () => {
 		it('should not contain itself in its peer list', async () => {
 			return peersEndpoint.makeRequest({}, 200).then(res => {
-				expect(res.body.data).is.an('array');
+				const responseData = res.body.data;
 
-				res.body.data.forEach(peer => {
-					expect(peer.wsPort).to.be.eql(p2p1.nodeInfo.wsPort);
+				expect(responseData).is.an('array');
+
+				responseData.forEach(peer => {
+					expect(peer.wsPort).to.not.be.eql(
+						__testContext.config.modules.network.wsPort
+					);
 				});
 			});
 		});


### PR DESCRIPTION
### What was the problem?

Too many self connect errors

```
09:30:35.899Z DEBUG lisk-framework: Peer disconnect event: Outbound connection of peer 134.209.90.103:5000 was closed with code 4101 and reason: Peer cannot connect to itself
09:30:35.900Z ERROR lisk-framework: Event 'rpc-request' was aborted due to a bad connection
09:30:35.900Z DEBUG lisk-framework: Socket connection closed with status code 4101 and reason: Peer cannot connect to itself
```

### How did I fix it?

Since a node is finding itself during discovery from other peers so we add it to the blacklist the first time we see it.

### How to test it?

`npm run test:integration`

### Review checklist

* The PR resolves #3651
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
