### PR TITLE
getTransactionFromNetwork does not serialize the transaction input - Closes #3738

### DIFF
--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -71,6 +71,7 @@ class Loader {
 			logic: {
 				account: scope.logic.account,
 				peers: scope.logic.peers,
+				initTransaction: scope.logic.initTransaction,
 			},
 			config: {
 				loading: {
@@ -258,7 +259,10 @@ __private.getTransactionsFromNetwork = async function() {
 	const validate = promisify(library.schema.validate.bind(library.schema));
 	await validate(result, definitions.WSTransactionsResponse);
 
-	const transactions = result.transactions;
+	const transactions = result.transactions.map(tx =>
+		library.logic.initTransaction.fromJson(tx)
+	);
+
 	try {
 		const {
 			transactionsResponses,


### PR DESCRIPTION
### What was the problem?
Transactions were not serialized when received from `getTransactionsFromNetwork`

### How did I fix it?
By adding the `initTransaction` logic to Loader and calling `fromJson` for each transaction

### How to test it?
Run the application on `testnet` or `mainnet` with a clean database.

### Review checklist

* The PR resolves #3738
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
