### PR TITLE
Missing await for async call - Closes #3922

### DIFF
--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -315,17 +315,15 @@ Chain.prototype.applyGenesisBlock = function(block, cb) {
  * @returns {Object} cb.err - Error if occurred
  */
 __private.applyTransactions = function(transactions, cb) {
+	// TODO: Need to add logic for handling exceptions for genesis block transactions
 	modules.processTransactions
 		.applyTransactions(transactions)
-		.then(({ stateStore }) => {
-			// TODO: Need to add logic for handling exceptions for genesis block transactions
-			stateStore.account.finalize();
-			return stateStore;
-		})
-		.then(stateStore => {
-			stateStore.round.setRoundForData(slots.calcRound(1));
-			return stateStore.round.finalize();
-		})
+		.then(({ stateStore }) =>
+			stateStore.account.finalize().then(() => {
+				stateStore.round.setRoundForData(slots.calcRound(1));
+				return stateStore.round.finalize();
+			})
+		)
 		.then(() => cb())
 		.catch(cb);
 };

--- a/framework/src/modules/chain/submodules/blocks/chain.js
+++ b/framework/src/modules/chain/submodules/blocks/chain.js
@@ -315,7 +315,6 @@ Chain.prototype.applyGenesisBlock = function(block, cb) {
  * @returns {Object} cb.err - Error if occurred
  */
 __private.applyTransactions = function(transactions, cb) {
-	// TODO: Need to add logic for handling exceptions for genesis block transactions
 	modules.processTransactions
 		.applyTransactions(transactions)
 		.then(({ stateStore }) =>


### PR DESCRIPTION
### What was the problem?
Apply transactions not being awaited when applying genesis block

### How did I fix it?
By waiting for `stateStore.account.finalize` to finish before proceed.

### How to test it?
Run regular test suite

### Review checklist

* The PR resolves #3922
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
