### PR TITLE
Add registerTransaction to README - Closes #3743

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -89,7 +89,7 @@ node index.js
 
 ### Configure your blockchain parameters
 
-You can also define your blockchain application parameters such as `block time`, `epoch time`, `max transactions per block` and more with an optional configurations object.
+You can also define your blockchain application parameters such as `BLOCK_TIME`, `EPOCH_TIME`, `MAX_TRANSACTIONS_PER_BLOCK` and more with an optional configurations object.
 
 ```js
 const app = new Application(genesisBlockDevnet, {
@@ -131,32 +131,6 @@ app
 ```
 
 For information on creating your own custom transaction, see the [lisk-docs repo](https://github.com/LiskHQ/lisk-docs/blob/development/start/custom-transactions.md) or [follow the tutorials](https://github.com/LiskHQ/lisk-docs/blob/development/start/tutorials/hello-world.md).
-
-### Registering a custom module
-
-You can [design and build custom modules with Lisk-SDK](https://github.com/LiskHQ/lisk-docs/blob/master/lisk-core/introduction.md#custom-modules).
-
-Add your own custom module to your blockchain application by registering it to the application instance:
-
-```js
-const { Application, genesisBlockDevnet } = require('lisk-sdk');
-
-const MyModule = require('./my_module');
-
-const app = new Application(genesisBlockDevnet);
-
-app.registerModule(MyModule); // register the custom module
-
-app
-	.run()
-	.then(() => app.logger.info('App started...'))
-	.catch(error => {
-		console.error('Faced error in application', error);
-		process.exit(1);
-	});
-```
-
-For information on creating your own custom module, see the [lisk-docs repo](https://github.com/LiskHQ/lisk-docs/blob/master/lisk-core/introduction.md#custom-modules).
 
 ## Get Involved
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -17,29 +17,15 @@ Please be advised we cannot guarantee blockchains created with the alpha release
 
 We hope you enjoy building your proof-of-concept blockchain applications using the Lisk SDK, and shall look forward to receiving your feedback and contributions during the alpha phase.
 
-## What is the Lisk SDK
+## What is the Lisk SDK?
 
 The Lisk SDK aims to provide an easy and reliable software development kit for building blockchain applications which are compatible with the [Lisk Protocol](https://lisk.io/documentation/lisk-protocol). The architecture of the Lisk SDK has been designed so that it can be extended to meet the requirements of a wide variety of blockchain application use-cases. The codebase is written entirely in JavaScript, which means for a majority of developers, no significant change of tools or mindset is required to get started. The Lisk SDK makes every effort to allow developers to focus simply and purely on writing the code that matters to their own blockchain application, and nothing more.
 
-### Architecture Overview
+## Usage 
 
-The Lisk SDK operates on the NodeJS runtime and consists primarily of an application framework (Lisk Framework), a collection of libraries providing blockchain application functionalities (Lisk Elements), and a powerful command-line tool (Lisk Commander) allowing developers to manage a Lisk node instance and interact with a Lisk compatible network. The diagram below provides a high-level overview of the architecture:
+#### Dependencies
 
-![Diagram](./docs/assets/diagram_sdk.png)
-
-## Package Directories
-
-| Directory                | Description                                                                                                                                          |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Framework](./framework) | An application framework responsible for establishing and maintaining the interactions between the modules of a Lisk blockchain application.         |
-| [Elements](./elements)   | A collection of libraries, each of them implementing some form of blockchain application functionality such as cryptography, transactions, p2p, etc. |
-| [Commander](./commander) | A command line tool allowing developers to manage a Lisk node instance and interact with a Lisk compatible network.                                  |
-
-## Installation
-
-### Dependencies
-
-The following dependencies need to be installed in order to run applications created with the Lisk SDK:
+Before running Lisk SDK, the following dependencies need to be installed in order to run applications created with the Lisk SDK:
 
 | Dependencies     | Version |
 | ---------------- | ------- |
@@ -51,15 +37,17 @@ You can find further details on installing these dependencies in our [pre-instal
 
 Mind, that you need to create a database before. The default database name is `lisk_dev`, so for the development purposes, a command `createdb lisk_dev` will set you up.
 
-### Installation of Lisk Framework
+### Installation
 
-To start using the Lisk SDK you need to install one npm package - `lisk-sdk`:
+The installation of Lisk Alpha SDK is straightforward and limited to getting a single NPM package to your Node.js project - `lisk-sdk`:
 
 ```
 npm install lisk-sdk@alpha
 ```
 
-## Usage
+Lisk SDK is all-in-one package that provides you with tools to create, run and maintain blockchain applications in JavaScript.
+
+### Set up new a blockchain application
 
 To start, create the project structure of your blockchain application. There are no special requirements here, you can create the basic Node.js project folder structure with `npm init`.
 
@@ -106,7 +94,7 @@ const app = new Application(genesisBlockDevnet, {
 
 For a complete list of configuration options see the [lisk-docs repo](https://github.com/LiskHQ/lisk-docs/blob/development/lisk-sdk/configuration.md).
 
-### Registering a custom transaction
+### Register a custom transaction
 
 You can [define your own transaction types](https://github.com/LiskHQ/lisk-docs/blob/development/start/custom-transactions.md) with Lisk-SDK. This is where the custom logic for your blockchain application lives.
 
@@ -131,6 +119,21 @@ app
 ```
 
 For information on creating your own custom transaction, see the [lisk-docs repo](https://github.com/LiskHQ/lisk-docs/blob/development/start/custom-transactions.md) or [follow the tutorials](https://github.com/LiskHQ/lisk-docs/blob/development/start/tutorials/hello-world.md).
+
+## Architecture Overview
+
+The Lisk SDK operates on the NodeJS runtime and consists primarily of an application framework (Lisk Framework), a collection of libraries providing blockchain application functionalities (Lisk Elements), and a powerful command-line tool (Lisk Commander) allowing developers to manage a Lisk node instance and interact with a Lisk compatible network. The diagram below provides a high-level overview of the architecture:
+
+![Diagram](./docs/assets/diagram_sdk.png)
+
+### Packages
+
+| Directory                | Description                                                                                                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Framework](./framework) | An application framework responsible for establishing and maintaining the interactions between the modules of a Lisk blockchain application.         |
+| [Elements](./elements)   | A collection of libraries, each of them implementing some form of blockchain application functionality such as cryptography, transactions, p2p, etc. |
+| [Commander](./commander) | A command line tool allowing developers to manage a Lisk node instance and interact with a Lisk compatible network.                                  |
+
 
 ## Get Involved
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -39,7 +39,7 @@ Mind, that you need to create a database before. The default database name is `l
 
 ### Installation
 
-The installation of Lisk Alpha SDK is straightforward and limited to getting a single NPM package to your Node.js project - `lisk-sdk`:
+The installation of Lisk Alpha SDK is straightforward and limited to getting a single NPM package, `lisk-sdk`, to your Node.js project:
 
 ```
 npm install lisk-sdk@alpha

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -87,7 +87,76 @@ After that you can start the application by:
 node index.js
 ```
 
-More usage examples and configuration samples will be made available during the alpha phase on the official Lisk [documentation portal](http://docs.lisk.io).
+### Configure your blockchain parameters
+
+You can also define your blockchain application parameters such as `block time`, `epoch time`, `max transactions per block` and more with an optional configurations object.
+
+```js
+const app = new Application(genesisBlockDevnet, {
+    app: {
+        label: 'my-blockchain-application',
+        genesisConfig: {
+            EPOCH_TIME: new Date(Date.UTC(2016, 4, 24, 17, 0, 0, 0)).toISOString(),
+            BLOCK_TIME: 10,
+            MAX_TRANSACTIONS_PER_BLOCK: 25,
+        },
+        ...
+});
+```
+
+For a complete list of configuration options see the [lisk-docs repo](https://github.com/LiskHQ/lisk-docs/blob/development/lisk-sdk/configuration.md).
+
+### Registering a custom transaction
+
+You can [define your own transaction types](https://github.com/LiskHQ/lisk-docs/blob/development/start/custom-transactions.md) with Lisk-SDK. This is where the custom logic for your blockchain application lives.
+
+Add your custom transaction type to your blockchain application by registering it to the application instance:
+
+```js
+const { Application, genesisBlockDevnet } = require('lisk-sdk');
+
+const MyTransaction = require('./my_transaction');
+
+const app = new Application(genesisBlockDevnet);
+
+app.registerTransaction(MyTransaction); // register the custom transaction
+
+app
+	.run()
+	.then(() => app.logger.info('App started...'))
+	.catch(error => {
+		console.error('Faced error in application', error);
+		process.exit(1);
+	});
+```
+
+For information on creating your own custom transaction, see the [lisk-docs repo](https://github.com/LiskHQ/lisk-docs/blob/development/start/custom-transactions.md) or [follow the tutorials](https://github.com/LiskHQ/lisk-docs/blob/development/start/tutorials/hello-world.md).
+
+### Registering a custom module
+
+You can [design and build custom modules with Lisk-SDK](https://github.com/LiskHQ/lisk-docs/blob/master/lisk-core/introduction.md#custom-modules).
+
+Add your own custom module to your blockchain application by registering it to the application instance:
+
+```js
+const { Application, genesisBlockDevnet } = require('lisk-sdk');
+
+const MyModule = require('./my_module');
+
+const app = new Application(genesisBlockDevnet);
+
+app.registerModule(MyModule); // register the custom module
+
+app
+	.run()
+	.then(() => app.logger.info('App started...'))
+	.catch(error => {
+		console.error('Faced error in application', error);
+		process.exit(1);
+	});
+```
+
+For information on creating your own custom module, see the [lisk-docs repo](https://github.com/LiskHQ/lisk-docs/blob/master/lisk-core/introduction.md#custom-modules).
 
 ## Get Involved
 


### PR DESCRIPTION
### What was the problem?

Incomplete README for alpha SDK.

### How did I fix it?

Added `registerTransaction`, `registerModule` instructions to README. 

### Review checklist

* The PR resolves #3743 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
