### PR TITLE
Add unit tests for __private.undoConfirmedStep and __private.popLastBlock -  Closes #3929

### DIFF
--- a/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
@@ -653,13 +653,10 @@ describe('blocks/chain', () => {
 				],
 			});
 
-			try {
-				// Act
-				await __private.applyConfirmedStep(filledBlock);
-			} catch (err) {
-				// Assert
-				expect(err).to.be.equal(errors);
-			}
+			// Act && Assert
+			await expect(
+				__private.applyConfirmedStep(filledBlock)
+			).to.eventually.be.rejected.and.deep.equal(errors);
 		});
 
 		it('should call stateStore.account.finalize', async () => {
@@ -1033,13 +1030,10 @@ describe('blocks/chain', () => {
 				],
 			});
 
-			try {
-				// Act
-				await __private.undoConfirmedStep(filledBlock);
-			} catch (err) {
-				// Assert
-				expect(err).to.be.equal(errors);
-			}
+			// Act && Assert
+			await expect(
+				__private.undoConfirmedStep(filledBlock)
+			).to.eventually.be.rejected.and.deep.equal(errors);
 		});
 
 		it('should call stateStore.account.finalize', async () => {

--- a/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
@@ -173,7 +173,7 @@ describe('blocks/chain', () => {
 			isActive: {
 				set: sinonSandbox.stub(),
 			},
-			calculateNewBroadhash: sinonSandbox.stub(),
+			calculateNewBroadhash: sinonSandbox.stub().resolves({}),
 		};
 
 		const modulesRoundsStub = {
@@ -1065,11 +1065,23 @@ describe('blocks/chain', () => {
 				});
 			});
 
-			// TODO: add new tests once improve_transaction_eficiency is done
 			describe('when __private.popLastBlock succeeds', () => {
-				/* eslint-disable mocha/no-pending-tests */
-				it('should return previousBlock');
-				/* eslint-enable mocha/no-pending-tests */
+				it('should return previousBlock', done => {
+					// Arrange
+					const previousBlock = { id: 5, height: 5 };
+					__private.popLastBlock.callsArgWith(1, null, previousBlock);
+					modules.blocks.lastBlock.set.returns(previousBlock);
+
+					// Act
+					blocksChainModule.deleteLastBlock((err, block) => {
+						expect(err).to.equal(null);
+						expect(modules.blocks.lastBlock.set).to.be.calledWith(
+							previousBlock
+						);
+						expect(block).to.equal(previousBlock);
+						done();
+					});
+				});
 			});
 		});
 	});

--- a/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
@@ -604,6 +604,17 @@ describe('blocks/chain', () => {
 			height: 1,
 			transactions: [{ id: 21 }, { id: 22 }],
 		};
+		let originalInertTransactions;
+
+		beforeEach(async () => {
+			// Arrange (Backup)
+			originalInertTransactions = global.exceptions.inertTransactions;
+		});
+
+		afterEach(async () => {
+			// Restore
+			global.exceptions.inertTransactions = originalInertTransactions;
+		});
 
 		it('should return when block.transactions includes no transactions', async () => {
 			// Arrange
@@ -619,15 +630,11 @@ describe('blocks/chain', () => {
 
 		it('should call modules.processTransactions.applyConfirmedStep', async () => {
 			// Arrange
-			const originalInertTransactions = global.exceptions.inertTransactions;
 			global.exceptions.inertTransactions = [filledBlock.transactions[0].id];
 			const dummyTx = {};
 
 			// Act
 			await __private.applyConfirmedStep(filledBlock, dummyTx);
-
-			// Cleanup
-			global.exceptions.inertTransactions = originalInertTransactions;
 
 			// Assert
 			return expect(
@@ -977,6 +984,18 @@ describe('blocks/chain', () => {
 			transactions: [{ id: 21 }, { id: 22 }],
 		};
 
+		let originalInertTransactions;
+
+		beforeEach(async () => {
+			// Arrange (Backup)
+			originalInertTransactions = global.exceptions.inertTransactions;
+		});
+
+		afterEach(async () => {
+			// Restore
+			global.exceptions.inertTransactions = originalInertTransactions;
+		});
+
 		it('should return when block.transactions includes no transactions', async () => {
 			// Arrange
 			const emptyBlock = {
@@ -991,15 +1010,11 @@ describe('blocks/chain', () => {
 
 		it('should call modules.processTransactions.undoTransactions', async () => {
 			// Arrange
-			const originalInertTransactions = global.exceptions.inertTransactions;
 			global.exceptions.inertTransactions = [filledBlock.transactions[0].id];
 			const dummyTx = {};
 
 			// Act
 			await __private.undoConfirmedStep(filledBlock, dummyTx);
-
-			// Cleanup
-			global.exceptions.inertTransactions = originalInertTransactions;
 
 			// Assert
 			return expect(

--- a/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
@@ -403,7 +403,7 @@ describe('blocks/chain', () => {
 					blocksChainModule.saveBlock(
 						blockWithTransactions,
 						async () => {
-							expect(__private.afterSave.calledOnce).to.be.true;
+							expect(__private.afterSave).to.be.calledOnce;
 							done();
 						},
 						txStub
@@ -449,7 +449,7 @@ describe('blocks/chain', () => {
 
 				it('should call __private.afterSave', done => {
 					blocksChainModule.saveBlock(blockWithTransactions, async () => {
-						expect(__private.afterSave.calledOnce).to.be.true;
+						expect(__private.afterSave).to.be.calledOnce;
 						done();
 					});
 				});
@@ -461,7 +461,7 @@ describe('blocks/chain', () => {
 		it('should call afterSave for all transactions', done => {
 			const spy = sinonSandbox.spy();
 			__private.afterSave(blockWithTransactions, spy);
-			expect(spy.calledOnce).to.be.true;
+			expect(spy).to.be.calledOnce;
 			done();
 		});
 	});
@@ -581,7 +581,7 @@ describe('blocks/chain', () => {
 								expect(__private.applyGenesisTransactions.callCount).to.equal(
 									1
 								);
-								expect(modules.blocks.lastBlock.set.calledOnce).to.be.true;
+								expect(modules.blocks.lastBlock.set).to.be.calledOnce;
 								expect(modules.blocks.lastBlock.set.args[0][0]).to.deep.equal(
 									blockWithTransactions
 								);
@@ -661,8 +661,8 @@ describe('blocks/chain', () => {
 
 			// Assert
 			return expect(
-				processTransactionMethodResponse.stateStore.account.finalize.calledOnce
-			).to.be.true;
+				processTransactionMethodResponse.stateStore.account.finalize
+			).to.be.calledOnce;
 		});
 
 		it('should call stateStore.round.setRoundForData with correct parameters', async () => {
@@ -682,9 +682,8 @@ describe('blocks/chain', () => {
 			await __private.applyConfirmedStep(filledBlock);
 
 			// Assert
-			return expect(
-				processTransactionMethodResponse.stateStore.round.finalize.calledOnce
-			).to.be.true;
+			return expect(processTransactionMethodResponse.stateStore.round.finalize)
+				.to.be.calledOnce;
 		});
 	});
 
@@ -734,7 +733,7 @@ describe('blocks/chain', () => {
 							expect(blocksChainModule.saveBlock.args[0][0]).to.deep.equal(
 								blockWithTransactions
 							);
-							expect(modules.blocks.lastBlock.set.calledOnce).to.be.false;
+							expect(modules.blocks.lastBlock.set).to.not.be.called;
 							done();
 						});
 				});
@@ -768,7 +767,7 @@ describe('blocks/chain', () => {
 							)
 							.catch(err => {
 								expect(err).to.equal('tick-ERR');
-								expect(library.bus.message.calledOnce).to.be.false;
+								expect(library.bus.message).to.not.be.called;
 								done();
 							});
 					});
@@ -786,7 +785,7 @@ describe('blocks/chain', () => {
 							)
 							.then(resolve => {
 								expect(resolve).to.be.undefined;
-								expect(library.bus.message.calledOnce).to.be.true;
+								expect(library.bus.message).to.be.calledOnce;
 								expect(library.bus.message.args[0][0]).to.deep.equal(
 									'newBlock'
 								);
@@ -813,7 +812,7 @@ describe('blocks/chain', () => {
 						)
 						.catch(err => {
 							expect(err).to.equal('tick-ERR');
-							expect(library.bus.message.calledOnce).to.be.false;
+							expect(library.bus.message).to.not.be.called;
 							done();
 						});
 				});
@@ -831,7 +830,7 @@ describe('blocks/chain', () => {
 						)
 						.then(resolve => {
 							expect(resolve).to.be.undefined;
-							expect(library.bus.message.calledOnce).to.be.true;
+							expect(library.bus.message).to.be.calledOnce;
 							expect(library.bus.message.args[0][0]).to.deep.equal('newBlock');
 							expect(library.bus.message.args[0][1]).to.deep.equal(
 								blockWithTransactions
@@ -918,7 +917,7 @@ describe('blocks/chain', () => {
 	describe('broadcastReducedBlock', () => {
 		it('should call library.bus.message with reducedBlock and broadcast', async () => {
 			blocksChainModule.broadcastReducedBlock(blockReduced, true);
-			expect(library.bus.message.calledOnce).to.be.true;
+			expect(library.bus.message).to.be.calledOnce;
 			expect(library.bus.message.args[0][0]).to.equal('broadcastBlock');
 			expect(library.bus.message.args[0][1]).to.deep.equal(blockReduced);
 			return expect(library.bus.message.args[0][2]).to.be.true;
@@ -1034,8 +1033,8 @@ describe('blocks/chain', () => {
 
 			// Assert
 			return expect(
-				processTransactionMethodResponse.stateStore.account.finalize.calledOnce
-			).to.be.true;
+				processTransactionMethodResponse.stateStore.account.finalize
+			).to.be.calledOnce;
 		});
 
 		it('should call stateStore.round.setRoundForData with correct parameters', async () => {
@@ -1055,9 +1054,8 @@ describe('blocks/chain', () => {
 			await __private.undoConfirmedStep(filledBlock);
 
 			// Assert
-			return expect(
-				processTransactionMethodResponse.stateStore.round.finalize.calledOnce
-			).to.be.true;
+			return expect(processTransactionMethodResponse.stateStore.round.finalize)
+				.to.be.calledOnce;
 		});
 	});
 
@@ -1176,7 +1174,7 @@ describe('blocks/chain', () => {
 
 		afterEach(done => {
 			__private.popLastBlock = popLastBlockTemp;
-			expect(modules.blocks.lastBlock.get.calledOnce).to.be.true;
+			expect(modules.blocks.lastBlock.get).to.be.calledOnce;
 			expect(loggerStub.warn.args[0][0]).to.equal('Deleting last block');
 			done();
 		});

--- a/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js
@@ -677,7 +677,7 @@ describe('blocks/chain', () => {
 			).to.have.been.calledWith(round);
 		});
 
-		it('should call tateStore.round.finalize', async () => {
+		it('should call stateStore.round.finalize', async () => {
 			// Act
 			await __private.applyConfirmedStep(filledBlock);
 
@@ -1050,7 +1050,7 @@ describe('blocks/chain', () => {
 			).to.have.been.calledWith(round);
 		});
 
-		it('should call tateStore.round.finalize', async () => {
+		it('should call stateStore.round.finalize', async () => {
 			// Act
 			await __private.undoConfirmedStep(filledBlock);
 


### PR DESCRIPTION
### What was the problem?

Following files were not covered with unit tests in `framework/test/mocha/unit/modules/chain/submodules/blocks/chain.js`

- __private.applyConfirmedStep 
- __private.undoConfirmedStep 
- __private.popLastBlock 
### How did I fix it?
I added unit test coverage.
### How to test it?
Run `npm run mocha:unit -- blocks/chain`
### Review checklist

* The PR resolves #3929 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
