### PR TITLE
Disconnect outbound peers periodically for shuffling - Closes #3347

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -345,8 +345,8 @@ export class P2P extends EventEmitter {
 				config.maxInboundConnections === undefined
 					? DEFAULT_MAX_INBOUND_CONNECTIONS
 					: config.maxInboundConnections,
-			outboundEvictionInterval: config.outboundEvictionInterval
-				? config.outboundEvictionInterval
+			outboundShuffleInterval: config.outboundShuffleInterval
+				? config.outboundShuffleInterval
 				: DEFAULT_OUTBOUND_SHUFFLE_INTERVAL,
 		});
 

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -121,6 +121,7 @@ export const DEFAULT_SEND_PEER_LIMIT = 25;
 const BASE_10_RADIX = 10;
 const DEFAULT_MAX_OUTBOUND_CONNECTIONS = 20;
 const DEFAULT_MAX_INBOUND_CONNECTIONS = 100;
+const DEFAULT_OUTBOUND_SHUFFLE_INTERVAL = 300000;
 
 const selectRandomPeerSample = (
 	peerList: ReadonlyArray<P2PDiscoveredPeerInfo>,
@@ -319,7 +320,6 @@ export class P2P extends EventEmitter {
 			// Re-emit the error to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_INBOUND_SOCKET_ERROR, error);
 		};
-
 		this._peerPool = new PeerPool({
 			connectTimeout: config.connectTimeout,
 			ackTimeout: config.ackTimeout,
@@ -345,6 +345,9 @@ export class P2P extends EventEmitter {
 				config.maxInboundConnections === undefined
 					? DEFAULT_MAX_INBOUND_CONNECTIONS
 					: config.maxInboundConnections,
+			outboundEvictionInterval: config.outboundEvictionInterval
+				? config.outboundEvictionInterval
+				: DEFAULT_OUTBOUND_SHUFFLE_INTERVAL,
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -92,13 +92,13 @@ export interface P2PConfig {
 	readonly populatorInterval?: number;
 	readonly maxOutboundConnections: number;
 	readonly maxInboundConnections: number;
-	readonly peerSelectionForSend?: P2PPeerSelectionForSendFunction;	
+	readonly peerSelectionForSend?: P2PPeerSelectionForSendFunction;
 	readonly peerSelectionForRequest?: P2PPeerSelectionForRequestFunction;
 	readonly peerSelectionForConnection?: P2PPeerSelectionForConnectionFunction;
 	readonly peerHandshakeCheck?: P2PCheckPeerCompatibility;
 	readonly peerBanTime?: number;
 	readonly sendPeerLimit?: number;
-	readonly outboundEvictionInterval?: number;
+	readonly outboundShuffleInterval?: number;
 }
 
 // Network info exposed by the P2P library.

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -98,6 +98,7 @@ export interface P2PConfig {
 	readonly peerHandshakeCheck?: P2PCheckPeerCompatibility;
 	readonly peerBanTime?: number;
 	readonly sendPeerLimit?: number;
+	readonly outboundEvictionInterval?: number;
 }
 
 // Network info exposed by the P2P library.

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -555,7 +555,7 @@ export class PeerPool extends EventEmitter {
 		}
 
 		if (kind === OutboundPeer) {
-			const peerIdToRemove = shuffle(peers.map(constructPeerIdFromPeerInfo))[0];
+			const peerIdToRemove = constructPeerIdFromPeerInfo(shuffle(peers)[0]);
 			this.removePeer(peerIdToRemove);
 		}
 	}

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -90,7 +90,7 @@ interface PeerPoolConfig {
 	readonly peerBanTime?: number;
 	readonly maxOutboundConnections: number;
 	readonly maxInboundConnections: number;
-	readonly outboundEvictionInterval?: number;
+	readonly outboundShuffleInterval?: number;
 }
 
 export const MAX_PEER_LIST_BATCH_SIZE = 100;
@@ -149,7 +149,7 @@ export class PeerPool extends EventEmitter {
 			() => {
 				this._evictPeer(OutboundPeer);
 			},
-			peerPoolConfig.outboundEvictionInterval as number,
+			peerPoolConfig.outboundShuffleInterval as number,
 		);
 
 		// This needs to be an arrow function so that it can be used as a listener.

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1406,12 +1406,12 @@ describe('Integration tests for P2P library', () => {
 		});
 	});
 
-	describe('Network with frequent peer evictions', () => {
+	describe('Network with frequent peer shuffling', () => {
 		const NETWORK_PEER_COUNT_WITH_LIMIT = 30;
 		const TEN_CONNECTIONS = 10;
 		const DISCOVERY_INTERVAL_WITH_LIMIT = 1000;
-		const POPULATOR_INTERVAL_WITH_LIMIT = 1000;
-		const OUTBOUND_EVICTION_INTERVAL = 500;
+		const POPULATOR_INTERVAL_WITH_LIMIT = 10000;
+		const OUTBOUND_SHUFFLE_INTERVAL = 500;
 		beforeEach(async () => {
 			p2pNodeList = [...new Array(NETWORK_PEER_COUNT_WITH_LIMIT).keys()].map(
 				index => {
@@ -1435,7 +1435,7 @@ describe('Integration tests for P2P library', () => {
 						populatorInterval: POPULATOR_INTERVAL_WITH_LIMIT,
 						maxOutboundConnections: TEN_CONNECTIONS,
 						maxInboundConnections: TEN_CONNECTIONS,
-						outboundEvictionInterval: OUTBOUND_EVICTION_INTERVAL,
+						outboundShuffleInterval: OUTBOUND_SHUFFLE_INTERVAL,
 						nodeInfo: {
 							wsPort: nodePort,
 							nethash:
@@ -1469,8 +1469,8 @@ describe('Integration tests for P2P library', () => {
 			await wait(100);
 		});
 
-		describe('Peer outbound eviction', () => {
-			it('should evict a random outbound peer in an interval', async () => {
+		describe('Peer outbound shuffling', () => {
+			it('should shuffle outbound peers in an interval', async () => {
 				const p2pNode = p2pNodeList[0];
 				const { outbound } = p2pNode['_peerPool'].getPeersCountPerKind();
 				// Wait for periodic shuffling
@@ -1479,7 +1479,7 @@ describe('Integration tests for P2P library', () => {
 					'_peerPool'
 				].getPeersCountPerKind();
 
-				expect(updatedOutbound).to.be.lessThan(outbound);
+				expect(updatedOutbound).to.equal(outbound - 1);
 			});
 		});
 	});

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1405,4 +1405,82 @@ describe('Integration tests for P2P library', () => {
 			});
 		});
 	});
+
+	describe('Network with frequent peer evictions', () => {
+		const NETWORK_PEER_COUNT_WITH_LIMIT = 30;
+		const TEN_CONNECTIONS = 10;
+		const DISCOVERY_INTERVAL_WITH_LIMIT = 1000;
+		const POPULATOR_INTERVAL_WITH_LIMIT = 1000;
+		const OUTBOUND_EVICTION_INTERVAL = 500;
+		beforeEach(async () => {
+			p2pNodeList = [...new Array(NETWORK_PEER_COUNT_WITH_LIMIT).keys()].map(
+				index => {
+					// Each node will have the previous node in the sequence as a seed peer except the first node.
+					const seedPeers = [
+						{
+							ipAddress: '127.0.0.1',
+							wsPort:
+								NETWORK_START_PORT +
+								((index + 1) % NETWORK_PEER_COUNT_WITH_LIMIT),
+						},
+					];
+
+					const nodePort = NETWORK_START_PORT + index;
+					return new P2P({
+						connectTimeout: 5000,
+						ackTimeout: 5000,
+						seedPeers,
+						wsEngine: 'ws',
+						discoveryInterval: DISCOVERY_INTERVAL_WITH_LIMIT,
+						populatorInterval: POPULATOR_INTERVAL_WITH_LIMIT,
+						maxOutboundConnections: TEN_CONNECTIONS,
+						maxInboundConnections: TEN_CONNECTIONS,
+						outboundEvictionInterval: OUTBOUND_EVICTION_INTERVAL,
+						nodeInfo: {
+							wsPort: nodePort,
+							nethash:
+								'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+							version: '1.0.1',
+							protocolVersion: '1.0.1',
+							minVersion: '1.0.0',
+							os: platform(),
+							height: 0,
+							broadhash:
+								'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
+							nonce: `O2wTkjqplHII${nodePort}`,
+						},
+					});
+				},
+			);
+
+			const peerStartPromises: ReadonlyArray<Promise<void>> = p2pNodeList.map(
+				p2p => p2p.start(),
+			);
+			await Promise.all(peerStartPromises);
+			await wait(1000);
+		});
+
+		afterEach(async () => {
+			await Promise.all(
+				p2pNodeList
+					.filter(p2p => p2p.isActive)
+					.map(async p2p => await p2p.stop()),
+			);
+			await wait(100);
+		});
+
+		describe('Peer outbound eviction', () => {
+			it('should evict a random outbound peer in an interval', async () => {
+				const p2pNode = p2pNodeList[0];
+				const { outbound } = p2pNode['_peerPool'].getPeersCountPerKind();
+				// Wait for periodic shuffling
+				await wait(500);
+				const { outbound: updatedOutbound } = p2pNode[
+					'_peerPool'
+				].getPeersCountPerKind();
+
+				expect(updatedOutbound).to.be.lessThan(outbound);
+			});
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?

Peer shuffling: Over the course of 30 blocks (approximately 5 minutes), one outgoing connection is chosen uniformly at random and terminated at a random time during the interval of 30 blocks. A new outbound peer is then added to the pool via the peer populator.

### How did I fix it?

Implemented outbound peer eviction functionality.

### Review checklist

* The PR resolves #3347
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
