### PR TITLE
Move transactions to the ready queue only if all transaction can be processed together

### DIFF
--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -560,31 +560,35 @@ export class TransactionPool extends EventEmitter {
 			queueCheckers.checkTransactionForId(failedTransactions),
 		);
 
-		// Keep transactions in the ready queue which still exist
-		this._queues.ready.enqueueMany(
-			this._queues.ready.removeFor(
-				queueCheckers.checkTransactionForId(passedTransactions),
-			),
-		);
+		// Empty failed transactions list gurantees that all transactions can be processed together
+		// So move all passed transactions to the ready queue
+		if (failedTransactions.length === 0) {
+			// Keep transactions in the ready queue which still exist
+			this._queues.ready.enqueueMany(
+				this._queues.ready.removeFor(
+					queueCheckers.checkTransactionForId(passedTransactions),
+				),
+			);
 
-		// Move processeable transactions from the verified queue to the ready queue
-		this._queues.ready.enqueueMany(
-			this._queues.verified.removeFor(
-				queueCheckers.checkTransactionForId(passedTransactions),
-			),
-		);
+			// Move processeable transactions from the verified queue to the ready queue
+			this._queues.ready.enqueueMany(
+				this._queues.verified.removeFor(
+					queueCheckers.checkTransactionForId(passedTransactions),
+				),
+			);
 
-		// Move processable transactions from the pending queue to the ready queue
-		this._queues.ready.enqueueMany(
-			this._queues.pending.removeFor(
-				queueCheckers.checkTransactionForId(passedTransactions),
-			),
-		);
+			// Move processable transactions from the pending queue to the ready queue
+			this._queues.ready.enqueueMany(
+				this._queues.pending.removeFor(
+					queueCheckers.checkTransactionForId(passedTransactions),
+				),
+			);
 
-		this.emit(EVENT_REMOVED_TRANSACTIONS, {
-			action: ACTION_PROCESS_VERIFIED_TRANSACTIONS,
-			payload: removedTransactions,
-		});
+			this.emit(EVENT_REMOVED_TRANSACTIONS, {
+				action: ACTION_PROCESS_VERIFIED_TRANSACTIONS,
+				payload: removedTransactions,
+			});
+		}
 
 		return {
 			passedTransactions,

--- a/elements/lisk-transaction-pool/test/integration/transaction_movement.ts
+++ b/elements/lisk-transaction-pool/test/integration/transaction_movement.ts
@@ -35,7 +35,7 @@ describe('transaction movement between queues', () => {
 
 	const validateTransactionFunction = fakeCheckFunctionGenerator(['1']);
 	const verifyTransactionFunction = fakeCheckFunctionGenerator(['2']);
-	const processTransactionsFunction = fakeCheckFunctionGenerator(['3']);
+	const processTransactionsFunction = fakeCheckFunctionGenerator(['-1']);
 
 	const dependencies = {
 		processTransactions: fakeCheckerFunctionGenerator(
@@ -199,6 +199,8 @@ describe('transaction movement between queues', () => {
 				});
 
 				it('should remove unverfied transactions from the transaction pool', async () => {
+					(transactionsToProcess[0].id as any) =
+						'-1' + transactionsToProcess[0].id;
 					await wrapExpectationInNextTick(() => {
 						unprocessableTransactions.forEach(transaction => {
 							expect(transactionPool.existsInTransactionPool(transaction.id)).to

--- a/framework/test/mocha/integration/transactions/0.0.address_collision.js
+++ b/framework/test/mocha/integration/transactions/0.0.address_collision.js
@@ -113,10 +113,12 @@ describe('integration test (type 0) - address collision', () => {
 
 		describe('after forging one block', () => {
 			before(done => {
-				localCommon.forge(library, (err, res) => {
-					expect(err).to.be.null;
-					expect(res).to.be.undefined;
-					done();
+				localCommon.fillPool(library, () => {
+					localCommon.forge(library, (err, res) => {
+						expect(err).to.be.null;
+						expect(res).to.be.undefined;
+						done();
+					});
 				});
 			});
 

--- a/framework/test/mocha/integration/transactions/0_0_transfer.js
+++ b/framework/test/mocha/integration/transactions/0_0_transfer.js
@@ -80,8 +80,10 @@ describe('integration test (type 0) - double transfers', () => {
 
 			describe('after forging one block', () => {
 				before(done => {
-					localCommon.forge(library, async () => {
-						done();
+					localCommon.fillPool(library, () => {
+						localCommon.forge(library, async () => {
+							done();
+						});
 					});
 				});
 

--- a/framework/test/mocha/integration/transactions/1_second_signature/1_1_second_signature.js
+++ b/framework/test/mocha/integration/transactions/1_second_signature/1_1_second_signature.js
@@ -71,8 +71,10 @@ describe('integration test (type 1) - double second signature registrations', ()
 
 	describe('after forging one block', () => {
 		before(done => {
-			localCommon.forge(library, async () => {
-				done();
+			localCommon.fillPool(library, () => {
+				localCommon.forge(library, async () => {
+					done();
+				});
 			});
 		});
 

--- a/framework/test/mocha/integration/transactions/2_delegates/1_same_account_same_username.js
+++ b/framework/test/mocha/integration/transactions/2_delegates/1_same_account_same_username.js
@@ -79,8 +79,10 @@ describe('integration test (type 2) - double delegate registrations', () => {
 
 				describe('after forging one block', () => {
 					before(done => {
-						localCommon.forge(library, async () => {
-							done();
+						localCommon.fillPool(library, () => {
+							localCommon.forge(library, async () => {
+								done();
+							});
 						});
 					});
 

--- a/framework/test/mocha/integration/transactions/2_delegates/2_same_account_different_usernames.js
+++ b/framework/test/mocha/integration/transactions/2_delegates/2_same_account_different_usernames.js
@@ -79,8 +79,10 @@ describe('integration test (type 2) - double delegate registrations', () => {
 
 				describe('after forging one block', () => {
 					before(done => {
-						localCommon.forge(library, async () => {
-							done();
+						localCommon.fillPool(library, () => {
+							localCommon.forge(library, async () => {
+								done();
+							});
 						});
 					});
 

--- a/framework/test/mocha/integration/transactions/2_delegates/3_different_accounts_same_username.js
+++ b/framework/test/mocha/integration/transactions/2_delegates/3_different_accounts_same_username.js
@@ -89,8 +89,10 @@ describe('integration test (type 2) - double delegate registrations', () => {
 
 				describe('after forging one block', () => {
 					before(done => {
-						localCommon.forge(library, async () => {
-							done();
+						localCommon.fillPool(library, () => {
+							localCommon.forge(library, async () => {
+								done();
+							});
 						});
 					});
 

--- a/framework/test/mocha/integration/transactions/3_3_votes.js
+++ b/framework/test/mocha/integration/transactions/3_3_votes.js
@@ -81,8 +81,10 @@ describe('integration test (type 3) - voting with duplicate submissions', () => 
 
 			describe('after forging one block', () => {
 				before(done => {
-					localCommon.forge(library, async () => {
-						done();
+					localCommon.fillPool(library, () => {
+						localCommon.forge(library, async () => {
+							done();
+						});
 					});
 				});
 
@@ -151,8 +153,10 @@ describe('integration test (type 3) - voting with duplicate submissions', () => 
 
 				describe('after forging a second block', () => {
 					before(done => {
-						localCommon.forge(library, async () => {
-							done();
+						localCommon.fillPool(library, () => {
+							localCommon.forge(library, async () => {
+								done();
+							});
 						});
 					});
 

--- a/framework/test/mocha/integration/transactions/4_multisignature/4_4_multisignature.js
+++ b/framework/test/mocha/integration/transactions/4_multisignature/4_4_multisignature.js
@@ -92,8 +92,10 @@ describe('integration test (type 4) - double multisignature registrations', () =
 
 	describe('after forging one block', () => {
 		before(done => {
-			localCommon.forge(library, async () => {
-				done();
+			localCommon.fillPool(library, () => {
+				localCommon.forge(library, async () => {
+					done();
+				});
 			});
 		});
 

--- a/framework/test/mocha/integration/transactions/4_multisignature/4_X_multisignature_edge_cases.js
+++ b/framework/test/mocha/integration/transactions/4_multisignature/4_X_multisignature_edge_cases.js
@@ -117,14 +117,16 @@ describe('integration test - multi signature edge cases', () => {
 		});
 
 		it('once account balance is not enough transactions should be removed from the queue', async () => {
-			return localCommon.forge(library, async () => {
-				localCommon.getMultisignatureTransactions(
-					library,
-					{},
-					(err, queueStatusRes) => {
-						return expect(queueStatusRes.count).to.eql(0);
-					}
-				);
+			return localCommon.fillPool(library, () => {
+				return localCommon.forge(library, async () => {
+					localCommon.getMultisignatureTransactions(
+						library,
+						{},
+						(err, queueStatusRes) => {
+							return expect(queueStatusRes.count).to.eql(0);
+						}
+					);
+				});
 			});
 		});
 
@@ -143,26 +145,28 @@ describe('integration test - multi signature edge cases', () => {
 		});
 
 		it('valid transactions should be confirmed', done => {
-			localCommon.forge(library, async () => {
-				const found = [];
-				const validTransactions = transactionIds.slice(0, 2);
-				async.map(
-					validTransactions,
-					(transactionId, eachCb) => {
-						localCommon.getTransactionFromModule(
-							library,
-							{ id: transactionId },
-							(err, res) => {
-								found.push(res.transactions[0].id);
-								eachCb();
-							}
-						);
-					},
-					async () => {
-						expect(found).to.have.members(validTransactions);
-						done();
-					}
-				);
+			localCommon.fillPool(library, () => {
+				localCommon.forge(library, async () => {
+					const found = [];
+					const validTransactions = transactionIds.slice(0, 2);
+					async.map(
+						validTransactions,
+						(transactionId, eachCb) => {
+							localCommon.getTransactionFromModule(
+								library,
+								{ id: transactionId },
+								(err, res) => {
+									found.push(res.transactions[0].id);
+									eachCb();
+								}
+							);
+						},
+						async () => {
+							expect(found).to.have.members(validTransactions);
+							done();
+						}
+					);
+				});
 			});
 		});
 	});

--- a/framework/test/mocha/integration/transactions/5_5_dapps.js
+++ b/framework/test/mocha/integration/transactions/5_5_dapps.js
@@ -148,8 +148,10 @@ describe('integration test (type 5) - dapp registrations with repeated values', 
 
 	describe('after forging one block', () => {
 		before(done => {
-			localCommon.forge(library, async () => {
-				done();
+			localCommon.fillPool(library, () => {
+				localCommon.forge(library, async () => {
+					done();
+				});
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
Invalid transactions got stuck in the transaction pool.
### How did I fix it?
Fixed the issue by removing the invalid (failed) transactions from the transaction pool and re-processing the passed transactions without adding any new transactions to the ready queue. 
### How to test it?
Implemented the tests which tackle this scenario, we can also test this feature by creating many conflicting transactions which cannot be processed together.
### Review checklist

* The PR resolves #3871 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
