### PR TITLE
Some transaction events are not being broadcasted - Closes #3962

### DIFF
--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -327,6 +327,7 @@ class Blocks extends EventEmitter {
 					await this._updateBroadhash();
 					this._lastBlock = newBlock;
 					this._isActive = false;
+					this.emit(EVENT_NEW_BLOCK, { block: cloneDeep(this._lastBlock) });
 				} catch (error) {
 					this._isActive = false;
 					this.logger.error(error);

--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -418,6 +418,7 @@ class Blocks extends EventEmitter {
 						validBlock => this.broadcast(validBlock)
 					);
 					await this._updateBroadhash();
+					this.emit(EVENT_NEW_BLOCK, { block: cloneDeep(this._lastBlock) });
 					this._isActive = false;
 				} catch (error) {
 					this.logger.error(error);

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -535,5 +535,7 @@ module.exports = class Chain {
 		this.blocks.removeAllListeners(EVENT_DELETE_BLOCK);
 		this.blocks.removeAllListeners(EVENT_NEW_BLOCK);
 		this.blocks.removeAllListeners(EVENT_NEW_BROADHASH);
+		this.blocks.removeAllListeners(EVENT_UNCONFIRMED_TRANSACTION);
+		this.blocks.removeAllListeners(EVENT_MULTISIGNATURE_SIGNATURE);
 	}
 };

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -27,7 +27,11 @@ const { bootstrapStorage, bootstrapCache } = require('./init_steps');
 const jobQueue = require('./utils/jobs_queue');
 const { Peers } = require('./peers');
 const { TransactionInterfaceAdapter } = require('./interface_adapters');
-const { TransactionPool } = require('./transaction_pool');
+const {
+	TransactionPool,
+	EVENT_MULTISIGNATURE_SIGNATURE,
+	EVENT_UNCONFIRMED_TRANSACTION,
+} = require('./transaction_pool');
 const { Rounds } = require('./rounds');
 const {
 	BlockSlots,
@@ -40,10 +44,6 @@ const {
 const { Loader } = require('./loader');
 const { Forger } = require('./forger');
 const { Transport } = require('./transport');
-const {
-	EVENT_MULTISIGNATURE_SIGNATURE,
-	EVENT_UNCONFIRMED_TRANSACTION,
-} = require('./transactions');
 
 const syncInterval = 10000;
 const forgeInterval = 1000;
@@ -510,7 +510,11 @@ module.exports = class Chain {
 		});
 
 		this.transactionPool.on(EVENT_UNCONFIRMED_TRANSACTION, transaction => {
-			this.logger.debug(`Broadcasting transaction ${transaction.id}`);
+			this.logger.trace(
+				`Received EVENT_UNCONFIRMED_TRANSACTION for transaction ${
+					transaction.id
+				}`
+			);
 			this.transport.onUnconfirmedTransaction(transaction, true);
 		});
 
@@ -519,7 +523,10 @@ module.exports = class Chain {
 		});
 
 		this.transactionPool.on(EVENT_MULTISIGNATURE_SIGNATURE, signature => {
-			this.logger.debug('Broadcasting signature ', signature);
+			this.logger.trace(
+				'Received EVENT_MULTISIGNATURE_SIGNATURE for signature ',
+				signature
+			);
 			this.transport.onSignature(signature, true);
 		});
 	}

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -40,6 +40,7 @@ const {
 const { Loader } = require('./loader');
 const { Forger } = require('./forger');
 const { Transport } = require('./transport');
+const { EVENT_UNCONFIRMED_TRANSACTION } = require('./transactions');
 
 const syncInterval = 10000;
 const forgeInterval = 1000;
@@ -503,6 +504,11 @@ module.exports = class Chain {
 				);
 			}
 			this.channel.publish('chain:blocks:change', block);
+		});
+
+		this.transactionPool.on(EVENT_UNCONFIRMED_TRANSACTION, transaction => {
+			this.logger.debug(`Broadcasting transaction ${transaction.id}`);
+			this.transport.onUnconfirmedTransaction(transaction, true);
 		});
 
 		this.blocks.on(EVENT_NEW_BROADHASH, ({ broadhash, height }) => {

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -40,7 +40,10 @@ const {
 const { Loader } = require('./loader');
 const { Forger } = require('./forger');
 const { Transport } = require('./transport');
-const { EVENT_UNCONFIRMED_TRANSACTION } = require('./transactions');
+const {
+	EVENT_MULTISIGNATURE_SIGNATURE,
+	EVENT_UNCONFIRMED_TRANSACTION,
+} = require('./transactions');
 
 const syncInterval = 10000;
 const forgeInterval = 1000;
@@ -513,6 +516,11 @@ module.exports = class Chain {
 
 		this.blocks.on(EVENT_NEW_BROADHASH, ({ broadhash, height }) => {
 			this.channel.invoke('app:updateApplicationState', { broadhash, height });
+		});
+
+		this.transactionPool.on(EVENT_MULTISIGNATURE_SIGNATURE, signature => {
+			this.logger.debug('Broadcasting signature ', signature);
+			this.transport.onSignature(signature, true);
 		});
 	}
 

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -511,9 +511,8 @@ module.exports = class Chain {
 
 		this.transactionPool.on(EVENT_UNCONFIRMED_TRANSACTION, transaction => {
 			this.logger.trace(
-				`Received EVENT_UNCONFIRMED_TRANSACTION for transaction ${
-					transaction.id
-				}`
+				{ transactionId: transaction.id },
+				'Received EVENT_UNCONFIRMED_TRANSACTION'
 			);
 			this.transport.onUnconfirmedTransaction(transaction, true);
 		});
@@ -524,8 +523,8 @@ module.exports = class Chain {
 
 		this.transactionPool.on(EVENT_MULTISIGNATURE_SIGNATURE, signature => {
 			this.logger.trace(
-				'Received EVENT_MULTISIGNATURE_SIGNATURE for signature ',
-				signature
+				{ signature },
+				'Received EVENT_MULTISIGNATURE_SIGNATURE'
 			);
 			this.transport.onSignature(signature, true);
 		});

--- a/framework/src/modules/chain/transaction_pool/index.js
+++ b/framework/src/modules/chain/transaction_pool/index.js
@@ -14,8 +14,14 @@
 
 'use strict';
 
-const { TransactionPool } = require('./transaction_pool');
+const {
+	TransactionPool,
+	EVENT_UNCONFIRMED_TRANSACTION,
+	EVENT_MULTISIGNATURE_SIGNATURE,
+} = require('./transaction_pool');
 
 module.exports = {
 	TransactionPool,
+	EVENT_UNCONFIRMED_TRANSACTION,
+	EVENT_MULTISIGNATURE_SIGNATURE,
 };

--- a/framework/src/modules/chain/transaction_pool/transaction_pool.js
+++ b/framework/src/modules/chain/transaction_pool/transaction_pool.js
@@ -25,6 +25,9 @@ const { getAddressFromPublicKey } = require('@liskhq/lisk-cryptography');
 const { sortBy } = require('./sort');
 const transactionsModule = require('../transactions');
 
+const EVENT_UNCONFIRMED_TRANSACTION = 'EVENT_UNCONFIRMED_TRANSACTION';
+const EVENT_MULTISIGNATURE_SIGNATURE = 'EVENT_MULTISIGNATURE_SIGNATURE';
+
 const handleAddTransactionResponse = (addTransactionResponse, transaction) => {
 	if (addTransactionResponse.isFull) {
 		throw new Error('Transaction pool is full');
@@ -160,10 +163,7 @@ class TransactionPool extends EventEmitter {
 		this.pool.on(pool.EVENT_VERIFIED_TRANSACTION_ONCE, ({ payload }) => {
 			if (payload.length > 0) {
 				payload.forEach(aTransaction =>
-					this.emit(
-						transactionsModule.EVENT_UNCONFIRMED_TRANSACTION,
-						aTransaction
-					)
+					this.emit(EVENT_UNCONFIRMED_TRANSACTION, aTransaction)
 				);
 			}
 		});
@@ -228,7 +228,7 @@ class TransactionPool extends EventEmitter {
 			throw transactionResponse.errors;
 		}
 
-		this.emit(transactionsModule.EVENT_MULTISIGNATURE_SIGNATURE, signature);
+		this.emit(EVENT_MULTISIGNATURE_SIGNATURE, signature);
 		return transactionResponse;
 	}
 
@@ -518,4 +518,8 @@ class TransactionPool extends EventEmitter {
 	}
 }
 
-module.exports = { TransactionPool };
+module.exports = {
+	TransactionPool,
+	EVENT_UNCONFIRMED_TRANSACTION,
+	EVENT_MULTISIGNATURE_SIGNATURE,
+};

--- a/framework/src/modules/chain/transaction_pool/transaction_pool.js
+++ b/framework/src/modules/chain/transaction_pool/transaction_pool.js
@@ -227,6 +227,8 @@ class TransactionPool extends EventEmitter {
 			this.logger.error(message, { signature });
 			throw transactionResponse.errors;
 		}
+
+		this.emit(transactionsModule.EVENT_MULTISIGNATURE_SIGNATURE, signature);
 		return transactionResponse;
 	}
 

--- a/framework/src/modules/chain/transaction_pool/transaction_pool.js
+++ b/framework/src/modules/chain/transaction_pool/transaction_pool.js
@@ -160,7 +160,10 @@ class TransactionPool extends EventEmitter {
 		this.pool.on(pool.EVENT_VERIFIED_TRANSACTION_ONCE, ({ payload }) => {
 			if (payload.length > 0) {
 				payload.forEach(aTransaction =>
-					this.emit('unconfirmedTransaction', aTransaction)
+					this.emit(
+						transactionsModule.EVENT_UNCONFIRMED_TRANSACTION,
+						aTransaction
+					)
 				);
 			}
 		});

--- a/framework/src/modules/chain/transactions/index.js
+++ b/framework/src/modules/chain/transactions/index.js
@@ -27,6 +27,8 @@ const {
 	applyGenesisTransactions,
 } = require('./transactions_handlers');
 
+const EVENT_UNCONFIRMED_TRANSACTION = 'unconfirmedTransaction';
+
 module.exports = {
 	composeTransactionSteps,
 	checkIfTransactionIsInert,
@@ -38,4 +40,5 @@ module.exports = {
 	undoTransactions,
 	verifyTransactions,
 	processSignature,
+	EVENT_UNCONFIRMED_TRANSACTION,
 };

--- a/framework/src/modules/chain/transactions/index.js
+++ b/framework/src/modules/chain/transactions/index.js
@@ -27,7 +27,7 @@ const {
 	applyGenesisTransactions,
 } = require('./transactions_handlers');
 
-const EVENT_UNCONFIRMED_TRANSACTION = 'unconfirmedTransaction';
+const EVENT_UNCONFIRMED_TRANSACTION = 'EVENT_UNCONFIRMED_TRANSACTION';
 const EVENT_MULTISIGNATURE_SIGNATURE = 'multisignature';
 
 module.exports = {

--- a/framework/src/modules/chain/transactions/index.js
+++ b/framework/src/modules/chain/transactions/index.js
@@ -28,6 +28,7 @@ const {
 } = require('./transactions_handlers');
 
 const EVENT_UNCONFIRMED_TRANSACTION = 'unconfirmedTransaction';
+const EVENT_MULTISIGNATURE_SIGNATURE = 'multisignature';
 
 module.exports = {
 	composeTransactionSteps,
@@ -41,4 +42,5 @@ module.exports = {
 	verifyTransactions,
 	processSignature,
 	EVENT_UNCONFIRMED_TRANSACTION,
+	EVENT_MULTISIGNATURE_SIGNATURE,
 };

--- a/framework/src/modules/chain/transactions/index.js
+++ b/framework/src/modules/chain/transactions/index.js
@@ -27,9 +27,6 @@ const {
 	applyGenesisTransactions,
 } = require('./transactions_handlers');
 
-const EVENT_UNCONFIRMED_TRANSACTION = 'EVENT_UNCONFIRMED_TRANSACTION';
-const EVENT_MULTISIGNATURE_SIGNATURE = 'multisignature';
-
 module.exports = {
 	composeTransactionSteps,
 	checkIfTransactionIsInert,
@@ -41,6 +38,4 @@ module.exports = {
 	undoTransactions,
 	verifyTransactions,
 	processSignature,
-	EVENT_UNCONFIRMED_TRANSACTION,
-	EVENT_MULTISIGNATURE_SIGNATURE,
 };

--- a/framework/src/modules/chain/transport/broadcaster.js
+++ b/framework/src/modules/chain/transport/broadcaster.js
@@ -257,7 +257,7 @@ class Broadcaster {
 		}
 		try {
 			await this.filterQueue();
-			const broadcasts = this.queue.splice(0, this.broadcasts.releaseLimit);
+			const broadcasts = this.queue.splice(0, this.config.releaseLimit);
 			const squashedBroadcasts = this.squashQueue(broadcasts);
 
 			await Promise.all(

--- a/framework/test/mocha/unit/modules/chain/blocks/blocks.js
+++ b/framework/test/mocha/unit/modules/chain/blocks/blocks.js
@@ -330,6 +330,23 @@ describe('blocks', () => {
 					expect(blocksInstance._isActive).to.be.false;
 					expect(loggerStub.warn).to.be.calledOnce;
 				});
+
+				it('should emit EVENT_NEW_BLOCK with block', async () => {
+					const emitSpy = sinonSandbox.spy(blocksInstance, 'emit');
+					const forkFiveBlock = {
+						id: '5',
+						generatorPublicKey: 'a',
+						previousBlock: '1',
+						height: 2,
+					};
+					await blocksInstance.receiveBlockFromNetwork(forkFiveBlock);
+
+					expect(blocksInstance.blocksProcess.processBlock).to.be.calledOnce;
+					expect(emitSpy.thirdCall.args).to.be.eql([
+						'EVENT_NEW_BLOCK',
+						{ block: forkFiveBlock },
+					]);
+				});
 			});
 
 			describe('when block.id === lastBlock.id', () => {

--- a/framework/test/mocha/unit/modules/chain/blocks/blocks.js
+++ b/framework/test/mocha/unit/modules/chain/blocks/blocks.js
@@ -232,6 +232,22 @@ describe('blocks', () => {
 
 					expect(blocksInstance.blocksProcess.processBlock).to.be.calledOnce;
 				});
+
+				it('should emit EVENT_NEW_BLOCK with block', async () => {
+					const emitSpy = sinonSandbox.spy(blocksInstance, 'emit');
+					const fakeBlock = {
+						id: '5',
+						previousBlock: '2',
+						height: 3,
+					};
+					await blocksInstance.receiveBlockFromNetwork(fakeBlock);
+
+					expect(blocksInstance.blocksProcess.processBlock).to.be.calledOnce;
+					expect(emitSpy.secondCall.args).to.be.eql([
+						'EVENT_NEW_BLOCK',
+						{ block: fakeBlock },
+					]);
+				});
 			});
 
 			describe('when block.previousBlock !== lastBlock.id && lastBlock.height + 1 === block.height', () => {


### PR DESCRIPTION
### What was the problem?

- Transaction were not being broadcasted by node
- Signatures were not being broadcasted by node
- Transactions were not being removed from the transaction pool when receiving block
- Broadcaster had a bug making the application crash when trying to broadcast

### How did I fix it?

- By adding missing code for broadcasting transactions
- By adding missing code for broadcasting signatures
- By clearing transactions from the transaction pool when receiving block
- Fixing the bug in Broadcaster
- Add tests

### How to test it?

- Build should be green
- Bring up a network and send transactions and signatures and they should be broadcasted

### Review checklist

* The PR resolves #3962
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
