### PR TITLE
Improve usability of StateStore to get and set new values for accounts - Closes #3913

### DIFF
--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -51,12 +51,12 @@ class AccountStore {
 	async cache(filter) {
 		const result = await this.account.get(filter, { extended: true }, this.tx);
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
-		return result;
+		return _.cloneDeep(this.data);
 	}
 
 	createSnapshot() {
-		this.originalData = _.clone(this.data);
-		this.updatedKeys = _.clone(this.updatedKeys);
+		this.originalData = _.cloneDeep(this.data);
+		this.updatedKeys = _.cloneDeep(this.updatedKeys);
 	}
 
 	restoreSnapshot() {
@@ -73,7 +73,7 @@ class AccountStore {
 				`${this.name} with ${this.primaryKey} = ${primaryValue} does not exist`
 			);
 		}
-		return element;
+		return _.cloneDeep(element);
 	}
 
 	getOrDefault(primaryValue) {
@@ -91,7 +91,7 @@ class AccountStore {
 		const newElementIndex = this.data.push(defaultElement) - 1;
 		this.updatedKeys[newElementIndex] = Object.keys(defaultElement);
 
-		return defaultElement;
+		return _.cloneDeep(defaultElement);
 	}
 
 	find(fn) {

--- a/framework/src/modules/chain/logic/state_store/account_store.js
+++ b/framework/src/modules/chain/logic/state_store/account_store.js
@@ -111,7 +111,7 @@ class AccountStore {
 
 		const updatedKeys = Object.entries(updatedElement).reduce(
 			(existingUpdatedKeys, [key, value]) => {
-				if (value !== this.data[elementIndex][key]) {
+				if (!_.isEqual(value, this.data[elementIndex][key])) {
 					existingUpdatedKeys.push(key);
 				}
 

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -317,9 +317,9 @@ Chain.prototype.applyGenesisBlock = function(block, cb) {
 __private.applyTransactions = function(transactions, cb) {
 	modules.processTransactions
 		.applyTransactions(transactions)
-		.then(({ stateStore }) => {
+		.then(async ({ stateStore }) => {
 			// TODO: Need to add logic for handling exceptions for genesis block transactions
-			stateStore.account.finalize();
+			await stateStore.account.finalize();
 			return stateStore;
 		})
 		.then(stateStore => {

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -315,17 +315,15 @@ Chain.prototype.applyGenesisBlock = function(block, cb) {
  * @returns {Object} cb.err - Error if occurred
  */
 __private.applyTransactions = function(transactions, cb) {
+	// TODO: Need to add logic for handling exceptions for genesis block transactions
 	modules.processTransactions
 		.applyTransactions(transactions)
-		.then(async ({ stateStore }) => {
-			// TODO: Need to add logic for handling exceptions for genesis block transactions
-			await stateStore.account.finalize();
-			return stateStore;
-		})
-		.then(stateStore => {
-			stateStore.round.setRoundForData(slots.calcRound(1));
-			return stateStore.round.finalize();
-		})
+		.then(({ stateStore }) =>
+			stateStore.account.finalize().then(() => {
+				stateStore.round.setRoundForData(slots.calcRound(1));
+				return stateStore.round.finalize();
+			})
+		)
 		.then(() => cb())
 		.catch(cb);
 };

--- a/framework/test/mocha/integration/state_store/account_store.js
+++ b/framework/test/mocha/integration/state_store/account_store.js
@@ -5,11 +5,9 @@ describe('system test - account store', () => {
 	let library;
 	let accountStore;
 	const persistedAddresses = ['1085993630748340485L', '16313739661670634666L'];
-	const updatedData = {
-		secondPublicKey:
-			'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
-		secondSignature: true,
-	};
+	const secondPublicKey =
+		'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8';
+	const secondSignature = true;
 
 	const accountQuery = [
 		{
@@ -89,57 +87,61 @@ describe('system test - account store', () => {
 	});
 
 	describe('set', () => {
-		let accounts;
-
 		beforeEach(async () => {
-			accounts = await accountStore.cache(accountQuery);
+			await accountStore.cache(accountQuery);
 		});
 
 		it('should set the updated values for the account', async () => {
-			const updateToAccount = {
-				...accounts[0],
-				...updatedData,
-			};
-			accountStore.set(updateToAccount.address, updateToAccount);
-			expect(accountStore.get(accounts[0].address)).to.deep.equal(
-				updateToAccount
+			const updatedAccount = accountStore.get(accountQuery[0].address);
+
+			updatedAccount.secondPublicKey = secondPublicKey;
+			updatedAccount.secondSignature = secondSignature;
+
+			accountStore.set(accountQuery[0].address, updatedAccount);
+			expect(accountStore.get(accountQuery[0].address)).to.deep.equal(
+				updatedAccount
 			);
 		});
 
 		it('should update the updateKeys property', async () => {
-			const updateToAccount = {
-				...accounts[0],
-				...updatedData,
-			};
-			accountStore.set(updateToAccount.address, updateToAccount);
-			expect(accountStore.updatedKeys[0]).to.deep.equal(
-				Object.keys(updatedData)
-			);
+			const updatedKeys = ['secondPublicKey', 'secondSignature'];
+			const updatedAccount = accountStore.get(accountQuery[0].address);
+
+			updatedAccount.secondPublicKey = secondPublicKey;
+			updatedAccount.secondSignature = secondSignature;
+
+			accountStore.set(accountQuery[0].address, updatedAccount);
+
+			expect(accountStore.updatedKeys[0]).to.deep.equal(updatedKeys);
 		});
 	});
 
 	describe('finalize', () => {
-		let accounts;
-		let updateToAccount;
+		let updatedAccount;
 
 		beforeEach(async () => {
-			accounts = await accountStore.cache(accountQuery);
-			updateToAccount = {
-				...accounts[0],
-				...updatedData,
-			};
-			accountStore.set(updateToAccount.address, updateToAccount);
+			await accountStore.cache(accountQuery);
+
+			updatedAccount = accountStore.get(accountQuery[0].address);
+
+			updatedAccount.secondPublicKey = secondPublicKey;
+			updatedAccount.secondSignature = secondSignature;
+
+			accountStore.set(updatedAccount.address, updatedAccount);
 		});
 
 		it('should save the account state in the database', async () => {
 			await accountStore.finalize();
-			accountStore = new AccountStore(
+
+			const newAccountStore = new AccountStore(
 				library.components.storage.entities.Account
 			);
-			const newResults = await accountStore.cache({
-				address: updateToAccount.address,
-			});
-			expect(newResults[0]).to.deep.equal(updateToAccount);
+
+			await newAccountStore.cache(accountQuery);
+
+			const newResult = newAccountStore.get(updatedAccount.address);
+
+			expect(newResult).to.deep.equal(updatedAccount);
 		});
 
 		it('should throw an error if mutate option is set to false', async () => {
@@ -147,6 +149,7 @@ describe('system test - account store', () => {
 				library.components.storage.entities.Account,
 				{ mutate: false }
 			);
+
 			expect(
 				accountStore.finalize.bind(accountStoreWithoutMutation)
 			).to.throw();


### PR DESCRIPTION
### What was the problem?
StateStore was returning the object pointer allowing users to mutate its state without using `set` method and consequentially breaking the `finalize` method.

### How did I fix it?
By deep cloning the object before returning it in `cache`, `get` and `getOrDefault` methods.

### How to test it?
```
const account = store.account.get(accountId);
account.asset = { newAttr: true };
store.account.set(accountId, account);
```

### Review checklist

* The PR resolves #3913
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
