### PR TITLE
Provide a default implementation of the prepare step in BaseTransaction - Closes #3730

### DIFF
--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -123,7 +123,6 @@ export abstract class BaseTransaction {
 		MultisignatureStatus.UNKNOWN;
 
 	public abstract assetToJSON(): object;
-	public abstract prepare(store: StateStorePrepare): Promise<void>;
 	protected abstract assetToBytes(): Buffer;
 	protected abstract validateAsset(): ReadonlyArray<TransactionError>;
 	protected abstract applyAsset(
@@ -349,6 +348,14 @@ export abstract class BaseTransaction {
 		errors.push(...assetErrors);
 
 		return createResponse(this.id, errors);
+	}
+
+	public async prepare(store: StateStorePrepare): Promise<void> {
+		await store.account.cache([
+			{
+				address: this.senderId,
+			},
+		]);
 	}
 
 	public addMultisignature(

--- a/framework/test/mocha/integration/blocks/verify/verify.js
+++ b/framework/test/mocha/integration/blocks/verify/verify.js
@@ -1044,10 +1044,12 @@ describe('blocks/verify', () => {
 				delete block2.transactions[0].type;
 				blocksVerify.processBlock(block2, false, true, err => {
 					if (err) {
+						expect(err)
+							.to.be.an('array')
+							.to.have.a.lengthOf(1);
 						expect(err[0].message).equal(
 							"'' should have required property 'type'"
 						);
-						expect(err[1].message).equal('Invalid type');
 						block2.transactions[0].type = transactionType;
 						done();
 					}


### PR DESCRIPTION
### What was the problem?
No default implementation for prepare function in BaseTransction, therefore this step is required for every transaction extending the base transaction to implement. It's recommended but should not be obligatory. 
### How did I fix it?
The sender's account is returned by default from the storage.
### How to test it?

### Review checklist

* The PR resolves #3730
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
