### PR TITLE
Uncaught TypeError in checkProtocolVersionCompatibility P2P validation method - Closes #3923

### DIFF
--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -308,10 +308,11 @@ describe('Integration tests for P2P library', () => {
 							nethash:
 								'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 							version: p2p.nodeInfo.version,
+							protocolVersion: '1.1',
 							wsPort: p2p.nodeInfo.wsPort,
 							height: 1000 + (p2p.nodeInfo.wsPort % NETWORK_START_PORT),
 							options: p2p.nodeInfo.options,
-						} as any);
+						});
 					}
 
 					await wait(200);
@@ -701,10 +702,11 @@ describe('Integration tests for P2P library', () => {
 					nethash:
 						'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 					version: firstP2PNode.nodeInfo.version,
+					protocolVersion: '1.1',
 					wsPort: firstP2PNode.nodeInfo.wsPort,
 					height: 10,
 					options: firstP2PNode.nodeInfo.options,
-				} as any);
+				});
 
 				await wait(200);
 


### PR DESCRIPTION
### What was the problem?

An error was thrown in the P2P validation logic. While investigating the issue, it was discovered that there was a missing check; this was addressed by https://github.com/LiskHQ/lisk-sdk/pull/3926/files in the 2.0 branch. In addition to this, there was another problem that the test code was not passing the `protocolVersion` field as expected.

### How did I fix it?

This PR addresses the second issue above; a `protocolVersion` field was added wherever `applyNodeInfo` is invoked in the test code. Note that this issue does not affect the 2.0 because the faulty test cases were added in the `feature/implement-lip-p2p` branch.

### How to test it?

`npm run test`

### Review checklist

* The PR resolves #3923
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
