### PR TITLE
Commander should remove backup on uninstall - Closes #3919

### DIFF
--- a/commander/src/commands/core/uninstall.ts
+++ b/commander/src/commands/core/uninstall.ts
@@ -17,6 +17,7 @@ import { flags as flagParser } from '@oclif/command';
 import * as fsExtra from 'fs-extra';
 import Listr from 'listr';
 import BaseCommand from '../../base';
+import { defaultBackupPath } from '../../utils/core/config';
 import {
 	describeApplication,
 	PM2ProcessInstance,
@@ -77,6 +78,12 @@ export default class UnInstallCommand extends BaseCommand {
 					task: async () => {
 						await unRegisterApplication(name);
 						fsExtra.removeSync(installationPath);
+					},
+				},
+				{
+					title: `Remove ${name} backup`,
+					task: () => {
+						fsExtra.removeSync(`${defaultBackupPath}/${name}`);
 					},
 				},
 			]);

--- a/commander/src/commands/core/upgrade.ts
+++ b/commander/src/commands/core/upgrade.ts
@@ -64,7 +64,7 @@ export default class UpgradeCommand extends BaseCommand {
 	static examples = [
 		'core:upgrade lisk-mainnet',
 		'core:upgrade --lisk-version=2.0.0 lisk-mainnet',
-		'core:upgrade --release-url=https://lisk-releases.ams3.digitaloceanspaces.com/lisk-core/lisk-1.6.0-rc.4-Linux-x86_64.tar.gz lisk-mainnet',
+		'core:upgrade --release-url=https://downloads.lisk.io/lisk/mainnet/2.1.0/lisk-2.1.0-Linux-x86_64.tar.gz lisk-mainnet',
 	];
 
 	static flags = {

--- a/commander/test/utils/core/commons.ts
+++ b/commander/test/utils/core/commons.ts
@@ -313,7 +313,7 @@ describe('commons core utils', () => {
 		it('should extract version from url', () => {
 			expect(
 				getSemver(
-					'https://lisk-releases.ams3.digitaloceanspaces.com/lisk-core/lisk-2.0.0-rc.1-Linux-x86_64.tar.gz',
+					'https://localhost/lisk-core/lisk-2.0.0-rc.1-Linux-x86_64.tar.gz',
 				),
 			).to.equal('2.0.0-rc.1');
 			return expect(getSemver(url)).to.equal('1.6.0-rc.4');


### PR DESCRIPTION
### What was the problem?
Instance backup was not removed after uninstall
### How did I fix it?
Removed instance backup during uninstall
### How to test it?
```
lisk core:install foo
lisk core:upgrade foo  # backup gets created as part of the upgrade process
lisk core:uninstall foo
ls -l ~/.lisk/backups/  # should remove backup of "foo"
```
### Review checklist

* The PR resolves #3919 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
