### PR TITLE
application_config_schema.js not being used and Application/Schema invalid syntax - Closes #3939

### DIFF
--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -29,7 +29,11 @@ const Controller = require('./controller');
 const version = require('../version');
 const validator = require('./validator');
 const configurator = require('./default_configurator');
-const { genesisBlockSchema, constantsSchema } = require('./schema');
+const {
+	genesisBlockSchema,
+	constantsSchema,
+	applicationConfigSchema,
+} = require('./schema');
 
 const { createLoggerComponent } = require('../components/logger');
 
@@ -114,6 +118,8 @@ class Application {
 	 */
 	constructor(genesisBlock, config = {}) {
 		validator.validate(genesisBlockSchema, genesisBlock);
+
+		validator.validate(applicationConfigSchema, config);
 
 		// Don't change the object parameters provided
 		let appConfig = _.cloneDeep(config);

--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -29,11 +29,7 @@ const Controller = require('./controller');
 const version = require('../version');
 const validator = require('./validator');
 const configurator = require('./default_configurator');
-const {
-	genesisBlockSchema,
-	constantsSchema,
-	applicationConfigSchema,
-} = require('./schema');
+const { genesisBlockSchema, constantsSchema } = require('./schema');
 
 const { createLoggerComponent } = require('../components/logger');
 
@@ -118,8 +114,6 @@ class Application {
 	 */
 	constructor(genesisBlock, config = {}) {
 		validator.validate(genesisBlockSchema, genesisBlock);
-
-		validator.validate(applicationConfigSchema, config);
 
 		// Don't change the object parameters provided
 		let appConfig = _.cloneDeep(config);

--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -133,11 +133,15 @@ module.exports = {
 							description:
 								'Timestamp indicating the start of Lisk Core (`Date.toISOString()`)',
 						},
+						// NOTICE: BLOCK_TIME and MAX_TRANSACTIONS_PER_BLOCK are related and it's values
+						// need to be changed togeter as per recommendations noted in https://github.com/LiskHQ/lisk-sdk/issues/3151
 						BLOCK_TIME: {
 							type: 'number',
 							minimum: 2,
 							description: 'Slot time interval in seconds',
 						},
+						// NOTICE: BLOCK_TIME and MAX_TRANSACTIONS_PER_BLOCK are related and it's values
+						// need to be changed togeter as per recommendations noted in https://github.com/LiskHQ/lisk-sdk/issues/3151
 						MAX_TRANSACTIONS_PER_BLOCK: {
 							type: 'integer',
 							minimum: 1,

--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -135,12 +135,13 @@ module.exports = {
 						},
 						BLOCK_TIME: {
 							type: 'number',
-							min: 1,
+							minimum: 2,
 							description: 'Slot time interval in seconds',
 						},
 						MAX_TRANSACTIONS_PER_BLOCK: {
 							type: 'integer',
-							min: 1,
+							minimum: 1,
+							maximum: 150,
 							description: 'Maximum number of transactions allowed per block',
 						},
 						REWARDS: {
@@ -159,12 +160,12 @@ module.exports = {
 								},
 								OFFSET: {
 									type: 'integer',
-									min: 1,
+									minimum: 1,
 									description: 'Start rewards at block (n)',
 								},
 								DISTANCE: {
 									type: 'integer',
-									min: 1,
+									minimum: 1,
 									description: 'Distance between each milestone',
 								},
 							},

--- a/framework/src/controller/schema/genesis_block_schema.js
+++ b/framework/src/controller/schema/genesis_block_schema.js
@@ -53,15 +53,15 @@ module.exports = {
 		},
 		timestamp: {
 			type: 'integer',
-			min: 0,
+			minimum: 0,
 		},
 		numberOfTransactions: {
 			type: 'integer',
-			min: 0,
+			minimum: 0,
 		},
 		payloadLength: {
 			type: 'integer',
-			min: 0,
+			minimum: 0,
 		},
 		previousBlock: {
 			type: ['null', 'string'],
@@ -133,7 +133,7 @@ module.exports = {
 		},
 		height: {
 			type: 'integer',
-			min: 1,
+			minimum: 1,
 		},
 		blockSignature: {
 			type: 'string',

--- a/framework/test/fixtures/config/devnet/config.json
+++ b/framework/test/fixtures/config/devnet/config.json
@@ -9,8 +9,8 @@
 		"label": "devnet",
 		"genesisConfig": {
 			"EPOCH_TIME": "2016-05-24T17:00:00.000Z",
-			"BLOCK_TIME": 2,
-			"MAX_TRANSACTIONS_PER_BLOCK": 150,
+			"BLOCK_TIME": 10,
+			"MAX_TRANSACTIONS_PER_BLOCK": 25,
 			"REWARDS": {
 				"MILESTONES": [
 					"500000000",

--- a/framework/test/fixtures/config/devnet/config.json
+++ b/framework/test/fixtures/config/devnet/config.json
@@ -2,6 +2,26 @@
 	"app": {
 		"ipc": {
 			"enabled": true
+		},
+		"version": "2.1.0",
+		"minVersion": "1.0.0",
+		"protocolVersion": "1.1",
+		"label": "devnet",
+		"genesisConfig": {
+			"EPOCH_TIME": "2016-05-24T17:00:00.000Z",
+			"BLOCK_TIME": 2,
+			"MAX_TRANSACTIONS_PER_BLOCK": 150,
+			"REWARDS": {
+				"MILESTONES": [
+					"500000000",
+					"400000000",
+					"300000000",
+					"200000000",
+					"100000000"
+				],
+				"OFFSET": 2160,
+				"DISTANCE": 3000000
+			}
 		}
 	},
 	"components": {

--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -4,9 +4,9 @@ exports[`Application #constructor should set internal variables 1`] = `
 Object {
   "app": Object {
     "genesisConfig": Object {
-      "BLOCK_TIME": 2,
+      "BLOCK_TIME": 10,
       "EPOCH_TIME": "2016-05-24T17:00:00.000Z",
-      "MAX_TRANSACTIONS_PER_BLOCK": 150,
+      "MAX_TRANSACTIONS_PER_BLOCK": 25,
       "REWARDS": Object {
         "DISTANCE": 3000000,
         "MILESTONES": Array [

--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -4,9 +4,9 @@ exports[`Application #constructor should set internal variables 1`] = `
 Object {
   "app": Object {
     "genesisConfig": Object {
-      "BLOCK_TIME": 10,
+      "BLOCK_TIME": 2,
       "EPOCH_TIME": "2016-05-24T17:00:00.000Z",
-      "MAX_TRANSACTIONS_PER_BLOCK": 25,
+      "MAX_TRANSACTIONS_PER_BLOCK": 150,
       "REWARDS": Object {
         "DISTANCE": 3000000,
         "MILESTONES": Array [
@@ -20,12 +20,12 @@ Object {
       },
     },
     "ipc": Object {
-      "enabled": false,
+      "enabled": true,
     },
-    "label": "jest-unit",
+    "label": "devnet",
     "minVersion": "1.0.0",
-    "protocolVersion": "1.0",
-    "version": "1.6.0",
+    "protocolVersion": "1.1",
+    "version": "2.1.0",
   },
   "components": Object {
     "cache": Object {

--- a/framework/test/jest/unit/specs/controller/application.spec.js
+++ b/framework/test/jest/unit/specs/controller/application.spec.js
@@ -26,6 +26,7 @@ const {
 	SchemaValidationError,
 	genesisBlockSchema,
 	constantsSchema,
+	applicationConfigSchema,
 } = require('../../../../../src/controller/schema');
 
 jest.mock('../../../../../src/components/logger');
@@ -35,12 +36,6 @@ const genesisBlock = require('../../../../fixtures/config/devnet/genesis_block')
 
 const config = {
 	...networkConfig,
-	app: {
-		label: 'jest-unit',
-		version: '1.6.0',
-		minVersion: '1.0.0',
-		protocolVersion: '1.0',
-	},
 };
 // eslint-disable-next-line
 describe('Application', () => {
@@ -58,12 +53,23 @@ describe('Application', () => {
 			// Act
 			const validateSpy = jest.spyOn(validator, 'validate');
 			new Application(genesisBlock, config);
-
 			// Assert
-			expect(validateSpy).toHaveBeenCalled();
-			expect(validateSpy).toHaveBeenCalledWith(
+			expect(validateSpy).toHaveBeenNthCalledWith(
+				1,
 				genesisBlockSchema,
 				genesisBlock
+			);
+		});
+
+		it('should validate appConfig', () => {
+			// Act
+			const validateSpy = jest.spyOn(validator, 'validate');
+			new Application(genesisBlock, config);
+			// Assert
+			expect(validateSpy).toHaveBeenNthCalledWith(
+				2,
+				applicationConfigSchema,
+				config
 			);
 		});
 
@@ -86,7 +92,7 @@ describe('Application', () => {
 		it('should set filename for logger if logger component was not provided', () => {
 			// Arrange
 			const configWithoutLogger = _.cloneDeep(config);
-			delete configWithoutLogger.components.logger;
+			configWithoutLogger.components.logger = {};
 
 			// Act
 			const app = new Application(genesisBlock, configWithoutLogger);
@@ -115,6 +121,19 @@ describe('Application', () => {
 
 			customConfig.app.genesisConfig = {
 				MAX_TRANSACTIONS_PER_BLOCK: 11,
+				EPOCH_TIME: '2016-05-24T17:00:00.000Z',
+				BLOCK_TIME: 2,
+				REWARDS: {
+					MILESTONES: [
+						'500000000',
+						'400000000',
+						'300000000',
+						'200000000',
+						'100000000',
+					],
+					OFFSET: 2160,
+					DISTANCE: 3000000,
+				},
 			};
 
 			const app = new Application(genesisBlock, customConfig);

--- a/framework/test/jest/unit/specs/controller/application.spec.js
+++ b/framework/test/jest/unit/specs/controller/application.spec.js
@@ -26,7 +26,6 @@ const {
 	SchemaValidationError,
 	genesisBlockSchema,
 	constantsSchema,
-	applicationConfigSchema,
 } = require('../../../../../src/controller/schema');
 
 jest.mock('../../../../../src/components/logger');
@@ -58,18 +57,6 @@ describe('Application', () => {
 				1,
 				genesisBlockSchema,
 				genesisBlock
-			);
-		});
-
-		it('should validate appConfig', () => {
-			// Act
-			const validateSpy = jest.spyOn(validator, 'validate');
-			new Application(genesisBlock, config);
-			// Assert
-			expect(validateSpy).toHaveBeenNthCalledWith(
-				2,
-				applicationConfigSchema,
-				config
 			);
 		});
 

--- a/framework/test/jest/unit/specs/controller/schema/__snapshots__/application_schema.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/schema/__snapshots__/application_schema.spec.js.snap
@@ -55,7 +55,7 @@ Object {
           "properties": Object {
             "BLOCK_TIME": Object {
               "description": "Slot time interval in seconds",
-              "min": 1,
+              "minimum": 2,
               "type": "number",
             },
             "EPOCH_TIME": Object {
@@ -65,7 +65,8 @@ Object {
             },
             "MAX_TRANSACTIONS_PER_BLOCK": Object {
               "description": "Maximum number of transactions allowed per block",
-              "min": 1,
+              "maximum": 150,
+              "minimum": 1,
               "type": "integer",
             },
             "REWARDS": Object {
@@ -75,7 +76,7 @@ Object {
               "properties": Object {
                 "DISTANCE": Object {
                   "description": "Distance between each milestone",
-                  "min": 1,
+                  "minimum": 1,
                   "type": "integer",
                 },
                 "MILESTONES": Object {
@@ -88,7 +89,7 @@ Object {
                 },
                 "OFFSET": Object {
                   "description": "Start rewards at block (n)",
-                  "min": 1,
+                  "minimum": 1,
                   "type": "integer",
                 },
               },

--- a/framework/test/jest/unit/specs/controller/schema/__snapshots__/genesis_block_schema.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/schema/__snapshots__/genesis_block_schema.spec.js.snap
@@ -14,7 +14,7 @@ Object {
       "type": "string",
     },
     "height": Object {
-      "min": 1,
+      "minimum": 1,
       "type": "integer",
     },
     "id": Object {
@@ -24,7 +24,7 @@ Object {
       "type": "string",
     },
     "numberOfTransactions": Object {
-      "min": 0,
+      "minimum": 0,
       "type": "integer",
     },
     "payloadHash": Object {
@@ -32,7 +32,7 @@ Object {
       "type": "string",
     },
     "payloadLength": Object {
-      "min": 0,
+      "minimum": 0,
       "type": "integer",
     },
     "previousBlock": Object {
@@ -49,7 +49,7 @@ Object {
       "type": "string",
     },
     "timestamp": Object {
-      "min": 0,
+      "minimum": 0,
       "type": "integer",
     },
     "totalAmount": Object {


### PR DESCRIPTION
### What was the problem?

- application_config_schema.js is validated in Application as genesisBlockSchema is.
- Suggested values in #3151 are added to application_config_schema.js
- Schema definition was using `min` and `max` instead of `minimum` and `maximum`

### How did I fix it?

- application_config_schema.js is being validated.
- schema is using min and max instead of minimum and maximum for limits which is invalid and pass validation with invalid values

### How to test it?

- Build should be green
- Change `framework/test/fixtures/config/devnet/config.json` with values that will fail validation and application should not start

### Review checklist

* The PR resolves #3939
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
