### PR TITLE
Jenkins fails when building branch - Closes #4031

### DIFF
--- a/Jenkinsfile.sdk
+++ b/Jenkinsfile.sdk
@@ -377,8 +377,10 @@ pipeline {
 				if (env.BRANCH_NAME == 'master') {
 					step([$class: 'MasterCoverageAction', scmVars: [GIT_URL: env.GIT_URL]])
 				}
+				if (env.CHANGE_ID != null) {
+					step([$class: 'CompareCoverageAction', publishResultAs: 'statusCheck', scmVars: [GIT_URL: env.GIT_URL]])
+				}
 			}
-			step([$class: 'CompareCoverageAction', publishResultAs: 'statusCheck', scmVars: [GIT_URL: env.GIT_URL]])
 		}
 		cleanup {
 			cleanWs()


### PR DESCRIPTION
### What was the problem?
Jenkins was trying to run `CompareCoverageAction` when building from a branch without PR and causing it to fail even if all tests passes.

### How did I solve it?
By checking `CHANGE_ID` environment variable (that represents the PR number) to make sure it's a PR and run `CompareCoverageAction`

Ref.: https://github.com/jenkinsci/github-pr-coverage-status-plugin

### How to manually test it?
There is no manual test

### Review checklist

- [x] The PR resolves #4031
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
