### PR TITLE
Node keep disconnecting with peers running older versions - Closes #3961

### DIFF
--- a/elements/lisk-p2p/package.json
+++ b/elements/lisk-p2p/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@liskhq/lisk-p2p",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.1-alpha.1",
 	"description": "Unstructured P2P library for use with Lisk-related software",
 	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "GPL-3.0",

--- a/elements/lisk-p2p/src/peer.ts
+++ b/elements/lisk-p2p/src/peer.ts
@@ -527,6 +527,15 @@ export class Peer extends EventEmitter {
 			});
 		});
 
+		// This is needed for backwards compatibility with older 1.x nodes.
+		// TODO: Remove this from versions 2.3 and above.
+		outboundSocket.on('message', () => {
+			const transport = (outboundSocket as any).transport;
+			if (transport) {
+				transport._resetPingTimeout();
+			}
+		});
+
 		// Bind RPC and remote event handlers
 		outboundSocket.on(REMOTE_EVENT_RPC_REQUEST, this._handleRawRPC);
 		outboundSocket.on(REMOTE_EVENT_MESSAGE, this._handleRawMessage);
@@ -551,6 +560,8 @@ export class Peer extends EventEmitter {
 		outboundSocket.off('connect');
 		outboundSocket.off('connectAbort');
 		outboundSocket.off('close');
+
+		outboundSocket.off('message');
 
 		// Unbind RPC and remote event handlers
 		outboundSocket.off(REMOTE_EVENT_RPC_REQUEST, this._handleRawRPC);

--- a/framework/package.json
+++ b/framework/package.json
@@ -49,7 +49,7 @@
 	},
 	"dependencies": {
 		"@liskhq/lisk-cryptography": "2.1.0",
-		"@liskhq/lisk-p2p": "0.1.1-alpha.0",
+		"@liskhq/lisk-p2p": "0.1.1-alpha.1",
 		"@liskhq/lisk-transaction-pool": "0.1.1-alpha.0",
 		"@liskhq/lisk-transactions": "2.1.1-alpha.0",
 		"ajv": "6.7.0",


### PR DESCRIPTION
### What was the problem?

New 2.0 nodes would disconnect with older 1.x nodes every 20 seconds because the servers on the old nodes were not sending ping heartbeats to our clients on the 2.0 nodes so we were treating them as dead. There is a subtle difference in the SC heartbeat mechanism which makes this occur.

### How did I fix it?

On the client, reset the ping timeout whenever we receive any message (even if it's not a ping). This is slightly more expensive but is closer to the old behaviour of SC ping/pong.

### How to test it?

QA

### Review checklist

* The PR resolves #3961
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
