### PR TITLE
Remove relayLimit from broadcaster - Closes #3819

### DIFF
--- a/framework/src/modules/chain/blocks/process.js
+++ b/framework/src/modules/chain/blocks/process.js
@@ -58,10 +58,11 @@ class BlocksProcess {
 		if (!verified) {
 			throw errors;
 		}
+		await this.blocksVerify.checkExists(normalizedBlock);
+
 		if (typeof broadcast === 'function') {
 			broadcast(normalizedBlock);
 		}
-		await this.blocksVerify.checkExists(normalizedBlock);
 		await this.blocksVerify.validateBlockSlot(normalizedBlock);
 		await this.blocksVerify.checkTransactions(normalizedBlock);
 		await this.blocksChain.applyBlock(normalizedBlock, true);

--- a/framework/src/modules/chain/defaults/config.js
+++ b/framework/src/modules/chain/defaults/config.js
@@ -33,13 +33,8 @@ const defaultConfig = {
 					minimum: 1,
 					maximum: 25,
 				},
-				relayLimit: {
-					type: 'integer',
-					minimum: 1,
-					maximum: 100,
-				},
 			},
-			required: ['broadcastInterval', 'releaseLimit', 'relayLimit'],
+			required: ['broadcastInterval', 'releaseLimit'],
 		},
 		transactions: {
 			type: 'object',
@@ -248,7 +243,6 @@ const defaultConfig = {
 			active: true,
 			broadcastInterval: 5000,
 			releaseLimit: 25,
-			relayLimit: 3,
 		},
 		transactions: {
 			maxTransactionsPerQueue: 1000,

--- a/framework/src/modules/chain/logic/broadcaster.js
+++ b/framework/src/modules/chain/logic/broadcaster.js
@@ -128,26 +128,6 @@ class Broadcaster {
 	}
 
 	/**
-	 * Counts relays and valid limit.
-	 *
-	 * @param {Object} object
-	 * @returns {boolean} true - If broadcast relays exhausted
-	 * @todo Add description for the params
-	 */
-	maxRelays(object) {
-		if (!Number.isInteger(object.relays)) {
-			object.relays = 0; // First broadcast
-		}
-
-		if (Math.abs(object.relays) >= this.config.relayLimit) {
-			library.logger.debug('Broadcast relays exhausted', object);
-			return true;
-		}
-		object.relays++; // Next broadcast
-		return false;
-	}
-
-	/**
 	 * Filters private queue based on broadcasts.
 	 *
 	 * @private

--- a/framework/src/modules/chain/transport.js
+++ b/framework/src/modules/chain/transport.js
@@ -28,7 +28,7 @@ const exceptions = global.exceptions;
 const { MAX_SHARED_TRANSACTIONS } = global.constants;
 
 function incrementRelays(packet) {
-	if (!packet.relays) {
+	if (!Number.isInteger(packet.relays)) {
 		packet.relays = 0;
 	}
 	packet.relays++;

--- a/framework/src/modules/chain/transport.js
+++ b/framework/src/modules/chain/transport.js
@@ -108,7 +108,9 @@ class Transport {
 	 */
 	// eslint-disable-next-line class-methods-use-this
 	onSignature(signature, broadcast) {
-		if (broadcast && !__private.broadcaster.maxRelays(signature)) {
+		if (broadcast) {
+			// TODO: Remove the relays property as part of the next hard fork. This needs to be set to a fixed value for backwards compatibility.
+			signature.relays = 1;
 			__private.broadcaster.enqueue(
 				{},
 				{
@@ -132,7 +134,9 @@ class Transport {
 	 */
 	// eslint-disable-next-line class-methods-use-this
 	onUnconfirmedTransaction(transaction, broadcast) {
-		if (broadcast && !__private.broadcaster.maxRelays(transaction)) {
+		if (broadcast) {
+			// TODO: Remove the relays property as part of the next hard fork. This needs to be set to a fixed value for backwards compatibility.
+			transaction.relays = 1;
 			const transactionJSON = transaction.toJSON();
 			__private.broadcaster.enqueue(
 				{},
@@ -160,13 +164,9 @@ class Transport {
 		// Exit immediately when 'broadcast' flag is not set
 		if (!broadcast) return null;
 
-		// Check if we are free to broadcast
-		if (__private.broadcaster.maxRelays(block)) {
-			library.logger.debug(
-				'Transport->onBroadcastBlock: Aborted - max block relays exhausted'
-			);
-			return null;
-		}
+		// TODO: Remove the relays property as part of the next hard fork. This needs to be set to a fixed value for backwards compatibility.
+		block.relays = 1;
+
 		if (modules.loader.syncing()) {
 			library.logger.debug(
 				'Transport->onBroadcastBlock: Aborted - blockchain synchronization in progress'

--- a/framework/src/modules/chain/transport.js
+++ b/framework/src/modules/chain/transport.js
@@ -27,6 +27,13 @@ const transactionsModule = require('./transactions');
 const exceptions = global.exceptions;
 const { MAX_SHARED_TRANSACTIONS } = global.constants;
 
+function incrementRelays(packet) {
+	if (!packet.relays) {
+		packet.relays = 0;
+	}
+	packet.relays++;
+}
+
 // Private fields
 let modules;
 let library;
@@ -109,8 +116,8 @@ class Transport {
 	// eslint-disable-next-line class-methods-use-this
 	onSignature(signature, broadcast) {
 		if (broadcast) {
-			// TODO: Remove the relays property as part of the next hard fork. This needs to be set to a fixed value for backwards compatibility.
-			signature.relays = 1;
+			// TODO: Remove the relays property as part of the next hard fork. This needs to be set for backwards compatibility.
+			incrementRelays(signature);
 			__private.broadcaster.enqueue(
 				{},
 				{
@@ -135,8 +142,8 @@ class Transport {
 	// eslint-disable-next-line class-methods-use-this
 	onUnconfirmedTransaction(transaction, broadcast) {
 		if (broadcast) {
-			// TODO: Remove the relays property as part of the next hard fork. This needs to be set to a fixed value for backwards compatibility.
-			transaction.relays = 1;
+			// TODO: Remove the relays property as part of the next hard fork. This needs to be set for backwards compatibility.
+			incrementRelays(transaction);
 			const transactionJSON = transaction.toJSON();
 			__private.broadcaster.enqueue(
 				{},
@@ -164,8 +171,8 @@ class Transport {
 		// Exit immediately when 'broadcast' flag is not set
 		if (!broadcast) return null;
 
-		// TODO: Remove the relays property as part of the next hard fork. This needs to be set to a fixed value for backwards compatibility.
-		block.relays = 1;
+		// TODO: Remove the relays property as part of the next hard fork. This needs to be set for backwards compatibility.
+		incrementRelays(block);
 
 		if (modules.loader.syncing()) {
 			library.logger.debug(

--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -64,7 +64,6 @@ Object {
         "broadcastInterval": 5000,
         "broadcastLimit": 25,
         "parallelLimit": 20,
-        "relayLimit": 3,
         "releaseLimit": 25,
       },
       "exceptions": Object {

--- a/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
+++ b/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
@@ -43,7 +43,6 @@ describe('Broadcaster', () => {
 			broadcastInterval: 10000,
 			releaseLimit: 10,
 			parallelLimit: 10,
-			relayLimit: 10,
 			broadcastLimit: 10,
 		};
 
@@ -157,14 +156,6 @@ describe('Broadcaster', () => {
 			expect(broadcaster.enqueue(auxParams, auxOptions)).to.eql(1);
 			return expect(broadcaster.enqueue(auxParams, auxOptions)).to.eql(2);
 		});
-	});
-
-	describe('maxRelays', () => {
-		it('should return true if exhausted', async () =>
-			expect(broadcaster.maxRelays({ relays: 11 })).to.be.true);
-
-		it('should return false if max relay is less than relay limit', async () =>
-			expect(broadcaster.maxRelays({ relays: 9 })).to.be.false);
 	});
 
 	describe('filterQueue', () => {

--- a/framework/test/mocha/unit/modules/chain/transport.js
+++ b/framework/test/mocha/unit/modules/chain/transport.js
@@ -847,7 +847,6 @@ describe('transport', () => {
 					__private.broadcaster = {
 						enqueue: sinonSandbox.stub(),
 					};
-					transportInstance.onUnconfirmedTransaction(transaction, true);
 				});
 
 				describe('when broadcast is defined', () => {

--- a/framework/test/mocha/unit/modules/chain/transport.js
+++ b/framework/test/mocha/unit/modules/chain/transport.js
@@ -806,7 +806,7 @@ describe('transport', () => {
 						transportInstance.onSignature(SAMPLE_SIGNATURE_1, true);
 					});
 
-					it('should call __private.broadcaster.enqueue with {} and {api: "postSignatures", data: {signature: signature}} as arguments', async () => {
+					it('should call __private.broadcaster.enqueue with {} and {api: "postSignatures", data: {signature: signature}} as arguments', () => {
 						expect(__private.broadcaster.enqueue.calledOnce).to.be.true;
 						return expect(
 							__private.broadcaster.enqueue.calledWith(
@@ -819,9 +819,9 @@ describe('transport', () => {
 						).to.be.true;
 					});
 
-					it('should call library.channel.publish with "chain:signature:change" and signature', async () => {
+					it('should call library.channel.publish with "chain:signature:change" and signature', () => {
 						expect(library.channel.publish).to.be.calledOnce;
-						expect(library.channel.publish).to.be.calledWith(
+						return expect(library.channel.publish).to.be.calledWith(
 							'chain:signature:change',
 							SAMPLE_SIGNATURE_1
 						);
@@ -863,7 +863,7 @@ describe('transport', () => {
 						transportInstance.onUnconfirmedTransaction(transaction, true);
 					});
 
-					it('should call __private.broadcaster.enqueue with {} and {api: "postTransactions", data: {transaction}}', async () => {
+					it('should call __private.broadcaster.enqueue with {} and {api: "postTransactions", data: {transaction}}', () => {
 						expect(__private.broadcaster.enqueue.calledOnce).to.be.true;
 						return expect(
 							__private.broadcaster.enqueue.calledWith(
@@ -876,9 +876,9 @@ describe('transport', () => {
 						).to.be.true;
 					});
 
-					it('should call library.channel.publish with "chain:transactions:change" and transaction as arguments', async () => {
+					it('should call library.channel.publish with "chain:transactions:change" and transaction as arguments', () => {
 						expect(library.channel.publish).to.be.calledOnce;
-						expect(library.channel.publish).to.be.calledWith(
+						return expect(library.channel.publish).to.be.calledWith(
 							'chain:transactions:change',
 							transaction.toJSON()
 						);
@@ -912,9 +912,9 @@ describe('transport', () => {
 						return transportInstance.onBroadcastBlock(block, true);
 					});
 
-					it('should call __private.broadcaster.broadcast', async () => {
+					it('should call __private.broadcaster.broadcast', () => {
 						expect(__private.broadcaster.broadcast.calledOnce).to.be.true;
-						expect(__private.broadcaster.broadcast).to.be.calledWith(
+						return expect(__private.broadcaster.broadcast).to.be.calledWith(
 							{
 								broadhash:
 									'81a410c4ff35e6d643d30e42a27a222dbbfc66f1e62c32e6a91dd3438defb70b',
@@ -929,17 +929,18 @@ describe('transport', () => {
 					});
 
 					describe('when modules.loader.syncing = true', () => {
-						beforeEach(async () => {
+						beforeEach(() => {
 							modules.loader.syncing = sinonSandbox.stub().returns(true);
-							transportInstance.onBroadcastBlock(block, true);
+							return transportInstance.onBroadcastBlock(block, true);
 						});
 
-						it('should call library.logger.debug with proper error message', async () =>
-							expect(
+						it('should call library.logger.debug with proper error message', () => {
+							return expect(
 								library.logger.debug.calledWith(
 									'Transport->onBroadcastBlock: Aborted - blockchain synchronization in progress'
 								)
-							).to.be.true);
+							).to.be.true;
+						});
 					});
 				});
 			});

--- a/framework/test/mocha/unit/modules/chain/transport.js
+++ b/framework/test/mocha/unit/modules/chain/transport.js
@@ -801,40 +801,30 @@ describe('transport', () => {
 				describe('when broadcast is defined', () => {
 					beforeEach(async () => {
 						__private.broadcaster = {
-							maxRelays: sinonSandbox.stub().returns(false),
 							enqueue: sinonSandbox.stub(),
 						};
 						transportInstance.onSignature(SAMPLE_SIGNATURE_1, true);
 					});
 
-					it('should call __private.broadcaster.maxRelays with signature', async () => {
-						expect(__private.broadcaster.maxRelays.calledOnce).to.be.true;
+					it('should call __private.broadcaster.enqueue with {} and {api: "postSignatures", data: {signature: signature}} as arguments', async () => {
+						expect(__private.broadcaster.enqueue.calledOnce).to.be.true;
 						return expect(
-							__private.broadcaster.maxRelays.calledWith(SAMPLE_SIGNATURE_1)
+							__private.broadcaster.enqueue.calledWith(
+								{},
+								{
+									api: 'postSignatures',
+									data: { signature: SAMPLE_SIGNATURE_1 },
+								}
+							)
 						).to.be.true;
 					});
 
-					describe('when result of __private.broadcaster.maxRelays is false', () => {
-						it('should call __private.broadcaster.enqueue with {} and {api: "postSignatures", data: {signature: signature}} as arguments', async () => {
-							expect(__private.broadcaster.enqueue.calledOnce).to.be.true;
-							return expect(
-								__private.broadcaster.enqueue.calledWith(
-									{},
-									{
-										api: 'postSignatures',
-										data: { signature: SAMPLE_SIGNATURE_1 },
-									}
-								)
-							).to.be.true;
-						});
-
-						it('should call library.channel.publish with "chain:signature:change" and signature', async () => {
-							expect(library.channel.publish).to.be.calledOnce;
-							expect(library.channel.publish).to.be.calledWith(
-								'chain:signature:change',
-								SAMPLE_SIGNATURE_1
-							);
-						});
+					it('should call library.channel.publish with "chain:signature:change" and signature', async () => {
+						expect(library.channel.publish).to.be.calledOnce;
+						expect(library.channel.publish).to.be.calledWith(
+							'chain:signature:change',
+							SAMPLE_SIGNATURE_1
+						);
 					});
 				});
 			});
@@ -855,55 +845,44 @@ describe('transport', () => {
 							'2821d93a742c4edf5fd960efad41a4def7bf0fd0f7c09869aed524f6f52bf9c97a617095e2c712bd28b4279078a29509b339ac55187854006591aa759784c205',
 					});
 					__private.broadcaster = {
-						maxRelays: sinonSandbox.stub().returns(true),
 						enqueue: sinonSandbox.stub(),
 					};
 					transportInstance.onUnconfirmedTransaction(transaction, true);
 				});
 
 				describe('when broadcast is defined', () => {
-					it('should call __private.broadcaster.maxRelays with transaction', async () => {
-						expect(__private.broadcaster.maxRelays.calledOnce).to.be.true;
-						return expect(__private.broadcaster.maxRelays).to.be.calledWith(
-							transaction
-						);
+					beforeEach(async () => {
+						__private.broadcaster = {
+							enqueue: sinonSandbox.stub(),
+						};
+						library.channel.invokeSync
+							.withArgs('lisk:getApplicationState')
+							.returns({
+								broadhash:
+									'81a410c4ff35e6d643d30e42a27a222dbbfc66f1e62c32e6a91dd3438defb70b',
+							});
+						transportInstance.onUnconfirmedTransaction(transaction, true);
 					});
 
-					describe('when result of __private.broadcaster.maxRelays is false', () => {
-						beforeEach(async () => {
-							__private.broadcaster = {
-								maxRelays: sinonSandbox.stub().returns(false),
-								enqueue: sinonSandbox.stub(),
-							};
-							library.channel.invokeSync
-								.withArgs('lisk:getApplicationState')
-								.returns({
-									broadhash:
-										'81a410c4ff35e6d643d30e42a27a222dbbfc66f1e62c32e6a91dd3438defb70b',
-								});
-							transportInstance.onUnconfirmedTransaction(transaction, true);
-						});
+					it('should call __private.broadcaster.enqueue with {} and {api: "postTransactions", data: {transaction}}', async () => {
+						expect(__private.broadcaster.enqueue.calledOnce).to.be.true;
+						return expect(
+							__private.broadcaster.enqueue.calledWith(
+								{},
+								{
+									api: 'postTransactions',
+									data: { transaction: transaction.toJSON() },
+								}
+							)
+						).to.be.true;
+					});
 
-						it('should call __private.broadcaster.enqueue with {} and {api: "postTransactions", data: {transaction}}', async () => {
-							expect(__private.broadcaster.enqueue.calledOnce).to.be.true;
-							return expect(
-								__private.broadcaster.enqueue.calledWith(
-									{},
-									{
-										api: 'postTransactions',
-										data: { transaction: transaction.toJSON() },
-									}
-								)
-							).to.be.true;
-						});
-
-						it('should call library.channel.publish with "chain:transactions:change" and transaction as arguments', async () => {
-							expect(library.channel.publish).to.be.calledOnce;
-							expect(library.channel.publish).to.be.calledWith(
-								'chain:transactions:change',
-								transaction.toJSON()
-							);
-						});
+					it('should call library.channel.publish with "chain:transactions:change" and transaction as arguments', async () => {
+						expect(library.channel.publish).to.be.calledOnce;
+						expect(library.channel.publish).to.be.calledWith(
+							'chain:transactions:change',
+							transaction.toJSON()
+						);
 					});
 				});
 			});
@@ -924,7 +903,6 @@ describe('transport', () => {
 							totalForged: '65000000',
 						};
 						__private.broadcaster = {
-							maxRelays: sinonSandbox.stub().returns(false),
 							enqueue: sinonSandbox.stub(),
 							broadcast: sinonSandbox.stub(),
 						};
@@ -933,12 +911,6 @@ describe('transport', () => {
 								'81a410c4ff35e6d643d30e42a27a222dbbfc66f1e62c32e6a91dd3438defb70b',
 						};
 						return transportInstance.onBroadcastBlock(block, true);
-					});
-
-					it('should call __private.broadcaster.maxRelays with block', async () => {
-						expect(__private.broadcaster.maxRelays.calledOnce).to.be.true;
-						return expect(__private.broadcaster.maxRelays.calledWith(block)).to
-							.be.true;
 					});
 
 					it('should call __private.broadcaster.broadcast', async () => {
@@ -955,22 +927,6 @@ describe('transport', () => {
 								},
 							}
 						);
-					});
-
-					describe('when __private.broadcaster.maxRelays returns true', () => {
-						beforeEach(async () => {
-							__private.broadcaster.maxRelays = sinonSandbox
-								.stub()
-								.returns(true);
-							transportInstance.onBroadcastBlock(block, true);
-						});
-
-						it('should call library.logger.debug with proper error message', async () =>
-							expect(
-								library.logger.debug.calledWith(
-									'Transport->onBroadcastBlock: Aborted - max block relays exhausted'
-								)
-							).to.be.true);
 					});
 
 					describe('when modules.loader.syncing = true', () => {

--- a/sdk/src/samples/config_devnet.json
+++ b/sdk/src/samples/config_devnet.json
@@ -504,8 +504,7 @@
 			"broadcasts": {
 				"active": true,
 				"broadcastInterval": 5000,
-				"releaseLimit": 25,
-				"relayLimit": 3
+				"releaseLimit": 25
 			},
 			"transactions": {
 				"maxTransactionsPerQueue": 1000


### PR DESCRIPTION
### What was the problem?

The relayLimit can cause issues with propagation. When a block, transaction or signature has already been processed, it will not be relayed so the relayLimit is not required.

### How did I fix it?

- Removed the `maxRelays(...)` check so that the broadcaster does not account for relayLimit when relaying a block, transaction or signature.
- The node will always set the `relayLimit` to `1`; this is to prevent breaking backwards compatibility with existing nodes. Also, keeping the `relayLimit` at `1` will prevent other nodes from hitting the relay limit.

### How to test it?

Run tests

### Review checklist

* The PR resolves #3819
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
