### PR TITLE
Enforce limits on the size of inbound messages/requests in P2P - Closes #3335

### DIFF
--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -53,6 +53,7 @@ export interface ClientOptionsUpdated {
 	readonly multiplex: boolean;
 	readonly ackTimeout?: number;
 	readonly connectTimeout?: number;
+	readonly maxPayload?: number;
 }
 
 export interface Productivity {
@@ -135,6 +136,7 @@ export const convertNodeInfoToLegacyFormat = (
 export interface PeerConfig {
 	readonly connectTimeout?: number;
 	readonly ackTimeout?: number;
+	readonly wsMaxPayload?: number;
 }
 
 export class Peer extends EventEmitter {

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -118,6 +118,7 @@ export class OutboundPeer extends Peer {
 			autoConnect: false,
 			autoReconnect: false,
 			pingTimeoutDisabled: true,
+			maxPayload: this._peerConfig.wsMaxPayload,
 		};
 
 		const outboundSocket = socketClusterClient.create(clientOptions);
@@ -253,6 +254,7 @@ export const connectAndRequest = async (
 				autoConnect: false,
 				autoReconnect: false,
 				pingTimeoutDisabled: true,
+				maxPayload: peerConfig ? peerConfig.wsMaxPayload : undefined,
 			};
 
 			const outboundSocket = socketClusterClient.create(clientOptions);

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -592,13 +592,18 @@ export class PeerPool extends EventEmitter {
 		}
 
 		if (kind === OutboundPeer) {
-			this.removePeer(shuffle(peers)[0].id);
+			const selectedPeer = shuffle(peers)[0];
+			if (selectedPeer) {
+				this.removePeer(selectedPeer.id);
+			}
 		}
 
 		if (kind === InboundPeer) {
 			const evictionCandidates = this._selectPeersForEviction();
 			const peerToEvict = shuffle(evictionCandidates)[0];
-			this.removePeer(peerToEvict.id);
+			if (peerToEvict) {
+				this.removePeer(peerToEvict.id);
+			}
 		}
 	}
 


### PR DESCRIPTION
### What was the problem?

Peers were not being disconnected if they sent a payload larger than maxPayload. This feature was broken due to significant changes in the last merge.

### How did I fix it?

Set the payload properties correctly and improved the relevant test cases.

### How to test it?

Run p2p integration tests.

### Review checklist

* The PR resolves #3335
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
