### PR TITLE
Unreacheable peers are kept as connected for too long - Close #3917

### DIFF
--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -43,19 +43,7 @@ import {
 	validateRPCRequest,
 } from './validation';
 
-// This interface is needed because pingTimeoutDisabled is missing from ClientOptions in socketcluster-client.
-interface ClientOptionsUpdated {
-	readonly hostname: string;
-	readonly port: number;
-	readonly query: string;
-	readonly autoConnect: boolean;
-	readonly autoReconnect: boolean;
-	readonly pingTimeoutDisabled: boolean;
-	readonly multiplex: boolean;
-	readonly ackTimeout?: number;
-	readonly connectTimeout?: number;
-}
-
+type ClientOptions = socketClusterClient.SCClientSocket.ClientOptions;
 type SCClientSocket = socketClusterClient.SCClientSocket;
 
 // Local emitted events.
@@ -475,7 +463,7 @@ export class Peer extends EventEmitter {
 			: DEFAULT_ACK_TIMEOUT;
 
 		// Ideally, we should JSON-serialize the whole NodeInfo object but this cannot be done for compatibility reasons, so instead we put it inside an options property.
-		const clientOptions: ClientOptionsUpdated = {
+		const clientOptions: ClientOptions = {
 			hostname: this._ipAddress,
 			port: this._wsPort,
 			query: querystring.stringify({
@@ -487,7 +475,6 @@ export class Peer extends EventEmitter {
 			multiplex: false,
 			autoConnect: false,
 			autoReconnect: false,
-			pingTimeoutDisabled: true,
 		};
 
 		const outboundSocket = socketClusterClient.create(clientOptions);
@@ -670,7 +657,7 @@ export const connectAndRequest = async (
 				procedure,
 			};
 			// Ideally, we should JSON-serialize the whole NodeInfo object but this cannot be done for compatibility reasons, so instead we put it inside an options property.
-			const clientOptions: ClientOptionsUpdated = {
+			const clientOptions: ClientOptions = {
 				hostname: basicPeerInfo.ipAddress,
 				port: basicPeerInfo.wsPort,
 				query: querystring.stringify({
@@ -690,7 +677,6 @@ export const connectAndRequest = async (
 				multiplex: false,
 				autoConnect: false,
 				autoReconnect: false,
-				pingTimeoutDisabled: true,
 			};
 
 			const outboundSocket = socketClusterClient.create(clientOptions);


### PR DESCRIPTION
### What was the problem?

Peers where not marked as disconnected after they were shut down.
Because the pingTimeout (heartbeat) was disabled, the low level WebSocket was not detecting the disconnection for several minutes.

### How did I fix it?

Removed the `pingTimeoutDisabled` option so that it uses the default ping behaviour.

### How to test it?

Run a network, shutdown some nodes (not gracefully).

### Review checklist

* The PR resolves #3917
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
