### PR TITLE
Inbound peer eviction method - Closes #3721

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -125,6 +125,7 @@ const BASE_10_RADIX = 10;
 const DEFAULT_MAX_OUTBOUND_CONNECTIONS = 20;
 const DEFAULT_MAX_INBOUND_CONNECTIONS = 100;
 const DEFAULT_OUTBOUND_SHUFFLE_INTERVAL = 300000;
+const DEFAULT_EVICTION_PROTECTION = 0.58;
 
 const selectRandomPeerSample = (
 	peerList: ReadonlyArray<P2PPeerInfo>,
@@ -363,8 +364,11 @@ export class P2P extends EventEmitter {
 			outboundShuffleInterval: config.outboundShuffleInterval
 				? config.outboundShuffleInterval
 				: DEFAULT_OUTBOUND_SHUFFLE_INTERVAL,
-			evictionProtectionEnabled: config.evictionProtectionEnabled === false ? false : true,
-			peerProtectionRatio: config.peerProtectionRatio ? config.peerProtectionRatio : 0.58,
+			evictionProtectionEnabled:
+				config.evictionProtectionEnabled === false ? false : true,
+			evictionProtectionRatio: config.evictionProtectionRatio
+				? config.evictionProtectionRatio
+				: DEFAULT_EVICTION_PROTECTION,
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -125,7 +125,8 @@ const BASE_10_RADIX = 10;
 const DEFAULT_MAX_OUTBOUND_CONNECTIONS = 20;
 const DEFAULT_MAX_INBOUND_CONNECTIONS = 100;
 const DEFAULT_OUTBOUND_SHUFFLE_INTERVAL = 300000;
-const DEFAULT_EVICTION_PROTECTION = 0.58;
+const DEFAULT_PEER_PROTECTION_FOR_LATENCY_AND_USEFULNESS = 0.068;
+const DEFAULT_PEER_PROTECTION_FOR_LONGEVITY = 0.5;
 
 const selectRandomPeerSample = (
 	peerList: ReadonlyArray<P2PPeerInfo>,
@@ -364,11 +365,18 @@ export class P2P extends EventEmitter {
 			outboundShuffleInterval: config.outboundShuffleInterval
 				? config.outboundShuffleInterval
 				: DEFAULT_OUTBOUND_SHUFFLE_INTERVAL,
-			evictionProtectionEnabled:
-				config.evictionProtectionEnabled === false ? false : true,
-			evictionProtectionRatio: config.evictionProtectionRatio
-				? config.evictionProtectionRatio
-				: DEFAULT_EVICTION_PROTECTION,
+			latencyProtectionRatio:
+				typeof config.latencyProtectionRatio === 'number'
+					? config.latencyProtectionRatio
+					: DEFAULT_PEER_PROTECTION_FOR_LATENCY_AND_USEFULNESS,
+			productivityProtectionRatio:
+				typeof config.productivityProtectionRatio === 'number'
+					? config.productivityProtectionRatio
+					: DEFAULT_PEER_PROTECTION_FOR_LATENCY_AND_USEFULNESS,
+			longevityProtectionRatio:
+				typeof config.longevityProtectionRatio === 'number'
+					? config.longevityProtectionRatio
+					: DEFAULT_PEER_PROTECTION_FOR_LONGEVITY,
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -334,6 +334,7 @@ export class P2P extends EventEmitter {
 			// Re-emit the error to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_INBOUND_SOCKET_ERROR, error);
 		};
+
 		this._peerPool = new PeerPool({
 			connectTimeout: config.connectTimeout,
 			ackTimeout: config.ackTimeout,
@@ -362,6 +363,8 @@ export class P2P extends EventEmitter {
 			outboundShuffleInterval: config.outboundShuffleInterval
 				? config.outboundShuffleInterval
 				: DEFAULT_OUTBOUND_SHUFFLE_INTERVAL,
+			evictionProtectionEnabled: config.evictionProtectionEnabled === false ? false : true,
+			peerProtectionRatio: config.peerProtectionRatio ? config.peerProtectionRatio : 0.58,
 		});
 
 		this._bindHandlersToPeerPool(this._peerPool);

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -126,7 +126,8 @@ const BASE_10_RADIX = 10;
 const DEFAULT_MAX_OUTBOUND_CONNECTIONS = 20;
 const DEFAULT_MAX_INBOUND_CONNECTIONS = 100;
 const DEFAULT_OUTBOUND_SHUFFLE_INTERVAL = 300000;
-const DEFAULT_PEER_PROTECTION_FOR_LATENCY_AND_USEFULNESS = 0.068;
+const DEFAULT_PEER_PROTECTION_FOR_LATENCY = 0.068;
+const DEFAULT_PEER_PROTECTION_FOR_USEFULNESS = 0.068;
 const DEFAULT_PEER_PROTECTION_FOR_LONGEVITY = 0.5;
 
 const selectRandomPeerSample = (
@@ -397,11 +398,11 @@ export class P2P extends EventEmitter {
 			latencyProtectionRatio:
 				typeof config.latencyProtectionRatio === 'number'
 					? config.latencyProtectionRatio
-					: DEFAULT_PEER_PROTECTION_FOR_LATENCY_AND_USEFULNESS,
+					: DEFAULT_PEER_PROTECTION_FOR_LATENCY,
 			productivityProtectionRatio:
 				typeof config.productivityProtectionRatio === 'number'
 					? config.productivityProtectionRatio
-					: DEFAULT_PEER_PROTECTION_FOR_LATENCY_AND_USEFULNESS,
+					: DEFAULT_PEER_PROTECTION_FOR_USEFULNESS,
 			longevityProtectionRatio:
 				typeof config.longevityProtectionRatio === 'number'
 					? config.longevityProtectionRatio

--- a/elements/lisk-p2p/src/p2p_request.ts
+++ b/elements/lisk-p2p/src/p2p_request.ts
@@ -32,12 +32,23 @@ export class P2PRequest {
 		data: unknown,
 		peerId: string,
 		rate: number,
+		productivity: {
+			// tslint:disable-next-line: readonly-keyword
+			requestCounter: number;
+			// tslint:disable-next-line: readonly-keyword
+			responseCounter: number;
+			// tslint:disable-next-line: readonly-keyword
+			responseRate: number;
+			// tslint:disable-next-line: readonly-keyword
+			lastResponded: number;
+		},
 		respondCallback: (responseError?: Error, responseData?: unknown) => void,
 	) {
 		this._procedure = procedure;
 		this._data = data;
 		this._peerId = peerId;
 		this._rate = rate;
+		productivity.requestCounter += 1;
 		this._respondCallback = (
 			responseError?: Error,
 			responsePacket?: P2PResponsePacket,
@@ -48,10 +59,16 @@ export class P2PRequest {
 				);
 			}
 			this._wasResponseSent = true;
+			// We assume peer performed useful work and update peer response rate
+			if (!responseError && responsePacket) {
+				productivity.lastResponded = Date.now();
+				productivity.responseCounter += 1;
+				productivity.responseRate =
+					productivity.responseCounter / productivity.requestCounter;
+			}
 			respondCallback(responseError, responsePacket);
 		};
 		this._wasResponseSent = false;
-		this._peerId = peerId;
 	}
 
 	public get procedure(): string {

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -101,6 +101,8 @@ export interface P2PConfig {
 	readonly peerBanTime?: number;
 	readonly sendPeerLimit?: number;
 	readonly outboundShuffleInterval?: number;
+	readonly evictionProtectionEnabled?: boolean;
+	readonly peerProtectionRatio?: number;
 }
 
 // Network info exposed by the P2P library.

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -101,7 +101,6 @@ export interface P2PConfig {
 	readonly peerBanTime?: number;
 	readonly sendPeerLimit?: number;
 	readonly outboundShuffleInterval?: number;
-	readonly evictionProtectionEnabled?: boolean;
 	readonly latencyProtectionRatio?: number;
 	readonly productivityProtectionRatio?: number;
 	readonly longevityProtectionRatio?: number;

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -102,7 +102,9 @@ export interface P2PConfig {
 	readonly sendPeerLimit?: number;
 	readonly outboundShuffleInterval?: number;
 	readonly evictionProtectionEnabled?: boolean;
-	readonly evictionProtectionRatio?: number;
+	readonly latencyProtectionRatio?: number;
+	readonly productivityProtectionRatio?: number;
+	readonly longevityProtectionRatio?: number;
 }
 
 // Network info exposed by the P2P library.

--- a/elements/lisk-p2p/src/p2p_types.ts
+++ b/elements/lisk-p2p/src/p2p_types.ts
@@ -102,7 +102,7 @@ export interface P2PConfig {
 	readonly sendPeerLimit?: number;
 	readonly outboundShuffleInterval?: number;
 	readonly evictionProtectionEnabled?: boolean;
-	readonly peerProtectionRatio?: number;
+	readonly evictionProtectionRatio?: number;
 }
 
 // Network info exposed by the P2P library.

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -91,7 +91,7 @@ export const DEFAULT_CONNECT_TIMEOUT = 2000;
 export const DEFAULT_ACK_TIMEOUT = 2000;
 export const DEFAULT_REPUTATION_SCORE = 100;
 export const DEFAULT_RATE_INTERVAL = 1000;
-export const DEFAULT_PRODUCTIVITY_RESET_INTERVAL = 3600000;
+export const DEFAULT_PRODUCTIVITY_RESET_INTERVAL = 2000;
 export const DEFAULT_PRODUCTIVITY = {
 	requestCounter: 0,
 	responseCounter: 0,
@@ -182,8 +182,11 @@ export class Peer extends EventEmitter {
 			this._callCounter = new Map();
 		}, DEFAULT_RATE_INTERVAL);
 		this._productivityResetInterval = setInterval(() => {
-			// If peer has not responded within an hour, reset productivity to 0
-			if(this.productivity.lastResponded < (Date.now() - DEFAULT_PRODUCTIVITY_RESET_INTERVAL)) {
+			// If peer has not recently responded, reset productivity to 0
+			if (
+				this.productivity.lastResponded <
+				Date.now() - DEFAULT_PRODUCTIVITY_RESET_INTERVAL
+			) {
 				this.productivity = DEFAULT_PRODUCTIVITY;
 			}
 		}, DEFAULT_PRODUCTIVITY_RESET_INTERVAL);

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -194,10 +194,10 @@ export class Peer extends EventEmitter {
 				this._productivity.lastResponded <
 				Date.now() - DEFAULT_PRODUCTIVITY_RESET_INTERVAL
 			) {
-				this._productivity = DEFAULT_PRODUCTIVITY;
+				this._productivity = { ...DEFAULT_PRODUCTIVITY };
 			}
 		}, DEFAULT_PRODUCTIVITY_RESET_INTERVAL);
-		this._productivity = DEFAULT_PRODUCTIVITY;
+		this._productivity = { ...DEFAULT_PRODUCTIVITY };
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handleRawRPC = (

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -135,9 +135,9 @@ export class Peer extends EventEmitter {
 	protected readonly _ipAddress: string;
 	protected readonly _wsPort: number;
 	private readonly _height: number;
-	public reputation: number;
-	public latency: number;
-	public connectTime: number;
+	protected _reputation: number;
+	protected _latency: number;
+	protected _connectTime: number;
 	public productivity: {
 		requestCounter: number;
 		responseCounter: number;
@@ -174,9 +174,9 @@ export class Peer extends EventEmitter {
 		this._wsPort = peerInfo.wsPort;
 		this._id = constructPeerId(this._ipAddress, this._wsPort);
 		this._height = peerInfo.height ? (peerInfo.height as number) : 0;
-		this.reputation = DEFAULT_REPUTATION_SCORE;
-		this.latency = 0;
-		this.connectTime = Date.now();
+		this._reputation = DEFAULT_REPUTATION_SCORE;
+		this._latency = 0;
+		this._connectTime = Date.now();
 		this._callCounter = new Map();
 		this._counterResetInterval = setInterval(() => {
 			this._callCounter = new Map();
@@ -293,6 +293,18 @@ export class Peer extends EventEmitter {
 		return this._ipAddress;
 	}
 
+	public get reputation(): number {
+		return this._reputation;
+	}
+
+	public get latency(): number {
+		return this._latency;
+	}
+
+	public get connectTime(): number {
+		return this._connectTime;
+	}
+
 	public updatePeerInfo(newPeerInfo: P2PDiscoveredPeerInfo): void {
 		// The ipAddress and wsPort properties cannot be updated after the initial discovery.
 		this._peerInfo = {
@@ -307,8 +319,8 @@ export class Peer extends EventEmitter {
 	}
 
 	public applyPenalty(penalty: number): void {
-		this.reputation -= penalty;
-		if (this.reputation <= 0) {
+		this._reputation -= penalty;
+		if (this._reputation <= 0) {
 			this._banPeer();
 		}
 	}

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -221,11 +221,13 @@ export class Peer extends EventEmitter {
 			const rate = this._getPeerRate(packet as P2PRequestPacket);
 
 			const request = new P2PRequest(
-				rawRequest.procedure,
-				rawRequest.data,
-				this._id,
-				rate,
-				this._productivity,
+				{
+					procedure: rawRequest.procedure,
+					data: rawRequest.data,
+					id: this._id,
+					rate,
+					productivity: this._productivity,
+				},
 				respond,
 			);
 

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -312,6 +312,10 @@ export class Peer extends EventEmitter {
 		return this._connectTime;
 	}
 
+	public get responseRate(): number {
+		return this._productivity.responseRate;
+	}
+
 	public get productivity(): Productivity {
 		return { ...this._productivity };
 	}

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -130,7 +130,7 @@ export class Peer extends EventEmitter {
 	private readonly _height: number;
 	public _reputation: number;
 	public _latency: number;
-	protected _connectTime: number;
+	public _connectTime: number;
 	private _callCounter: Map<string, number>;
 	private readonly _counterResetInterval: NodeJS.Timer;
 	protected _peerInfo: P2PPeerInfo;

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -128,7 +128,9 @@ export class Peer extends EventEmitter {
 	protected readonly _ipAddress: string;
 	protected readonly _wsPort: number;
 	private readonly _height: number;
-	private _reputation: number;
+	public _reputation: number;
+	public _latency: number;
+	protected _connectTime: number;
 	private _callCounter: Map<string, number>;
 	private readonly _counterResetInterval: NodeJS.Timer;
 	protected _peerInfo: P2PPeerInfo;
@@ -159,6 +161,8 @@ export class Peer extends EventEmitter {
 		this._id = constructPeerId(this._ipAddress, this._wsPort);
 		this._height = peerInfo.height ? (peerInfo.height as number) : 0;
 		this._reputation = DEFAULT_REPUTATION_SCORE;
+		this._latency = 0;
+		this._connectTime = Date.now();
 		this._callCounter = new Map();
 		this._counterResetInterval = setInterval(() => {
 			this._callCounter = new Map();

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -98,7 +98,7 @@ export const DEFAULT_CONNECT_TIMEOUT = 2000;
 export const DEFAULT_ACK_TIMEOUT = 2000;
 export const DEFAULT_REPUTATION_SCORE = 100;
 export const DEFAULT_RATE_INTERVAL = 1000;
-export const DEFAULT_PRODUCTIVITY_RESET_INTERVAL = 2000;
+export const DEFAULT_PRODUCTIVITY_RESET_INTERVAL = 20000;
 export const DEFAULT_PRODUCTIVITY = {
 	requestCounter: 0,
 	responseCounter: 0,

--- a/elements/lisk-p2p/src/peer/inbound.ts
+++ b/elements/lisk-p2p/src/peer/inbound.ts
@@ -57,8 +57,8 @@ export class InboundPeer extends Peer {
 				reason,
 			});
 		};
-		this._handlePong = (startTime: number) => {
-			const latency = Date.now() - startTime;
+		this._handlePong = (responseTime: number) => {
+			const latency = Date.now() - responseTime;
 			this._latency = latency;
 		};
 		this._socket = peerSocket;

--- a/elements/lisk-p2p/src/peer/inbound.ts
+++ b/elements/lisk-p2p/src/peer/inbound.ts
@@ -44,7 +44,6 @@ export class InboundPeer extends Peer {
 	) => void;
 	private readonly _sendPing: () => void;
 	private _pingTimeoutId: NodeJS.Timer;
-	private _pingStart: number;
 
 	public constructor(
 		peerInfo: P2PDiscoveredPeerInfo,
@@ -65,12 +64,10 @@ export class InboundPeer extends Peer {
 				reason,
 			});
 		};
-		this._pingStart = Date.now();
 		this._sendPing = () => {
-			clearTimeout(this._pingTimeoutId);
-			this._pingStart = Date.now();
+			const pingStart = Date.now();
 			this._socket.emit(EVENT_PING, undefined, (_: Error, __: unknown) => {
-				this._latency = Date.now() - this._pingStart;
+				this._latency = Date.now() - pingStart;
 				this._pingTimeoutId = setTimeout(this._sendPing, getRandomPingDelay());
 			});
 		};

--- a/elements/lisk-p2p/src/peer/inbound.ts
+++ b/elements/lisk-p2p/src/peer/inbound.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-
 import {
 	Peer,
 	PeerConfig,
@@ -27,7 +26,7 @@ import { SCServerSocket } from 'socketcluster-server';
 
 export const EVENT_CLOSE_INBOUND = 'closeInbound';
 export const EVENT_INBOUND_SOCKET_ERROR = 'inboundSocketError';
-const DEFAULT_PING_INTERVAL = 1000;
+const DEFAULT_PING_INTERVAL = 500;
 export class InboundPeer extends Peer {
 	protected _socket: SCServerSocketUpdated;
 	protected readonly _handleInboundSocketError: (error: Error) => void;
@@ -59,7 +58,7 @@ export class InboundPeer extends Peer {
 		};
 		this._handlePong = (responseTime: number) => {
 			const latency = Date.now() - responseTime;
-			this._latency = latency;
+			this.latency = latency;
 		};
 		this._socket = peerSocket;
 		this._pingIntervalId = setInterval(() => {

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -165,6 +165,10 @@ export class OutboundPeer extends Peer {
 			});
 		});
 
+		outboundSocket.on('ping', () => {
+			this.emit('pong', Date.now());
+		});
+
 		// Bind RPC and remote event handlers
 		outboundSocket.on(REMOTE_EVENT_RPC_REQUEST, this._handleRawRPC);
 		outboundSocket.on(REMOTE_EVENT_MESSAGE, this._handleRawMessage);
@@ -202,6 +206,7 @@ export class OutboundPeer extends Peer {
 			'postTransactions',
 			this._handleRawLegacyMessagePostTransactions,
 		);
+		outboundSocket.off('ping');
 	}
 }
 
@@ -248,6 +253,9 @@ export const connectAndRequest = async (
 			// Bind an error handler immediately after creating the socket; otherwise errors may crash the process
 			// tslint:disable-next-line no-empty
 			outboundSocket.on('error', () => {});
+			outboundSocket.on('ping' as any, () => {
+				outboundSocket.emit('pong', Date.now());
+			});
 
 			// tslint:disable-next-line no-let
 			let disconnectStatusCode: number;

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -32,7 +32,7 @@ import {
 	REMOTE_RPC_GET_NODE_INFO,
 } from './base';
 
-import { EVENT_PING, EVENT_PONG } from './inbound';
+import { EVENT_PING } from './inbound';
 
 import {
 	P2PDiscoveredPeerInfo,
@@ -167,9 +167,12 @@ export class OutboundPeer extends Peer {
 			});
 		});
 
-		outboundSocket.on(EVENT_PING, () => {
-			this.emit(EVENT_PONG);
-		});
+		outboundSocket.on(
+			EVENT_PING,
+			(_: undefined, res: (_: undefined, data: string) => void) => {
+				res(undefined, 'pong');
+			},
+		);
 
 		// Bind RPC and remote event handlers
 		outboundSocket.on(REMOTE_EVENT_RPC_REQUEST, this._handleRawRPC);
@@ -255,9 +258,12 @@ export const connectAndRequest = async (
 			// Bind an error handler immediately after creating the socket; otherwise errors may crash the process
 			// tslint:disable-next-line no-empty
 			outboundSocket.on('error', () => {});
-			outboundSocket.on(EVENT_PING as any, () => {
-				outboundSocket.emit(EVENT_PONG, Date.now());
-			});
+			outboundSocket.on(
+				EVENT_PING,
+				(_: undefined, res: (_: undefined, data: string) => void) => {
+					res(undefined, 'pong');
+				},
+			);
 
 			// tslint:disable-next-line no-let
 			let disconnectStatusCode: number;

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -32,6 +32,8 @@ import {
 	REMOTE_RPC_GET_NODE_INFO,
 } from './base';
 
+import { EVENT_PING, EVENT_PONG } from './inbound';
+
 import {
 	P2PDiscoveredPeerInfo,
 	P2PMessagePacket,
@@ -165,8 +167,8 @@ export class OutboundPeer extends Peer {
 			});
 		});
 
-		outboundSocket.on('ping', () => {
-			this.emit('pong', Date.now());
+		outboundSocket.on(EVENT_PING, () => {
+			this.emit(EVENT_PONG);
 		});
 
 		// Bind RPC and remote event handlers
@@ -206,7 +208,7 @@ export class OutboundPeer extends Peer {
 			'postTransactions',
 			this._handleRawLegacyMessagePostTransactions,
 		);
-		outboundSocket.off('ping');
+		outboundSocket.off(EVENT_PING);
 	}
 }
 
@@ -253,8 +255,8 @@ export const connectAndRequest = async (
 			// Bind an error handler immediately after creating the socket; otherwise errors may crash the process
 			// tslint:disable-next-line no-empty
 			outboundSocket.on('error', () => {});
-			outboundSocket.on('ping' as any, () => {
-				outboundSocket.emit('pong', Date.now());
+			outboundSocket.on(EVENT_PING as any, () => {
+				outboundSocket.emit(EVENT_PONG, Date.now());
 			});
 
 			// tslint:disable-next-line no-let

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -54,6 +54,7 @@ export const EVENT_CONNECT_OUTBOUND = 'connectOutbound';
 export const EVENT_CONNECT_ABORT_OUTBOUND = 'connectAbortOutbound';
 export const EVENT_CLOSE_OUTBOUND = 'closeOutbound';
 export const EVENT_OUTBOUND_SOCKET_ERROR = 'outboundSocketError';
+export const RESPONSE_PONG = 'pong';
 
 export interface PeerInfoAndOutboundConnection {
 	readonly peerInfo: P2PDiscoveredPeerInfo;
@@ -170,7 +171,7 @@ export class OutboundPeer extends Peer {
 		outboundSocket.on(
 			EVENT_PING,
 			(_: undefined, res: (_: undefined, data: string) => void) => {
-				res(undefined, 'pong');
+				res(undefined, RESPONSE_PONG);
 			},
 		);
 
@@ -261,7 +262,7 @@ export const connectAndRequest = async (
 			outboundSocket.on(
 				EVENT_PING,
 				(_: undefined, res: (_: undefined, data: string) => void) => {
-					res(undefined, 'pong');
+					res(undefined, RESPONSE_PONG);
 				},
 			);
 

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -343,7 +343,7 @@ export class PeerPool extends EventEmitter {
 	): Peer {
 		const inboundPeers = this.getPeers(InboundPeer);
 		if (inboundPeers.length >= this._maxInboundConnections) {
-			this.removePeer(shuffle(inboundPeers)[0].id);
+			this._evictPeer(InboundPeer);
 		}
 
 		const peerConfig = {

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -102,6 +102,8 @@ interface PeerPoolConfig {
 
 export const MAX_PEER_LIST_BATCH_SIZE = 100;
 export const MAX_PEER_DISCOVERY_PROBE_SAMPLE_SIZE = 100;
+export const PEER_PROTECTION_PERCENTAGE_PER_CATEGORY = 0.068;
+export const LONGEVITY_CATEGORY_PERCENTAGE = 0.5;
 
 export class PeerPool extends EventEmitter {
 	private readonly _peerMap: Map<string, Peer>;
@@ -497,8 +499,6 @@ export class PeerPool extends EventEmitter {
 	private _selectPeersForEviction(peers: Peer[]): Peer[] {
 		const evictionProtectionRatio = this._peerPoolConfig
 			.evictionProtectionRatio;
-		const PEER_PROTECTION_PERCENTAGE_PER_CATEGORY = 0.068;
-
 		// Cannot manipulate without physically moving nodes closer to the target.
 		const LATENCY_CATEGORY_PERCENTAGE =
 			evictionProtectionRatio * PEER_PROTECTION_PERCENTAGE_PER_CATEGORY;
@@ -512,7 +512,6 @@ export class PeerPool extends EventEmitter {
 		if (filteredPeersByLatency.length <= 1) {
 			return filteredPeersByLatency;
 		}
-
 		// Cannot manipulate this metric without performing useful work.
 		const RESPONSIVENESS_CATEGORY_PERCENTAGE =
 			evictionProtectionRatio * PEER_PROTECTION_PERCENTAGE_PER_CATEGORY;
@@ -530,9 +529,7 @@ export class PeerPool extends EventEmitter {
 		if (filteredPeersByResponsiveness.length <= 1) {
 			return filteredPeersByResponsiveness;
 		}
-
 		// Protect remaining half of peers by longevity, precludes attacks that start later.
-		const LONGEVITY_CATEGORY_PERCENTAGE = 0.5;
 		const STEADY_PEER_COUNT =
 			filteredPeersByResponsiveness.length * LONGEVITY_CATEGORY_PERCENTAGE;
 		const filteredPeersByConnectTime = filteredPeersByResponsiveness

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1832,7 +1832,7 @@ describe('Integration tests for P2P library', () => {
 		describe('Inbound peer evictions', () => {
 			// Due to randomization from shuffling and timing of the nodes
 			// This test may experience some instability and not always evict.
-			it('should  not evict earliest connected peers', async () => {
+			it('should not evict earliest connected peers', async () => {
 				// We watch middle node for more predictable connection behavior
 				const middleNode = p2pNodeList[5];
 				const inboundPeers = middleNode['_peerPool']

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1842,6 +1842,9 @@ describe('Integration tests for P2P library', () => {
 					(n: Number[]) => n.includes(5003) || n.includes(5004),
 				);
 			});
+
+			it.skip('should not evict peers with low latency', async () => {});
+			it.skip('should not evict peers with high responseRate', async () => {});
 		});
 	});
 });

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -321,11 +321,10 @@ describe('Integration tests for P2P library', () => {
 							nethash:
 								'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 							version: p2p.nodeInfo.version,
-							protocolVersion: '1.1',
 							wsPort: p2p.nodeInfo.wsPort,
 							height: 1000 + (p2p.nodeInfo.wsPort % NETWORK_START_PORT),
 							options: p2p.nodeInfo.options,
-						});
+						} as any);
 					});
 
 					await wait(200);
@@ -727,11 +726,10 @@ describe('Integration tests for P2P library', () => {
 					nethash:
 						'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 					version: firstP2PNode.nodeInfo.version,
-					protocolVersion: '1.1',
 					wsPort: firstP2PNode.nodeInfo.wsPort,
 					height: 10,
 					options: firstP2PNode.nodeInfo.options,
-				});
+				} as any);
 
 				await wait(100);
 

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1337,6 +1337,7 @@ describe('Integration tests for P2P library', () => {
 						populatorInterval: POPULATOR_INTERVAL_WITH_LIMIT,
 						maxOutboundConnections: TEN_CONNECTIONS,
 						maxInboundConnections: TEN_CONNECTIONS,
+						evictionProtectionEnabled: false,
 						nodeInfo: {
 							wsPort: nodePort,
 							nethash:

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1769,7 +1769,7 @@ describe('Integration tests for P2P library', () => {
 	describe('Network with peer inbound eviction protection for connectTime enabled', () => {
 		const NETWORK_PEER_COUNT_WITH_LIMIT = 10;
 		const MAX_INBOUND_CONNECTIONS = 3;
-		const POPULATOR_INTERVAL_WITH_LIMIT = 400;
+		const POPULATOR_INTERVAL_WITH_LIMIT = 150;
 		beforeEach(async () => {
 			p2pNodeList = [...new Array(NETWORK_PEER_COUNT_WITH_LIMIT).keys()].map(
 				index => {
@@ -1830,13 +1830,17 @@ describe('Integration tests for P2P library', () => {
 		});
 
 		describe('Inbound peer evictions', () => {
-			it('should evict inbound peer which connected the latest', async () => {
-				const firstNode = p2pNodeList[0];
-				const inboundPeers = firstNode['_peerPool']
+			// Due to randomization from shuffling and timing of the nodes
+			// This test may experience some instability and not always evict.
+			it('should  not evict earliest connected peers', async () => {
+				// We watch middle node for more predictable connection behavior
+				const middleNode = p2pNodeList[5];
+				const inboundPeers = middleNode['_peerPool']
 					.getPeers(InboundPeer)
 					.map(peer => peer.wsPort);
-				await wait(200);
-				expect(inboundPeers).not.to.include(5000);
+				expect(inboundPeers).to.satisfy(
+					(n: Number[]) => n.includes(5003) || n.includes(5004),
+				);
 			});
 		});
 	});

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1479,7 +1479,6 @@ describe('Integration tests for P2P library', () => {
 	describe('Network with peer inbound eviction protection enabled', () => {
 		const NETWORK_PEER_COUNT_WITH_LIMIT = 10;
 		const MAX_INBOUND_CONNECTIONS = 5;
-		const DISCOVERY_INTERVAL_WITH_LIMIT = 5;
 		const POPULATOR_INTERVAL_WITH_LIMIT = 10;
 		beforeEach(async () => {
 			p2pNodeList = [...new Array(NETWORK_PEER_COUNT_WITH_LIMIT).keys()].map(
@@ -1496,11 +1495,10 @@ describe('Integration tests for P2P library', () => {
 
 					const nodePort = NETWORK_START_PORT + index;
 					return new P2P({
-						connectTimeout: 5000,
+						connectTimeout: 300,
 						ackTimeout: 5000,
 						seedPeers,
 						wsEngine: 'ws',
-						discoveryInterval: DISCOVERY_INTERVAL_WITH_LIMIT,
 						populatorInterval: POPULATOR_INTERVAL_WITH_LIMIT,
 						maxOutboundConnections: MAX_INBOUND_CONNECTIONS,
 						maxInboundConnections: 5,


### PR DESCRIPTION
### What was the problem?

In the current implementation, when the maximum number of inbound peers are connected and a new peer attempts to connect to the node, we randomly select and remove an ongoing inbound peer connection.

### How did I fix it?

In the new protocol, we use the strategy of protecting a number of peers for several distinct characteristics for increased security. 

Netgroups: We calculate a randomized value `keyedNetgroup` based on IP group for each eviction candidate. We protect 4 peers with the smallest  `keyedNetgroup` values. An attacker cannot predict which netgroups will be protected.
* To be started in bucket system milestone

- [x] Peer latency: We protect a number of peers with optimal latency. An attacker cannot manipulate this metric without physically moving nodes closer to the target.

- [x] Useful work: We protect peers who perform useful work, such as peers who have recently sent blocks and transactions. An attacker cannot manipulate this metric without performing useful work.

- [x] Connection time: We protect half of the remaining nodes who have been connected the longest. This precludes attacks that start later.

### Review checklist

* The PR resolves #3721 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
