### PR TITLE
Enable forging on Genesis Delegates while starting devnet - Closes #3734

### DIFF
--- a/framework/src/errors.js
+++ b/framework/src/errors.js
@@ -38,6 +38,7 @@ class SchemaValidationError extends FrameworkError {
 	constructor(errors) {
 		super('Schema validation error');
 		this.errors = errors;
+		this.message = JSON.stringify(errors, null, 2);
 	}
 }
 

--- a/sdk/src/index.js
+++ b/sdk/src/index.js
@@ -24,7 +24,7 @@ const {
 	configurator,
 } = require('lisk-framework');
 
-const { genesisBlockDevnet } = require('./samples');
+const samples = require('./samples');
 
 module.exports = {
 	Application,
@@ -32,7 +32,7 @@ module.exports = {
 	systemDirs,
 	configurator,
 	BigNum,
-	genesisBlockDevnet,
 	cryptography,
 	transactions,
+	...samples,
 };

--- a/sdk/src/samples/config_devnet.json
+++ b/sdk/src/samples/config_devnet.json
@@ -1,12 +1,12 @@
 {
 	"app": {
-		"ipc": {
-			"enabled": true
-		},
-		"label": "hello-world-app",
+		"label": "devnet-alpha-sdk",
 		"minVersion": "0.0.0",
 		"version": "0.0.0",
-		"protocolVersion": "0.0"
+		"protocolVersion": "1.1",
+		"ipc": {
+			"enabled": true
+		}
 	},
 	"components": {
 		"logger": {

--- a/sdk/src/samples/config_devnet.json
+++ b/sdk/src/samples/config_devnet.json
@@ -2,7 +2,11 @@
 	"app": {
 		"ipc": {
 			"enabled": true
-		}
+		},
+		"label": "hello-world-app",
+		"minVersion": "0.0.0",
+		"version": "0.0.0",
+		"protocolVersion": "0.0"
 	},
 	"components": {
 		"logger": {

--- a/sdk/src/samples/config_devnet.json
+++ b/sdk/src/samples/config_devnet.json
@@ -1,0 +1,539 @@
+{
+	"app": {
+		"ipc": {
+			"enabled": true
+		}
+	},
+	"components": {
+		"logger": {
+			"fileLogLevel": "debug",
+			"logFileName": "logs/devnet/lisk.log",
+			"consoleLogLevel": "info"
+		},
+		"storage": {
+			"logFileName": "logs/devnet/lisk_db.log",
+			"host": "localhost",
+			"port": 5432,
+			"database": "lisk_dev",
+			"user": "lisk",
+			"password": "password",
+			"min": 10,
+			"max": 95,
+			"poolIdleTimeout": 30000,
+			"reapIntervalMillis": 1000,
+			"logEvents": ["error"]
+		},
+		"cache": {
+			"enabled": false,
+			"host": "127.0.0.1",
+			"port": 6380,
+			"db": 0,
+			"password": null
+		}
+	},
+	"modules": {
+		"http_api": {
+			"enabled": true,
+			"httpPort": 4000,
+			"address": "0.0.0.0",
+			"trustProxy": false,
+			"access": {
+				"public": false,
+				"whiteList": ["127.0.0.1"]
+			},
+			"ssl": {
+				"enabled": false,
+				"options": {
+					"port": 443,
+					"address": "0.0.0.0",
+					"key": "./ssl/lisk.key",
+					"cert": "./ssl/lisk.crt"
+				}
+			},
+			"options": {
+				"limits": {
+					"max": 0,
+					"delayMs": 0,
+					"delayAfter": 0,
+					"windowMs": 60000,
+					"headersTimeout": 5000,
+					"serverSetTimeout": 20000
+				},
+				"cors": {
+					"origin": "*",
+					"methods": ["GET", "POST", "PUT"]
+				}
+			},
+			"forging": {
+				"access": {
+					"whiteList": ["127.0.0.1"]
+				}
+			}
+		},
+		"chain": {
+			"forging": {
+				"force": true,
+				"delegates": [
+					{
+						"encryptedPassphrase": "iterations=1&salt=476d4299531718af8c88156aab0bb7d6&cipherText=663dde611776d87029ec188dc616d96d813ecabcef62ed0ad05ffe30528f5462c8d499db943ba2ded55c3b7c506815d8db1c2d4c35121e1d27e740dc41f6c405ce8ab8e3120b23f546d8b35823a30639&iv=1a83940b72adc57ec060a648&tag=b5b1e6c6e225c428a4473735bc8f1fc9&version=1",
+						"publicKey": "9d3058175acab969f41ad9b86f7a2926c74258670fe56b37c429c01fca9f2f0f"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=fd0f3c5267f321001b30bd75839bdf98&cipherText=9a32f838bb3d9849e841455e5b4ac799ca39fcda2ff4b2f868113cba6487690546416b1e9f606df80e720a3cc12f12fe44968d6c96c3ba76fc6ef66ef5b00bcf52f808d15bf6714a4b89841f&iv=3d422f7cbe6f282f85fe6672&tag=6d07b5b1a11acb263627b783227a4196&version=1",
+						"publicKey": "141b16ac8d5bd150f16b1caa08f689057ca4c4434445e56661831f4e671b7c0a"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=406a1a836699a0e0995a340cf8c68e89&cipherText=9b071ed3623a3a144b146d7e7ceebb28edd6da42590b339fe5a455b79beb2c25b87eb6194f73d8e57c39721295de2af7dfac972952d1b5c963cca14f4fa6cce68cb72cdae51f16131db0bcd5fa3e&iv=9d1c1763e7b5d53bf2ae230b&tag=ef84e213896a68742435dab2ea91523a&version=1",
+						"publicKey": "3ff32442bb6da7d60c1b7752b24e6467813c9b698e0f278d48c43580da972135"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=6c4891b587ba61542ef4975c94a34c7d&cipherText=9ef6b1c252a7f901b889dc7bfd5a0a65d4529bb79629d3066e20c9a5835c229ee731158ee1299739aafd0634ca71c297086e83d81e16384efbc02b6ca0d5bf6d211a4ebc27c8815159&iv=5eab1ce106ac14f67d0b5295&tag=d7274cab49cc7eae9f7c55a32cc3d822&version=1",
+						"publicKey": "5d28e992b80172f38d3a2f9592cad740fd18d3c2e187745cd5f7badf285ed819"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=401baf11420ae664026954e67cc7be0f&cipherText=d333da6345b65fac03ecb4abb55ea52e9cdf1928003578504f4820ad3ce1a094bab39a3e81e9ec7a0c376625d24fdee9b7262820daff60f8ddfe5de19e206579767224c01f5e1837e3&iv=5f2c5c819266d3c29c36253d&tag=28ca62a5d58840a4f4f7c38fd3af9913&version=1",
+						"publicKey": "4fe5cd087a319956ddc05725651e56486961b7d5733ecd23e26e463bf9253bb5"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=749d5f1cf3dbdb64302fa0e96d28046d&cipherText=7e0d71df461ad2999c4a0819c7aa20279bee1ff96c35ccf2f342773e94c318ca72dd8c46a3e71d1a28a1445dc9860b274a2b1738cfc98be12d31ec14aef413c5bbb8a7d14b01ed13546274edb8&iv=6c2ef6fe60c19d7f69f392c0&tag=af5c1232b6925a521a0a5994529326e9&version=1",
+						"publicKey": "a796e9c0516a40ccd0eee7a32fdc2dc297fee40a9c76fef9c1bb0cf41ae69750"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=d3e4c10d1f889d45fc1f23dd1a55a4ed&cipherText=c030aae98cb41b3cadf6cf8b71d8dc1304c709696880e09c6c5f41361666ced2ce804407ac99c05799f06ea513be9cb80bbb824db6e0e69fa252f3ce2fe654d34d4f7344fcaeafe143d3b1&iv=03414e5d5e79f22c04f20a57&tag=5025de28a5134e2cf6c4cc3a3212723b&version=1",
+						"publicKey": "67651d29dc8d94bcb1174d5bd602762850a89850503b01a5ffde3b726b43d3d2"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=0cd3f87a6b2a237681e2faa2f5a5e0ae&cipherText=445277105496e4e6c0ffab44d5767fac2b30bb2bc66c8c91b86c6ddfd97fd912a0f3f890a473081d16c85bc38907a0452ee70495da1b7826915e11ce9568aee2e07d32ebe9e9757174f50bfeaf40&iv=18c888d21d44e13bf689edfe&tag=cee800df14cf95cb24fdfd6c4a117fef&version=1",
+						"publicKey": "c3d1bc76dea367512df3832c437c7b2c95508e140f655425a733090da86fb82d"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=90c05ca97b30bd1ae1434d1c26e943f0&cipherText=961b7e70e162e673f692f812f6f1edb4dfde28c2fdbd800c097e058cc3d45321bbaa6db74e966ced945920a593bfb19fee764ae5327af2b90d31414baf479c8f5b0a38e2dc2d2fe0dc9f71f5&iv=cfe2618ca39c85326f8bf4e2&tag=ef5181e6b408996a8c35e1eec0f0bfe6&version=1",
+						"publicKey": "640dfec4541daed209a455577d7ba519ad92b18692edd9ae71d1a02958f47b1b"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=bd37eb84e85a408f808f2b2ce92928bd&cipherText=2c9eb0d50476f4ab41e0eec76a469a145353ed91afb4816de9ec7c63c860dc62b0f05b00a11e83ae65c70beda729100c8f22beaf118e584b4d1da554079577acdfc5069b5e7f90593cd4a683&iv=b4322beec8d4c3347bd7f405&tag=15764625c7ac374e06ac7c0358af5e86&version=1",
+						"publicKey": "3ea481498521e9fb1201b2295d0e9afa826ac6a3ef51de2f00365f915ac7ac06"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=5bfcb73e406e018d229334b09cce45e8&cipherText=5da0cd1751a2a53fe4b2618a099ee9578eb9ce253b38131053a83534e1045f35c9e3e5cccfa1ac91d9456ecc8d3b96dfa950891f63caab49ed1b2e30860d01b364f1416d04db31a4b6e84f&iv=13dd27cdd2282e4a1ef15285&tag=0b13b147743637faa97146b016945e4a&version=1",
+						"publicKey": "5c4af5cb0c1c92df2ed4feeb9751e54e951f9d3f77196511f13e636cf6064e74"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=8d8b7ceb94a110807ce16fa2bf302881&cipherText=8fa56d1e5acd027aae12fa48c32c4eb6e32baeaedb4f5459ede6d2e1a818a656a9b2775871c7046d665599b81d372d5eb8483c0fa38fb7f40f10f6022d5cf683e2dfe18666fa&iv=68263a56951815538479b130&tag=8bbce07e7c8f7f8c8281791ddd2d5173&version=1",
+						"publicKey": "399a7d14610c4da8800ed929fc6a05133deb8fbac8403dec93226e96fa7590ee"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=799c06e835ef165fab2d2351deef9843&cipherText=ac75be14b7e192f79fa3b72c5215b143dcb26d44cae944ad6b0df8dfad8f643af297eeef584f2ac577a9a62db6200376eeb9d1c9f81f00b4571df64d492117f6685b83e72cf65ed9&iv=08d3621cca6be2f71cd4ac8a&tag=9bacaadf957aa8134a93f1d163123155&version=1",
+						"publicKey": "6e904b2f678eb3b6c3042acb188a607d903d441d61508d047fe36b3c982995c8"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=87f9a5f645c1edf6447abf6ffe8e5e10&cipherText=594085d0cce481aadac04ec9d5d12ce266fc055661ddb3c3ba201f394213da61496ac82a9632f7a7216765eb52ef9ef4aecb8dbba303719f92e30ec3bb2dca5a9009d4463d856c1b6bbd30815413257def7558f57f&iv=7b97874ef11c8f17061af101&tag=b57c3c31fdd12af009d15b43b24d4032&version=1",
+						"publicKey": "1af35b29ca515ff5b805a5e3a0ab8c518915b780d5988e76b0672a71b5a3be02"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=d9b78cbc92de7ff357a62023e912e32f&cipherText=7ba486a8b674070062cadbbab13b546c18c41464c2bd2d3c0f8ab4deda39aefd5cd4134ecfeac267a0196c5af5042e0714822e1e8f6868201dd138b323b16b9023005a3bda70&iv=b6afb5fcf6fb4a8d089416c2&tag=71304d8c847588c87b945a1a38fdc83b&version=1",
+						"publicKey": "d8daea40fd098d4d546aa76b8e006ce4368c052ffe2c26b6eb843e925d54a408"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=443485c1a1b75cf87aa0f3f07f090728&cipherText=9184b6cb7c0996a8b5683776a700222c7b722b3e8e9ff9be5eb87ed310e7cb25d13d38dcbfbe1ab2b6f4745375bb0acfacb6f62eeda6307b397f81871b8e027ace87a69e8e6a27c7bfd9050d6d0a&iv=7fa9b305ac93524263524c7c&tag=f8645c36d2eb163ab52b8ba47f437df9&version=1",
+						"publicKey": "386217d98eee87268a54d2d76ce9e801ac86271284d793154989e37cb31bcd0e"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=7ecd63a584b04e3ca5cefc964f153cce&cipherText=0d33cf54e913385d4602e6c76160e4e0070e8c73b3a1b7edfbd37362004d73080b296dffbdff09c9f971708499da91990f6f2e7b6e4679271646fe876bb29299e1ee9fd3ff1940810125&iv=94732f45d8df8bfb2a64ad0d&tag=6706f5bc3b61b34d1746f30af6abd74e&version=1",
+						"publicKey": "86499879448d1b0215d59cbf078836e3d7d9d2782d56a2274a568761bff36f19"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=504374266b47e648497928f7d7b09844&cipherText=39ea8afabd6e32c85e7782fe3fbc4fe3fe9ba561bd4be7a2f09ea9b62ce6a31944acc136ac360254ea544356fdaf22609a7d9ccf39de5c687ac7affa354066bbecc4c34da868ed0281d74c2c63f1f33c4675a3c52c961f&iv=ea942f09f6f99d444bdcbd1d&tag=20565991019efafd5cbbc87d591f8a3c&version=1",
+						"publicKey": "948b8b509579306694c00833ec1c0f81e964487db2206ddb1517bfeca2b0dc1b"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=d6c5f3e6bd8a50582a85aaf0531de562&cipherText=f4caff0081e42d68c11e437bbd55a6b005cd3ac703a7b27d74ef6aaa57450084375efe6cc4d9ce6b5a09b392b9c53ee97f88b77d506321ce0c1157eaa8efa24a1b274f72bf&iv=39e8b461cd391aac8eb68b57&tag=a769ff1d5f0981f36c5a8fb99ea4fed6&version=1",
+						"publicKey": "b00269bd169f0f89bd2f278788616521dd1539868ced5a63b652208a04ee1556"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=4ee975b4ea0a0ae4adc4f073da812518&cipherText=1775a51cfaa40c42370a00457e88c52bc63b39eb46639ac88920a279617a8196f241dd23ed7946e158620ac770a7618b12e1b20c0d616c0bafd344b7252e89739afe2fc7515e0170dd35&iv=da30a9d4f6cb22b5d6985a11&tag=840cdb9b7c12ba2343dede57099d7105&version=1",
+						"publicKey": "e13a0267444e026fe755ec128858bf3c519864631e0e4c474ba33f2470a18b83"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=4e00b7975bf3e40d9f2b7d4eb6e99afa&cipherText=8974c03a39cfe46dd65c5ae7190b4c40b98e2acd9419e2729d224f631f4eaff10b27c5e4092f9b1ab61739b750bf902cea43822c40a5ed4c9a4ee381f856d0ac11dea8dee566c06a60a1ebc8a96e21105e&iv=e00a9fb7e1344881dcfc90cd&tag=27df04b1df35c9b08d1a9960ed6179ae&version=1",
+						"publicKey": "1cc68fa0b12521158e09779fd5978ccc0ac26bf99320e00a9549b542dd9ada16"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=b84099807b133f090e44d79ea128d37f&cipherText=bb2c20369449f6b9d80bda1528173ede993d53614e26647fb23fda657358e879daa61c98e9c6636e413cd4fa0fd47df20c92c887ce72e789d17bb7df670cd5baecd0362d6604b85d18450cba2e&iv=e28c99555ebc718bfd078056&tag=e7f173ac67e46bcc51983d22b031b944&version=1",
+						"publicKey": "a10f963752b3a44702dfa48b429ac742bea94d97849b1180a36750df3a783621"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=37b61e74de53234a4894e14a18f2e1c7&cipherText=167715ef885c8105c12e9f3c67adccc36c47b6f8dd71f8797c6c437bc5855f043cb53550fbc32e1b44cbe89e438828950c3813d587e1ddfde3d2484c697914caefc67ed7ea37bcf1&iv=a79219b86bbf35168ff8591f&tag=fc547ae0c8019f45e65fb03b0aedc2ba&version=1",
+						"publicKey": "f33f93aa1f3ddcfd4e42d3206ddaab966f7f1b6672e5096d6da6adefd38edc67"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=21ee09c7d299464b5966158aa7327009&cipherText=9bf850e7ad3dcb907ddf5a94db0a9a9b71514ae588226f8e505f4b538a9c0ce5aa741b6c711d910dbd05c2a0f70f72b6f151bc9db45a544c1224e3824dd9cb8967359e73df445b9d731ccf&iv=564bae53d07e2cb2c2349860&tag=ac3b0a356dd1f280a9dad8213fed997b&version=1",
+						"publicKey": "b5341e839b25c4cc2aaf421704c0fb6ba987d537678e23e45d3ca32454a2908c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=829bc4362f2acd4515f1b7a244cb611b&cipherText=e0d97c6a6f60ccc82a2d791245a0f1fca4c5d49187facde2dd30d6b514189fce7c1f083e3d53b63e1ce2d4d0be406488d7dd7b941fed3ef1117bcbcb1205fae676a2eb54d3729a522787614de0&iv=75488c8e6dfde59c00dc08b9&tag=ce1fc057aced14139cfdd56bcf3d8fe0&version=1",
+						"publicKey": "da673805f349faf9ca1db167cb941b27f4517a36d23b3c21da4159cff0045fbe"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=345e8712a439ba55811d94b136a494f4&cipherText=bad54ab8d66efb1411c01343abdc23d8c1db23023b4cc867fcdd7a84c1905e133d92e0e9b976a914cf5867bcb32c2033a3ecb433de75c4f9a36949b35cdaf20e764d959d&iv=f11f1eeea0b1fa63e6dcb729&tag=5d0def467f40377168b193bae6eb32f0&version=1",
+						"publicKey": "55405aed8c3a1eabe678be3ad4d36043d6ef8e637d213b84ee703d87f6b250ed"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=bbae75dc182f623f07a5aaacbc9d340f&cipherText=9aab8850e716b3052c36d31aeff9eba7f070ecbfc2b2da67a83cf3a0987b1ac88d7adfd928784a2ab45c834b03a3df5f6d8263c8176a8da2b21d1c32eed6ce5146bdcb7121c3bce3478fa4fea69a8f&iv=8043c44e8c4ca363c2f6066b&tag=5a78c196f337ce5718d8bd9944e9a767&version=1",
+						"publicKey": "19ffdf99dee16e4be2db4b0e000b56ab3a4e10bee9f457d8988f75ff7a79fc00"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=13357859f3f2345b62b1f14f813db6d4&cipherText=9d86347cf865bae81a2954d432a7aaaaf81b3a93e1ee570b9c3cc2f55dbd9f16c0706f767c3f6a7fbdeb125dc59fe807adbb017623d54dc5c7f9d862402e088b07d7f5c0d1e96bfb27065a1a1106fe6a&iv=23956c826b18bb77e0a81ab0&tag=362232c5edb8baeade125ea379422256&version=1",
+						"publicKey": "85b07e51ffe528f272b7eb734d0496158f2b0f890155ebe59ba2989a8ccc9a49"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=2e7bd243b16df52bb40a34a54548b998&cipherText=1713b96f34cdf43a8e2070c815269c1d32e216e19521a8c99040b3734221bb03de60c35759c64246b905b98d021eb9be4b50eaa7d73391821fe6077e27f3904cdc72f4fc8d0f0e953b1c&iv=d1b1e4141fcd27db139fc846&tag=ed81d3ff7384993f283e2bf07d6c92be&version=1",
+						"publicKey": "8a0bcba8e909036b7a0fdb244f049d847b117d871d203ef7cc4c3917c94fd5fd"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=59523643645e7c161ed3e3603a9c167d&cipherText=1bc580068d546b26500f5cdc3d96a33e5747a9e9fce98d6dbca3dbedcf86d9014f52690273501fc748712ff6dd597e1a02b84bb5ffe6ca7abb0b2ed32f6db5331703e948c9f52e1b39329eee85b016ba2cb0&iv=5c4caa98da0f8049a24579a6&tag=7574ac302e5722d39eb5e576f5a5705b&version=1",
+						"publicKey": "95ea7eb026e250741be85e3593166ef0c4cb3a6eb9114dba8f0974987f10403f"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=17cbc7271d149c28032dd02742815265&cipherText=c30a8536b595dacc064a57ec8b9e3e80bded4135604132113723741689b32d77ffd73cc99e83fc807be49707d997c92099253b7606e8def61d36e22d68474aa2d5038f112c9b31798ebb7e&iv=4d6dbf7b01a8c67d24485af5&tag=4d2c5a760faf379bad2c0a6a4fc90951&version=1",
+						"publicKey": "cf8a3bf23d1936a34facc4ff63d86d21cc2e1ac17e0010035dc3ef7ae85010dc"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=b91d5e61fce99f1e9d0c41a77fd6cdd7&cipherText=e3330b56e4592d6cf867bc8a53292a77d39f899774c9ebbf5917a9be4a2452aeaf5afd2abcc362b46103bdbd15f102b67adc9b3ccfe60ce9e22789a198f83fabc86fe802be411de947&iv=014e65dd0c6f63ba97e930b5&tag=4cd890ddeb14eff6650ac38bac1f205d&version=1",
+						"publicKey": "82174ee408161186e650427032f4cfb2496f429b4157da78888cbcea39c387fc"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=0f90ffb41ee6e2fc6cdd77c9e778fe62&cipherText=090d97a35a5a75c518af9526715beeb39c5194a22b7b9d2d1106ca37e2a9db863fb261782108c6debcd0702a9490724ea36c6b69ec485b94c27cf5e7cb0f5f6784056b&iv=5a66d8938e78598c928c613f&tag=dd3345ae80b534d95935b294e5e5cc7c&version=1",
+						"publicKey": "4bde949c19a0803631768148019473929b5f8661e9e48efb8d895efa9dd24aef"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=3d44ec09734de580ad8dc29f07b289ee&cipherText=12701e7bba4ef4badb55289e2cfa01e52c7e08ac7cc132053c763b847865ba488592e26975da729f9870d843f05c4d83821d089a19b87d22f758316dded6c74a1932f00d9db9d9e839c4c8&iv=745a000f7cb27bf0f4fa36f1&tag=a2bc872d693ed4624ff954b5ddbdbc20&version=1",
+						"publicKey": "2f9b9a43b915bb8dcea45ea3b8552ebec202eb196a7889c2495d948e15f4a724"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=b6b59e54cca810e7d06526144592859d&cipherText=a13da5c30d4cd6d4e974c0bfe105841a85a6cf5ff138a1eeda6e85a540f478d9efca01c03612e131fc106d39a0112607f2df261a5b075264f0c431fe26d1025e501b76f4ae36db7469bcce9533a1b479503641a6&iv=1875d3b7bd1e7f77b283a102&tag=3beecc690f5d5c859d2bef3844bc6c73&version=1",
+						"publicKey": "9503d36c0810f9ac1a9d7d45bf778387a2baab151a45d77ac1289fbe29abb18f"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=3280c6ad1e69704a95e9855f23f10ea4&cipherText=519c5a9b4115e75c748c08f74ffc0da392a10edee346be0a2ec73379855e4ae930f0b3343b522a1880d2fb4dd13edb0fe84f3b3c49325b3ada419614e1c963d946347ce449eb471712&iv=07b9bb901f1d384592311ef5&tag=171e836d1770c32631c9bb94277ca530&version=1",
+						"publicKey": "a50a55d4476bb118ba5121a07b51c185a8fe0a92b65840143b006b9820124df4"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=5675ddaa689417f0ac99fced36c2ea0e&cipherText=ae53872acc5e31c0f30f762002ea23f8dd608dbe6659d18553cc6803eb390d15342157f95cd02722370981c7f6fcf20c05379032f714470829e3610900b8d3bcfe2775817d9fa02d04f600e468c5&iv=b6fbea43cebda9f2fd79a054&tag=cad90fbfcc74cfca053faeb91808df94&version=1",
+						"publicKey": "fc8672466cc16688b5e239a784cd0e4c0acf214af039d9b2bf7a006da4043883"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=ca3430c8600fa55843092eec14032659&cipherText=8e75b7c0298bb4530f4fbea10df566d7fb343e572b2668e1efc9483905cc981930b5c793ab0cc6fea7050c0ba1d591a2aa759729d0cc5578cfaf5b5e8af79b87313ac5bf9cc45a5191d05a4179&iv=198997a5f645c0b7ce175c27&tag=4d0d3b8f999ce7c9856e26204b04c500&version=1",
+						"publicKey": "db821a4f828db977c6a8d186cc4a44280a6ef6f54ac18ec9eb32f78735f38683"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=00f8ef221d5e0bcc87b8a7fe4b52497a&cipherText=32bd7529a70fcc135241199779083db82933963416bc3d1cc5b9edaa840985b7e0b7205843aebe135c7d4e8473ac46bc0edfb29fedb383e8fda4f1c4b6c6189d68efc6311ea20f&iv=574dcaefafb70497af61643c&tag=7ad0ce5ddd1db60590c4a695f05a8805&version=1",
+						"publicKey": "ba7acc3bcbd47dbf13d744e57f696341c260ce2ea8f332919f18cb543b1f3fc7"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=5e011cbe7d0c29a4d34fcc921c7c56e2&cipherText=e3325d4ad1d69bbfe5090ae49a132e3e2c40c4092c30a00441375435e21efa43da3dbca82d6788089b1695c76f51a330832c9cefa6bbbfd8080587d6005c673da5540b08223201e100990de133&iv=79811a35230512cfc9593145&tag=1cc5babd6c86ed8c02cecd7835c15a3f&version=1",
+						"publicKey": "47c8b3d6a9e418f0920ef58383260bcd04799db150612d4ff6eb399bcd07f216"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=acddc709257d15d815fb09732d52f4d9&cipherText=e657aca6627f005c8a63e656a91cd2635b6cf948fb616a807c45c4ffb852bdff1b1539487b935b381c1ee77f643052cd889721269572403a5969530b10ebfd909ac602c9ee4602fb4d805df1bb468c3e&iv=cb1213c5a75ff4b13dff6dd6&tag=25cc917f87b90f713a4342d7299415c8&version=1",
+						"publicKey": "d1c3a2cb254554971db289b917a665b5c547617d6fd20c2d6051bc5dfc805b34"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=eae1d88c2802365cab74b4cabb553365&cipherText=c9145118e3d1d5f88541104b47a4c165af8505221890f1695b09e036e4deafb66e1d77f0d22ee3a99a99c809808007f1731dae3a6d4bbefe4a97e639dca188df3154d0304a3434a4c4187466&iv=9437c2fcef8d56e46f41f23f&tag=1395e253833de0cb2f8de8df2d1cd445&version=1",
+						"publicKey": "47b9b07df72d38c19867c6a8c12429e6b8e4d2be48b27cd407da590c7a2af0dc"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=cb866d88c4120fb9f4bb59710ca0b227&cipherText=04289b5ded6f83cbfdc3a75b1994547e2a328d61dc27596b2a19baf7c4005ca48eb5821374728c4e1ba9e3f3de11efae68bacdc546d0290873e2e7d8a466ef2638a13ad5502c5ffadbee286b6972&iv=513251d83c9e8b0561f0dfaa&tag=1de6aa64082a39e3e45b967d19394a6c&version=1",
+						"publicKey": "9a7452495138cf7cf5a1564c3ef16b186dd8ab4f96423f160e22a3aec6eb614f"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=9d8281f9bb778493bb23d994e94179ad&cipherText=6ac4c4386a7c2f706323dba997521b721c1a1ea4dbafd7381ce1f6c900b2dbc78b82c9bcfc5f698eb3c65384e70e10cd7dd206d8145b413fc222384ea626c5ec4642a0890f4dd3dfb9b109&iv=2b84ee759af48cdf02ae5907&tag=31eab344bdc7dedc3b9934d1f2068616&version=1",
+						"publicKey": "c4dfedeb4f639f749e498a2307f1545ddd6bda62e5503ac1832b122c4a5aedf9"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=6b36e67e7e17ef28ca6dcce6ec05b2e9&cipherText=c79a29e0f615751295db1481dde6cfb022f6256db332ba4ea1b98be2dbcdebc53a94a7e2e2f2d5f7a51c04dc7ef0807589a08ecb74c96add9a7ed45624e84d46e3dc6dfd34646233d4&iv=1593d256d8923854f45f4c91&tag=317bb0dc8d07adfbfa60301e86683b7f&version=1",
+						"publicKey": "96c16a6251e1b9a8c918d5821a5aa8dfb9385607258338297221c5a226eca5c6"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=cde0b7fbe70f0407e5386654ebfd03fe&cipherText=f1e571dfaa52ee53918474717cf3c16537a53aefb4731480098d150876cda0ba1e585ae5182bfdf374b8a3699c1b16dfa9e22adf4538b58c1afa7d5f36a03fc4de637872578f8fd5332713439dcc9f8985bc717cf08e200fa179&iv=6388afe81123047f07161608&tag=b20b64bee72f63e90e5070b1405703f0&version=1",
+						"publicKey": "910da2a8e20f25ccbcb029fdcafd369b43d75e5bc4dc6d92352c29404acc350f"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=937a488695507e8d4b5276ef4f612486&cipherText=95f0ec46a3305ba8e511d7e43b857ffb610a746c7edf1c551554d1c621da4b9354eee15cd2094ea9598f6865c6e2a7fe3b024d5470d6db2de7804d5cc4762b0ff4eeba04bc2eed66577220b7791b1c1cf38300&iv=05006351212b4b676ad9b157&tag=617cc0ff9dcb1fe31b298587f8461aaf&version=1",
+						"publicKey": "eabfe7093ef2394deb1b84287f2ceb1b55fe638edc3358a28fc74f64b3498094"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=d2d5903ed07b5909d955daab0f034208&cipherText=63f42e705a233dffbbdf7d0c5583815f98bdbaa1cef3df3a1428db90ca034c2d059c8b4cea0bbad2fd6f0e5aab381d2f308d28a131bce40ef056c3acfe776b4017c6ebfb404f9f257e149d7f66d185b0&iv=0218f8c873219ef8c49ee928&tag=e41abff83e531364dbeeb8b5829675c3&version=1",
+						"publicKey": "94b163c5a5ad346db1c84edaff51604164476cf78b8834b6b610dd03bd6b65d9"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=9954e52c67f7defcb5dc6a96b2df3366&cipherText=70b45f72903ef0b002a495e64a9e6ea1e00c95243a56caebbbd8411b988a74c2c4317a25ce4ac6e9e70274c9e780c38bc1d9a3d00254ab18a6ec17f404aee1755063092462441dba46543a8a59a42a96ac819d6f85&iv=7953bb3b757fbf0b510db067&tag=61dd3027cc7e0a5aba69f1186833c77a&version=1",
+						"publicKey": "6164b0cc68f8de44cde90c78e838b9ee1d6041fa61cf0cfbd834d76bb369a10e"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=bc511b59b6489ecde10a81a51bce52d4&cipherText=c42526b5c7a999d8650e81810ff3d8e72a2a9333db201212f413eaee83d8524f087f167edbb0a25601208b192f5ef4c6ce62bd06f4f7fd8eb8d8107f60d31eecc144a262be3f44198f566f7b&iv=a6fa43923e3322e2253e06cd&tag=bad17fd7f77ea65d8fa2fb6671e6e663&version=1",
+						"publicKey": "3476bba16437ee0e04a29daa34d753139fbcfc14152372d7be5b7c75d51bac6c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=56d97425f89df606aaf7136fb067c111&cipherText=55952b5bccca85d904fe916882a44d5f9579006fa1182e98dff4ad1847b8700d8af5471e3e440a60caac8317d7ad71884c14614806efa027e00c0571cb8ad95427c43513b467e3d266de3f7937fa&iv=a2e85c508aeac9a5a6936096&tag=87751fe1ad3d0c0fe28ac7061551d40e&version=1",
+						"publicKey": "01389197bbaf1afb0acd47bbfeabb34aca80fb372a8f694a1c0716b3398db746"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=53c522dfb9fbc75dba93e4a701264509&cipherText=c33bd666e9e9dbef122b11ec0a295798f72c68f8606ac7482c75fd68b965345ebeed8c75b3dbcbae04a0f84095726f8b2067be9ed333c47c4139c6af7408d110881df992dbb3f7eaf095&iv=f3ff68f724aaa052c2be1329&tag=f4b0d81bc6975e550f8e3b3846600a81&version=1",
+						"publicKey": "aa33af13b440746b4f24312cba5fa910eb077ce6b16b84ebb482cb7720b5c686"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=7a292ced16cf7b1e546deb529bc79655&cipherText=4b9b1b15b78e3024e4dde59bcec853da5656d150a6972c5f369179ac0997887e2ae705cb6589ece1f2a2c9bdaa96fab41aa2b2f7b4764f09175cc198cf09ce414be6724c15b938549d29f10878340b&iv=a6bc97cd9b20e249cec4c3d8&tag=8a0a4a6b399202faafe338d191e19a59&version=1",
+						"publicKey": "6f04988de7e63537c8f14e84b0eb51e0ea9c5da8b4b9256243b3e40b1aeccb76"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=cd5b2d4fbed29891132a8d6aeba4df67&cipherText=c43548a0e9ea6bf13d365ff3ebf3dc17f411be3fbe14c87709b1b093f75f5fc0771feabf12f8387bac7e99a4ea4ea422dc1818178a43905715b1ab5779772d3f5a40925b8adbc7f3f859fe3697&iv=8c3de4e42d24e9530a42db36&tag=581c603e002d3492bb87ad8204390fba&version=1",
+						"publicKey": "07935c642c7409c365258c8488760e96a851cee618aec72eeeb135c9c827f0f9"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=d3e046d1a21ee9c9eb008265d201ff6b&cipherText=dcc2365286f71216d8e86fd6573deee2644e0145ec2a89430f33063e9f0f11c3301088b2395df9c7a1e0c5ad5d1efcbec8b4633467b23727d53e3edb34205c66e40207188cd1c802be751c3cf7c3c3&iv=8d8c54bc7af8532456db3e43&tag=26b0fd90af60afef0e3e314ccc2f6b7b&version=1",
+						"publicKey": "526931663cbee883ff22369172cba091a5dd5fa1200284fa790d7aeca53d37af"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=378c3bf696ad6704beefec1e448fd476&cipherText=fe4d8a5eb3e53b7c6eebcced6262ca98a807b40533c34789dc5596eb147f06a18af87ae25aefacfc00f2632494f46fa777883aefdf9420bdfa3239465806b6114d02c0b1bb5ab53ffe3ed2&iv=5ddb446799abb99374559bcb&tag=b3d714afc0733559d4bd14e37896f0a2&version=1",
+						"publicKey": "f7b9751d59dd6be6029aa36a81a3f6436e2970cf4348845ab6254678fb946c18"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=b660f3f9aa4296d3c89798d7e09c6418&cipherText=e75823378c55a62ae127be899c292afed7acb34ccef00fe1c0692ebe43a78307ec738697fcabc2f512d7da361a21767dc480746008c465e7a81a87844e592f2fa6dd60732116c6&iv=a12c03ce123a8fe1a61e2716&tag=7821f758ccb184ced781f72a636336b1&version=1",
+						"publicKey": "5f6cc5a8aac752d37c676b0d46a798f7625e37dfa1e96091983274e04ab7ffe2"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=cbe9a35e3937d74fa32ac74cf2e14447&cipherText=8931bfe1e34610f9a3988e8eea2edf664f77c4f02716d8c7bb194af2ce3c54466a471ab4330f0c7c9b3f91a74706de80a9d404ed8ba309103aa69b3b50f172f000d9477215d237390708c13e8321f44247db&iv=2400b3a0a1e696a5461e9502&tag=54fc8f113ad3d230d66c7b4c17bea1cd&version=1",
+						"publicKey": "9c16751dbe57f4dff7b3fb8911a62c0cb2bdee6240e3f3fefe76832788cb14c6"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=d054673cf97d5d7a267b98a82734b58b&cipherText=01cf72b38a57eb32077d04e0daa3bb330d5a7741918ade08c9ea61b964e1670a857737263764b69264c08fcf5acbf68a090049b432e366dd1a3dd29c558b53cfd579ac152c389cc2c513d9&iv=389b6bd34b241a2b625a6632&tag=6c95d50d7424e0995588bb2858322302&version=1",
+						"publicKey": "ba2ea5e324eeb42fa6f4d1132a1d79911721e8507033bb0abd49715f531877b4"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=c87959c78b550f774ff56a88cf06fb14&cipherText=df75fa311c3caab3cf027ad32ffc4ca31d6652a05eafd9209b53f39bf4440fb7fc58dccf9cfa8c8a58bbf58cfc32345ba13d3a10474d11d1f243541de0468e305e368c2daa378c57720a18e043c5&iv=f1959655c6052c78f1c8f7d8&tag=bea0c2e220de55915c164eb9695fd120&version=1",
+						"publicKey": "0186d6cbee0c9b1a9783e7202f57fc234b1d98197ada1cc29cfbdf697a636ef1"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=a508647cae0806d3d7d37e2f37ccb1ff&cipherText=265d567e4506e4628786e969b3db714659fd5b3e40c38b76e215745d085c5a09fca28921a82f2804b7e435aa61759b0747da87127ac977e81a9716485632faef401a0011312669&iv=d64ed7f9ab06f54773270bea&tag=ee00e9b550022c5f8ac56addf164cd4c&version=1",
+						"publicKey": "edbb9828fbe62da2a59afbc8623e8ebc5ed2f9b7f77a0cd1cdcf55edea30521c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=b6808c9981c9e1dff5110e74906c5e77&cipherText=0845692afa36d2ab6b9d70fa9373e5e10abde0ba68e4243497a82f5425bd8f080d8f0dfb5d006717ce9a523d6fa6187e9b31922808a959bfd4f8224d3a66a5419994188c81&iv=fefc72917d444208e0b084d0&tag=dc5d907706f0e5e5c61b874d12c63afa&version=1",
+						"publicKey": "b6ac700bf890b887e218dbd55b8f6b091dfc5a684d0fd7a6f69db7dc0313b51b"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=339035d16186e2c8429c94a98b86e082&cipherText=925d71a68299cbaf34a8e5674941fb151b2e41fcf0a883b87d39ab0fcb33e373f3f5916f32d13bf1252d7ca9bc0f52d2c88c5bfd9193b8201200236293a0b3e3b6f4e5b1f00ef879c48295e5663b&iv=ced10155acda4c38917f8612&tag=f429e5e236d1340815335ce78f873be6&version=1",
+						"publicKey": "62bbb3c41e43df73de2c3f87e6577d095b84cf6deb1b2d6e87612a9156b980f8"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=518c8e1cfb161ff26a7e90a759f95bd1&cipherText=d4b68bcecc06d7f13d1d1de827c947da0614f1493bf8c34513f7aff0010ca6415b9e1edf0fea4e97327bba585bee4e77432e9e6b41d6833f53293e342b7aca7e0b8be6dc1fea1792fa555d5df3&iv=1bbbedc9172edee4aeaab870&tag=1c5d3b59cdec7cb9b51fe2d87e552064&version=1",
+						"publicKey": "6fb2e0882cd9d895e1e441b9f9be7f98e877aa0a16ae230ee5caceb7a1b896ae"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=b40a17b5772764025fd402314fd45e7e&cipherText=743f505ca60034b38c8eabbd2fba017c1594104ebb2a63b86f896f4c46bc0cc9e52726cf2a569e3001dd4c5c434efe0a63e8598416f814ab81538138719efcfd81d7eda79f5ce62e6605&iv=8eeab0a56fcf071042a31ed5&tag=32c63216decf52b2a19a930123188eaa&version=1",
+						"publicKey": "9a0f19e60581003b70291cf4a874e8217b04871e676b2c53c85a18ab95c2683b"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=704ebe0aea30e97ab6a596fe6f1f6779&cipherText=ed558f2abf56ca63436e563652f59769d0bd4b5d815a6218bb34f2bf6467d19d886964eb7cabf0ae7cad2897013b3f07eefccff89bde11a2563dce9751b225db56b963426618f97cd2dfc023&iv=03eb521cef9580fb9ce331c5&tag=7da92f746d76a418b369486622f94eb8&version=1",
+						"publicKey": "1e6ce18addd973ad432f05f16a4c86372eaca054cbdbcaf1169ad6df033f6b85"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=aa449e199e3a365ac51f904dc6b8754f&cipherText=59d3b7244952df622e6bb764a47b6de81798e868274a2ef4df6497b0321cc2af5a95cac80f5e174b0164a53012dc5a531adbe0b576382b30268f1378fa63459b9d2ef9252f2489e41ec6003748cdd4&iv=29c0762f4763a691c99cdcd5&tag=3dd75f79ff50748f5f6acf63d1760d19&version=1",
+						"publicKey": "27f43391cca75cbc82d1750307649508d1d318cd015f1f172b97318f17ab954e"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=b6d04450c128d5c33a02d0c7d0755e1a&cipherText=900d1ce6a2990bf7cc13aa40248adfbb42d7c4aa25c7a5e181d0da5d267c6288c5d814b185c4b7a9786a4a88f652a7c682ac924ef6122f4b61d0061ff6ee55df2576202175ca91aa42580c56b552aa&iv=d8d96d7448171cf4219fb6d8&tag=584ac53a5cf715170c00a17247129154&version=1",
+						"publicKey": "644a971f2c0d0d4b657d050fca27e5f9265e3dfa02a71f7fbf834cc2f2a6a4c8"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=8a156c0a45b17593afd1ce32b8b67d82&cipherText=79f1450e6cdbfe2700bbac0d9e366e16b16530f98e6276f766ba362cc37b37b0ba27d9c2096f3d698b07b245eb4fcad8567ed16631417dcdb891936404f3262a34f2b43c014722&iv=ab8869df3859a886c68d495c&tag=2c98f190e358bde2d2f2f803f058375c&version=1",
+						"publicKey": "cdd68a321ea737e82bce23d2208040f79471d36f2e6f84c74ea36ab26245e522"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=c02b665cd8ad74b57b1bba2409fcdaf6&cipherText=062649146024f6f99dbfb232cca9e0bd48c12c22a9d3542c318587ea593f51f9f6252d49262ff35b49bcb33657b452830020f0a152c56f907bc7f602efe5cc839100ba9c31ab388f085def7ff1&iv=38297d560779f8cccf81a4d5&tag=07ad0e084938726d36735dd2d1d11c22&version=1",
+						"publicKey": "f9f6ff873c10c24eba834be28a56415a49c9c67b7c0ee9f106da827847168986"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=8c599d465e68a296e717ac3b4cbb41be&cipherText=3b4f50abbfb8156a2ae4780297105b2f16b26fd64c16df91edba708b75497ff4621a6bce83b482ebb7c369d8ac036d3c4717c637e32c814b924aa79107c5f2a4380b118171df06d7cb9f8ca672&iv=2526cdfd00f9529c42c4ecd3&tag=8d23d6107d3477882b66eda3880563df&version=1",
+						"publicKey": "fab7b58be4c1e9542c342023b52e9d359ea89a3af34440bdb97318273e8555f0"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=f0bbde4047756108ffb104ca6c60e458&cipherText=a0efeab22fd697c1602c8268383cdf1baa70cee2fac0b438042bb57ac71840e1aca4571d8bee459887b6dc5c9d31ef705b4e6e9af6f29e49da27d77fe8e4651acc8c2f660dd3f4032e6083872c0f8a1b52&iv=18248b0322a1afa013441cdf&tag=a4b95cf943a964d1461528d98296b0c2&version=1",
+						"publicKey": "1b5a93c7622c666b0228236a70ee1a31407828b71bfb6daaa29a1509e87d4d3c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=38c91aac2d37393e312446b5fd810af0&cipherText=e79d28b2db845d2695a3ec67c78730edef016609ccde3c755d850fd0045fecb053560b6ed11a312446bb74ca501f3197aeb690727fb4c7f3b51793a78b721150364f36992d96536dc2da6af3aef1c36af9&iv=287b20a642f82adc09b09210&tag=00921b0029841e13d8faa5cb5f689632&version=1",
+						"publicKey": "74583aba9c0b92e4f08c8c75e6df341c255ca007971195ff64d6f909dc4b7177"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=53cbf32de2ba5dc749806d767a807425&cipherText=d8025cc04e58e539f21bf9957d58280ec6d79926418529a9440946fd09e85e1903cb18ba4135af23ff073a2ed667166b981ee84099395d36c2bae494b14dda73837bd7fc81d0951abbf09b0efb36c74b4ec8&iv=d01cc5c55158b6a21f9a45f5&tag=bfeb0d0ac406a8db5b89454c5627d412&version=1",
+						"publicKey": "2b6f49383af36fd9f1a72d5d2708c8c354add89aaea7edc702c420e2d5fdf22e"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=4a2cf7b2fca333f2a83e454921e5e6e1&cipherText=ecfe886b0b9ccf24b78aacf90a3db73bc94c6f48394d40cb4c9653b19b2ef082198de4985095bd4da7a1c71b0d47a218ede998ec1816a461ae5fd1e472f51821248b5fbd220d18e2&iv=6488a4ec2d94807456c202d1&tag=e13c9449f7f16b56585943811ad60b1a&version=1",
+						"publicKey": "a10ed9c59dac2c4b8264dc34f2d318719fb5f20ecdd8d6be2d7abfe32294f20d"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=9a83ed73e72d80683c68517ebbd74ffb&cipherText=c2a506b28aae8003f1f4628ff13e50195e38609b93f67d3d1b6aff3df4443cbfd8a78c5b86bfdfb1c077704fdc03a6c6af86fbd2b943c69f27fe4eee2d7a66f41667ef7dbb92ce2201f3d6&iv=6c391a12c1a347531bdbad1a&tag=c77b73c0a823bd0c8b44e044f03cd6bf&version=1",
+						"publicKey": "c61d0822bbdbfe2a0b5503daff0ce8441c623115c94c0cfcf047a51f8b7160d3"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=4d32588230fe24c29b46ee6a69fa8a05&cipherText=e15fff113b67fb58938cce887f8c212efea3232be33036a5a51051ad2fa5047c3b69e18130b2b13f47d3accd364b4048a80a93b2ed1f3fb170200ab4f68e0f8b7018e20e3e5a713650&iv=88551c8f576c4202457fae99&tag=481e0ccd62ef37d74fe2551d94948313&version=1",
+						"publicKey": "031e27beab583e2c94cb3167d128fc1a356c1ae88adfcfaa2334abffa3ae0b4c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=05d58ec3fb72e6064ceee652ef82cba2&cipherText=650df8fe07c1bb5e2fc151b315a0fc41082792724ae3870d2b0e7e3ae9999446f7ffff4e604f63bcf100619289d63f717b5dbf0d1e2e1bf0a81f50bb4bf048e83a57b7d71ac454063fc65b519c520b&iv=6a08abc3e3cd3b3d78769e55&tag=4223f77742c7591dd3bcbeb83cba22db&version=1",
+						"publicKey": "9986cedd4b5a28e4c81d9b4bff0461dddaa25099df00b8632fe99e88df28ce73"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=33e01f2a5eae51dcc68804011f4e0a38&cipherText=a975f6579f3fec3edf90822c2124a39dc795a7202265952070edb4f1cc51ac940ea5ec9eef37440cd894adab1eb58806a5a3b7e2f2d317e7129295e1a767e9823eae969e44fa874ff07c069863&iv=f2b12a3ec75f0df57e5d6341&tag=4949ff98991190b46b00165699d4a1dd&version=1",
+						"publicKey": "03e811dda4f51323ac712cd12299410830d655ddffb104f2c9974d90bf8c583a"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=486d3b1defbc7d6d6c37638ee5ea6569&cipherText=d4baaca2015ad4ca5db76fe480d1702eb7e74eb0ccf424a70ad8bdf55cc92dde0d3629c11d1e51155cec5de01dc188a1b7dfa54f6caf3ef9096635656750a184560da9d3014b263321&iv=e205eeb8fad5cbfd88a93956&tag=78535732ed58820d88bcccc751856fb6&version=1",
+						"publicKey": "64db2bce729e302f6021047dfd39b6c53caf83b42da4b5b881cb153a3fb31613"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=8aa88242899ee5caff298c1f93d43e01&cipherText=c9f4c33135d1f1dc5b75beba15ef3c7f80c14cfd1cdcd70bb3558bbcb612b5c25767f767e6d97a581dfe0973b6c0df7799b6ab77d5f2d804faf84322b044d2f9f9270ce5bfd9000beb7e7cd43729916f&iv=96df8361844d264593868c9e&tag=2795ab674a866097350f51cd426dbd5b&version=1",
+						"publicKey": "f827f60366fae9f9ed65384979de780f4a18c6dbfbefb1c7d100957dde51a06d"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=374488d4b8e9a2d100301442d2551684&cipherText=574ecfa10533785aac2a3a2c24a0608fae098684db92a62d484338bd86876574cf9edc1d69fd5fd512a1cd03c1985b5ab8ff4f5aa516a8d748ffc78de3ddb774c956db111479fac3d205&iv=45cf3ebd827b01ae0afe96d8&tag=8ce723621842f6c496dfd0af38b93b58&version=1",
+						"publicKey": "68680ca0bcd4676489976837edeac305c34f652e970386013ef26e67589a2516"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=bc362de5931227ddd1694143a5347c23&cipherText=e0e69439818bf8e0397b21b23486719e723662cf3b616c14d6d7882fb8df07aa63554f32ca1d49f1a6bcfc20e8028a3a2b121b949644be737d1fbf8d31b504c1caf07dfbe2a9cf068d5143&iv=d1500f108fd8e8f1ee682bb7&tag=f5012b5e537a48bbe6f9b75986399cae&version=1",
+						"publicKey": "f25af3c59ac7f5155c7a9f36762bd941b9dc9c5c051a1bc2d4e34ed773dd04a3"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=ca480bf56db36e804d9ec0f704a2e6fd&cipherText=440f411e65c6e98117ef9880300e9b1884127d7a621e97313f5880ed574da4a4e6fa9c072ced0ec951b0e63e0d53c30115fbc8fe86099b453a871ae695d25047250b5a400f5944a0d1c09f06&iv=d3ee6fed699c5f7e5585cb0d&tag=c35d3497742c5e88b75be519aa5a7db0&version=1",
+						"publicKey": "d3e3c8348bca51461eabfc382f8a01e8e284db54104ad37ec0695d48ae5531ac"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=857b679c3c7c665f68ea8c9473165ec6&cipherText=691c58def5a6b90eb711e46f368494cd0e922f9763fe57e5334e9c503f90d643c12a9dc11ebe6a8ee82610270be6717c66756a433af555b827477d7b3623cd69973329a113bcfca2968c027536ac74&iv=e012b3d0f273f517928a3f3f&tag=5516714ebd8e4d28fed654fc84567b02&version=1",
+						"publicKey": "3be2eb47134d5158e5f7d52076b624b76744b3fba8aa50791b46ba21408524c9"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=53e87bce5fad02924b1e5358394133bf&cipherText=df0dd2802eda7c1b784fe19d21ffa27471ad3f7d23a8aa789b358b4b3b20f6d751347b8ce1ee965694c4d55f5546ea056aa904af1760400b7947b41791bd448fd891ce9f81dd8653eba3e2f5bcb04c43388e1d&iv=c36905de665a29449e63e43f&tag=d6d559f2145905ff2801e23926d00d7c&version=1",
+						"publicKey": "9f2fcc688518324273da230afff9756312bf23592174896fab669c2d78b1533c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=c7ab21a4c20be6f7eb531a29ac57d8b3&cipherText=3e91fe16e0c1a5e4dbb0bd2c799f86b642ac804ceeb2495482bab451533a4b4e9a31a847717a156b04def2287b15057ce58340b6b72d72243976371e54f58489e4ed0d51d1d3b6dcd5&iv=7ef6d719ca38cf67586d2395&tag=c88bf424d4992b62f18865fc3cdc0186&version=1",
+						"publicKey": "e818ac2e8e9ffacd2d49f0f2f6739e16711644194d10bb1a8e9e434603125fa1"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=2a4dea763f1beef3a21232c479db608e&cipherText=de3c09c3c4371a5bf789a3d84fa6899983e997834ed031729d67a9d8ee65645ba6c6640889570d67ef2b112a59bcad177f7ca41afd8898161df087cdb69ea85c271a070c6d21204f87d29c8d9338&iv=84d01bcc98887a93f8217ce1&tag=980a03c0157ed55afd45e2a2953499fb&version=1",
+						"publicKey": "19d55c023d85d6061d1e196fa440a50907878e2d425bcd893366fa04bc23b4de"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=f73d7957fe08ca767a99ae14383ea09c&cipherText=7ba7714c7c3af6771b389ab94c798331cee6fb14061f88feecd63340648b36632f36c3134e50c3f0ecd6cc66283815961ff17148b348969c3c2c23832b7bcedb0a4522e60e5e539830cec11b8cf0&iv=aa597247d51d12f14e75d931&tag=20151849124856647123819addee4f60&version=1",
+						"publicKey": "6d462852d410e84ca199a34d7ccad443784471f22cf3de37c531ce3b87ebbc41"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=83cf709ba6c751b4c8ff910926f61292&cipherText=c04fbe4ecbf7f4515efc496fcbbfce97926086f866ef1fbbf054ae16eca19d3b5e5f6189e0a31b1bf6ee60e97fd60b4d0dffdd740485c062d3ea04e26520996838d6837ec962c20e7d13883d&iv=21421f8153872e6344da540a&tag=cccab6353d4995539df7fc4fa2af93cf&version=1",
+						"publicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=7fbf1eb7596ee0477b9f080b74c61e6c&cipherText=be85bb77db114f35003e3671bdbf3ac4c22ca2ef9d6d3eb0de44725e7514d74474fe8171b462a35706891e5c795ea77a7d29c48fe6f32b5202b4babaaa99e8dd1fc856ffa5&iv=5130a498faa50a56f6c139d5&tag=02fafcf87c2038710eac3d5990e9d34d&version=1",
+						"publicKey": "0779ca873bbda77f2850965c8a3a3d40a6ee4ec56af55f0a3f16c7c34c0f298b"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=6874a535bd829db89422ee2ddebe0116&cipherText=edf81a2dd5af543647779437676e102aeb6d6bbe24e21ae727a8c7334976b260edf737b546975284bf6fa25f5f77b225f73449b4465f7bdf9acdb496cf4e0be166ce6aacb72067&iv=b913cf639e33078eb4ca5cb3&tag=ce50bf56298fd5af2a0852da21490436&version=1",
+						"publicKey": "73fec19d4bfe361c0680a7cfd24b3f744a1c1b29d932c4d89ce6157679f8af7d"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=15a89895c161b6e2d2e9f9e0c36700c9&cipherText=ed54749efddfdcc036886f8ecac0356be0b052e9a8f389cfcc3df25a2bf15f5c38d1fdf93b843c91c98d00f6784b287f99f87e3663e749b920ecebc98a5eff7e01be73c8b5166652434fc4f6ecf25a94636a52bb&iv=2a0f9ccca3ef150a30b31fc5&tag=e8655a27a74086f83a4f302e8101b919&version=1",
+						"publicKey": "1e82c7db09da2010e7f5fef24d83bc46238a20ef7ecdf12d9f32e4318a818777"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=0954538d2d8b0c8a60499ee64f046944&cipherText=3162493e9b78cabf8f112d5c67dce64e7f99e4bcd3fa9ba5453f40369710b3dc2317e6cc029d245da6a84074b9571795d08b5103692bdcbf25af3ffe0309f853f9e84bbc9e972deb97&iv=6cafa832ffe25b01b876ff37&tag=645f3a69c45e7717a163decbdc316c39&version=1",
+						"publicKey": "e42bfabc4a61f02131760af5f2fa0311007932a819a508da25f2ce6af2468156"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=a2f8c2d2aaf96e1294a123e89708eb00&cipherText=6d4b4c961c6f257ca34c138b6a7db5f32920974f758ab01a5e88b2885b202a4663908e781d4d77fd0facb26714fdbe6f6463d28eb56ecc69c566d5eea4f8aefd3e05d8aca093241535c758cd&iv=5d2bcb9a15cb39d4e42f118a&tag=7847d9c8ca2c03d7d3a330c5dc683433&version=1",
+						"publicKey": "bf9f5cfc548d29983cc0dfa5c4ec47c66c31df0f87aa669869678996902ab47f"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=963146476f4335872b779d20d412d3a3&cipherText=549f70be28042a21040a6828c52e507fc9060d09b198cb4d81450a4bf8fa878b315e3d3ceab8c72c827e483f0d4e733488a36836aed1a73976052cccdd76a85d13170e6f583540e4ae&iv=bc9d381d382238feca2cf68c&tag=c1202d91e3d514f240812955e06bf920&version=1",
+						"publicKey": "b137de324fcc79dd1a21ae39a2ee8eed05e76b86d8e89d378f8bb766afb8719f"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=ba493d579d9092e33a98a5b429968541&cipherText=d1f8100fada59023c146349db6570b6a809d395f3fbaf6aa91f4f11a6cb5efe2264be17f48a256bb5fa5d1549eab1e5b791bcf788df7efd20172f80339318f41fe4bd9859acaf1a91f27082e1d&iv=6482ff7d017b3e0573041968&tag=af62ae0dbc6223cebcfc3a6ee8e55690&version=1",
+						"publicKey": "31402977c7eaf9e38d18d0689a45d719d615de941f7e80f6db388453b46f4df5"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=4dc16441d680218997c8d0e395b55874&cipherText=eb2cbc80d41db3e4e50bf0e3216b47a401d98f88796eb0c83e07c85fd3eea74d38e2051497e331045858bb50beaf7e26e73026d92f6ef33163022592c1052889942227fe959f02e1ab556f&iv=28f660848a500d14ca07d993&tag=de53946ce4ff4901512caae0c3e69302&version=1",
+						"publicKey": "f62062b7590d46f382fb8c37a26ab0a1bd512951777aedcaa96822230727d3a1"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=4ba0d3869948e39a7f9a096679674655&cipherText=f0a1f0009ded34c79a0af40f12fcf35071a88de0778abea2a1f07861386a4b5c6b13f308f1ebf1af9098b66ed77cb22fc8bd872fa71ff71f3dbed1194928b7e447cb4089359a8be64093f9c1c8a3dca8&iv=e0f1fb7574873142c672a565&tag=ad56e67c5115e9a211c3907c400b9458&version=1",
+						"publicKey": "76c9494237e608d43fd6fb0114106a7517f5503cf79d7482db58a02304339b6c"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=df1895b701abe3dcf29b4d92fc46d3f9&cipherText=0cea5e7df167d98203a679a4bf33e90f2e79a61d78443752014fc99a45c794e6fd7feaf710d89363cd954e51592917e77a2b8918ac680b0a0aa19003b34fa0b34dbd55ff9a8b59f98d9abdcbae970d72949b67&iv=61dc8fe3468f3b959f997f73&tag=33e7c771a90b10a0bb78f70cc72f701c&version=1",
+						"publicKey": "addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9"
+					},
+					{
+						"encryptedPassphrase": "iterations=1&salt=7ea547604c978413b57cec9cbbe091c1&cipherText=f337705e4a7987fe83c0aaf3bb45931cbf9a4973201849493612e08f59c87682d68303d9370f9c8e7190ef8d370a4b88b874aa6c052f3ec5111b18078aa91788351126c100fafb&iv=214dfb8da1a51a83bf1fa09d&tag=56ae2bd0357cdeebc8e3166da13a8d50&version=1",
+						"publicKey": "904c294899819cce0283d8d351cb10febfa0e9f0acd90a820ec8eb90a7084c37"
+					}
+				],
+				"defaultPassword": "elephant tree paris dragon chair galaxy"
+			},
+			"broadcasts": {
+				"active": true,
+				"broadcastInterval": 5000,
+				"releaseLimit": 25,
+				"relayLimit": 3
+			},
+			"transactions": {
+				"maxTransactionsPerQueue": 1000
+			},
+			"syncing": {
+				"active": true
+			},
+			"loading": {
+				"loadPerIteration": 5000,
+				"rebuildUpToRound": null
+			},
+			"exceptions": {
+				"blockRewards": [],
+				"senderPublicKey": [],
+				"signatures": [],
+				"signSignature": [],
+				"multisignatures": [],
+				"votes": [],
+				"inertTransactions": [],
+				"rounds": {},
+				"precedent": {
+					"disableDappTransfer": 0,
+					"disableDappTransaction": 0
+				},
+				"ignoreDelegateListCacheForRounds": [],
+				"blockVersions": {},
+				"roundVotes": [],
+				"recipientLeadingZero": {},
+				"recipientExceedingUint64": {},
+				"duplicatedSignatures": {},
+				"transactionWithNullByte": []
+			}
+		},
+		"network": {
+			"wsPort": 5000,
+			"address": "0.0.0.0",
+			"discoveryInterval": 30000,
+			"seedPeers": [
+				{
+					"ip": "127.0.0.1",
+					"wsPort": 5000
+				}
+			],
+			"blacklistedPeers": [],
+			"ackTimeout": 20000,
+			"connectTimeout": 5000,
+			"wsEngine": "ws",
+			"emitPeerLimit": 25
+		}
+	}
+}

--- a/sdk/src/samples/config_devnet.json
+++ b/sdk/src/samples/config_devnet.json
@@ -6,6 +6,22 @@
 		"protocolVersion": "1.1",
 		"ipc": {
 			"enabled": true
+		},
+		"genesisConfig": {
+			"EPOCH_TIME": "2016-05-24T17:00:00.000Z",
+			"BLOCK_TIME": 10,
+			"MAX_TRANSACTIONS_PER_BLOCK": 25,
+			"REWARDS": {
+				"MILESTONES": [
+					"500000000",
+					"400000000",
+					"300000000",
+					"200000000",
+					"100000000"
+				],
+				"OFFSET": 2160,
+				"DISTANCE": 3000000
+			}
 		}
 	},
 	"components": {

--- a/sdk/src/samples/index.js
+++ b/sdk/src/samples/index.js
@@ -1,5 +1,7 @@
 const genesisBlockDevnet = require('./genesis_block_devnet');
+const configDevnet = require('./config_devnet');
 
 module.exports = {
+	configDevnet,
 	genesisBlockDevnet,
 };


### PR DESCRIPTION
### What was the problem?
Each time I start an application created using Alpha SDK I need to specify the full set of delegates in the entry file of a project. 
### How did I fix it?

- Create a devnet genesis block containing all possible defaults 
- Assign chain default configuration using devnet sample 
- Assign http_api default configuration using devnet sample 
- Assign network default configuration using devnet sample
- Assign components defaults configuration using devnet sample

### How to test it?
Start a sample app and verify whether the "Forgin enabled" logs are there.
### Review checklist

* The PR resolves #3734 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
