### PR TITLE
Uncaught TypeError in checkProtocolVersionCompatibility P2P validation method - Closes #3923

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -445,8 +445,7 @@ export class P2P extends EventEmitter {
 				if (
 					typeof queryObject.wsPort !== 'string' ||
 					typeof queryObject.version !== 'string' ||
-					typeof queryObject.nethash !== 'string' ||
-					typeof queryObject.protocolVersion !== 'string'
+					typeof queryObject.nethash !== 'string'
 				) {
 					this._disconnectSocketDueToFailedHandshake(
 						socket,

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -445,7 +445,8 @@ export class P2P extends EventEmitter {
 				if (
 					typeof queryObject.wsPort !== 'string' ||
 					typeof queryObject.version !== 'string' ||
-					typeof queryObject.nethash !== 'string'
+					typeof queryObject.nethash !== 'string' ||
+					typeof queryObject.protocolVersion !== 'string'
 				) {
 					this._disconnectSocketDueToFailedHandshake(
 						socket,

--- a/elements/lisk-p2p/src/validation.ts
+++ b/elements/lisk-p2p/src/validation.ts
@@ -159,12 +159,19 @@ export const checkProtocolVersionCompatibility = (
 	peerInfo: P2PDiscoveredPeerInfo,
 	nodeInfo: P2PNodeInfo,
 ): boolean => {
+	if (typeof nodeInfo.protocolVersion !== 'string') {
+		return false;
+	}
+	// Backwards compatibility for older peers which do not have a protocolVersion field.
 	if (!peerInfo.protocolVersion) {
 		try {
 			return isVersionGTE(peerInfo.version, nodeInfo.minVersion as string);
 		} catch (error) {
 			return false;
 		}
+	}
+	if (typeof peerInfo.protocolVersion !== 'string') {
+		return false;
 	}
 
 	const peerHardForks = parseInt(peerInfo.protocolVersion.split('.')[0], 10);

--- a/elements/lisk-p2p/src/validation.ts
+++ b/elements/lisk-p2p/src/validation.ts
@@ -159,9 +159,6 @@ export const checkProtocolVersionCompatibility = (
 	peerInfo: P2PDiscoveredPeerInfo,
 	nodeInfo: P2PNodeInfo,
 ): boolean => {
-	if (typeof nodeInfo.protocolVersion !== 'string') {
-		return false;
-	}
 	// Backwards compatibility for older peers which do not have a protocolVersion field.
 	if (!peerInfo.protocolVersion) {
 		try {


### PR DESCRIPTION
### What was the problem?

- There were validation issues which would cause an error to be thrown and crash the node in some situations.

### How did I fix it?

- Perform additional checks on data from peers to prevent invalid method calls.

### Review checklist

* The PR resolves #3923
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
