### PR TITLE
Fix failure to generate block within delegate slot due to Inadequate broadhash consensus - Closes #3687 & #3682

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -216,6 +216,7 @@ export class P2P extends EventEmitter {
 		this._handlePeerInfoUpdate = (peerInfo: P2PDiscoveredPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
 			const foundTriedPeer = this._triedPeers.get(peerId);
+			const foundNewPeer = this._newPeers.get(peerId);
 
 			if (foundTriedPeer) {
 				const updatedPeerInfo = {
@@ -224,6 +225,15 @@ export class P2P extends EventEmitter {
 					wsPort: foundTriedPeer.wsPort,
 				};
 				this._triedPeers.set(peerId, updatedPeerInfo);
+			}
+
+			if (foundNewPeer) {
+				const updatedPeerInfo = {
+					...peerInfo,
+					ipAddress: foundNewPeer.ipAddress,
+					wsPort: foundNewPeer.wsPort,
+				};
+				this._newPeers.set(peerId, updatedPeerInfo);
 			}
 
 			// Re-emit the message to allow it to bubble up the class hierarchy.
@@ -279,7 +289,10 @@ export class P2P extends EventEmitter {
 			peerSelectionForConnection: config.peerSelectionForConnection
 				? config.peerSelectionForConnection
 				: selectPeersForConnection,
-			sendPeerLimit: config.sendPeerLimit === undefined ? DEFAULT_SEND_PEER_LIMIT : config.sendPeerLimit,
+			sendPeerLimit:
+				config.sendPeerLimit === undefined
+					? DEFAULT_SEND_PEER_LIMIT
+					: config.sendPeerLimit,
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/validation.ts
+++ b/elements/lisk-p2p/src/validation.ts
@@ -81,9 +81,7 @@ export const validatePeerInfo = (
 			? +protocolPeer.height
 			: 0;
 	const { options, ...protocolPeerWithoutOptions } = protocolPeer;
-
 	const peerInfo: P2PDiscoveredPeerInfo = {
-		...(options as object),
 		...protocolPeerWithoutOptions,
 		ipAddress: protocolPeerWithoutOptions.ip,
 		wsPort,

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -626,6 +626,179 @@
 				"methods": "^1.1.2"
 			}
 		},
+		"@opencensus/core": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.9.tgz",
+			"integrity": "sha512-31Q4VWtbzXpVUd2m9JS6HEaPjlKvNMOiF7lWKNmXF84yUcgfAFL5re7/hjDmdyQbOp32oGc+RFV78jXIldVz6Q==",
+			"dev": true,
+			"requires": {
+				"continuation-local-storage": "^3.2.1",
+				"log-driver": "^1.2.7",
+				"semver": "^5.5.0",
+				"shimmer": "^1.2.0",
+				"uuid": "^3.2.1"
+			}
+		},
+		"@opencensus/propagation-b3": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/@opencensus/propagation-b3/-/propagation-b3-0.0.8.tgz",
+			"integrity": "sha512-PffXX2AL8Sh0VHQ52jJC4u3T0H6wDK6N/4bg7xh4ngMYOIi13aR1kzVvX1sVDBgfGwDOkMbl4c54Xm3tlPx/+A==",
+			"dev": true,
+			"requires": {
+				"@opencensus/core": "^0.0.8",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"@opencensus/core": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.8.tgz",
+					"integrity": "sha512-yUFT59SFhGMYQgX0PhoTR0LBff2BEhPrD9io1jWfF/VDbakRfs6Pq60rjv0Z7iaTav5gQlttJCX2+VPxFWCuoQ==",
+					"dev": true,
+					"requires": {
+						"continuation-local-storage": "^3.2.1",
+						"log-driver": "^1.2.7",
+						"semver": "^5.5.0",
+						"shimmer": "^1.2.0",
+						"uuid": "^3.2.1"
+					}
+				}
+			}
+		},
+		"@pm2/agent": {
+			"version": "0.5.25",
+			"resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.25.tgz",
+			"integrity": "sha512-MeIPvxcWq2VTCDedF0jnLrvt4OIWWMTnXPsCLmPWp2oWG2OR3d6gLsrXCN1NO7Oo39LBjZbS5ckOaiBpJuqM9w==",
+			"dev": true,
+			"requires": {
+				"async": "^2.6.0",
+				"chalk": "^2.3.2",
+				"eventemitter2": "^5.0.1",
+				"fclone": "^1.0.11",
+				"moment": "^2.21.0",
+				"nssocket": "^0.6.0",
+				"pm2-axon": "^3.2.0",
+				"pm2-axon-rpc": "^0.5.0",
+				"proxy-agent": "^3.1.0",
+				"semver": "^5.5.0",
+				"ws": "^5.1.0"
+			}
+		},
+		"@pm2/agent-node": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@pm2/agent-node/-/agent-node-1.1.9.tgz",
+			"integrity": "sha512-DEtMFWr7B6uYl/8pxH3+q6hk+D1eavfeojDmkdk68w0s7CHb7pPDffkaRgRVPnl85Yw4i66IHYzLVb8NGy09lw==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.1.0",
+				"eventemitter2": "^5.0.1",
+				"proxy-agent": "^3.0.3",
+				"ws": "^6.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
+		"@pm2/io": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@pm2/io/-/io-4.2.1.tgz",
+			"integrity": "sha512-WoOqkWzXyH7ftpFFVVUT3YPosmvvVLfPMWTHY53HxVWEM8cALX63aAZLXneB4r76nK5bAaV5VEDE6fHpbDuQCw==",
+			"dev": true,
+			"requires": {
+				"@opencensus/core": "^0.0.9",
+				"@opencensus/propagation-b3": "^0.0.8",
+				"@pm2/agent-node": "~1.1.8",
+				"async": "~2.6.1",
+				"debug": "3.1.0",
+				"event-loop-inspector": "~1.2.0",
+				"eventemitter2": "~5.0.1",
+				"require-in-the-middle": "^4.0.0",
+				"semver": "5.5.0",
+				"shimmer": "~1.2.0",
+				"signal-exit": "3.0.2",
+				"tslib": "1.9.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+					"dev": true
+				}
+			}
+		},
+		"@pm2/js-api": {
+			"version": "0.5.57",
+			"resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.57.tgz",
+			"integrity": "sha512-sfD7+yWo2YHvnNWz+cYSHEI7p8O/bqsAtRylDxJSfhTljcUTH+nOvBAqrZoKEhkimcXoDPvFVEPgj2j2l7Jr6Q==",
+			"dev": true,
+			"requires": {
+				"async": "^2.4.1",
+				"axios": "^0.16.2",
+				"debug": "^2.6.8",
+				"eventemitter2": "^4.1.0",
+				"ws": "^3.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"eventemitter2": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
+					"integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
+					"dev": true
+				},
+				"ws": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
+					}
+				}
+			}
+		},
 		"@sailshq/lodash": {
 			"version": "3.10.3",
 			"resolved": "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.3.tgz",
@@ -712,6 +885,12 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
 			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "8.10.48",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.48.tgz",
+			"integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -1049,6 +1228,12 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
+		"ast-types": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.1.tgz",
+			"integrity": "sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ==",
+			"dev": true
+		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1063,10 +1248,26 @@
 				"lodash": "^4.17.10"
 			}
 		},
+		"async-each": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"dev": true
+		},
 		"async-limiter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
 			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+		},
+		"async-listener": {
+			"version": "0.6.10",
+			"resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+			"integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+			"dev": true,
+			"requires": {
+				"semver": "^5.3.0",
+				"shimmer": "^1.1.0"
+			}
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -1088,6 +1289,16 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+		},
+		"axios": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+			"integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
+			"dev": true,
+			"requires": {
+				"follow-redirects": "^1.2.3",
+				"is-buffer": "^1.1.5"
+			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -1459,6 +1670,12 @@
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
 			"integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw=="
 		},
+		"binary-extensions": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+			"dev": true
+		},
 		"bl": {
 			"version": "0.9.5",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
@@ -1494,6 +1711,12 @@
 				}
 			}
 		},
+		"blessed": {
+			"version": "0.1.81",
+			"resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
+			"integrity": "sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk=",
+			"dev": true
+		},
 		"blob": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -1503,6 +1726,12 @@
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
 			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+		},
+		"bodec": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
+			"integrity": "sha1-vIUVVUMPI8n3ZQp172TGqUw0GMw=",
+			"dev": true
 		},
 		"body-parser": {
 			"version": "1.18.3",
@@ -1864,11 +2093,37 @@
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 			"dev": true
 		},
+		"charm": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+			"integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY=",
+			"dev": true
+		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
 			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
 			"dev": true
+		},
+		"chokidar": {
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+			"integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+			"dev": true,
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.3",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^3.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
+			}
 		},
 		"ci-info": {
 			"version": "2.0.0",
@@ -1930,6 +2185,42 @@
 			"dev": true,
 			"requires": {
 				"restore-cursor": "^2.0.0"
+			}
+		},
+		"cli-table-redemption": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cli-table-redemption/-/cli-table-redemption-1.0.1.tgz",
+			"integrity": "sha512-SjVCciRyx01I4azo2K2rcc0NP/wOceXGzG1ZpYkEulbbIxDA/5YWv0oxG2HtQ4v8zPC6bgbRI7SbNaTZCxMNkg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				}
 			}
 		},
 		"cli-width": {
@@ -2172,6 +2463,16 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
 		},
+		"continuation-local-storage": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+			"integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+			"dev": true,
+			"requires": {
+				"async-listener": "^0.6.0",
+				"emitter-listener": "^1.1.1"
+			}
+		},
 		"convert-source-map": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -2290,6 +2591,15 @@
 				}
 			}
 		},
+		"cron": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/cron/-/cron-1.7.1.tgz",
+			"integrity": "sha512-gmMB/pJcqUVs/NklR1sCGlNYM7TizEw+1gebz20BMc/8bTm/r7QUp3ZPSPlG8Z5XRlvb7qhjEjq/+bdIfUCL2A==",
+			"dev": true,
+			"requires": {
+				"moment-timezone": "^0.5.x"
+			}
+		},
 		"cross-spawn": {
 			"version": "6.0.5",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2322,6 +2632,12 @@
 				"cssom": "0.3.x"
 			}
 		},
+		"culvert": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
+			"integrity": "sha1-lQL18BVKLVoioCPnn3HMk2+m728=",
+			"dev": true
+		},
 		"d": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -2336,6 +2652,15 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
 				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-uri-to-buffer": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.1.tgz",
+			"integrity": "sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^8.0.7"
 			}
 		},
 		"data-urls": {
@@ -2361,6 +2686,12 @@
 					}
 				}
 			}
+		},
+		"date-fns": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+			"dev": true
 		},
 		"debug": {
 			"version": "4.1.1",
@@ -2487,6 +2818,25 @@
 						"is-data-descriptor": "^1.0.0",
 						"kind-of": "^6.0.2"
 					}
+				}
+			}
+		},
+		"degenerator": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+			"integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+			"dev": true,
+			"requires": {
+				"ast-types": "0.x.x",
+				"escodegen": "1.x.x",
+				"esprima": "3.x.x"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
 				}
 			}
 		},
@@ -2670,6 +3020,15 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"emitter-listener": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+			"integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+			"dev": true,
+			"requires": {
+				"shimmer": "^1.2.0"
+			}
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -3257,6 +3616,12 @@
 				"es5-ext": "~0.10.14"
 			}
 		},
+		"event-loop-inspector": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/event-loop-inspector/-/event-loop-inspector-1.2.2.tgz",
+			"integrity": "sha512-v7OqIPmO0jqpmSH4Uc6IrY/H6lOidYzrXHE8vPHLDDOfV1Pw+yu+KEIE/AWnoFheWYlunZbxzKpZBAezVlrU9g==",
+			"dev": true
+		},
 		"eventemitter2": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
@@ -3615,6 +3980,12 @@
 				"bser": "^2.0.0"
 			}
 		},
+		"fclone": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
+			"integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=",
+			"dev": true
+		},
 		"figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -3633,6 +4004,12 @@
 				"flat-cache": "^1.2.1",
 				"object-assign": "^4.0.1"
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true
 		},
 		"filename-regex": {
 			"version": "2.0.1",
@@ -4408,6 +4785,42 @@
 				}
 			}
 		},
+		"ftp": {
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+			"integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "1.1.x",
+				"xregexp": "2.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
+			}
+		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4439,6 +4852,33 @@
 				"pump": "^3.0.0"
 			}
 		},
+		"get-uri": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.3.tgz",
+			"integrity": "sha512-x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==",
+			"dev": true,
+			"requires": {
+				"data-uri-to-buffer": "2",
+				"debug": "4",
+				"extend": "~3.0.2",
+				"file-uri-to-path": "1",
+				"ftp": "~0.3.10",
+				"readable-stream": "3"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -4452,6 +4892,18 @@
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
+		},
+		"git-node-fs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/git-node-fs/-/git-node-fs-1.0.0.tgz",
+			"integrity": "sha1-SbIV4kLr5Dqkx1Ybu6SZUhdSCA8=",
+			"dev": true
+		},
+		"git-sha1": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/git-sha1/-/git-sha1-0.1.2.tgz",
+			"integrity": "sha1-WZrBkrcYdYJeE6RF86bgURjC90U=",
+			"dev": true
 		},
 		"glob": {
 			"version": "6.0.4",
@@ -4498,6 +4950,27 @@
 					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
+					}
+				}
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"dev": true,
+			"requires": {
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.0"
 					}
 				}
 			}
@@ -4693,6 +5166,27 @@
 				"requires-port": "^1.0.0"
 			}
 		},
+		"http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
 		"http-server": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
@@ -4870,6 +5364,12 @@
 				}
 			}
 		},
+		"interpret": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+			"dev": true
+		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -4919,6 +5419,15 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
+		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"dev": true,
+			"requires": {
+				"binary-extensions": "^1.0.0"
+			}
 		},
 		"is-buffer": {
 			"version": "1.1.6",
@@ -5007,6 +5516,12 @@
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"dev": true
 		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
+		},
 		"is-finite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
@@ -5032,6 +5547,15 @@
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true
+		},
+		"is-glob": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
 		},
 		"is-lower-case": {
 			"version": "1.1.3",
@@ -6357,6 +6881,18 @@
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
 			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
 		},
+		"js-git": {
+			"version": "0.7.8",
+			"resolved": "https://registry.npmjs.org/js-git/-/js-git-0.7.8.tgz",
+			"integrity": "sha1-UvplWrYYd9bxB578ZTS1VPMeVEQ=",
+			"dev": true,
+			"requires": {
+				"bodec": "^0.1.0",
+				"culvert": "^0.1.2",
+				"git-sha1": "^0.1.2",
+				"pako": "^0.2.5"
+			}
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6750,6 +7286,12 @@
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
+		"lazy": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+			"integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=",
+			"dev": true
+		},
 		"lazystream": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
@@ -6870,6 +7412,18 @@
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
+		"lodash.findindex": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
+			"integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY=",
+			"dev": true
+		},
+		"lodash.foreach": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+			"dev": true
+		},
 		"lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -6914,6 +7468,12 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
 			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+			"dev": true
+		},
+		"lodash.last": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+			"integrity": "sha1-JC9mMRLdTG5jcoxgo8kJ0b2tvUw=",
 			"dev": true
 		},
 		"lodash.once": {
@@ -7402,11 +7962,26 @@
 				}
 			}
 		},
+		"module-details-from-path": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+			"integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=",
+			"dev": true
+		},
 		"moment": {
 			"version": "2.23.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
 			"integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==",
 			"dev": true
+		},
+		"moment-timezone": {
+			"version": "0.5.25",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
+			"integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
+			"dev": true,
+			"requires": {
+				"moment": ">= 2.9.0"
+			}
 		},
 		"ms": {
 			"version": "2.0.0",
@@ -7432,6 +8007,12 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
 			"integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
+		},
+		"mute-stream": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true
 		},
 		"mv": {
 			"version": "2.1.1",
@@ -7494,6 +8075,34 @@
 			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
 			"optional": true
 		},
+		"needle": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+			"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.2.6",
+				"iconv-lite": "^0.4.4",
+				"sax": "^1.2.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
 		"negotiator": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -7503,6 +8112,12 @@
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
 			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
+		"netmask": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
 			"dev": true
 		},
 		"newrelic": {
@@ -7665,12 +8280,36 @@
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
+		"normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
+		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"requires": {
 				"path-key": "^2.0.0"
+			}
+		},
+		"nssocket": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/nssocket/-/nssocket-0.6.0.tgz",
+			"integrity": "sha1-Wflvb/MhVm8zxw99vu7N/cBxVPo=",
+			"dev": true,
+			"requires": {
+				"eventemitter2": "~0.4.14",
+				"lazy": "~1.0.11"
+			},
+			"dependencies": {
+				"eventemitter2": {
+					"version": "0.4.14",
+					"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+					"integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+					"dev": true
+				}
 			}
 		},
 		"number-is-nan": {
@@ -7945,10 +8584,62 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 		},
+		"pac-proxy-agent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.0.tgz",
+			"integrity": "sha512-AOUX9jES/EkQX2zRz0AW7lSx9jD//hQS8wFXBvcnd/J2Py9KaMJMqV/LPqJssj1tgGufotb2mmopGPR15ODv1Q==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^4.2.0",
+				"debug": "^3.1.0",
+				"get-uri": "^2.0.0",
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1",
+				"pac-resolver": "^3.0.0",
+				"raw-body": "^2.2.0",
+				"socks-proxy-agent": "^4.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"pac-resolver": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
+			"integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+			"dev": true,
+			"requires": {
+				"co": "^4.6.0",
+				"degenerator": "^1.0.4",
+				"ip": "^1.1.5",
+				"netmask": "^1.0.6",
+				"thunkify": "^2.1.2"
+			}
+		},
 		"packet-reader": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
 			"integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
+		},
+		"pako": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+			"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+			"dev": true
 		},
 		"param-case": {
 			"version": "2.1.1",
@@ -8054,6 +8745,12 @@
 			"requires": {
 				"no-case": "^2.2.0"
 			}
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+			"dev": true
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -8190,6 +8887,15 @@
 				"split": "^1.0.0"
 			}
 		},
+		"pidusage": {
+			"version": "2.0.17",
+			"resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.17.tgz",
+			"integrity": "sha512-N8X5v18rBmlBoArfS83vrnD0gIFyZkXEo7a5pAS2aT0i2OLVymFb2AzVg+v8l/QcXnE1JwZcaXR8daJcoJqtjw==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.2"
+			}
+		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -8270,6 +8976,73 @@
 			"integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
 			"dev": true
 		},
+		"pm2": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/pm2/-/pm2-3.5.1.tgz",
+			"integrity": "sha512-pDPBetbI48JDynxmtSPNSKRDk/LRbhsHrJ/WSCKVD1TUNnb6XNMe6GzO7DCNijJBvdaQ+u1WxNudxqExlXdhEw==",
+			"dev": true,
+			"requires": {
+				"@pm2/agent": "^0.5.22",
+				"@pm2/io": "^4.1.2",
+				"@pm2/js-api": "^0.5.43",
+				"async": "^2.6.1",
+				"blessed": "^0.1.81",
+				"chalk": "^2.4.1",
+				"chokidar": "^2.0.4",
+				"cli-table-redemption": "^1.0.0",
+				"commander": "2.15.1",
+				"cron": "^1.3",
+				"date-fns": "^1.29.0",
+				"debug": "^3.1",
+				"eventemitter2": "5.0.1",
+				"fclone": "1.0.11",
+				"mkdirp": "0.5.1",
+				"moment": "^2.22.2",
+				"needle": "^2.2.1",
+				"pidusage": "^2.0.14",
+				"pm2-axon": "3.3.0",
+				"pm2-axon-rpc": "^0.5.1",
+				"pm2-deploy": "^0.4.0",
+				"pm2-multimeter": "^0.1.2",
+				"promptly": "^2",
+				"semver": "^5.5",
+				"shelljs": "~0.8.2",
+				"source-map-support": "^0.5.6",
+				"sprintf-js": "1.1.1",
+				"v8-compile-cache": "^2.0.0",
+				"vizion": "~2.0.2",
+				"yamljs": "^0.3.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.15.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"sprintf-js": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+					"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+					"dev": true
+				}
+			}
+		},
 		"pm2-axon": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-3.3.0.tgz",
@@ -8317,6 +9090,25 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
+			}
+		},
+		"pm2-deploy": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/pm2-deploy/-/pm2-deploy-0.4.0.tgz",
+			"integrity": "sha512-3BdCghcGwMKwl3ffHZhc+j5JY5dldH9nq8m/I9W5wehJuSRZIyO96VOgKTMv3hYp7Yk5E+2lRGm8WFNlp65vOA==",
+			"dev": true,
+			"requires": {
+				"async": "^2.6",
+				"tv4": "^1.3"
+			}
+		},
+		"pm2-multimeter": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/pm2-multimeter/-/pm2-multimeter-0.1.2.tgz",
+			"integrity": "sha1-Gh5VFT1BoFU0zqI8/oYKuqDrSs4=",
+			"dev": true,
+			"requires": {
+				"charm": "~0.1.1"
 			}
 		},
 		"pn": {
@@ -8442,6 +9234,15 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
+		"promptly": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
+			"integrity": "sha1-KhP6BjaIoqWYOxYf/wEIoH0m/HQ=",
+			"dev": true,
+			"requires": {
+				"read": "^1.0.4"
+			}
+		},
 		"prompts": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
@@ -8460,6 +9261,45 @@
 				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.9.0"
 			}
+		},
+		"proxy-agent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.0.tgz",
+			"integrity": "sha512-IkbZL4ClW3wwBL/ABFD2zJ8iP84CY0uKMvBPk/OceQe/cEjrxzN1pMHsLwhbzUoRhG9QbSxYC+Z7LBkTiBNvrA==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^4.2.0",
+				"debug": "^3.1.0",
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.1",
+				"lru-cache": "^4.1.2",
+				"pac-proxy-agent": "^3.0.0",
+				"proxy-from-env": "^1.0.0",
+				"socks-proxy-agent": "^4.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
 		},
 		"ps-list": {
 			"version": "6.1.0",
@@ -8579,6 +9419,15 @@
 			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
 			"dev": true
 		},
+		"read": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"dev": true,
+			"requires": {
+				"mute-stream": "~0.0.4"
+			}
+		},
 		"read-pkg": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -8659,6 +9508,17 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
+		"readdirp": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"realpath-native": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -8666,6 +9526,15 @@
 			"dev": true,
 			"requires": {
 				"util.promisify": "^1.0.0"
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "^1.1.6"
 			}
 		},
 		"redis": {
@@ -8813,6 +9682,17 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+		},
+		"require-in-the-middle": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-4.0.0.tgz",
+			"integrity": "sha512-GX12iFhCUzzNuIqvei0dTLUbBEjZ420KTY/MmDxe2GQKPDGyH/wgfGMWFABpnM/M6sLwC3IaSg8A95U6gIb+HQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.1",
+				"module-details-from-path": "^1.0.3",
+				"resolve": "^1.10.0"
+			}
 		},
 		"require-main-filename": {
 			"version": "2.0.0",
@@ -9493,10 +10373,43 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
+		"shelljs": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+			"integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
+		},
 		"shellwords": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
+		"shimmer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
 			"dev": true
 		},
 		"signal-exit": {
@@ -9546,6 +10459,12 @@
 				"astral-regex": "^1.0.0",
 				"is-fullwidth-code-point": "^2.0.0"
 			}
+		},
+		"smart-buffer": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+			"integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
+			"dev": true
 		},
 		"snake-case": {
 			"version": "2.1.0",
@@ -9909,6 +10828,26 @@
 						"async-limiter": "~1.0.0"
 					}
 				}
+			}
+		},
+		"socks": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+			"integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+			"dev": true,
+			"requires": {
+				"ip": "^1.1.5",
+				"smart-buffer": "4.0.2"
+			}
+		},
+		"socks-proxy-agent": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+			"integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "~4.2.1",
+				"socks": "~2.3.2"
 			}
 		},
 		"sodium-native": {
@@ -10651,6 +11590,12 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
+		"thunkify": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+			"integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
+			"dev": true
+		},
 		"timers-ext": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
@@ -10781,6 +11726,12 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"tv4": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+			"integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=",
+			"dev": true
+		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -10838,6 +11789,12 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
 			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+			"dev": true
+		},
+		"ultron": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
 			"dev": true
 		},
 		"underscore": {
@@ -10972,6 +11929,12 @@
 				}
 			}
 		},
+		"upath": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+			"integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+			"dev": true
+		},
 		"upper-case": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
@@ -11036,6 +11999,12 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
+		"v8-compile-cache": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+			"dev": true
+		},
 		"valid-url": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
@@ -11069,6 +12038,22 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			}
+		},
+		"vizion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/vizion/-/vizion-2.0.2.tgz",
+			"integrity": "sha512-UGDB/UdC1iyPkwyQaI9AFMwKcluQyD4FleEXObrlu254MEf16MV8l+AZdpFErY/iVKZVWlQ+OgJlVVJIdeMUYg==",
+			"dev": true,
+			"requires": {
+				"async": "2.6.1",
+				"git-node-fs": "^1.0.0",
+				"ini": "^1.3.4",
+				"js-git": "^0.7.8",
+				"lodash.findindex": "^4.6.0",
+				"lodash.foreach": "^4.5.0",
+				"lodash.get": "^4.4.2",
+				"lodash.last": "^3.0.0"
 			}
 		},
 		"w3c-hr-time": {
@@ -11239,6 +12224,12 @@
 			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
 			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
 		},
+		"xregexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+			"integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+			"dev": true
+		},
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -11254,6 +12245,32 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
 			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 			"dev": true
+		},
+		"yamljs": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+			"integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"glob": "^7.0.5"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
 		},
 		"yargs": {
 			"version": "13.2.2",

--- a/framework/package.json
+++ b/framework/package.json
@@ -122,6 +122,7 @@
 		"mocha": "5.2.0",
 		"moment": "2.23.0",
 		"node-mocks-http": "^1.7.3",
+		"pm2": "3.5.1",
 		"popsicle": "9.1.0",
 		"prettier": "1.16.4",
 		"rewire": "4.0.1",

--- a/framework/test/mocha/network/index.js
+++ b/framework/test/mocha/network/index.js
@@ -29,8 +29,7 @@ _.range(TOTAL_PEERS).map(index => {
 	return WSPORTS.push(5000 + index);
 });
 
-// eslint-disable-next-line
-describe.skip(`Start a network of ${TOTAL_PEERS} nodes with address "127.0.0.1", WS ports 500[0-9] and HTTP ports 400[0-9] using separate databases`, () => {
+describe(`Start a network of ${TOTAL_PEERS} nodes with address "127.0.0.1", WS ports 500[0-9] and HTTP ports 400[0-9] using separate databases`, () => {
 	const configurations = setup.config.generateLiskConfigs(TOTAL_PEERS);
 	const network = new Network(configurations);
 	const suiteFolder = 'test/mocha/network/scenarios/';

--- a/framework/test/mocha/network/network.js
+++ b/framework/test/mocha/network/network.js
@@ -424,7 +424,7 @@ class Network {
 	// eslint-disable-next-line class-methods-use-this
 	stopNode(nodeName) {
 		return new Promise((resolve, reject) => {
-			childProcess.exec(`node_modules/.bin/pm2 stop ${nodeName}`, err => {
+			childProcess.exec(`npx pm2 stop ${nodeName}`, err => {
 				if (err) {
 					return reject(
 						new Error(`Failed to stop node ${nodeName}: ${err.message || err}`)
@@ -437,7 +437,7 @@ class Network {
 
 	startNode(nodeName, waitForSync) {
 		let startPromise = new Promise((resolve, reject) => {
-			childProcess.exec(`node_modules/.bin/pm2 start ${nodeName}`, err => {
+			childProcess.exec(`npx pm2 start ${nodeName}`, err => {
 				if (err) {
 					return reject(
 						new Error(`Failed to start node ${nodeName}: ${err.message || err}`)
@@ -476,7 +476,7 @@ class Network {
 
 		await new Promise((resolve, reject) => {
 			childProcess.exec(
-				`node_modules/.bin/pm2 reload test/mocha/network/pm2.network.json --only ${nodeName}${update}`,
+				`npx pm2 reload test/mocha/network/pm2.network.json --only ${nodeName}${update}`,
 				err => {
 					if (err) {
 						return reject(

--- a/framework/test/mocha/network/network.js
+++ b/framework/test/mocha/network/network.js
@@ -25,7 +25,10 @@ const WAIT_BEFORE_CONNECT_MS = 20000;
 const getPeersStatus = peers => {
 	return Promise.all(
 		peers.map(peer => {
-			return utils.http.getNodeStatus(peer.httpPort, peer.ip);
+			return utils.http.getNodeStatus({
+				httpPort: peer.httpPort,
+				ip: peer.ip,
+			});
 		})
 	);
 };
@@ -338,10 +341,10 @@ class Network {
 			configuration.modules.chain.forging.delegates
 				.filter(() => !configuration.modules.chain.forging.force)
 				.map(keys => {
-					const enableForgingPromise = utils.http.enableForging(
+					const enableForgingPromise = utils.http.enableForging({
 						keys,
-						configuration.modules.http_api.httpPort
-					);
+						httPort: configuration.modules.http_api.httpPort,
+					});
 					return enableForgingPromises.push(enableForgingPromise);
 				});
 		});

--- a/framework/test/mocha/network/network.js
+++ b/framework/test/mocha/network/network.js
@@ -26,7 +26,7 @@ const getPeersStatus = peers => {
 	return Promise.all(
 		peers.map(peer => {
 			return utils.http.getNodeStatus({
-				httpPort: peer.httpPort,
+				port: peer.httpPort,
 				ip: peer.ip,
 			});
 		})
@@ -343,7 +343,7 @@ class Network {
 				.map(keys => {
 					const enableForgingPromise = utils.http.enableForging({
 						keys,
-						httPort: configuration.modules.http_api.httpPort,
+						port: configuration.modules.http_api.httpPort,
 					});
 					return enableForgingPromises.push(enableForgingPromise);
 				});
@@ -526,6 +526,18 @@ class Network {
 				};
 				return status;
 			});
+	}
+
+	async wait(number) {
+		this.logger.info(
+			`Waiting ${number /
+				(60 * 1000)} minute to check how many blocks are forged`
+		);
+		return new Promise(resolve => {
+			setTimeout(() => {
+				resolve();
+			}, number);
+		});
 	}
 }
 

--- a/framework/test/mocha/network/scenarios/propagation/blocks.js
+++ b/framework/test/mocha/network/scenarios/propagation/blocks.js
@@ -28,7 +28,7 @@ module.exports = function(configurations, network) {
 					return Promise.all(
 						configurations.map(configuration => {
 							return utils.http.getBlocks({
-								httPort: configuration.modules.http_api.httpPort,
+								port: configuration.modules.http_api.httpPort,
 							});
 						})
 					);
@@ -39,11 +39,11 @@ module.exports = function(configurations, network) {
 		});
 
 		it('should be able to get blocks list from every peer', async () => {
-			return expect(nodesBlocks).to.have.lengthOf(configurations.length);
+			expect(nodesBlocks).to.have.lengthOf(configurations.length);
 		});
 
 		it('should contain non empty blocks', async () => {
-			return nodesBlocks.map(blocks => {
+			nodesBlocks.map(blocks => {
 				return expect(blocks).to.be.an('array').and.not.to.be.empty;
 			});
 		});
@@ -53,16 +53,28 @@ module.exports = function(configurations, network) {
 				.map('length')
 				.uniq()
 				.value();
-			return expect(uniquePeersHeights).to.have.lengthOf.at.least(1);
+			expect(uniquePeersHeights).to.have.lengthOf.at.least(1);
 		});
 
 		it('should have all blocks the same at all peers', async () => {
 			const blocksFromOtherNodes = nodesBlocks.splice(1);
 			const blocksFromNode0 = nodesBlocks[0];
 
-			return blocksFromOtherNodes.map(blocksFromNode => {
+			blocksFromOtherNodes.map(blocksFromNode => {
 				return expect(blocksFromNode).to.include.deep.members(blocksFromNode0);
 			});
+		});
+
+		it('should forge 6 blocks within 1 minute', async () => {
+			const currentHeight = await utils.http.getHeight({
+				port: configurations[0].modules.http_api.httpPort,
+			});
+			const expectedHeight = currentHeight + 6;
+			await network.wait(60000);
+			const futureHeight = await utils.http.getHeight({
+				port: configurations[0].modules.http_api.httpPort,
+			});
+			expect(futureHeight).to.eql(expectedHeight);
 		});
 	});
 };

--- a/framework/test/mocha/network/scenarios/propagation/blocks.js
+++ b/framework/test/mocha/network/scenarios/propagation/blocks.js
@@ -27,9 +27,9 @@ module.exports = function(configurations, network) {
 				.then(() => {
 					return Promise.all(
 						configurations.map(configuration => {
-							return utils.http.getBlocks(
-								configuration.modules.http_api.httpPort
-							);
+							return utils.http.getBlocks({
+								httPort: configuration.modules.http_api.httpPort,
+							});
 						})
 					);
 				})

--- a/framework/test/mocha/network/scenarios/propagation/multisignatures.js
+++ b/framework/test/mocha/network/scenarios/propagation/multisignatures.js
@@ -39,8 +39,9 @@ module.exports = function(configurations, network) {
 		const signatures = [];
 		const numbers = _.range(numberOfTransactions);
 		// Adding two extra blocks as a safety timeframe
-		const blocksToWait =
-			Math.ceil(numberOfTransactions / MAX_TRANSACTIONS_PER_BLOCK) + 2;
+		const blocksToWait = Math.ceil(
+			numberOfTransactions / MAX_TRANSACTIONS_PER_BLOCK
+		);
 
 		const postSignatures = signature => {
 			const signaturesToPost = {

--- a/framework/test/mocha/network/scenarios/propagation/multisignatures.js
+++ b/framework/test/mocha/network/scenarios/propagation/multisignatures.js
@@ -19,14 +19,14 @@ const {
 	transfer,
 	registerMultisignature,
 } = require('@liskhq/lisk-transactions');
-const accountFixtures = require('../../../../../fixtures/accounts');
-const randomUtil = require('../../../../../common/utils/random');
+const accountFixtures = require('../../../fixtures/accounts');
+const randomUtil = require('../../../common/utils/random');
 const {
 	createSignatureObject,
 	sendTransactionPromise,
 	getPendingMultisignaturesPromise,
-} = require('../../../../../common/helpers/api');
-const confirmTransactionsOnAllNodes = require('../../../../utils/transactions')
+} = require('../../../common/helpers/api');
+const confirmTransactionsOnAllNodes = require('../../utils/transactions')
 	.confirmTransactionsOnAllNodes;
 
 const { MAX_TRANSACTIONS_PER_BLOCK } = __testContext.config.constants;

--- a/framework/test/mocha/network/setup/config.js
+++ b/framework/test/mocha/network/setup/config.js
@@ -63,13 +63,27 @@ const config = {
 			delete devConfigCopy.modules.http_api.genesisBlock;
 			delete devConfigCopy.modules.http_api.constants;
 			delete devConfigCopy.initialState;
+			delete devConfigCopy.modules.network.loadAsChildProcess;
+			delete devConfigCopy.modules.network.version;
+			delete devConfigCopy.modules.network.minVersion;
+			delete devConfigCopy.modules.network.protocolVersion;
+			delete devConfigCopy.modules.network.nethash;
+			delete devConfigCopy.modules.network.nonce;
+			delete devConfigCopy.modules.network.genesisBlock;
+			delete devConfigCopy.modules.network.constants;
+			delete devConfigCopy.modules.network.lastCommitId;
+			delete devConfigCopy.modules.network.buildVersion;
+			delete devConfigCopy.modules.network.access;
+			delete devConfigCopy.modules.network.list;
+			delete devConfigCopy.NORMALIZER;
+			delete devConfigCopy.ADDITIONAL_DATA;
+			delete devConfigCopy.MAX_VOTES_PER_TRANSACTION;
+			delete devConfigCopy.MULTISIG_CONSTRAINTS;
 
 			const wsPort = 5000 + index;
 			// TODO: Remove when p2p library automatically removes itself
 			devConfigCopy.modules.network.wsPort = wsPort;
-			devConfigCopy.modules.network.access = {
-				blackList: [{ ip: '127.0.0.1', wsPort }],
-			};
+
 			devConfigCopy.modules.http_api.httpPort = 4000 + index;
 			devConfigCopy.app.label = `lisk-devnet-${4000 + index}`;
 			devConfigCopy.components.logger.logFileName = `../logs/lisk_node_${index}.log`;
@@ -78,7 +92,7 @@ const config = {
 
 		// Generate peers for each node
 		configurations.forEach(configuration => {
-			configuration.modules.network.list = config.generatePeers(
+			configuration.modules.network.seedPeers = config.generatePeers(
 				configurations,
 				config.SYNC_MODES.ALL_TO_GROUP,
 				{

--- a/framework/test/mocha/network/setup/config.js
+++ b/framework/test/mocha/network/setup/config.js
@@ -150,8 +150,6 @@ const config = {
 					NODE_ENV: 'test',
 					CUSTOM_CONFIG_FILE: `test/mocha/network/configs/config.node-${index}.json`,
 				},
-				error_file: `test/mocha/network/logs/lisk-test-node-${index}.err.log`,
-				out_file: `test/mocha/network/logs/lisk-test-node-${index}.out.log`,
 				configuration,
 			});
 			return pm2Config;

--- a/framework/test/mocha/network/setup/shell.js
+++ b/framework/test/mocha/network/setup/shell.js
@@ -35,7 +35,7 @@ module.exports = {
 
 	launchTestNodes(cb) {
 		child_process.exec(
-			'node_modules/.bin/pm2 start test/mocha/network/pm2.network.json',
+			'npx pm2 start test/mocha/network/pm2.network.json',
 			err => {
 				return cb(err);
 			}
@@ -49,7 +49,7 @@ module.exports = {
 	},
 
 	killTestNodes(cb) {
-		child_process.exec('node_modules/.bin/pm2 kill', err => {
+		child_process.exec('npx pm2 kill', err => {
 			if (err) {
 				console.warn(
 					'Failed to killed PM2 process. Please execute command "pm2 kill" manually'

--- a/framework/test/mocha/network/utils/http.js
+++ b/framework/test/mocha/network/utils/http.js
@@ -74,13 +74,10 @@ module.exports = {
 		currentVersion = version;
 	},
 
-	getBlocks(port, ip) {
+	getBlocks({ port = 4000, ip = '127.0.0.1' }) {
 		return popsicle
 			.get({
-				url: endpoints.versions[currentVersion].getBlocks(
-					ip || '127.0.0.1',
-					port || 4000
-				),
+				url: endpoints.versions[currentVersion].getBlocks(ip, port),
 				headers,
 			})
 			.then(res => {
@@ -91,13 +88,10 @@ module.exports = {
 			});
 	},
 
-	getHeight(port, ip) {
+	getHeight({ port = 4000, ip = '127.0.0.1' }) {
 		return popsicle
 			.get({
-				url: endpoints.versions[currentVersion].getHeight(
-					ip || '127.0.0.1',
-					port || 4000
-				),
+				url: endpoints.versions[currentVersion].getHeight(ip, port),
 				headers,
 			})
 			.then(res => {
@@ -105,13 +99,10 @@ module.exports = {
 			});
 	},
 
-	getNodeStatus(port, ip) {
+	getNodeStatus({ port = 4000, ip = '127.0.0.1' }) {
 		return popsicle
 			.get({
-				url: endpoints.versions[currentVersion].getNodeStatus(
-					ip || '127.0.0.1',
-					port || 4000
-				),
+				url: endpoints.versions[currentVersion].getNodeStatus(ip, port),
 				headers,
 			})
 			.then(res => {
@@ -119,13 +110,13 @@ module.exports = {
 			});
 	},
 
-	getTransaction(transactionId, port, ip) {
+	getTransaction({ id, port = 4000, ip = '127.0.0.1' }) {
 		return popsicle
 			.get({
 				url: `${endpoints.versions[currentVersion].getTransactions(
-					ip || '127.0.0.1',
-					port || 4000
-				)}?id=${transactionId}`,
+					ip,
+					port
+				)}?id=${id}`,
 				headers,
 			})
 			.then(res => {
@@ -153,13 +144,10 @@ module.exports = {
 			});
 	},
 
-	enableForging(keys, port, ip) {
+	enableForging({ keys, port = 4000, ip = '127.0.0.1' }) {
 		return popsicle
 			.put({
-				url: endpoints.versions[currentVersion].enableForging(
-					ip || '127.0.0.1',
-					port || 4000
-				),
+				url: endpoints.versions[currentVersion].enableForging(ip, port),
 				headers,
 				body: {
 					password: 'elephant tree paris dragon chair galaxy',
@@ -186,13 +174,10 @@ module.exports = {
 			});
 	},
 
-	getPeers(port, ip) {
+	getPeers({ port = 4000, ip = '127.0.0.1' }) {
 		return popsicle
 			.get({
-				url: endpoints.versions[currentVersion].getPeers(
-					ip || '127.0.0.1',
-					port || 4000
-				),
+				url: endpoints.versions[currentVersion].getPeers(ip, port),
 				headers,
 			})
 			.then(res => {

--- a/framework/test/mocha/network/utils/http.js
+++ b/framework/test/mocha/network/utils/http.js
@@ -136,6 +136,23 @@ module.exports = {
 			});
 	},
 
+	getTransactionsFromBlock({ blockId, port = 4000, ip = '127.0.0.1' }) {
+		return popsicle
+			.get({
+				url: `${endpoints.versions[currentVersion].getTransactions(
+					ip,
+					port
+				)}?blockId=${blockId}`,
+				headers,
+			})
+			.then(res => {
+				if (currentVersion === '1.0.0') {
+					return JSON.parse(res.body).data;
+				}
+				return JSON.parse(res.body).transactions;
+			});
+	},
+
 	enableForging(keys, port, ip) {
 		return popsicle
 			.put({

--- a/framework/test/mocha/network/utils/http.js
+++ b/framework/test/mocha/network/utils/http.js
@@ -88,14 +88,14 @@ module.exports = {
 			});
 	},
 
-	getHeight({ port = 4000, ip = '127.0.0.1' }) {
+	async getHeight({ port = 4000, ip = '127.0.0.1' }) {
 		return popsicle
 			.get({
 				url: endpoints.versions[currentVersion].getHeight(ip, port),
 				headers,
 			})
 			.then(res => {
-				return res.body.height;
+				return JSON.parse(res.body).data.height;
 			});
 	},
 

--- a/framework/test/mocha/network/utils/transactions.js
+++ b/framework/test/mocha/network/utils/transactions.js
@@ -23,7 +23,7 @@ module.exports = {
 				return transactions.map(transaction => {
 					return getTransaction({
 						id: transaction.id,
-						httPort: configuration.modules.http_api.httpPort,
+						port: configuration.modules.http_api.httpPort,
 					});
 				});
 			})

--- a/framework/test/mocha/network/utils/transactions.js
+++ b/framework/test/mocha/network/utils/transactions.js
@@ -21,10 +21,10 @@ module.exports = {
 		return Promise.all(
 			_.flatMap(configurations, configuration => {
 				return transactions.map(transaction => {
-					return getTransaction(
-						transaction.id,
-						configuration.modules.http_api.httpPort
-					);
+					return getTransaction({
+						id: transaction.id,
+						httPort: configuration.modules.http_api.httpPort,
+					});
 				});
 			})
 		).then(results => {


### PR DESCRIPTION
### What was the problem?

P2P library was not updating the `_newPeers` list when receiving a peer info notification update.

### How did I fix it?

Re-enabling network tests and adding a new test case to propagation scenario.
https://github.com/LiskHQ/lisk-sdk/pull/3741/commits/db5f015efbdb3e99aa140112a13a323580d3ea15

### How to test it?

`npm run mocha:network`

### Review checklist

* The PR resolves #3687 & #3682
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
