### PR TITLE
Rename cacheReady to ready - Closes #3606

### DIFF
--- a/framework/src/components/cache/cache.js
+++ b/framework/src/components/cache/cache.js
@@ -34,7 +34,7 @@ class Cache {
 	constructor(options, logger) {
 		this.options = options;
 		this.logger = logger;
-		this.cacheReady = false;
+		this.ready = false;
 	}
 
 	async bootstrap() {
@@ -82,21 +82,21 @@ class Cache {
 	 */
 	isReady() {
 		// Use client.ready because this constant is updated on client connection
-		return this.client && this.client.ready && this.cacheReady;
+		return this.client && this.client.ready && this.ready;
 	}
 
 	/**
 	 * Enables cache client
 	 */
 	enable() {
-		this.cacheReady = true;
+		this.ready = true;
 	}
 
 	/**
 	 * Disables cache client
 	 */
 	disable() {
-		this.cacheReady = false;
+		this.ready = false;
 	}
 
 	/**

--- a/framework/src/modules/chain/loader.js
+++ b/framework/src/modules/chain/loader.js
@@ -161,7 +161,7 @@ class Loader {
 	// eslint-disable-next-line class-methods-use-this
 	sync(cb) {
 		library.logger.info('Starting sync');
-		if (components.cache.cacheReady) {
+		if (components.cache.ready) {
 			components.cache.disable();
 		}
 
@@ -190,7 +190,7 @@ class Loader {
 				__private.blocksToSync = 0;
 
 				library.logger.info('Finished sync');
-				if (components.cache.cacheReady) {
+				if (components.cache.ready) {
 					components.cache.enable();
 				}
 				return setImmediate(cb, err);

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -352,7 +352,7 @@ async function _getNetworkHeight() {
  */
 async function _getConfirmedTransactionCount() {
 	// if cache is ready, then get cache and return
-	if (library.components.cache.cacheReady) {
+	if (library.components.cache.ready) {
 		try {
 			const { confirmed } = await library.components.cache.getJsonForKey(
 				CACHE_KEYS_TRANSACTION_COUNT
@@ -369,7 +369,7 @@ async function _getConfirmedTransactionCount() {
 	}
 	const confirmed = await library.components.storage.entities.Transaction.count();
 	// only update cache if ready
-	if (library.components.cache.cacheReady) {
+	if (library.components.cache.ready) {
 		try {
 			await library.components.cache.setJsonForKey(
 				CACHE_KEYS_TRANSACTION_COUNT,


### PR DESCRIPTION
### What was the problem?

- name used as property for cache readiness named redundantly

### How did I fix it?

- renamed the property `cacheReady` to `ready` for the cache component

### How to test it?

- Build should be green

### Review checklist

* The PR resolves #3606
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
