### PR TITLE
Add missing unit tests for transactions processing - Closes #3951

### DIFF
--- a/framework/src/modules/chain/submodules/process_transactions.js
+++ b/framework/src/modules/chain/submodules/process_transactions.js
@@ -101,11 +101,11 @@ class ProcessTransactions {
 		const persistedTransactions = transactions.filter(transaction =>
 			persistedTransactionIds.includes(transaction.id)
 		);
-		const unpersistedTransactions = transactions.filter(
+		const nonPersistedTransactions = transactions.filter(
 			transaction => !persistedTransactionIds.includes(transaction.id)
 		);
 		const transactionsResponses = [
-			...unpersistedTransactions.map(transaction => ({
+			...nonPersistedTransactions.map(transaction => ({
 				id: transaction.id,
 				status: TransactionStatus.OK,
 				errors: [],

--- a/framework/src/modules/chain/submodules/process_transactions.js
+++ b/framework/src/modules/chain/submodules/process_transactions.js
@@ -255,12 +255,12 @@ class ProcessTransactions {
 			return transactionResponse;
 		});
 
-		const unundoableTransactionsResponse = transactionsResponses.filter(
+		const nonUndoableTransactionsResponse = transactionsResponses.filter(
 			transactionResponse => transactionResponse.status !== TransactionStatus.OK
 		);
 
 		updateTransactionResponseForExceptionTransactions(
-			unundoableTransactionsResponse,
+			nonUndoableTransactionsResponse,
 			transactions
 		);
 

--- a/framework/src/modules/chain/submodules/process_transactions.js
+++ b/framework/src/modules/chain/submodules/process_transactions.js
@@ -283,7 +283,7 @@ class ProcessTransactions {
 			stateStore.createSnapshot();
 			const transactionResponse = transaction.apply(stateStore);
 			if (slots.getSlotNumber(transaction.timestamp) > slots.getSlotNumber()) {
-				transactionResponse.status = 0;
+				transactionResponse.status = TransactionStatus.FAIL;
 				transactionResponse.errors.push(
 					new TransactionError(
 						'Invalid transaction timestamp. Timestamp is in the future',

--- a/framework/test/mocha/unit/modules/chain/submodules/process_transactions.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/process_transactions.js
@@ -878,6 +878,43 @@ describe('ProcessTransactions', () => {
 		});
 	});
 
+	describe('processSignature()', () => {
+		const signature = '12356677';
+		let addMultisignatureStub;
+
+		beforeEach(async () => {
+			addMultisignatureStub = sinonSandbox.stub();
+
+			trs1.addMultisignature = addMultisignatureStub;
+		});
+
+		it('should initialize the state store', async () => {
+			await processTransactions.processSignature(trs1, signature);
+
+			expect(StateStoreStub).to.be.calledOnce;
+			expect(StateStoreStub).to.be.calledWithExactly(storageMock, {
+				mutate: false,
+			});
+		});
+
+		it('should prepare transaction', async () => {
+			await processTransactions.processSignature(trs1, signature);
+
+			expect(trs1.prepare).to.be.calledOnce;
+			expect(trs1.prepare).to.be.calledWithExactly(stateStoreMock);
+		});
+
+		it('should add signature to transaction', async () => {
+			await processTransactions.processSignature(trs1, signature);
+
+			expect(addMultisignatureStub).to.be.calledOnce;
+			expect(addMultisignatureStub).to.be.calledWithExactly(
+				stateStoreMock,
+				signature
+			);
+		});
+	});
+
 	describe('_getCurrentContext', () => {
 		let result;
 

--- a/framework/test/mocha/unit/modules/chain/submodules/process_transactions.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/process_transactions.js
@@ -65,7 +65,7 @@ describe('ProcessTransactions', () => {
 		it('should assign parameters correctly', async () => {
 			const library = ProcessTransactions.__get__('library');
 
-			expect(library.storage).to.be.equal(paramScope.components.storage);
+			expect(library.storage).to.be.eql(paramScope.components.storage);
 		});
 
 		it('should invoke the callback', done => {
@@ -75,6 +75,14 @@ describe('ProcessTransactions', () => {
 				done();
 			};
 			new ProcessTransactions(cb, paramScope);
+		});
+	});
+
+	describe('onBind()', () => {
+		it('should assign params correctly to library', async () => {
+			const library = ProcessTransactions.__get__('library');
+
+			expect(library.modules.blocks).to.be.eql(paramScope.modules.blocks);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

There were no unit test for `submoduels/transactions_processing.js`

### How did I fix it?

Added the unit tests 

### How to test it?

`cd framework && npm run mocha:unit test/mocha/unit/modules/chain/submodules/process_transactions.js`

### Review checklist

* The PR resolves #3951
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
