### PR TITLE
Reenable and fix skipped Application unit tests - Closes #3947

### DIFF
--- a/framework/src/controller/application.js
+++ b/framework/src/controller/application.js
@@ -274,7 +274,7 @@ class Application {
 	 */
 	registerMigrations(namespace, migrations) {
 		assert(namespace, 'Namespace is required');
-		assert(migrations instanceof Array, 'Migrations list should be an array');
+		assert(Array.isArray(migrations), 'Migrations list should be an array');
 		assert(
 			!Object.keys(this.getMigrations()).includes(namespace),
 			`Migrations for "${namespace}" was already registered.`

--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -20,7 +20,7 @@ Object {
       },
     },
     "ipc": Object {
-      "enabled": true,
+      "enabled": false,
     },
     "label": "devnet",
     "minVersion": "1.0.0",


### PR DESCRIPTION
### What was the problem?
Jest Unit tests for `application.js` were skipped and all of them were failing.
### How did I fix it?
By reenabling them and replacing the faulty `migrations instanceof Array` by `Array.isArray(migrations)` which was causing the assertion in `registerMigrations` method to throw.
### How to test it?
Run `npm run jest:unit application.spec.js`
### Review checklist

* The PR resolves #3947
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
