### PR TITLE
Delay in syncing with network due to too many failed to load block from network - Closes #3954

### DIFF
--- a/framework/src/modules/chain/loader.js
+++ b/framework/src/modules/chain/loader.js
@@ -283,19 +283,12 @@ class Loader {
 		const lastBlock = this.blocksModule.lastBlock;
 		// TODO: If there is an error, invoke the applyPenalty action on the Network module once it is implemented.
 		// TODO: Rename procedure to include target module name. E.g. chain:blocks
-		let data;
-		try {
-			const response = await this.channel.invoke('network:request', {
-				procedure: 'blocks',
-				data: {
-					lastBlockId: lastBlock.id,
-				},
-			});
-			data = response.data;
-		} catch (p2pError) {
-			this.logger.error('Failed to load block from network', p2pError);
-			return [];
-		}
+		const { data } = await this.channel.invoke('network:request', {
+			procedure: 'blocks',
+			data: {
+				lastBlockId: lastBlock.id,
+			},
+		});
 
 		if (!data) {
 			throw new Error('Received an invalid blocks response from the network');


### PR DESCRIPTION
### What was the problem?
`_loadBlocksFromNetwork` was returning an empty array whenever `channel.invoke('network:request')` failed causing the syncing process to incompletely exit. After exiting it had to wait the sync task to be triggered again (which happens every 10 seconds) delaying the syncing process.

### How did I fix it?
By forcing `_getBlocksFromNetwork` to throw in case it fails triggering the retry process.

**Note that this PR doesn't fix the `channel.invoke('network:request')` timeout that is frequently happening during sync.**

### How to test it?
Start syncing process on testnet and monitor the logs.
The syncing process should not be interrupted until it finishes.

### Review checklist

* The PR resolves #3954
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
