### PR TITLE
Implement create and sign any transaction functionality in Lisk Transactions - Closes #3739

### DIFF
--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -221,6 +221,10 @@ export abstract class BaseTransaction {
 		return transaction;
 	}
 
+	public stringify(): string {
+		return JSON.stringify(this.toJSON());
+	}
+
 	public isReady(): boolean {
 		return (
 			this._multisignatureStatus === MultisignatureStatus.READY ||

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -15,7 +15,6 @@
 import * as BigNum from '@liskhq/bignum';
 import {
 	bigNumberToBuffer,
-	getAddressFromPublicKey,
 	hash,
 	hexToBuffer,
 	signData,
@@ -35,6 +34,8 @@ import {
 import { createResponse, Status } from './response';
 import { Account, TransactionJSON } from './transaction_types';
 import {
+	decideOnRecipientId,
+	decideOnSenderId,
 	getId,
 	isValidNumber,
 	validateSenderIdAndPublicKey,
@@ -150,16 +151,13 @@ export abstract class BaseTransaction {
 		);
 
 		this._id = tx.id;
-		this.recipientId = tx.recipientId || '';
+		this.recipientId = decideOnRecipientId(
+			tx.recipientId,
+			tx.recipientPublicKey,
+		);
 		this.recipientPublicKey = tx.recipientPublicKey || undefined;
 		this.senderPublicKey = tx.senderPublicKey || '';
-		try {
-			this.senderId = tx.senderId
-				? tx.senderId
-				: getAddressFromPublicKey(this.senderPublicKey);
-		} catch (error) {
-			this.senderId = '';
-		}
+		this.senderId = decideOnSenderId(tx.senderId, this.senderPublicKey);
 
 		this._signature = tx.signature;
 		this.signatures = (tx.signatures as string[]) || [];

--- a/elements/lisk-transactions/src/utils/constructor.ts
+++ b/elements/lisk-transactions/src/utils/constructor.ts
@@ -1,0 +1,52 @@
+import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
+
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+export const decideOnRecipientId = (
+	recipientId?: string | null,
+	recipientPublicKey?: string,
+	noValue = '',
+): string => {
+	// Always assign passed receipientId if present
+	if (recipientId) {
+		return recipientId;
+	}
+	// Obtain recipientId out of recipientPublicKey if no recipientId
+	if (recipientPublicKey) {
+		return getAddressFromPublicKey(recipientPublicKey);
+	}
+
+	// Assign noValue if neither recipientId nor recipientPublicKey
+	return noValue;
+};
+
+export const decideOnSenderId = (
+	senderId?: string | null,
+	senderPublicKey?: string,
+	noValue = '',
+): string => {
+	// Always assign passed senderId if present
+	if (senderId) {
+		return senderId;
+	}
+	// Obtain senderId out of senderPublicKey if no recipientId
+	if (senderPublicKey) {
+		return getAddressFromPublicKey(senderPublicKey);
+	}
+
+	// Assign noValue if neither senderId nor senderPublicKey
+	return noValue;
+};

--- a/elements/lisk-transactions/src/utils/index.ts
+++ b/elements/lisk-transactions/src/utils/index.ts
@@ -13,6 +13,7 @@
  *
  */
 export * from './address';
+export * from './constructor';
 export * from './create_base_transaction';
 export * from './get_transaction_bytes';
 export * from './get_transaction_hash';


### PR DESCRIPTION
### What was the problem?
There wasn't a functionality allowing to create and sign any transaction extending BaseTransaction in an easy way.

### Review checklist

* The PR resolves #3739 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
