### PR TITLE
Remove stdin and gc - Closes #3839

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -48,15 +48,6 @@ const { Transport } = require('./transport');
 const syncInterval = 10000;
 const forgeInterval = 1000;
 
-// Begin reading from stdin
-process.stdin.resume();
-
-if (typeof gc !== 'undefined') {
-	setInterval(() => {
-		gc(); // eslint-disable-line no-undef
-	}, 60000);
-}
-
 /**
  * Chain Module
  *


### PR DESCRIPTION
### What was the problem?
`process.stdin.resume` and `gc` was used without reason.
We do not use `--expose-gc` so, `gc` function is not exposed. Therefore, it is no longer used.
Also, we do not make application on hold by `stdin.resume` anywhere. Therefore, it's no longer needed.

### How did I solve it?
Remove those two functions.

### How to manually test it?
Start the application and see if it works fine
`node framework/test/test_app`

### Review checklist

- [x] The PR resolves #3839 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
