### PR TITLE
Check the error exists or not and then return with proper message

### DIFF
--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -813,7 +813,7 @@ __private.loadBlocksFromNetwork = function(cb) {
 						modules.blocks.process.loadBlocksFromNetwork(
 							(loadBlocksFromNetworkErr, lastValidBlock) => {
 								if (loadBlocksFromNetworkErr) {
-									library.logger.error(
+									library.logger.debug(
 										loadBlocksFromNetworkErr instanceof Error
 											? loadBlocksFromNetworkErr
 											: new Error(loadBlocksFromNetworkErr),

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -819,8 +819,13 @@ __private.loadBlocksFromNetwork = function(cb) {
 											'Perform chain recovery due to poor consensus'
 										);
 										return modules.blocks.chain.recoverChain(recoveryError => {
+											if (recoveryError) {
+												waterCb(
+													`Failed chain recovery after failing to load blocks while network consensus was low. ${recoveryError}`
+												);
+											}
 											waterCb(
-												`Failed chain recovery after failing to load blocks while network consensus was low. ${recoveryError}`
+												`Failed chain recovery after failing to load blocks. ${loadBlocksFromNetworkErr}`
 											);
 										});
 									}

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -813,6 +813,12 @@ __private.loadBlocksFromNetwork = function(cb) {
 						modules.blocks.process.loadBlocksFromNetwork(
 							(loadBlocksFromNetworkErr, lastValidBlock) => {
 								if (loadBlocksFromNetworkErr) {
+									library.logger.error(
+										loadBlocksFromNetworkErr instanceof Error
+											? loadBlocksFromNetworkErr
+											: new Error(loadBlocksFromNetworkErr),
+										'Failed chain recovery after failing to load blocks'
+									);
 									// If comparison failed and current consensus is low - perform chain recovery
 									if (modules.peers.isPoorConsensus()) {
 										library.logger.debug(
@@ -829,10 +835,6 @@ __private.loadBlocksFromNetwork = function(cb) {
 											);
 										});
 									}
-									library.logger.error(
-										'Failed to process block from network',
-										loadBlocksFromNetworkErr
-									);
 									return waterCb(
 										`Failed to load blocks from the network. ${loadBlocksFromNetworkErr}`
 									);

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -826,11 +826,11 @@ __private.loadBlocksFromNetwork = function(cb) {
 										);
 										return modules.blocks.chain.recoverChain(recoveryError => {
 											if (recoveryError) {
-												waterCb(
+												return waterCb(
 													`Chain recovery failed after failing to load blocks while network consensus was low. ${recoveryError}`
 												);
 											}
-											waterCb(
+											return waterCb(
 												`Chain recovery failed chain recovery after failing to load blocks ${loadBlocksFromNetworkErr}`
 											);
 										});

--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -817,7 +817,7 @@ __private.loadBlocksFromNetwork = function(cb) {
 										loadBlocksFromNetworkErr instanceof Error
 											? loadBlocksFromNetworkErr
 											: new Error(loadBlocksFromNetworkErr),
-										'Failed chain recovery after failing to load blocks'
+										'Chain recovery failed after failing to load blocks from the network'
 									);
 									// If comparison failed and current consensus is low - perform chain recovery
 									if (modules.peers.isPoorConsensus()) {
@@ -827,11 +827,11 @@ __private.loadBlocksFromNetwork = function(cb) {
 										return modules.blocks.chain.recoverChain(recoveryError => {
 											if (recoveryError) {
 												waterCb(
-													`Failed chain recovery after failing to load blocks while network consensus was low. ${recoveryError}`
+													`Chain recovery failed after failing to load blocks while network consensus was low. ${recoveryError}`
 												);
 											}
 											waterCb(
-												`Failed chain recovery after failing to load blocks. ${loadBlocksFromNetworkErr}`
+												`Chain recovery failed chain recovery after failing to load blocks ${loadBlocksFromNetworkErr}`
 											);
 										});
 									}

--- a/framework/test/mocha/unit/modules/chain/submodules/loader.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/loader.js
@@ -195,6 +195,42 @@ describe('loader', () => {
 				});
 			});
 		});
+
+		describe('when modules.blocks.chain.recoverChain throws an error', () => {
+			const chainRecoveryErrorMessage =
+				'Chain recovery failed after failing to load blocks while network consensus was low.';
+			const recoverChainError = new Error('Error While Recovery');
+			let loadBlocksFromNetworkBlocksModule;
+			let recoverChainStub;
+			let lastBlockGetStub;
+
+			beforeEach(async () => {
+				lastBlockGetStub = sinonSandbox
+					.stub(library.modules.blocks.lastBlock, 'get')
+					.resolves({});
+				loadBlocksFromNetworkBlocksModule = sinonSandbox
+					.stub(library.modules.blocks.process, 'loadBlocksFromNetwork')
+					.callsArgWith(0, loadBlockModulesError, {});
+				recoverChainStub = sinonSandbox
+					.stub(library.modules.blocks.chain, 'recoverChain')
+					.callsArgWith(0, recoverChainError);
+			});
+
+			afterEach(async () => {
+				loadBlocksFromNetworkBlocksModule.restore();
+				recoverChainStub.restore();
+				lastBlockGetStub.restore();
+			});
+
+			it('should throw error returned by modules.blocks.chain.recoverChain', done => {
+				__private.loadBlocksFromNetwork(() => {
+					expect(loggerStub.error).to.be.calledWith(
+						`${chainRecoveryErrorMessage} Error: ${recoverChainError.message}`
+					);
+					done();
+				});
+			});
+		});
 	});
 
 	describe('__private.rebuildAccounts', () => {

--- a/framework/test/mocha/unit/modules/chain/submodules/loader.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/loader.js
@@ -134,6 +134,69 @@ describe('loader', () => {
 		});
 	});
 
+	describe('__private.loadBlocksFromNetwork', () => {
+		let loggerStub;
+		let poorConsensusStub;
+		let restoreLogger;
+		const loadBlockModulesError = new Error(
+			'Error occurred while loading blocks'
+		);
+		const chainRecoveryFailError =
+			'Chain recovery failed chain recovery after failing to load blocks';
+
+		beforeEach(async () => {
+			loggerStub = {
+				error: sinonSandbox.stub(),
+				debug: sinonSandbox.stub(),
+			};
+			poorConsensusStub = sinonSandbox
+				.stub(library.modules.peers, 'isPoorConsensus')
+				.resolves(true);
+			restoreLogger = library.rewiredModules.loader.__set__(
+				'library.logger',
+				loggerStub
+			);
+		});
+
+		afterEach(async () => {
+			poorConsensusStub.restore();
+			restoreLogger();
+		});
+
+		describe('when modules.blocks.process.loadBlocksFromNetwork throws an error', () => {
+			let loadBlocksFromNetworkBlocksModule;
+			let recoverChainStub;
+			let lastBlockGetStub;
+
+			beforeEach(async () => {
+				lastBlockGetStub = sinonSandbox
+					.stub(library.modules.blocks.lastBlock, 'get')
+					.resolves({});
+				loadBlocksFromNetworkBlocksModule = sinonSandbox
+					.stub(library.modules.blocks.process, 'loadBlocksFromNetwork')
+					.callsArgWith(0, loadBlockModulesError, {});
+				recoverChainStub = sinonSandbox
+					.stub(library.modules.blocks.chain, 'recoverChain')
+					.callsArgWith(0, null, true);
+			});
+
+			afterEach(async () => {
+				loadBlocksFromNetworkBlocksModule.restore();
+				recoverChainStub.restore();
+				lastBlockGetStub.restore();
+			});
+
+			it('should throw error when modules.blocks.process.loadBlocksFromNetwork fails and logs it', done => {
+				__private.loadBlocksFromNetwork(() => {
+					expect(loggerStub.error).to.be.calledWith(
+						`${chainRecoveryFailError} Error: ${loadBlockModulesError.message}`
+					);
+					done();
+				});
+			});
+		});
+	});
+
 	describe('__private.rebuildAccounts', () => {
 		let __privateVar;
 		let libraryVar;


### PR DESCRIPTION
### What was the problem?

Chain comparison is failing even when nodes have the same block.

we get the wierd error,
```
11:41:58.869Z ERROR lisk-framework: Failed chain recovery after failing to load blocks while network consensus was low. null
```

### How did I fix it?

Check if the error exists or not and form a proper error message.

The below error will be resolved in #3612 
```
 Error: Error loading blocks: Transaction: 5608333921440497612 failed at .multisignature.keysgroup: '.multisignature.keysgroup' should NOT have fewer than 1 items
```
### How to test it?

Sync with alphanet `(jenkinsnet-19).`

### Review checklist

* The PR resolves #3915
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
