### PR TITLE
Remove unnecessary argument code from cleanup - Closes #3368

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -260,16 +260,11 @@ module.exports = class Chain {
 		};
 	}
 
-	async cleanup(code, error) {
+	async cleanup(error) {
 		this._unsubscribeToEvents();
 		const { modules, components } = this.scope;
 		if (error) {
 			this.logger.fatal(error.toString());
-			if (code === undefined) {
-				code = 1;
-			}
-		} else if (code === undefined || code === null) {
-			code = 0;
 		}
 		this.logger.info('Cleaning chain...');
 

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -140,6 +140,6 @@ module.exports = class ChainModule extends BaseModule {
 	}
 
 	async unload() {
-		return this.chain.cleanup(0);
+		return this.chain.cleanup();
 	}
 };


### PR DESCRIPTION
### What was the problem?

`code` argument provided to `cleanup` method is never used in the method after it's defined.

### How did I fix it?

Removed the argument and related code.

### How to test it?

Run and exit the application to see if the cleanup is working properly.

### Review checklist

* The PR resolves #3368
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
