### PR TITLE
Use transaction not transactions in lisk-client readme - Closes #3925

### DIFF
--- a/elements/lisk-client/src/index.ts
+++ b/elements/lisk-client/src/index.ts
@@ -16,14 +16,17 @@ import { APIClient as APIClientModule } from '@liskhq/lisk-api-client';
 import * as constantsModule from '@liskhq/lisk-constants';
 import * as cryptographyModule from '@liskhq/lisk-cryptography';
 import * as passphraseModule from '@liskhq/lisk-passphrase';
-import * as transactionModule from '@liskhq/lisk-transactions';
+import * as transactionsModule from '@liskhq/lisk-transactions';
 
 // tslint:disable-next-line variable-name
 export const APIClient = APIClientModule;
 export const constants = constantsModule;
 export const cryptography = cryptographyModule;
 export const passphrase = passphraseModule;
-export const transaction = transactionModule;
+export const transactions = transactionsModule;
+// Also export as `transacation` for backward compatibility.
+// See https://github.com/LiskHQ/lisk-sdk/issues/3925#issuecomment-508664703
+export const transaction = transactionsModule;
 
 // tslint:disable-next-line no-default-export
 export default {
@@ -31,5 +34,8 @@ export default {
 	constants,
 	cryptography,
 	passphrase,
-	transaction,
+	transactions,
+	// Also export as `transacation` for backward compatibility.
+	// See https://github.com/LiskHQ/lisk-sdk/issues/3925#issuecomment-508664703
+	transaction: transactions,
 };

--- a/elements/lisk-client/test/index.ts
+++ b/elements/lisk-client/test/index.ts
@@ -18,6 +18,7 @@ import {
 	constants,
 	cryptography,
 	passphrase,
+	transactions,
 	transaction,
 } from '../src';
 
@@ -36,6 +37,10 @@ describe('lisk-client', () => {
 
 	it('passphrase should be an object', () => {
 		return expect(passphrase).to.be.an('object');
+	});
+
+	it('transactions should be an object', () => {
+		return expect(transactions).to.be.an('object');
 	});
 
 	it('transaction should be an object', () => {

--- a/elements/lisk-elements/src/index.ts
+++ b/elements/lisk-elements/src/index.ts
@@ -16,6 +16,15 @@ import { APIClient } from '@liskhq/lisk-api-client';
 import * as constants from '@liskhq/lisk-constants';
 import * as cryptography from '@liskhq/lisk-cryptography';
 import * as passphrase from '@liskhq/lisk-passphrase';
-import * as transaction from '@liskhq/lisk-transactions';
+import * as transactions from '@liskhq/lisk-transactions';
 
-export { APIClient, constants, cryptography, passphrase, transaction };
+export {
+	APIClient,
+	constants,
+	cryptography,
+	passphrase,
+	transactions,
+	// Also export as `transacation` for backward compatibility.
+	// See https://github.com/LiskHQ/lisk-sdk/issues/3925#issuecomment-508664703
+	transactions as transaction,
+};

--- a/elements/lisk-elements/test/index.ts
+++ b/elements/lisk-elements/test/index.ts
@@ -18,6 +18,7 @@ import {
 	constants,
 	cryptography,
 	passphrase,
+	transactions,
 	transaction,
 } from '../src';
 
@@ -36,6 +37,10 @@ describe('lisk-elements', () => {
 
 	it('passphrase should be an object', () => {
 		return expect(passphrase).to.be.an('object');
+	});
+
+	it('transactions should be an object', () => {
+		return expect(transactions).to.be.an('object');
 	});
 
 	it('transaction should be an object', () => {


### PR DESCRIPTION
### What was the problem?
`@liskhq/lisk-transactions` exported as `transaction` from `@liskhq/lisk-client` and it should be `transactions` for consistency with other packages.

### How did I fix it?
By exporting `@liskhq/lisk-transactions` as `transactions` from `@liskhq/lisk-client`.
`transaction` was kept for backward compatibility.

### How to test it?
`import { transactions } from '@liskhq/lisk-client';`

### Review checklist

* The PR resolves #3925
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
