### PR TITLE
Fix disappearing broadcasts from broadcaster queue - Closes #3809

### DIFF
--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -237,11 +237,6 @@ export class TransactionPool extends EventEmitter {
 	public addPendingTransaction(transaction: Transaction): AddTransactionResult {
 		const pendingQueue: QueueNames = 'pending';
 
-		this.emit(EVENT_VERIFIED_TRANSACTION_ONCE, {
-			action: ACTION_ADD_PENDING_TRANSACTIONS,
-			payload: [transaction],
-		});
-
 		return this.addTransactionToQueue(pendingQueue, transaction);
 	}
 
@@ -249,11 +244,6 @@ export class TransactionPool extends EventEmitter {
 		transaction: Transaction,
 	): AddTransactionResult {
 		const verifiedQueue: QueueNames = 'verified';
-
-		this.emit(EVENT_VERIFIED_TRANSACTION_ONCE, {
-			action: ACTION_ADD_VERIFIED_TRANSACTIONS,
-			payload: [transaction],
-		});
 
 		return this.addTransactionToQueue(verifiedQueue, transaction);
 	}
@@ -471,6 +461,17 @@ export class TransactionPool extends EventEmitter {
 			to: queueName,
 			payload: [transaction],
 		});
+
+		// If transaction is added to one of the queues which semantically mean that transactions are verified, then fire the event.
+		if (queueName === 'verified' || queueName === 'pending') {
+			this.emit(EVENT_VERIFIED_TRANSACTION_ONCE, {
+				action:
+					queueName === 'verified'
+						? ACTION_ADD_VERIFIED_TRANSACTIONS
+						: ACTION_ADD_PENDING_TRANSACTIONS,
+				payload: [transaction],
+			});
+		}
 
 		return {
 			isFull: false,

--- a/framework/src/modules/chain/logic/broadcaster.js
+++ b/framework/src/modules/chain/logic/broadcaster.js
@@ -150,49 +150,71 @@ class Broadcaster {
 	async filterQueue() {
 		library.logger.debug(`Broadcasts before filtering: ${this.queue.length}`);
 
-		this.queue = await this.queue.reduce(async (prev, broadcast) => {
-			const filteredBroadcast = await prev;
+		const transactionIdsNotInPool = [];
+		this.queue = this.queue.filter(broadcast => {
 			if (broadcast.options.immediate) {
-				return filteredBroadcast;
+				return false;
 			}
 
 			if (broadcast.options.data) {
 				let transactionId;
 				if (broadcast.options.data.transaction) {
-					// Look for a transaction of a given "id" when broadcasting transactions
+					// Look for a transaction of a given "id"
 					transactionId = broadcast.options.data.transaction.id;
 				} else if (broadcast.options.data.signature) {
-					// Look for a corresponding "transactionId" of a given signature when broadcasting signatures
+					// Look for a corresponding "transactionId" of a given signature
 					transactionId = broadcast.options.data.signature.transactionId;
 				}
 				if (!transactionId) {
-					return filteredBroadcast;
+					return false;
 				}
 				// Broadcast if transaction is in transaction pool
-				if (modules.transactions.transactionInPool(transactionId)) {
-					filteredBroadcast.push(broadcast);
-					return filteredBroadcast;
+				if (!modules.transactions.transactionInPool(transactionId)) {
+					transactionIdsNotInPool.push(transactionId);
 				}
-				// Don't broadcast if transaction is already confirmed
+				return true;
+			}
+			return true;
+		});
+
+		const persistedTransactionIds = (await Promise.all(
+			transactionIdsNotInPool.map(async transactionId => {
 				try {
 					const isPersisted = await library.storage.entities.Transaction.isPersisted(
 						{
 							id: transactionId,
 						}
 					);
-					if (!isPersisted) {
-						filteredBroadcast.push(broadcast);
-					}
-					return filteredBroadcast;
-				} catch (err) {
-					return filteredBroadcast;
+					return {
+						transactionId,
+						isPersisted,
+					};
+				} catch (e) {
+					// if there is an error for transaction id then remove it from the broadcasts
+					return {
+						transactionId,
+						isPersisted: true,
+					};
 				}
+			})
+		))
+			.filter(({ isPersisted }) => isPersisted)
+			.map(({ transactionId }) => transactionId);
+
+		this.queue = this.queue.filter(broadcast => {
+			if (broadcast.options.data) {
+				let transactionId;
+				if (broadcast.options.data.transaction) {
+					// Look for a transaction of a given "id"
+					transactionId = broadcast.options.data.transaction.id;
+				} else if (broadcast.options.data.signature) {
+					// Look for a corresponding "transactionId" of a given signature
+					transactionId = broadcast.options.data.signature.transactionId;
+				}
+				return !persistedTransactionIds.includes(transactionId);
 			}
-
-			filteredBroadcast.push(broadcast);
-
-			return filteredBroadcast;
-		}, []);
+			return true;
+		});
 
 		library.logger.debug(`Broadcasts after filtering: ${this.queue.length}`);
 

--- a/framework/src/modules/chain/logic/transaction_pool.js
+++ b/framework/src/modules/chain/logic/transaction_pool.js
@@ -366,6 +366,10 @@ class TransactionPool {
 			]);
 		}
 
+		if (transaction.bundled) {
+			return this.addBundledTransaction(transaction, cb);
+		}
+
 		return this.verifyTransactions([transaction]).then(
 			({ transactionsResponses }) => {
 				if (transactionsResponses[0].status === TransactionStatus.OK) {

--- a/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
+++ b/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
@@ -421,6 +421,20 @@ describe('Broadcaster', () => {
 						.to.eql(auxBroadcasts);
 				});
 			});
+
+			describe('when all transactions are confirmed', () => {
+				beforeEach(async () => {
+					modulesStub.transactions.transactionInPool.returns(false);
+					library.storage.entities.Transaction.isPersisted.resolves(true);
+				});
+
+				it('should remove all of them from broadcaster.queue', async () => {
+					await broadcaster.filterQueue();
+					expect(broadcaster.queue)
+						.to.be.an('Array')
+						.to.eql([]);
+				});
+			});
 		});
 	});
 

--- a/framework/test/mocha/unit/modules/chain/logic/transaction_pool.js
+++ b/framework/test/mocha/unit/modules/chain/logic/transaction_pool.js
@@ -400,6 +400,17 @@ describe('transactionPool', () => {
 			});
 		});
 
+		it('should add transaction to the received queue if the bundled property = true', done => {
+			transaction.bundled = true;
+			const addBundledTransactionStub = sinonSandbox
+				.stub(transactionPool, 'addBundledTransaction')
+				.callsArg(1);
+			transactionPool.processUnconfirmedTransaction(transaction, false, () => {
+				expect(addBundledTransactionStub).to.be.calledWith(transaction);
+				done();
+			});
+		});
+
 		it('should add transaction to the verified queue when status is OK', done => {
 			const transactionsResponses = [
 				{


### PR DESCRIPTION
### What was the problem?
The broadcasts were removed in the broadcaster queue in the case when the node received transactions/signatures during the filtering of the queue due to a race condition.
### How did I fix it?
Fixed the race condition
### How to test it?
The PR needs to be tested against the scenario which produced #3809
### Review checklist

* The PR resolves #3809
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
