### PR TITLE
Update sodium-native to latest version (includes libsodium 1.0.17) - Closes #3414

### DIFF
--- a/elements/lisk-cryptography/package-lock.json
+++ b/elements/lisk-cryptography/package-lock.json
@@ -2148,8 +2148,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inline-source-map": {
 			"version": "0.6.2",
@@ -2983,10 +2982,10 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-			"dev": true
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+			"optional": true
 		},
 		"neo-async": {
 			"version": "2.6.1",
@@ -3028,10 +3027,10 @@
 			}
 		},
 		"node-gyp-build": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.5.0.tgz",
-			"integrity": "sha512-qjEE8eIWVyqZhkAFUzytGpOGvLHeX5kXBB6MYyTOCPZBrBlsLyXAAzTsp/hWMbVlg8kVpzDJCZZowIrnKpwmqQ==",
-			"dev": true
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.0.tgz",
+			"integrity": "sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg==",
+			"optional": true
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -3851,14 +3850,14 @@
 			"dev": true
 		},
 		"sodium-native": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
-			"integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
-			"dev": true,
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.5.tgz",
+			"integrity": "sha512-G1uhd4l1OexzUC/6eHIbAvoivCs9T7ncDlEWodZglPZVUOXi6jtSe7tCi25aYB06zRoOjVfE4SL+hZ4EfkyZgw==",
+			"optional": true,
 			"requires": {
 				"ini": "^1.3.5",
-				"nan": "^2.4.0",
-				"node-gyp-build": "^3.0.0"
+				"nan": "^2.14.0",
+				"node-gyp-build": "^4.1.0"
 			}
 		},
 		"source-map": {

--- a/elements/lisk-cryptography/package.json
+++ b/elements/lisk-cryptography/package.json
@@ -66,7 +66,7 @@
 		"varuint-bitcoin": "1.1.0"
 	},
 	"optionalDependencies": {
-		"sodium-native": "2.2.1"
+		"sodium-native": "2.4.5"
 	},
 	"devDependencies": {
 		"@types/jquery": "3.3.29",
@@ -80,7 +80,6 @@
 		"nyc": "14.1.1",
 		"prettier": "1.16.4",
 		"sinon": "7.2.3",
-		"sodium-native": "2.2.1",
 		"source-map-support": "0.5.10",
 		"ts-node": "8.0.2",
 		"tsconfig-paths": "3.8.0",

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -7674,9 +7674,9 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"node-gyp-build": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
-			"integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.0.tgz",
+			"integrity": "sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg=="
 		},
 		"node-int64": {
 			"version": "0.3.3",
@@ -10216,13 +10216,13 @@
 			}
 		},
 		"sodium-native": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.4.tgz",
-			"integrity": "sha512-zE3lJAEN9R/XzJmNUqfyqL3vAnES9rFuyeq5ouHmCOdkVcY5UKbCcl7eUyZ+LG4RcqVfx8CAcgwv9HRpgoNrlg==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.5.tgz",
+			"integrity": "sha512-G1uhd4l1OexzUC/6eHIbAvoivCs9T7ncDlEWodZglPZVUOXi6jtSe7tCi25aYB06zRoOjVfE4SL+hZ4EfkyZgw==",
 			"requires": {
 				"ini": "^1.3.5",
-				"nan": "^2.4.0",
-				"node-gyp-build": "^3.0.0"
+				"nan": "^2.14.0",
+				"node-gyp-build": "^4.1.0"
 			}
 		},
 		"source-map": {

--- a/framework/package.json
+++ b/framework/package.json
@@ -49,8 +49,8 @@
 	},
 	"dependencies": {
 		"@liskhq/bignum": "1.3.1",
-		"@liskhq/lisk-p2p": "0.3.0-alpha.0",
 		"@liskhq/lisk-cryptography": "2.3.0-alpha.0",
+		"@liskhq/lisk-p2p": "0.3.0-alpha.0",
 		"@liskhq/lisk-transaction-pool": "0.1.2",
 		"@liskhq/lisk-transactions": "2.3.0",
 		"@liskhq/lisk-validator": "0.2.0",
@@ -84,7 +84,7 @@
 		"randomstring": "1.1.5",
 		"redis": "2.8.0",
 		"socket.io": "2.2.0",
-		"sodium-native": "2.2.4",
+		"sodium-native": "2.4.5",
 		"swagger-node-runner": "0.7.3",
 		"sway": "2.0.5",
 		"yargs": "13.2.2",


### PR DESCRIPTION
### What was the problem?

sodium-native was not updated and it included an older release of libsodium

### How did I solve it?

by updating to sodium-native 2.4.5 which includes libsodium 1.0.17

### How to manually test it?

- build should be green
- check package.json for framework and lisk-cryptography

### Review checklist

- [x] The PR resolves #3414
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
