### PR TITLE
Node fail to sync when block contains multisignature transaction - Closes #3612

### DIFF
--- a/elements/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/4_multisignature_transaction.ts
@@ -394,15 +394,17 @@ export class MultisignatureTransaction extends BaseTransaction {
 		if (!raw.m_keysgroup) {
 			return undefined;
 		}
+
+		// When syncing, nodes should receive `m_keysgroup` as csv string and then split the values into an array
+		// Due to the issue https://github.com/LiskHQ/lisk-sdk/issues/3612, v1.6 nodes will send `m_keysgroup` as an array thus skipping the array convertion
 		const multisignature = {
 			min: raw.m_min,
 			lifetime: raw.m_lifetime,
-			keysgroup: [],
+			keysgroup:
+				typeof raw.m_keysgroup === 'string'
+					? raw.m_keysgroup.split(',')
+					: raw.m_keysgroup,
 		};
-
-		if (typeof raw.m_keysgroup === 'string') {
-			multisignature.keysgroup = raw.m_keysgroup.split(',');
-		}
 
 		return { multisignature };
 	}

--- a/elements/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/elements/lisk-transactions/test/4_multisignature_transaction.ts
@@ -595,6 +595,17 @@ describe('Multisignature transaction class', () => {
 			expect(multisigAsset).to.be.undefined;
 		});
 
+		it('should return undefined when m_keysgroup is null', async () => {
+			// act
+			const multisigAsset = (validTestTransaction as any).assetFromSync({
+				...assetFromSync,
+				m_keysgroup: null,
+			});
+
+			// assert
+			expect(multisigAsset).to.be.undefined;
+		});
+
 		it('should return keygroup as array when m_keysgroup is csv string', async () => {
 			// act
 			const multisigAsset = (validTestTransaction as any).assetFromSync(
@@ -616,6 +627,7 @@ describe('Multisignature transaction class', () => {
 					'+542fdc008964eacc580089271353268d655ab5ec2829687aadc278653fad33cf',
 				],
 			};
+
 			// act
 			const multisigAsset = (validTestTransaction as any).assetFromSync(
 				assetInput,

--- a/elements/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/elements/lisk-transactions/test/4_multisignature_transaction.ts
@@ -535,4 +535,94 @@ describe('Multisignature transaction class', () => {
 			expect(multisigTrs.signatures.length).to.eql(1);
 		});
 	});
+
+	describe('#assetFromSync', () => {
+		const assetFromSync = {
+			m_min: 2,
+			m_lifetime: 1,
+			m_keysgroup:
+				'+40af643265a718844f3dac56ce17ae1d7d47d0a24a35a277a0a6cb0baaa1939f,+d042ad3f1a5b042ddc5aa80c4267b5bfd3b4dda3a682da0a3ef7269409347adb,+542fdc008964eacc580089271353268d655ab5ec2829687aadc278653fad33cf',
+		};
+
+		const assetOutput = {
+			multisignature: {
+				min: 2,
+				lifetime: 1,
+				keysgroup: [
+					'+40af643265a718844f3dac56ce17ae1d7d47d0a24a35a277a0a6cb0baaa1939f',
+					'+d042ad3f1a5b042ddc5aa80c4267b5bfd3b4dda3a682da0a3ef7269409347adb',
+					'+542fdc008964eacc580089271353268d655ab5ec2829687aadc278653fad33cf',
+				],
+			},
+		};
+
+		it('should return the correct keys when input is valid', async () => {
+			// prepare
+			const outputKeys = ['min', 'lifetime', 'keysgroup'];
+
+			// act
+			const {
+				multisignature: multisigAsset,
+			} = (validTestTransaction as any).assetFromSync(assetFromSync);
+
+			// assert
+			expect(Object.keys(multisigAsset)).to.be.eql(outputKeys);
+		});
+
+		it('should return the correct values when input is valid', async () => {
+			// act
+			const multisigAsset = (validTestTransaction as any).assetFromSync(
+				assetFromSync,
+			);
+
+			// assert
+			expect(multisigAsset).to.be.eql(assetOutput);
+		});
+
+		it('should return undefined when m_keysgroup is not given', async () => {
+			// prepare
+			const assetFromSync = {
+				m_min: 2,
+				m_lifetime: 1,
+			};
+
+			// act
+			const multisigAsset = (validTestTransaction as any).assetFromSync(
+				assetFromSync,
+			);
+
+			// assert
+			expect(multisigAsset).to.be.undefined;
+		});
+
+		it('should return keygroup as array when m_keysgroup is csv string', async () => {
+			// act
+			const multisigAsset = (validTestTransaction as any).assetFromSync(
+				assetFromSync,
+			);
+
+			// assert
+			expect(multisigAsset).to.be.eql(assetOutput);
+		});
+
+		it('should return keygroup as array when m_keysgroup is an array', async () => {
+			// prepare
+			const assetInput = {
+				m_min: 2,
+				m_lifetime: 1,
+				m_keysgroup: [
+					'+40af643265a718844f3dac56ce17ae1d7d47d0a24a35a277a0a6cb0baaa1939f',
+					'+d042ad3f1a5b042ddc5aa80c4267b5bfd3b4dda3a682da0a3ef7269409347adb',
+					'+542fdc008964eacc580089271353268d655ab5ec2829687aadc278653fad33cf',
+				],
+			};
+			// act
+			const multisigAsset = (validTestTransaction as any).assetFromSync(
+				assetInput,
+			);
+
+			// assert
+			expect(multisigAsset).to.be.eql(assetOutput);
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?
`MultisignatureTransaction.assetFromSync` was assigning empty array to `keysgroup` when `m_keysgroup` was an array

### How did I fix it?
By assigning the passed value for that scenario

### How to test it?
Sync with v1.6 nodes
Run `elements/lisk-transactions/test/4_multisignature_transaction.ts` test

### Review checklist

* The PR resolves #3612
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
