### PR TITLE
Functional WS tests constantly failing - Closes #3607

### DIFF
--- a/framework/test/mocha/common/generatePeerHeader.js
+++ b/framework/test/mocha/common/generatePeerHeader.js
@@ -51,7 +51,8 @@ const generatePeerHeader = function(headers = {}) {
 			ipAddress: v.ip,
 			wsPort: v.wsPort,
 		})),
-		ackTimeout: 20000,
+		ackTimeout: 40000,
+		connectTimeout: 20000,
 		nodeInfo,
 	};
 };


### PR DESCRIPTION
### What was the problem?

Functional WS tests were failing around 80% of the time

### How did I fix it?

By configuring `connectionTimeout` and tweaking `ackTimeout` 

### How to test it?

- Build should be green
- Several runs of the build should always yield a green Functional WS test run

### Review checklist

* The PR resolves #3607
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
