### PR TITLE
Sequence should not be used in Loader - Closes #3977

### DIFF
--- a/framework/src/modules/chain/loader.js
+++ b/framework/src/modules/chain/loader.js
@@ -189,22 +189,20 @@ class Loader {
 
 		const { signatures } = result;
 
-		await this.sequence.add(async () => {
-			const signatureCount = signatures.length;
-			for (let i = 0; i < signatureCount; i++) {
-				const signaturePacket = signatures[i];
-				const subSignatureCount = signaturePacket.signatures.length;
-				for (let j = 0; j < subSignatureCount; j++) {
-					const signature = signaturePacket.signatures[j];
+		const signatureCount = signatures.length;
+		for (let i = 0; i < signatureCount; i++) {
+			const signaturePacket = signatures[i];
+			const subSignatureCount = signaturePacket.signatures.length;
+			for (let j = 0; j < subSignatureCount; j++) {
+				const signature = signaturePacket.signatures[j];
 
-					// eslint-disable-next-line no-await-in-loop
-					await this.transactionPoolModule.getTransactionAndProcessSignature({
-						signature,
-						transactionId: signature.transactionId,
-					});
-				}
+				// eslint-disable-next-line no-await-in-loop
+				await this.transactionPoolModule.getTransactionAndProcessSignature({
+					signature,
+					transactionId: signature.transactionId,
+				});
 			}
-		});
+		}
 	}
 
 	/**


### PR DESCRIPTION
### What was the problem?

Sequence was removed in 2.2.* but one call was still present in Loader

### How did I fix it?

By removing the call to sequence.add() from Loader

### How to test it?

Build should be green

### Review checklist

* The PR resolves #3977
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
