### PR TITLE
Error when loading transactions from network - Closes #3736

### DIFF
--- a/framework/src/modules/chain/loader.js
+++ b/framework/src/modules/chain/loader.js
@@ -463,6 +463,7 @@ class Loader {
 
 		modules = {
 			transactionPool: scope.modules.transactionPool,
+			interfaceAdapters: scope.modules.interfaceAdapters,
 			blocks: scope.modules.blocks,
 			peers: scope.modules.peers,
 		};
@@ -533,7 +534,10 @@ __private.getTransactionsFromNetwork = async function() {
 	const validate = promisify(library.schema.validate.bind(library.schema));
 	await validate(result, definitions.WSTransactionsResponse);
 
-	const transactions = result.transactions;
+	const transactions = result.transactions.map(tx =>
+		modules.interfaceAdapters.transactions.fromJson(tx)
+	);
+
 	try {
 		const { transactionsResponses } = validateTransactions()(transactions);
 		const invalidTransactionResponse = transactionsResponses.find(


### PR DESCRIPTION
### What was the problem?
Transactions received from network was not being instantiated.

### How did I fix it?
By adding `interfaceAdapters` as dependency for `loader` and calling `transactions.fromJson` for each transaction received.

### How to test it?
Start application using `mainnet` or `testnet`

### Review checklist

* The PR resolves #3736
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
