### PR TITLE
Commander does not allow upgrading using a custom build - Closes #3901 #3898 #3911

### DIFF
--- a/commander/src/commands/core/install.ts
+++ b/commander/src/commands/core/install.ts
@@ -239,11 +239,7 @@ export default class InstallCommand extends BaseCommand {
 							task: async ctx => {
 								const { liskTarUrl }: Options = ctx.options;
 
-								if (
-									!noSnapshot ||
-									network.toLowerCase() in ['testnet', 'mainnet'] ||
-									snapshotUrl
-								) {
+								if (!noSnapshot && snapshotURL.trim() !== '') {
 									await download(snapshotURL, cacheDir);
 								}
 								await downloadAndValidate(liskTarUrl, cacheDir);

--- a/commander/src/commands/core/install.ts
+++ b/commander/src/commands/core/install.ts
@@ -239,7 +239,11 @@ export default class InstallCommand extends BaseCommand {
 							task: async ctx => {
 								const { liskTarUrl }: Options = ctx.options;
 
-								if (!noSnapshot) {
+								if (
+									!noSnapshot ||
+									network.toLowerCase() in ['testnet', 'mainnet'] ||
+									snapshotUrl
+								) {
 									await download(snapshotURL, cacheDir);
 								}
 								await downloadAndValidate(liskTarUrl, cacheDir);

--- a/commander/src/commands/core/install.ts
+++ b/commander/src/commands/core/install.ts
@@ -225,11 +225,12 @@ export default class InstallCommand extends BaseCommand {
 						{
 							title: 'Validate root user, flags, prerequisites',
 							task: async ctx => {
+								const { installDir, releaseUrl } = ctx.options;
 								validateNotARootUser();
 								validateFlags(flags as Flags);
-								validatePrerequisite(ctx.options.installDir);
+								validatePrerequisite(installDir);
 								if (liskVersion) {
-									await validateVersion(network, liskVersion);
+									await validateVersion(releaseUrl, liskVersion);
 									ctx.options.version = liskVersion;
 								}
 							},

--- a/commander/src/commands/core/upgrade.ts
+++ b/commander/src/commands/core/upgrade.ts
@@ -120,12 +120,12 @@ export default class UpgradeCommand extends BaseCommand {
 			{
 				title: 'Validate Version Input',
 				task: async () => {
-					await validateVersion(releaseUrl, upgradeVersion);
 					if (semver.lte(upgradeVersion, currentVersion)) {
 						throw new Error(
 							`Upgrade version:${upgradeVersion} should be greater than current version: ${currentVersion}`,
 						);
 					}
+					await validateVersion(releaseUrl, upgradeVersion);
 				},
 			},
 			{

--- a/commander/src/commands/core/upgrade.ts
+++ b/commander/src/commands/core/upgrade.ts
@@ -156,7 +156,9 @@ export default class UpgradeCommand extends BaseCommand {
 						},
 						{
 							title: `Backup Lisk Core: ${currentVersion} installed as ${name}`,
-							task: () => backupLisk(installationPath, name),
+							task: () => {
+								backupLisk(installationPath, name);
+							},
 						},
 						{
 							title: `Install Lisk Core: ${upgradeVersion}`,

--- a/commander/src/commands/core/upgrade.ts
+++ b/commander/src/commands/core/upgrade.ts
@@ -156,9 +156,7 @@ export default class UpgradeCommand extends BaseCommand {
 						},
 						{
 							title: `Backup Lisk Core: ${currentVersion} installed as ${name}`,
-							task: async () => {
-								await backupLisk(installationPath);
-							},
+							task: () => backupLisk(installationPath, name),
 						},
 						{
 							title: `Install Lisk Core: ${upgradeVersion}`,

--- a/commander/src/commands/core/upgrade.ts
+++ b/commander/src/commands/core/upgrade.ts
@@ -120,7 +120,7 @@ export default class UpgradeCommand extends BaseCommand {
 			{
 				title: 'Validate Version Input',
 				task: async () => {
-					await validateVersion(network, upgradeVersion);
+					await validateVersion(releaseUrl, upgradeVersion);
 					if (semver.lte(upgradeVersion, currentVersion)) {
 						throw new Error(
 							`Upgrade version:${upgradeVersion} should be greater than current version: ${currentVersion}`,

--- a/commander/src/utils/core/commons.ts
+++ b/commander/src/utils/core/commons.ts
@@ -175,22 +175,19 @@ export const upgradeLisk = async (
 };
 
 export const validateVersion = async (
-	network: NETWORK,
+	releaseUrl: string,
 	version: string,
 ): Promise<void> => {
 	if (!semver.valid(version)) {
-		throw new Error(
-			`Upgrade version: ${version} has invalid format, Please refer version from release url: ${RELEASE_URL}/${network}`,
-		);
+		throw new Error(`Upgrade version: ${version} has invalid semver format`);
 	}
 
-	const url = `${RELEASE_URL}/${network}/${version}`;
 	try {
-		await getLatestVersion(url);
+		await getLatestVersion(releaseUrl);
 	} catch (error) {
 		if (error.message === 'Request failed with status code 404') {
 			throw new Error(
-				`Upgrade version: ${version} doesn't exists in ${RELEASE_URL}/${network}`,
+				`Upgrade version: ${version} doesn't exists in ${RELEASE_URL}`,
 			);
 		}
 		throw new Error(error.message);

--- a/commander/src/utils/core/commons.ts
+++ b/commander/src/utils/core/commons.ts
@@ -23,6 +23,7 @@ import {
 	POSTGRES_PORT,
 	REDIS_PORT,
 	RELEASE_URL,
+	SNAPSHOT_URL,
 	WS_PORTS,
 } from '../constants';
 import { exec, ExecResult } from '../worker-process';
@@ -53,6 +54,13 @@ export const liskLatestUrl = (url: string, network: NETWORK) =>
 	`${url}/${network}/latest.txt`;
 
 export const liskSnapshotUrl = (url: string, network: NETWORK): string => {
+	if (
+		!['testnet', 'mainnet'].includes(network.toLowerCase()) &&
+		url === SNAPSHOT_URL
+	) {
+		return '';
+	}
+
 	if (url && url.search(RELEASE_URL) >= 0 && url.search('db.gz') >= 0) {
 		return `${RELEASE_URL}/${network}/blockchain.db.gz`;
 	}

--- a/commander/src/utils/core/commons.ts
+++ b/commander/src/utils/core/commons.ts
@@ -140,13 +140,9 @@ export const getVersionToInstall = async (
 };
 
 export const backupLisk = (installDir: string, instanceName: string): void => {
-	try {
-		const backupPath = `${defaultBackupPath}/${instanceName}`;
-		fsExtra.removeSync(backupPath);
-		fsExtra.moveSync(installDir, backupPath);
-	} catch (error) {
-		throw new Error(error);
-	}
+	const backupPath = `${defaultBackupPath}/${instanceName}`;
+	fsExtra.removeSync(backupPath);
+	fsExtra.moveSync(installDir, backupPath);
 };
 
 export const upgradeLisk = async (

--- a/commander/src/utils/core/commons.ts
+++ b/commander/src/utils/core/commons.ts
@@ -139,13 +139,13 @@ export const getVersionToInstall = async (
 	return version;
 };
 
-export const backupLisk = async (installDir: string): Promise<void> => {
-	fsExtra.emptyDirSync(defaultBackupPath);
-	const { stderr }: ExecResult = await exec(
-		`mv -f ${installDir} ${defaultBackupPath}`,
-	);
-	if (stderr) {
-		throw new Error(stderr);
+export const backupLisk = (installDir: string, instanceName: string): void => {
+	try {
+		const backupPath = `${defaultBackupPath}/${instanceName}`;
+		fsExtra.emptyDirSync(backupPath);
+		fsExtra.moveSync(installDir, backupPath);
+	} catch (error) {
+		throw new Error(error);
 	}
 };
 
@@ -170,8 +170,6 @@ export const upgradeLisk = async (
 	if (stderr) {
 		throw new Error(stderr);
 	}
-
-	fsExtra.emptyDirSync(defaultBackupPath);
 };
 
 export const validateVersion = async (

--- a/commander/src/utils/core/commons.ts
+++ b/commander/src/utils/core/commons.ts
@@ -113,7 +113,7 @@ export const validURL = (url: string): void => {
 
 export const getSemver = (str: string): string => {
 	const exp = new RegExp(
-		/(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?\.?(?:0|[1-9]\d*)?/,
+		/(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:[1-9]\d*|[\da-z-]*[a-z][\da-z]*))*)?\.?(?:0|[1-9]\d*)?/,
 	);
 	const result = exp.exec(str) as ReadonlyArray<string>;
 

--- a/commander/src/utils/core/commons.ts
+++ b/commander/src/utils/core/commons.ts
@@ -142,7 +142,7 @@ export const getVersionToInstall = async (
 export const backupLisk = (installDir: string, instanceName: string): void => {
 	try {
 		const backupPath = `${defaultBackupPath}/${instanceName}`;
-		fsExtra.emptyDirSync(backupPath);
+		fsExtra.removeSync(backupPath);
 		fsExtra.moveSync(installDir, backupPath);
 	} catch (error) {
 		throw new Error(error);

--- a/commander/src/utils/core/config.ts
+++ b/commander/src/utils/core/config.ts
@@ -48,7 +48,7 @@ export interface LiskConfig {
 export const defaultLiskPath = path.join(os.homedir(), '.lisk');
 export const defaultLiskPm2Path = `${defaultLiskPath}/pm2`;
 export const defaultLiskInstancePath = `${defaultLiskPath}/instances`;
-export const defaultBackupPath = `${defaultLiskPath}/backup`;
+export const defaultBackupPath = `${defaultLiskPath}/backups`;
 const NODE_BIN = './bin/node';
 
 export const getLiskConfig = async (

--- a/commander/src/utils/core/config.ts
+++ b/commander/src/utils/core/config.ts
@@ -48,7 +48,7 @@ export interface LiskConfig {
 export const defaultLiskPath = path.join(os.homedir(), '.lisk');
 export const defaultLiskPm2Path = `${defaultLiskPath}/pm2`;
 export const defaultLiskInstancePath = `${defaultLiskPath}/instances`;
-export const defaultBackupPath = `${defaultLiskInstancePath}/backup`;
+export const defaultBackupPath = `${defaultLiskPath}/backup`;
 const NODE_BIN = './bin/node';
 
 export const getLiskConfig = async (

--- a/commander/test/utils/core/commons.ts
+++ b/commander/test/utils/core/commons.ts
@@ -24,7 +24,11 @@ import {
 	getDownloadedFileInfo,
 	dateDiff,
 } from '../../../src/utils/core/commons';
-import { NETWORK, RELEASE_URL } from '../../../src/utils/constants';
+import {
+	NETWORK,
+	RELEASE_URL,
+	SNAPSHOT_URL,
+} from '../../../src/utils/constants';
 import { defaultLiskInstancePath } from '../../../src/utils/core/config';
 import * as release from '../../../src/utils/core/release';
 import * as workerProcess from '../../../src/utils/worker-process';
@@ -116,6 +120,24 @@ describe('commons core utils', () => {
 			const url: string =
 				'http://snapshots.lisk.io.s3-eu-west-1.amazonaws.com/lisk/mainnet/blockchain.db.gz';
 			return expect(liskSnapshotUrl(url, NETWORK.MAINNET)).to.equal(url);
+		});
+
+		it('should return empty string if network is not testnet or mainnet', () => {
+			return [NETWORK.ALPHANET, NETWORK.BETANET, NETWORK.DEVNET].map(
+				network => {
+					expect(liskSnapshotUrl(SNAPSHOT_URL, network)).to.equal('');
+				},
+			);
+		});
+
+		it('should return custom snapshot url for dev/alpha/beta net if specified', () => {
+			const url: string =
+				'http://snapshots.lisk.io.s3-eu-west-1.amazonaws.com/lisk/mainnet/blockchain.db.gz';
+			return [NETWORK.ALPHANET, NETWORK.BETANET, NETWORK.DEVNET].map(
+				network => {
+					expect(liskSnapshotUrl(url, network)).to.equal(url);
+				},
+			);
 		});
 	});
 
@@ -300,6 +322,9 @@ describe('commons core utils', () => {
 
 	describe('#getSemver', () => {
 		it('should extract version from url', () => {
+			expect(
+				getSemver('http://localhost/lisk-2.0.0-rc.1-Linux-x86_64.tar.gz'),
+			).to.equal('2.0.0-rc.1');
 			return expect(getSemver(url)).to.equal('1.6.0-rc.4');
 		});
 	});

--- a/commander/test/utils/core/commons.ts
+++ b/commander/test/utils/core/commons.ts
@@ -202,7 +202,7 @@ describe('commons core utils', () => {
 
 		it('should create directory if it does not exists', () => {
 			pathExistsSyncStub.returns(false);
-			ensureDirSync.returns();
+			ensureDirSync.returns(true);
 			return expect(createDirectory(defaultLiskInstancePath)).not.to.throw;
 		});
 	});
@@ -237,21 +237,21 @@ describe('commons core utils', () => {
 	});
 
 	describe('#backupLisk', () => {
-		let execStub: SinonStub;
+		let moveSyncStub: SinonStub;
 		beforeEach(() => {
 			sandbox.stub(fsExtra, 'emptyDirSync').returns();
-			execStub = sandbox.stub(workerProcess, 'exec');
+			moveSyncStub = sandbox.stub(fsExtra, 'moveSync');
 		});
 
 		it('should backup the lisk installation', () => {
-			execStub.resolves({ stdout: '', stderr: null });
-			return expect(backupLisk(defaultLiskInstancePath)).not.to.throw;
+			moveSyncStub.returns(true);
+			return expect(backupLisk(defaultLiskInstancePath, 'test')).not.to.throw;
 		});
 
-		it('should throw error of failed to backup', () => {
-			execStub.resolves({ stdout: null, stderr: 'failed to move' });
-			return expect(backupLisk(defaultLiskInstancePath)).rejectedWith(
-				'failed to move',
+		it('should throw error if failed to backup', () => {
+			moveSyncStub.throws('Directory does not exists');
+			return expect(() => backupLisk(defaultLiskInstancePath, 'test')).to.throw(
+				'Directory does not exists',
 			);
 		});
 	});
@@ -316,7 +316,7 @@ describe('commons core utils', () => {
 		});
 	});
 
-	describe.only('#getSemver', () => {
+	describe('#getSemver', () => {
 		it('should extract version from url', () => {
 			expect(
 				getSemver(

--- a/commander/test/utils/core/commons.ts
+++ b/commander/test/utils/core/commons.ts
@@ -289,34 +289,30 @@ describe('commons core utils', () => {
 
 		it('should throw if version is invalid', () => {
 			const invalidVersion = 'rc.1.0.0';
-			return expect(
-				validateVersion(NETWORK.MAINNET, invalidVersion),
-			).to.rejectedWith(
-				`Upgrade version: ${invalidVersion} has invalid format, Please refer version from release url: https://downloads.lisk.io/lisk/mainnet`,
+			return expect(validateVersion(url, invalidVersion)).to.rejectedWith(
+				`Upgrade version: ${invalidVersion} has invalid semver format`,
 			);
 		});
 
 		it('should throw if the requested version does not exists', () => {
 			releaseStub.rejects(new Error('Request failed with status code 404'));
 			const invalidVersion = '9.9.9';
-			return expect(
-				validateVersion(NETWORK.MAINNET, invalidVersion),
-			).to.rejectedWith(
-				`Upgrade version: ${invalidVersion} doesn't exists in https://downloads.lisk.io/lisk/mainnet`,
+			return expect(validateVersion(url, invalidVersion)).to.rejectedWith(
+				`Upgrade version: ${invalidVersion} doesn't exists in ${RELEASE_URL}`,
 			);
 		});
 
 		it('should throw if failed to get version', () => {
 			releaseStub.rejects(new Error('failed to get version'));
 			const invalidVersion = '9.9.9';
-			return expect(
-				validateVersion(NETWORK.MAINNET, invalidVersion),
-			).to.rejectedWith('failed to get version');
+			return expect(validateVersion(url, invalidVersion)).to.rejectedWith(
+				'failed to get version',
+			);
 		});
 
 		it('should successed for valid version', () => {
 			releaseStub.resolves('1.0.0');
-			return expect(validateVersion(NETWORK.MAINNET, '1.0.0')).not.to.throw;
+			return expect(validateVersion(url, '1.0.0')).not.to.throw;
 		});
 	});
 

--- a/commander/test/utils/core/commons.ts
+++ b/commander/test/utils/core/commons.ts
@@ -239,7 +239,7 @@ describe('commons core utils', () => {
 	describe('#backupLisk', () => {
 		let moveSyncStub: SinonStub;
 		beforeEach(() => {
-			sandbox.stub(fsExtra, 'emptyDirSync').returns();
+			sandbox.stub(fsExtra, 'removeSync').returns();
 			moveSyncStub = sandbox.stub(fsExtra, 'moveSync');
 		});
 

--- a/commander/test/utils/core/commons.ts
+++ b/commander/test/utils/core/commons.ts
@@ -316,10 +316,12 @@ describe('commons core utils', () => {
 		});
 	});
 
-	describe('#getSemver', () => {
+	describe.only('#getSemver', () => {
 		it('should extract version from url', () => {
 			expect(
-				getSemver('http://localhost/lisk-2.0.0-rc.1-Linux-x86_64.tar.gz'),
+				getSemver(
+					'https://lisk-releases.ams3.digitaloceanspaces.com/lisk-core/lisk-2.0.0-rc.1-Linux-x86_64.tar.gz',
+				),
 			).to.equal('2.0.0-rc.1');
 			return expect(getSemver(url)).to.equal('1.6.0-rc.4');
 		});

--- a/commander/test/utils/core/commons.ts
+++ b/commander/test/utils/core/commons.ts
@@ -247,13 +247,6 @@ describe('commons core utils', () => {
 			moveSyncStub.returns(true);
 			return expect(backupLisk(defaultLiskInstancePath, 'test')).not.to.throw;
 		});
-
-		it('should throw error if failed to backup', () => {
-			moveSyncStub.throws('Directory does not exists');
-			return expect(() => backupLisk(defaultLiskInstancePath, 'test')).to.throw(
-				'Directory does not exists',
-			);
-		});
 	});
 
 	describe('#upgradeLisk', () => {

--- a/commander/test/utils/core/config.ts
+++ b/commander/test/utils/core/config.ts
@@ -33,7 +33,7 @@ describe('config core utils', () => {
 
 	it('should return defaultBackupPath constant', () => {
 		return expect(defaultBackupPath).to.equal(
-			path.join(`${defaultLiskPath}/backup`),
+			path.join(`${defaultLiskPath}/backups`),
 		);
 	});
 

--- a/commander/test/utils/core/config.ts
+++ b/commander/test/utils/core/config.ts
@@ -33,7 +33,7 @@ describe('config core utils', () => {
 
 	it('should return defaultBackupPath constant', () => {
 		return expect(defaultBackupPath).to.equal(
-			path.join(`${defaultLiskInstancePath}/backup`),
+			path.join(`${defaultLiskPath}/backup`),
 		);
 	});
 


### PR DESCRIPTION
### What was the problem?
- Upgrading devnet using custom url was broken
- Commander should not download snapshot for devnet/alphanet/betanet
### How did I fix it?
- Allowing custom url for upgrade 
- Restricting snapshot download for devnet/alphanet/betanet 
### How to test it?
```
lisk core:install --network devnet --release-url=http://localhost/lisk-2.0.0-rc.0-Linux-x86_64.tar.gz --no-snapshot lisk-devnet
lisk core:upgrade --release-url=http://localhost/lisk-2.0.0-rc.1-Linux-x86_64.tar.gz lisk-devnet
```
### Review checklist

* The PR resolves #3898 #3901 #3911 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
