### PR TITLE
API misreporting the connected peer count and state property is wrong - Closes #3881 #3885 #3907

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -361,7 +361,7 @@ export class P2P extends EventEmitter {
 		return {
 			newPeers: [...this._newPeers.values()],
 			triedPeers: [...this._triedPeers.values()],
-			connectedPeers: this._peerPool.getAllPeerInfos(),
+			connectedPeers: this._peerPool.getAllConnectedPeerInfos(),
 		};
 	}
 

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -432,7 +432,7 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public getConnectedPeers(): ReadonlyArray<Peer> {
-		const peers = [...this._peerMap.values()];
+		const peers = this.getAllPeers();
 
 		return peers.filter(
 			peer =>

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -427,6 +427,20 @@ export class PeerPool extends EventEmitter {
 		});
 	}
 
+	public getAllConnectedPeerInfos(): ReadonlyArray<P2PDiscoveredPeerInfo> {
+		return this.getConnectedPeers().map(peer => peer.peerInfo);
+	}
+
+	public getConnectedPeers(): ReadonlyArray<Peer> {
+		const peers = [...this._peerMap.values()];
+
+		return peers.filter(
+			peer =>
+				peer.state.outbound === ConnectionState.CONNECTED ||
+				peer.state.inbound === ConnectionState.CONNECTED,
+		);
+	}
+
 	public getAllPeerInfos(): ReadonlyArray<P2PDiscoveredPeerInfo> {
 		return this.getAllPeers().map(peer => peer.peerInfo);
 	}

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect } from 'chai';
+import { PeerPool } from '../../src/peer_pool';
+import {
+	selectPeersForConnection,
+	selectPeersForRequest,
+	selectPeersForSend,
+} from '../../src/peer_selection';
+import { Peer, ConnectionState } from '../../src/peer';
+import { initializePeerList } from '../utils/peers';
+import { P2PDiscoveredPeerInfo } from '../../src/p2p_types';
+
+describe.only('peerPool', () => {
+	const peerPool = new PeerPool({
+		peerSelectionForConnection: selectPeersForConnection,
+		peerSelectionForRequest: selectPeersForRequest,
+		peerSelectionForSend: selectPeersForSend,
+		sendPeerLimit: 25,
+	});
+
+	describe('#constructor', () => {
+		it('should be an object and instance of PeerPool', () => {
+			return expect(peerPool)
+				.to.be.an('object')
+				.and.be.instanceof(PeerPool);
+		});
+	});
+
+	describe('#getConnectedPeers', () => {
+		const peerList: ReadonlyArray<Peer> = initializePeerList();
+
+		let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
+		beforeEach(async () => {
+			sandbox.stub(peerList[0], 'state').get(() => {
+				return {
+					inbound: ConnectionState.CONNECTED,
+					outbound: ConnectionState.CONNECTED,
+				};
+			});
+			sandbox.stub(peerList[1], 'state').get(() => {
+				return {
+					inbound: ConnectionState.CONNECTED,
+					outbound: ConnectionState.CONNECTED,
+				};
+			});
+			activePeersInfoList = [peerList[0], peerList[1]].map(
+				peer => peer.peerInfo,
+			);
+
+			sandbox.stub(peerPool, 'getAllPeers').returns(peerList);
+		});
+
+		it('should return active peers', async () => {
+			expect(peerPool.getConnectedPeers().map(peer => peer.peerInfo)).eql(
+				activePeersInfoList,
+			);
+		});
+	});
+
+	describe('#getAllConnectedPeerInfos', () => {
+		const peerList: ReadonlyArray<Peer> = initializePeerList();
+
+		let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
+		beforeEach(async () => {
+			sandbox.stub(peerList[0], 'state').get(() => {
+				return {
+					inbound: ConnectionState.CONNECTED,
+					outbound: ConnectionState.CONNECTED,
+				};
+			});
+			sandbox.stub(peerList[1], 'state').get(() => {
+				return {
+					inbound: ConnectionState.CONNECTED,
+					outbound: ConnectionState.CONNECTED,
+				};
+			});
+
+			sandbox
+				.stub(peerPool, 'getConnectedPeers')
+				.returns(
+					peerList.filter(
+						peer => peer.state.inbound === 1 || peer.state.outbound === 1,
+					),
+				);
+			activePeersInfoList = [peerList[0].peerInfo, peerList[1].peerInfo];
+		});
+
+		it('should returns list of peerInfos of active peers', async () => {
+			expect(peerPool.getAllConnectedPeerInfos()).eql(activePeersInfoList);
+		});
+	});
+});

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -23,7 +23,7 @@ import { Peer, ConnectionState } from '../../src/peer';
 import { initializePeerList } from '../utils/peers';
 import { P2PDiscoveredPeerInfo } from '../../src/p2p_types';
 
-describe.only('peerPool', () => {
+describe('peerPool', () => {
 	const peerPool = new PeerPool({
 		peerSelectionForConnection: selectPeersForConnection,
 		peerSelectionForRequest: selectPeersForRequest,

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -23,7 +23,7 @@ import { Peer, ConnectionState } from '../../src/peer';
 import { initializePeerList } from '../utils/peers';
 import { P2PDiscoveredPeerInfo } from '../../src/p2p_types';
 
-describe('peerPool', () => {
+describe.only('peerPool', () => {
 	const peerPool = new PeerPool({
 		peerSelectionForConnection: selectPeersForConnection,
 		peerSelectionForRequest: selectPeersForRequest,
@@ -40,66 +40,302 @@ describe('peerPool', () => {
 	});
 
 	describe('#getConnectedPeers', () => {
-		const peerList: ReadonlyArray<Peer> = initializePeerList();
+		describe('when there are some active peers in inbound and outbound', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+			let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
 
-		let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
-		beforeEach(async () => {
-			sandbox.stub(peerList[0], 'state').get(() => {
-				return {
-					inbound: ConnectionState.CONNECTED,
-					outbound: ConnectionState.CONNECTED,
-				};
-			});
-			sandbox.stub(peerList[1], 'state').get(() => {
-				return {
-					inbound: ConnectionState.CONNECTED,
-					outbound: ConnectionState.CONNECTED,
-				};
-			});
-			activePeersInfoList = [peerList[0], peerList[1]].map(
-				peer => peer.peerInfo,
-			);
+			beforeEach(async () => {
+				sandbox.stub(peerList[0], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[1], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[2], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
 
-			sandbox.stub(peerPool, 'getAllPeers').returns(peerList);
+				activePeersInfoList = [peerList[0], peerList[1]].map(
+					peer => peer.peerInfo,
+				);
+				sandbox.stub(peerPool, 'getAllPeers').returns(peerList);
+			});
+
+			it('should return active peers', async () => {
+				expect(peerPool.getConnectedPeers().map(peer => peer.peerInfo)).eql(
+					activePeersInfoList,
+				);
+			});
 		});
 
-		it('should return active peers', async () => {
-			expect(peerPool.getConnectedPeers().map(peer => peer.peerInfo)).eql(
-				activePeersInfoList,
-			);
+		describe('when there are some active peers only in inbound', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+			let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
+
+			beforeEach(async () => {
+				sandbox.stub(peerList[0], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+				sandbox.stub(peerList[1], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+				sandbox.stub(peerList[2], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+				sandbox.stub(peerList[3], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+
+				activePeersInfoList = [peerList[0], peerList[1], peerList[2]].map(
+					peer => peer.peerInfo,
+				);
+				sandbox.stub(peerPool, 'getAllPeers').returns(peerList);
+			});
+
+			it('should return active peers having inbound connection', async () => {
+				expect(peerPool.getConnectedPeers().map(peer => peer.peerInfo)).eql(
+					activePeersInfoList,
+				);
+			});
+		});
+
+		describe('when there are some active peers only in outbound', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+			let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
+
+			beforeEach(async () => {
+				sandbox.stub(peerList[0], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[1], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[2], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[3], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+
+				activePeersInfoList = [peerList[0], peerList[1], peerList[2]].map(
+					peer => peer.peerInfo,
+				);
+				sandbox.stub(peerPool, 'getAllPeers').returns(peerList);
+			});
+
+			it('should return active peers having outbound connection', async () => {
+				expect(peerPool.getConnectedPeers().map(peer => peer.peerInfo)).eql(
+					activePeersInfoList,
+				);
+			});
+		});
+
+		describe('when there are no active peers', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+
+			beforeEach(async () => {
+				peerList.forEach(peer =>
+					sandbox.stub(peer, 'state').get(() => {
+						return {
+							inbound: ConnectionState.DISCONNECTED,
+							outbound: ConnectionState.DISCONNECTED,
+						};
+					}),
+				);
+
+				sandbox.stub(peerPool, 'getAllPeers').returns(peerList);
+			});
+
+			it('should return an empty array', async () => {
+				expect(peerPool.getConnectedPeers().map(peer => peer.peerInfo)).eql([]);
+			});
 		});
 	});
 
 	describe('#getAllConnectedPeerInfos', () => {
-		const peerList: ReadonlyArray<Peer> = initializePeerList();
+		describe('when there are some active peers in inbound and outbound', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+			let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
 
-		let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
-		beforeEach(async () => {
-			sandbox.stub(peerList[0], 'state').get(() => {
-				return {
-					inbound: ConnectionState.CONNECTED,
-					outbound: ConnectionState.CONNECTED,
-				};
-			});
-			sandbox.stub(peerList[1], 'state').get(() => {
-				return {
-					inbound: ConnectionState.CONNECTED,
-					outbound: ConnectionState.CONNECTED,
-				};
+			beforeEach(async () => {
+				sandbox.stub(peerList[0], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[1], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[2], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+
+				sandbox
+					.stub(peerPool, 'getConnectedPeers')
+					.returns(
+						peerList.filter(
+							peer =>
+								peer.state.inbound === ConnectionState.CONNECTED ||
+								peer.state.outbound === ConnectionState.CONNECTED,
+						),
+					);
+				activePeersInfoList = [peerList[0].peerInfo, peerList[1].peerInfo];
 			});
 
-			sandbox
-				.stub(peerPool, 'getConnectedPeers')
-				.returns(
-					peerList.filter(
-						peer => peer.state.inbound === 1 || peer.state.outbound === 1,
-					),
-				);
-			activePeersInfoList = [peerList[0].peerInfo, peerList[1].peerInfo];
+			it('should returns list of peerInfos of active peers', async () => {
+				expect(peerPool.getAllConnectedPeerInfos()).eql(activePeersInfoList);
+			});
 		});
 
-		it('should returns list of peerInfos of active peers', async () => {
-			expect(peerPool.getAllConnectedPeerInfos()).eql(activePeersInfoList);
+		describe('when there are some active peers in inbound only', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+			let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
+
+			beforeEach(async () => {
+				sandbox.stub(peerList[0], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+				sandbox.stub(peerList[1], 'state').get(() => {
+					return {
+						inbound: ConnectionState.CONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+				sandbox.stub(peerList[2], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+
+				sandbox
+					.stub(peerPool, 'getConnectedPeers')
+					.returns(
+						peerList.filter(
+							peer =>
+								peer.state.inbound === ConnectionState.CONNECTED ||
+								peer.state.outbound === ConnectionState.CONNECTED,
+						),
+					);
+				activePeersInfoList = [peerList[0].peerInfo, peerList[1].peerInfo];
+			});
+
+			it('should returns list of peerInfos of active peers only in inbound', async () => {
+				expect(peerPool.getAllConnectedPeerInfos()).eql(activePeersInfoList);
+			});
+		});
+
+		describe('when there are some active peers in outbound only', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+			let activePeersInfoList: ReadonlyArray<P2PDiscoveredPeerInfo>;
+
+			beforeEach(async () => {
+				sandbox.stub(peerList[0], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[1], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.CONNECTED,
+					};
+				});
+				sandbox.stub(peerList[2], 'state').get(() => {
+					return {
+						inbound: ConnectionState.DISCONNECTED,
+						outbound: ConnectionState.DISCONNECTED,
+					};
+				});
+
+				sandbox
+					.stub(peerPool, 'getConnectedPeers')
+					.returns(
+						peerList.filter(
+							peer =>
+								peer.state.inbound === ConnectionState.CONNECTED ||
+								peer.state.outbound === ConnectionState.CONNECTED,
+						),
+					);
+				activePeersInfoList = [peerList[0].peerInfo, peerList[1].peerInfo];
+			});
+
+			it('should returns list of peerInfos of active peers only in outbound', async () => {
+				expect(peerPool.getAllConnectedPeerInfos()).eql(activePeersInfoList);
+			});
+		});
+
+		describe('when there are no active peers', () => {
+			const peerList: ReadonlyArray<Peer> = initializePeerList();
+
+			beforeEach(async () => {
+				peerList.forEach(peer =>
+					sandbox.stub(peer, 'state').get(() => {
+						return {
+							inbound: ConnectionState.DISCONNECTED,
+							outbound: ConnectionState.DISCONNECTED,
+						};
+					}),
+				);
+
+				sandbox
+					.stub(peerPool, 'getConnectedPeers')
+					.returns(
+						peerList.filter(
+							peer =>
+								peer.state.inbound === ConnectionState.CONNECTED ||
+								peer.state.outbound === ConnectionState.CONNECTED,
+						),
+					);
+			});
+
+			it('should return an empty array', async () => {
+				expect(peerPool.getAllConnectedPeerInfos()).eql([]);
+			});
 		});
 	});
 });

--- a/framework/src/modules/chain/submodules/peers.js
+++ b/framework/src/modules/chain/submodules/peers.js
@@ -21,7 +21,6 @@ let library;
 let self;
 const { MIN_BROADHASH_CONSENSUS } = global.constants;
 
-const PEER_STATE_CONNECTED = 2;
 const MAX_PEERS = 100;
 
 /**
@@ -84,16 +83,13 @@ Peers.prototype.getLastConsensus = function() {
 Peers.prototype.calculateConsensus = async function() {
 	const { broadhash } = library.applicationState;
 	const activeCount = Math.min(
-		await library.channel.invoke('network:getPeersCountByFilter', {
-			state: PEER_STATE_CONNECTED,
-		}),
+		await library.channel.invoke('network:getConnectedPeersCountByFilter'),
 		MAX_PEERS
 	);
 
 	const matchedCount = Math.min(
-		await library.channel.invoke('network:getPeersCountByFilter', {
+		await library.channel.invoke('network:getConnectedPeersCountByFilter', {
 			broadhash,
-			state: PEER_STATE_CONNECTED,
 		}),
 		MAX_PEERS
 	);

--- a/framework/src/modules/chain/submodules/peers.js
+++ b/framework/src/modules/chain/submodules/peers.js
@@ -83,7 +83,7 @@ Peers.prototype.getLastConsensus = function() {
 Peers.prototype.calculateConsensus = async function() {
 	const { broadhash } = library.applicationState;
 	const activeCount = Math.min(
-		await library.channel.invoke('network:getConnectedPeersCountByFilter'),
+		await library.channel.invoke('network:getConnectedPeersCountByFilter', {}),
 		MAX_PEERS
 	);
 

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -20,6 +20,7 @@ const apiCodes = require('../api_codes');
 const swaggerHelper = require('../helpers/swagger');
 
 const { EPOCH_TIME, FEES } = global.constants;
+const PEER_CONNECTED_STATE = 2;
 
 // Private Fields
 let library;
@@ -296,6 +297,7 @@ async function _getForgingStatus(publicKey) {
 async function _getNetworkHeight() {
 	const peers = await library.channel.invoke('network:getPeers', {
 		limit: 100,
+		state: PEER_CONNECTED_STATE,
 	});
 	if (!peers || !peers.length) {
 		return 0;

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -20,7 +20,6 @@ const apiCodes = require('../api_codes');
 const swaggerHelper = require('../helpers/swagger');
 
 const { EPOCH_TIME, FEES } = global.constants;
-const PEER_CONNECTED_STATE = 2;
 
 // Private Fields
 let library;
@@ -295,9 +294,8 @@ async function _getForgingStatus(publicKey) {
  * @private
  */
 async function _getNetworkHeight() {
-	const peers = await library.channel.invoke('network:getPeers', {
+	const peers = await library.channel.invoke('network:getConnectedPeers', {
 		limit: 100,
-		state: PEER_CONNECTED_STATE,
 	});
 	if (!peers || !peers.length) {
 		return 0;

--- a/framework/src/modules/network/filter_peers.js
+++ b/framework/src/modules/network/filter_peers.js
@@ -168,8 +168,11 @@ const getCountByFilter = (peers, filter) => {
  * @returns {int} count
  * @todo Add description for the params
  */
-const getConsolidatedPeersList = networkStatus => {
-	const { connectedPeers, newPeers, triedPeers } = networkStatus;
+const getConsolidatedPeersList = ({
+	connectedPeers,
+	newPeers = [],
+	triedPeers = [],
+}) => {
 	// Assign state 2 to the connected peers
 	const connectedList = connectedPeers.map(peer => {
 		const { ipAddress, options, minVersion, nethash, ...peerWithoutIp } = peer;

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -61,8 +61,15 @@ module.exports = class NetworkModule extends BaseModule {
 			getPeers: {
 				handler: action => this.network.actions.getPeers(action),
 			},
+			getConnectedPeers: {
+				handler: action => this.network.actions.getConnectedPeers(action),
+			},
 			getPeersCountByFilter: {
 				handler: action => this.network.actions.getPeersCountByFilter(action),
+			},
+			getConnectedPeersCountByFilter: {
+				handler: action =>
+					this.network.actions.getConnectedPeersCountByFilter(action),
 			},
 		};
 	}

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -279,8 +279,20 @@ module.exports = class Network {
 
 				return getByFilter(peerList, action.params);
 			},
+			getConnectedPeers: action => {
+				const { connectedPeers } = this.p2p.getNetworkStatus();
+				const peerList = getConsolidatedPeersList({ connectedPeers });
+
+				return getByFilter(peerList, action.params);
+			},
 			getPeersCountByFilter: action => {
 				const peerList = getConsolidatedPeersList(this.p2p.getNetworkStatus());
+
+				return getCountByFilter(peerList, action.params);
+			},
+			getConnectedPeersCountByFilter: action => {
+				const { connectedPeers } = this.p2p.getNetworkStatus();
+				const peerList = getConsolidatedPeersList({ connectedPeers });
 
 				return getCountByFilter(peerList, action.params);
 			},

--- a/framework/test/mocha/unit/modules/chain/submodules/peers.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/peers.js
@@ -169,7 +169,8 @@ describe('peers', () => {
 			it('should call channel invoke with action network:getConnectedPeersCountByFilter', async () =>
 				expect(
 					channelMock.invoke.calledWithExactly(
-						'network:getConnectedPeersCountByFilter'
+						'network:getConnectedPeersCountByFilter',
+						{}
 					)
 				).to.be.true);
 

--- a/framework/test/mocha/unit/modules/chain/submodules/peers.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/peers.js
@@ -20,7 +20,6 @@ const prefixedPeer = require('../../../../fixtures/peers').randomNormalizedPeer;
 const modulesLoader = require('../../../../common/modules_loader');
 
 describe('peers', () => {
-	const PEER_STATE_CONNECTED = 2;
 	const NONCE = randomstring.generate(16);
 
 	let storageMock;
@@ -150,14 +149,11 @@ describe('peers', () => {
 		describe('when all CONNECTED peers match our broadhash', () => {
 			before(async () => {
 				channelMock.invoke
-					.withArgs('network:getPeersCountByFilter', {
-						state: PEER_STATE_CONNECTED,
-					})
+					.withArgs('network:getConnectedPeersCountByFilter')
 					.returns(2);
 				channelMock.invoke
-					.withArgs('network:getPeersCountByFilter', {
+					.withArgs('network:getConnectedPeersCountByFilter', {
 						broadhash: prefixedPeer.broadhash,
-						state: PEER_STATE_CONNECTED,
 					})
 					.returns(2);
 			});
@@ -170,19 +166,18 @@ describe('peers', () => {
 			it('should call channel invoke twice', async () =>
 				expect(channelMock.invoke.calledTwice).to.be.true);
 
-			it('should call channel invoke with action network:getPeersCountByFilter and filter state', async () =>
+			it('should call channel invoke with action network:getConnectedPeersCountByFilter', async () =>
 				expect(
 					channelMock.invoke.calledWithExactly(
-						'network:getPeersCountByFilter',
-						{ state: PEER_STATE_CONNECTED }
+						'network:getConnectedPeersCountByFilter'
 					)
 				).to.be.true);
 
-			it('should call channel invoke with action network:getPeersCountByFilter and filter broadhash', async () =>
+			it('should call channel invoke with action network:getConnectedPeersCountByFilter and filter broadhash', async () =>
 				expect(
 					channelMock.invoke.calledWithExactly(
-						'network:getPeersCountByFilter',
-						{ broadhash: prefixedPeer.broadhash, state: PEER_STATE_CONNECTED }
+						'network:getConnectedPeersCountByFilter',
+						{ broadhash: prefixedPeer.broadhash }
 					)
 				).to.be.true);
 
@@ -196,14 +191,11 @@ describe('peers', () => {
 		describe('when half of connected peers match our broadhash', () => {
 			before(async () => {
 				channelMock.invoke
-					.withArgs('network:getPeersCountByFilter', {
-						state: PEER_STATE_CONNECTED,
-					})
+					.withArgs('network:getConnectedPeersCountByFilter')
 					.returns(2);
 				channelMock.invoke
-					.withArgs('network:getPeersCountByFilter', {
+					.withArgs('network:getConnectedPeersCountByFilter', {
 						broadhash: prefixedPeer.broadhash,
-						state: PEER_STATE_CONNECTED,
 					})
 					.returns(1);
 			});

--- a/framework/test/mocha/unit/modules/http_api/controllers/node.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/node.js
@@ -160,7 +160,9 @@ describe('node/api', () => {
 		describe('when chain:getNodeStatus answers with all parameters', () => {
 			beforeEach(async () => {
 				channelStub.invoke.withArgs('chain:getNodeStatus').returns(status);
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
 			});
 
 			it('should return an object status with all properties', async () =>
@@ -185,7 +187,9 @@ describe('node/api', () => {
 				channelStub.invoke
 					.withArgs('chain:getNodeStatus')
 					.returns(statusWithoutSomeParameters);
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
 			});
 
 			it('should return an object status with some properties to 0', async () =>
@@ -222,7 +226,9 @@ describe('node/api', () => {
 						height: 438,
 					},
 				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
 				networkHeight = await getNetworkHeight();
 			});
 
@@ -231,14 +237,173 @@ describe('node/api', () => {
 			});
 		});
 
-		describe('When network:getPeers returns a blank list of peers', () => {
+		describe('When network:getConnectedPeers returns a blank list of peers', () => {
 			beforeEach(async () => {
-				channelStub.invoke.withArgs('network:getPeers').returns([]);
+				channelStub.invoke.withArgs('network:getConnectedPeers').returns([]);
 				networkHeight = await getNetworkHeight();
 			});
 
-			it('should return correct networkHeight based on majority', async () => {
+			it('should return zero when there are no peers with height', async () => {
 				expect(networkHeight).to.be.eql(0);
+			});
+		});
+
+		describe('When network:getConnectedPeers returns a list of peers with 2 different equal set of peers height', () => {
+			beforeEach(async () => {
+				const defaultPeers = [
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+				];
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
+				networkHeight = await getNetworkHeight();
+			});
+
+			it('should return height of majority with lower height', async () => {
+				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
+			});
+		});
+
+		describe('When network:getConnectedPeers returns a list of peers with 3 different equal set of peers height', () => {
+			beforeEach(async () => {
+				const defaultPeers = [
+					{
+						height: MAJORITY_HEIGHT + 2,
+					},
+					{
+						height: MAJORITY_HEIGHT + 2,
+					},
+					{
+						height: MAJORITY_HEIGHT + 2,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+				];
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
+				networkHeight = await getNetworkHeight();
+			});
+
+			it('should return height of majority with lower height', async () => {
+				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
+			});
+		});
+
+		describe('When network:getConnectedPeers returns a list of peers with 2 different unequal set of peers height', () => {
+			beforeEach(async () => {
+				const defaultPeers = [
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+					{
+						height: MAJORITY_HEIGHT + 1,
+					},
+				];
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
+				networkHeight = await getNetworkHeight();
+			});
+
+			it('should return height of majority', async () => {
+				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT + 1);
+			});
+		});
+
+		describe('When network:getConnectedPeers returns only one peer', () => {
+			beforeEach(async () => {
+				const defaultPeers = [
+					{
+						height: MAJORITY_HEIGHT,
+					},
+				];
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
+				networkHeight = await getNetworkHeight();
+			});
+
+			it('should return height of one peer', async () => {
+				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
+			});
+		});
+
+		describe('When network:getConnectedPeers returns majority of peers with very low height compared to others', () => {
+			beforeEach(async () => {
+				const defaultPeers = [
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: MAJORITY_HEIGHT,
+					},
+					{
+						height: 1,
+					},
+					{
+						height: 1,
+					},
+					{
+						height: 1,
+					},
+					{
+						height: 1,
+					},
+				];
+				channelStub.invoke
+					.withArgs('network:getConnectedPeers')
+					.returns(defaultPeers);
+				networkHeight = await getNetworkHeight();
+			});
+
+			it('should return height of the majority even though its very low compared to others', async () => {
+				expect(networkHeight).to.be.eql(1);
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

The connected peer count should be accurate and not fluctuate randomly.

### How did I fix it?

All the connectedPeers are coming from `PeerPool` that has all the peers that are connected but sometimes during the discovery, PeerPool adds a peer without successfully connecting and that's why the number fluctuates with every discovery round.

### How to test it?

Run the application and hit `/api/peers` endpoint

### Review checklist

* The PR resolves #3881 #3885 #3907
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
