### PR TITLE
Update broadcastLimit with emitPeerLimit and its values across framework - Closes #3905

### DIFF
--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -62,7 +62,6 @@ Object {
       "broadcasts": Object {
         "active": true,
         "broadcastInterval": 5000,
-        "broadcastLimit": 25,
         "parallelLimit": 20,
         "relayLimit": 3,
         "releaseLimit": 25,
@@ -505,6 +504,7 @@ Object {
         },
         "address": "0.0.0.0",
         "enabled": true,
+        "emitPeerLimit": 25,
         "list": Array [
           Object {
             "ip": "127.0.0.1",

--- a/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
+++ b/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
@@ -45,7 +45,7 @@ describe('Broadcaster', () => {
 			releaseLimit: 10,
 			parallelLimit: 10,
 			relayLimit: 10,
-			broadcastLimit: 10,
+			emitPeerLimit: 25,
 		};
 
 		loggerStub = {

--- a/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
+++ b/framework/test/mocha/unit/modules/chain/logic/broadcaster.js
@@ -45,7 +45,6 @@ describe('Broadcaster', () => {
 			releaseLimit: 10,
 			parallelLimit: 10,
 			relayLimit: 10,
-			emitPeerLimit: 25,
 		};
 
 		loggerStub = {


### PR DESCRIPTION
### What was the problem?

`modules.chain.broadcasts.broadcastLimit` (previously used only for blocks broadcasts) was changed to `modules.network.emitPeerLimit` and behavior is now different 

### How did I fix it?

Updated in the tests.

https://github.com/LiskHQ/lisk-sdk/blob/5f094a1ede78e470a1908a63845f9be416134621/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap#L507
https://github.com/LiskHQ/lisk-sdk/blob/5f094a1ede78e470a1908a63845f9be416134621/framework/test/mocha/unit/modules/chain/logic/broadcaster.js#L48

### How to test it?

`npm run mocha:unit`

### Review checklist

* The PR resolves #3905
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
