### PR TITLE
Use mergeWith to overwrite array elements in config properly - Closes #3723

### DIFF
--- a/framework/src/controller/configurator/configurator.js
+++ b/framework/src/controller/configurator/configurator.js
@@ -75,7 +75,12 @@ class Configurator {
 
 		return parseEnvArgAndValidate(
 			this.configSchema,
-			_.defaultsDeep(...[{}, ...this.customData, overrideValues].reverse())
+			_.mergeWith(
+				{},
+				...this.customData,
+				overrideValues,
+				(objValue, srcValue) => (_.isArray(objValue) ? srcValue : undefined)
+			)
 		);
 	}
 


### PR DESCRIPTION
### What was the problem?

During blocks verification, the node is still trying to connect to other peers or receive connections from other peers.

### How did I fix it?

The peers can be found or they can connect to us in two conditions,
[So even if we pass blank seed peers...#issuecomment-497644826](https://github.com/LiskHQ/lisk-sdk/issues/3723#issuecomment-497644826)

Given that we are in isolated from the network with fresh ip or port then it should not happen, so that means somewhere seed peers still passed through the config overwriting and reach to P2P instance. We were using `_.defaultsDeep` which was merging the peer lists from `{network}/config` with `{custom}/config` which was resulting in non-empty `seedPeers` list.

[@ishantiw That's the behaviour from lodash defaultsDeep it tries...#issuecomment-497668613](https://github.com/LiskHQ/lisk-sdk/issues/3723#issuecomment-497668613)

Now using `_.mergeWith` function of lodash with custom function that doesn't allow merging of array elements but overwrites them.


### How to test it?

Use a custom config file. Example, [here the configuration...#issuecomment-496548938](https://github.com/LiskHQ/lisk-sdk/issues/3723#issuecomment-496548938)

and run,

`node dist/index.js -b 90000 -n mainnet -c config.json`

### Review checklist

* The PR resolves #3723
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
