### PR TITLE
Remove block dependency from block/utils - Closes #4012

### DIFF
--- a/framework/src/modules/chain/blocks/block.js
+++ b/framework/src/modules/chain/blocks/block.js
@@ -88,6 +88,176 @@ const objectNormalizeFunc = {
 const objectNormalize = (block, exceptions) =>
 	objectNormalizeFunc[block.version](block, exceptions);
 
+/**
+ * Normalize blocks and their transactions.
+ *
+ * @param {Array} rows - Data from full_blocks_list view
+ * @returns {Array} blocks - List of normalized blocks with transactions
+ */
+const readDbRows = (rows, interfaceAdapters, genesisBlock) => {
+	let blocks = {};
+	const order = [];
+
+	// eslint-disable-next-line no-plusplus
+	for (let i = 0, { length } = rows; i < length; i++) {
+		// Normalize block
+		// FIXME: Can have poor performance because it performs SHA256 hash calculation for each block
+		const block = dbRead(rows[i]);
+
+		if (block) {
+			// If block is not already in the list...
+			if (!blocks[block.id]) {
+				if (block.id === genesisBlock.id) {
+					// Generate fake signature for genesis block
+					block.generationSignature = new Array(65).join('0');
+				}
+
+				// Add block ID to order list
+				order.push(block.id);
+				// Add block to list
+				blocks[block.id] = block;
+			}
+
+			// Normalize transaction
+			const transaction = interfaceAdapters.transactions.dbRead(rows[i]);
+			// Set empty object if there are no transactions in block
+			blocks[block.id].transactions = blocks[block.id].transactions || {};
+
+			if (transaction) {
+				// Add transaction to block if not there already
+				if (!blocks[block.id].transactions[transaction.id]) {
+					blocks[block.id].transactions[transaction.id] = transaction;
+				}
+			}
+		}
+	}
+
+	// Reorganize list
+	blocks = order.map(v => {
+		blocks[v].transactions = Object.keys(blocks[v].transactions).map(
+			t => blocks[v].transactions[t],
+		);
+		return blocks[v];
+	});
+
+	return blocks;
+};
+
+/**
+ * Normalize blocks and their transactions.
+ *
+ * @param {Array} rows - Data from extended block entity
+ * @returns {Array} blocks - List of normalized blocks with transactions
+ */
+const readStorageRows = (rows, interfaceAdapters, genesisBlock) => {
+	const blocks = rows.map(block => {
+		// Normalize block
+		// FIXME: Can have poor performance because it performs SHA256 hash calculation for each block
+		block = storageRead(block);
+
+		if (block) {
+			if (block.id === genesisBlock.id) {
+				// Generate fake signature for genesis block
+				block.generationSignature = new Array(65).join('0');
+			}
+
+			// Normalize transaction
+			if (block.transactions) {
+				block.transactions = interfaceAdapters.transactions.fromBlock(block);
+			}
+		}
+		return block;
+	});
+
+	return blocks;
+};
+
+/**
+ * Load blocks with offset
+ *
+ *
+ * @param {number} height - Block height
+ * @param {object} tx - Database transaction object
+ * @returns {function} cb - Callback function from params (through setImmediate)
+ * @returns {Object} cb.err - Error if occurred
+ * @returns {Object} cb.block - Block with requested height
+ */
+const loadBlocksWithOffset = async (
+	storage,
+	interfaceAdapters,
+	genesisBlock,
+	blocksAmount,
+	fromHeight = 0,
+) => {
+	// Calculate toHeight
+	const toHeight = fromHeight + blocksAmount;
+
+	const filters = {
+		height_gte: fromHeight,
+		height_lt: toHeight,
+	};
+
+	const options = {
+		limit: null,
+		sort: ['height:asc', 'rowId:asc'],
+		extended: true,
+	};
+
+	// Loads extended blocks from storage
+	const rows = await storage.entities.Block.get(filters, options);
+	return readStorageRows(rows, interfaceAdapters, genesisBlock);
+};
+
+/**
+ * Loads full normalized last block from database, see: loader.loadBlockChain (private).
+ *
+ * @param {function} cb - Callback function
+ * @returns {function} cb - Callback function from params (through setImmediate)
+ * @returns {Object} cb.err - Error message if error occurred
+ * @returns {Object} cb.block - Full normalized last block
+ */
+const loadLastBlock = async (storage, interfaceAdapters, genesisBlock) => {
+	// Get full last block from database
+	// FIXME: Review SQL order by clause
+	const rows = await storage.entities.Block.get(
+		{},
+		{ sort: 'height:desc', limit: 1, extended: true },
+	);
+	if (!rows) {
+		throw new Error('Failed to load last block');
+	}
+	// Normalize block
+	return readStorageRows(rows, interfaceAdapters, genesisBlock)[0];
+
+	// Update last block
+	// TODO: Update from callee
+	// modules.blocks.lastBlock.set(block);
+};
+
+/**
+ * Load full block with a particular height
+ *
+ * @param {number} height - Block height
+ * @param {object} tx - Database transaction object
+ * @returns {function} cb - Callback function from params (through setImmediate)
+ * @returns {Object} cb.err - Error if occurred
+ * @returns {Object} cb.block - Block with requested height
+ */
+const loadBlockByHeight = async (
+	storage,
+	height,
+	interfaceAdapters,
+	genesisBlock,
+	tx,
+) => {
+	const row = await storage.entities.Block.getOne(
+		{ height },
+		{ extended: true },
+		tx,
+	);
+	return readStorageRows([row], interfaceAdapters, genesisBlock)[0];
+};
+
 module.exports = {
 	sign,
 	getHash,
@@ -98,4 +268,9 @@ module.exports = {
 	getBytes,
 	verifySignature,
 	objectNormalize,
+	readDbRows,
+	readStorageRows,
+	loadBlocksWithOffset,
+	loadLastBlock,
+	loadBlockByHeight,
 };

--- a/framework/src/modules/chain/blocks/block_v1.js
+++ b/framework/src/modules/chain/blocks/block_v1.js
@@ -30,9 +30,7 @@ const BigNum = require('@liskhq/bignum');
 const { validator } = require('@liskhq/lisk-validator');
 const { validateTransactions } = require('../transactions');
 const blockVersion = require('./block_version');
-
-// TODO: remove type constraints
-const TRANSACTION_TYPES_MULTI = 4;
+const blocksUtils = require('./utils');
 
 const blockSchema = {
 	type: 'object',
@@ -276,38 +274,7 @@ const create = ({
 	maxPayloadLength,
 	exceptions,
 }) => {
-	// TODO: move to transactions module logic
-	const sortedTransactions = transactions.sort((a, b) => {
-		// Place MULTI transaction after all other transaction types
-		if (
-			a.type === TRANSACTION_TYPES_MULTI &&
-			b.type !== TRANSACTION_TYPES_MULTI
-		) {
-			return 1;
-		}
-		// Place all other transaction types before MULTI transaction
-		if (
-			a.type !== TRANSACTION_TYPES_MULTI &&
-			b.type === TRANSACTION_TYPES_MULTI
-		) {
-			return -1;
-		}
-		// Place depending on type (lower first)
-		if (a.type < b.type) {
-			return -1;
-		}
-		if (a.type > b.type) {
-			return 1;
-		}
-		// Place depending on amount (lower first)
-		if (a.amount.lt(b.amount)) {
-			return -1;
-		}
-		if (a.amount.gt(b.amount)) {
-			return 1;
-		}
-		return 0;
-	});
+	const sortedTransactions = blocksUtils.sortTransactions(transactions);
 
 	const nextHeight = previousBlock ? previousBlock.height + 1 : 1;
 

--- a/framework/src/modules/chain/blocks/block_v2.js
+++ b/framework/src/modules/chain/blocks/block_v2.js
@@ -30,9 +30,7 @@ const BigNum = require('@liskhq/bignum');
 const { validator } = require('@liskhq/lisk-validator');
 const { validateTransactions } = require('../transactions');
 const blockVersion = require('./block_version');
-
-// TODO: remove type constraints
-const TRANSACTION_TYPES_MULTI = 4;
+const blocksUtils = require('./utils');
 
 /**
  * Block headers buffer size and endianness
@@ -301,38 +299,7 @@ const create = ({
 	prevotedConfirmedUptoHeight,
 	exceptions,
 }) => {
-	// TODO: move to transactions module logic
-	const sortedTransactions = transactions.sort((a, b) => {
-		// Place MULTI transaction after all other transaction types
-		if (
-			a.type === TRANSACTION_TYPES_MULTI &&
-			b.type !== TRANSACTION_TYPES_MULTI
-		) {
-			return 1;
-		}
-		// Place all other transaction types before MULTI transaction
-		if (
-			a.type !== TRANSACTION_TYPES_MULTI &&
-			b.type === TRANSACTION_TYPES_MULTI
-		) {
-			return -1;
-		}
-		// Place depending on type (lower first)
-		if (a.type < b.type) {
-			return -1;
-		}
-		if (a.type > b.type) {
-			return 1;
-		}
-		// Place depending on amount (lower first)
-		if (a.amount.lt(b.amount)) {
-			return -1;
-		}
-		if (a.amount.gt(b.amount)) {
-			return 1;
-		}
-		return 0;
-	});
+	const sortedTransactions = blocksUtils.sortTransactions(transactions);
 
 	const nextHeight = previousBlock ? previousBlock.height + 1 : 1;
 

--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -17,7 +17,7 @@
 const EventEmitter = require('events');
 const { cloneDeep } = require('lodash');
 const blocksUtils = require('./utils');
-const Block = require('./block');
+const blocksLogic = require('./block');
 const { BlocksProcess } = require('./process');
 const { BlocksVerify } = require('./verify');
 const blockVersion = require('./block_version');
@@ -290,7 +290,7 @@ class Blocks extends EventEmitter {
 			return;
 		}
 		try {
-			this._lastBlock = await Block.loadLastBlock(
+			this._lastBlock = await blocksLogic.loadLastBlock(
 				this.storage,
 				this.interfaceAdapters,
 				this.genesisBlock,
@@ -577,7 +577,7 @@ class Blocks extends EventEmitter {
 		this._isActive = true;
 
 		try {
-			const normalizedBlocks = Block.readDbRows(
+			const normalizedBlocks = blocksLogic.readDbRows(
 				blocks,
 				this.interfaceAdapters,
 				this.genesisBlock,

--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -17,6 +17,7 @@
 const EventEmitter = require('events');
 const { cloneDeep } = require('lodash');
 const blocksUtils = require('./utils');
+const Block = require('./block');
 const { BlocksProcess } = require('./process');
 const { BlocksVerify } = require('./verify');
 const blockVersion = require('./block_version');
@@ -289,7 +290,7 @@ class Blocks extends EventEmitter {
 			return;
 		}
 		try {
-			this._lastBlock = await blocksUtils.loadLastBlock(
+			this._lastBlock = await Block.loadLastBlock(
 				this.storage,
 				this.interfaceAdapters,
 				this.genesisBlock,
@@ -576,7 +577,7 @@ class Blocks extends EventEmitter {
 		this._isActive = true;
 
 		try {
-			const normalizedBlocks = blocksUtils.readDbRows(
+			const normalizedBlocks = Block.readDbRows(
 				blocks,
 				this.interfaceAdapters,
 				this.genesisBlock,

--- a/framework/src/modules/chain/blocks/process.js
+++ b/framework/src/modules/chain/blocks/process.js
@@ -130,7 +130,7 @@ class BlocksProcess {
 	}
 
 	async recoverInvalidOwnChain(currentBlock, onDelete) {
-		const lastBlock = await blocksUtils.loadBlockByHeight(
+		const lastBlock = await blocksLogic.loadBlockByHeight(
 			this.storage,
 			currentBlock.height - 1,
 			this.interfaceAdapters,
@@ -167,7 +167,7 @@ class BlocksProcess {
 		loadPerIteration,
 	) {
 		const limit = loadPerIteration;
-		const blocks = await blocksUtils.loadBlocksWithOffset(
+		const blocks = await blocksLogic.loadBlocksWithOffset(
 			this.storage,
 			this.interfaceAdapters,
 			this.genesisBlock,

--- a/framework/src/modules/chain/blocks/utils.js
+++ b/framework/src/modules/chain/blocks/utils.js
@@ -17,7 +17,6 @@
 const _ = require('lodash');
 const { hash } = require('@liskhq/lisk-cryptography');
 const BigNum = require('@liskhq/bignum');
-const blocksLogic = require('./block');
 
 /**
  * Generates a list of full blocks structured as full_blocks_list DB view
@@ -171,127 +170,6 @@ const loadBlocksDataWS = async (storage, filter, tx) => {
 };
 
 /**
- * Load full block with a particular height
- *
- * @param {number} height - Block height
- * @param {function} cb - Callback function
- * @param {object} tx - Database transaction object
- * @returns {function} cb - Callback function from params (through setImmediate)
- * @returns {Object} cb.err - Error if occurred
- * @returns {Object} cb.block - Block with requested height
- */
-/**
- * Normalize blocks and their transactions.
- *
- * @param {Array} rows - Data from extended block entity
- * @returns {Array} blocks - List of normalized blocks with transactions
- */
-const readStorageRows = (rows, interfaceAdapters, genesisBlock) => {
-	const blocks = rows.map(block => {
-		// Normalize block
-		// FIXME: Can have poor performance because it performs SHA256 hash calculation for each block
-		block = blocksLogic.storageRead(block);
-
-		if (block) {
-			if (block.id === genesisBlock.id) {
-				// Generate fake signature for genesis block
-				block.generationSignature = new Array(65).join('0');
-			}
-
-			// Normalize transaction
-			if (block.transactions) {
-				block.transactions = interfaceAdapters.transactions.fromBlock(block);
-			}
-		}
-		return block;
-	});
-
-	return blocks;
-};
-
-/**
- * Normalize blocks and their transactions.
- *
- * @param {Array} rows - Data from full_blocks_list view
- * @returns {Array} blocks - List of normalized blocks with transactions
- */
-
-const readDbRows = (rows, interfaceAdapters, genesisBlock) => {
-	let blocks = {};
-	const order = [];
-
-	// eslint-disable-next-line no-plusplus
-	for (let i = 0, { length } = rows; i < length; i++) {
-		// Normalize block
-		// FIXME: Can have poor performance because it performs SHA256 hash calculation for each block
-		const block = blocksLogic.dbRead(rows[i]);
-
-		if (block) {
-			// If block is not already in the list...
-			if (!blocks[block.id]) {
-				if (block.id === genesisBlock.id) {
-					// Generate fake signature for genesis block
-					block.generationSignature = new Array(65).join('0');
-				}
-
-				// Add block ID to order list
-				order.push(block.id);
-				// Add block to list
-				blocks[block.id] = block;
-			}
-
-			// Normalize transaction
-			const transaction = interfaceAdapters.transactions.dbRead(rows[i]);
-			// Set empty object if there are no transactions in block
-			blocks[block.id].transactions = blocks[block.id].transactions || {};
-
-			if (transaction) {
-				// Add transaction to block if not there already
-				if (!blocks[block.id].transactions[transaction.id]) {
-					blocks[block.id].transactions[transaction.id] = transaction;
-				}
-			}
-		}
-	}
-
-	// Reorganize list
-	blocks = order.map(v => {
-		blocks[v].transactions = Object.keys(blocks[v].transactions).map(
-			t => blocks[v].transactions[t],
-		);
-		return blocks[v];
-	});
-
-	return blocks;
-};
-
-/**
- * Loads full normalized last block from database, see: loader.loadBlockChain (private).
- *
- * @param {function} cb - Callback function
- * @returns {function} cb - Callback function from params (through setImmediate)
- * @returns {Object} cb.err - Error message if error occurred
- * @returns {Object} cb.block - Full normalized last block
- */
-const loadLastBlock = async (storage, interfaceAdapters, genesisBlock) => {
-	// Get full last block from database
-	// FIXME: Review SQL order by clause
-	const rows = await storage.entities.Block.get(
-		{},
-		{ sort: 'height:desc', limit: 1, extended: true },
-	);
-	if (!rows) {
-		throw new Error('Failed to load last block');
-	}
-	// Normalize block
-	return readStorageRows(rows, interfaceAdapters, genesisBlock)[0];
-
-	// Update last block
-	// TODO: Update from callee
-	// modules.blocks.lastBlock.set(block);
-};
-
-/**
  * Get blocks IDs sequence - last block ID, IDs of first blocks of last 5 rounds, genesis block ID.
  *
  * @param {number} height - Block height
@@ -354,66 +232,6 @@ const getIdSequence = async (
 		firstHeight: rows[0].height,
 		ids: ids.join(),
 	};
-};
-
-/**
- * Load full block with a particular height
- *
- * @param {number} height - Block height
- * @param {object} tx - Database transaction object
- * @returns {function} cb - Callback function from params (through setImmediate)
- * @returns {Object} cb.err - Error if occurred
- * @returns {Object} cb.block - Block with requested height
- */
-const loadBlockByHeight = async (
-	storage,
-	height,
-	interfaceAdapters,
-	genesisBlock,
-	tx,
-) => {
-	const row = await storage.entities.Block.getOne(
-		{ height },
-		{ extended: true },
-		tx,
-	);
-	return readStorageRows([row], interfaceAdapters, genesisBlock)[0];
-};
-
-/**
- * Load blocks with offset
- *
- *
- * @param {number} height - Block height
- * @param {object} tx - Database transaction object
- * @returns {function} cb - Callback function from params (through setImmediate)
- * @returns {Object} cb.err - Error if occurred
- * @returns {Object} cb.block - Block with requested height
- */
-const loadBlocksWithOffset = async (
-	storage,
-	interfaceAdapters,
-	genesisBlock,
-	blocksAmount,
-	fromHeight = 0,
-) => {
-	// Calculate toHeight
-	const toHeight = fromHeight + blocksAmount;
-
-	const filters = {
-		height_gte: fromHeight,
-		height_lt: toHeight,
-	};
-
-	const options = {
-		limit: null,
-		sort: ['height:asc', 'rowId:asc'],
-		extended: true,
-	};
-
-	// Loads extended blocks from storage
-	const rows = await storage.entities.Block.get(filters, options);
-	return readStorageRows(rows, interfaceAdapters, genesisBlock);
 };
 
 /**
@@ -593,12 +411,7 @@ const sortTransactions = transactions =>
 module.exports = {
 	parseStorageObjToLegacyObj,
 	getIdSequence,
-	readStorageRows,
-	readDbRows,
 	loadBlocksDataWS,
-	loadLastBlock,
-	loadBlockByHeight,
-	loadBlocksWithOffset,
 	loadMemTables,
 	calculateNewBroadhash,
 	setHeight,

--- a/framework/src/modules/chain/blocks/verify.js
+++ b/framework/src/modules/chain/blocks/verify.js
@@ -511,7 +511,7 @@ class BlocksVerify {
 		const secondLastRound = currentRound - 2;
 		const validateTillHeight =
 			secondLastRound < 1 ? 2 : this.slots.calcRoundEndHeight(secondLastRound);
-		const secondLastBlock = await blocksUtils.loadBlockByHeight(
+		const secondLastBlock = await blocksLogic.loadBlockByHeight(
 			this.storage,
 			currentHeight - 1,
 			this.interfaceAdapters,
@@ -521,13 +521,13 @@ class BlocksVerify {
 		if (currentBlockResult.verified) {
 			return false;
 		}
-		const startBlock = await blocksUtils.loadBlockByHeight(
+		const startBlock = await blocksLogic.loadBlockByHeight(
 			this.storage,
 			validateTillHeight,
 			this.interfaceAdapters,
 			this.genesisBlock,
 		);
-		const startBlockLastBlock = await blocksUtils.loadBlockByHeight(
+		const startBlockLastBlock = await blocksLogic.loadBlockByHeight(
 			this.storage,
 			startBlock.height - 1,
 			this.interfaceAdapters,

--- a/framework/test/mocha/integration/blocks/process/process.js
+++ b/framework/test/mocha/integration/blocks/process/process.js
@@ -16,7 +16,7 @@
 
 const async = require('async');
 const blockVersion = require('../../../../../src/modules/chain/blocks/block_version');
-const blocksUtils = require('../../../../../src/modules/chain/blocks/utils');
+const blocksLogic = require('../../../../../src/modules/chain/blocks/block');
 const application = require('../../../common/application');
 const modulesLoader = require('../../../common/modules_loader');
 const clearDatabaseTable = require('../../../common/storage_sandbox')
@@ -132,7 +132,7 @@ describe('integration test (blocks) - process', () => {
 
 	describe('loadBlocksWithOffset() - no errors', () => {
 		it('should load block 2 from db: block without transactions', async () => {
-			const loadedBlocks = await blocksUtils.loadBlocksWithOffset(
+			const loadedBlocks = await blocksLogic.loadBlocksWithOffset(
 				storage,
 				interfaceAdapters,
 				__testContext.config.genesisBlock,
@@ -145,7 +145,7 @@ describe('integration test (blocks) - process', () => {
 		});
 
 		it('should load block 3 from db: block with transactions', async () => {
-			const loadedBlocks = await blocksUtils.loadBlocksWithOffset(
+			const loadedBlocks = await blocksLogic.loadBlocksWithOffset(
 				storage,
 				interfaceAdapters,
 				__testContext.config.genesisBlock,

--- a/framework/test/mocha/unit/modules/chain/blocks/block.js
+++ b/framework/test/mocha/unit/modules/chain/blocks/block.js
@@ -1,0 +1,320 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const blocksLogic = require('../../../../../../src/modules/chain/blocks/block');
+
+describe('blocks/utils', () => {
+	const genesisBlock = {
+		id: '6524861224470851795',
+		height: 1,
+	};
+
+	const fullBlocksListRows = [
+		{
+			b_id: '13068833527549895884',
+			b_height: 3, // Block 1
+			b_generatorPublicKey:
+				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
+			t_id: '6950874693022090568',
+			t_type: 0,
+			b_totalAmount: 100,
+			b_totalFee: 10,
+			b_reward: 1,
+			b_version: 1,
+		},
+		{
+			b_id: '13068833527549895884',
+			b_height: 3, // Block 1
+			b_generatorPublicKey:
+				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
+			t_id: '13831767660337349834',
+			t_type: 1,
+			b_totalAmount: 100,
+			b_totalFee: 10,
+			b_reward: 1,
+			b_version: 1,
+		},
+		{
+			b_id: '7018883617995376402',
+			b_height: 4, // Block 2
+			b_generatorPublicKey:
+				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
+			t_id: '10550826199952791739',
+			t_type: 2,
+			b_totalAmount: 100,
+			b_totalFee: 10,
+			b_reward: 1,
+			b_version: 1,
+		},
+		{
+			b_id: '7018883617995376402',
+			b_height: 4, // Block 2
+			b_generatorPublicKey:
+				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
+			t_id: '3502881310841638511',
+			t_type: 3,
+			b_totalAmount: 100,
+			b_totalFee: 10,
+			b_reward: 1,
+			b_version: 1,
+		},
+	];
+
+	const storageBlocksListRows = [
+		{
+			id: '13068833527549895884',
+			generatorPublicKey:
+				'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+			height: 3, // Block 1
+			version: 0,
+			transactions: [
+				{
+					id: '6950874693022090568',
+					type: 5,
+					asset: {
+						dapp: {
+							category: 0,
+							description: 'my app desc',
+							icon: 'app.icon',
+							link: 'app-link.com',
+							name: 'App Name',
+							tags: null,
+							type: 0,
+						},
+					},
+				},
+			],
+			totalAmount: 100,
+			totalFee: 10,
+			reward: 1,
+		},
+		{
+			id: '13068833527549895884',
+			generatorPublicKey:
+				'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+			height: 3, // Block 1
+			version: '0',
+			transactions: [
+				{
+					id: '13831767660337349834',
+					type: 1,
+				},
+			],
+			totalAmount: 100,
+			totalFee: 10,
+			reward: 1,
+		},
+		{
+			id: '7018883617995376402',
+			generatorPublicKey:
+				'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+			height: 4, // Block 2
+			version: '1',
+			transactions: [
+				{
+					id: '10550826199952791739',
+					type: 2,
+				},
+			],
+			totalAmount: 100,
+			totalFee: 10,
+			reward: 1,
+		},
+		{
+			id: '7018883617995376402',
+			generatorPublicKey:
+				'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+			height: 4, // Block 2
+			version: 1,
+			transactions: [
+				{
+					id: '3502881310841638511',
+					type: 3,
+				},
+			],
+			totalAmount: 100,
+			totalFee: 10,
+			reward: 1,
+		},
+	];
+
+	let storageStub;
+	let interfaceAdaptersMock;
+
+	beforeEach(async () => {
+		storageStub = {
+			entities: {
+				Account: {
+					delegateBlocksRewards: sinonSandbox.stub().resolves(),
+				},
+				Block: {
+					get: sinonSandbox.stub().resolves(['1']),
+					getFirstBlockIdOfLastRounds: sinonSandbox
+						.stub()
+						.resolves([...storageBlocksListRows]),
+				},
+			},
+		};
+
+		interfaceAdaptersMock = {
+			transactions: {
+				dbRead(input) {
+					return { id: input.t_id, type: input.t_type };
+				},
+				fromBlock(input) {
+					return input;
+				},
+			},
+		};
+	});
+
+	afterEach(() => sinonSandbox.restore());
+
+	describe('readDbRows', () => {
+		beforeEach(async () => {
+			sinonSandbox.spy(interfaceAdaptersMock.transactions, 'dbRead');
+		});
+
+		it('should call library.logic.block.dbRead with each block', async () => {
+			blocksLogic.readDbRows(
+				fullBlocksListRows,
+				interfaceAdaptersMock,
+				genesisBlock,
+			);
+
+			fullBlocksListRows.forEach(block => {
+				expect(interfaceAdaptersMock.transactions.dbRead).to.have.callCount(4);
+				expect(
+					interfaceAdaptersMock.transactions.dbRead,
+				).to.have.been.calledWith(block);
+			});
+		});
+
+		it('should read an empty array', async () =>
+			expect(blocksLogic.readDbRows([])).to.be.an('array'));
+
+		describe('with 2 blocks each containing 2 transactions', () => {
+			let blocks;
+
+			beforeEach(async () => {
+				blocks = blocksLogic.readDbRows(
+					fullBlocksListRows,
+					interfaceAdaptersMock,
+					genesisBlock,
+				);
+				expect(blocks).to.be.an('array');
+			});
+
+			it('should read the rows correctly', async () => {
+				// Block 1
+				expect(blocks[0]).to.be.an('object');
+				expect(blocks[0].id).to.equal('13068833527549895884');
+				expect(blocks[0].height).to.equal(3);
+				expect(blocks[0].transactions).to.be.an('array');
+				expect(blocks[0].transactions[0]).to.be.an('object');
+				expect(blocks[0].transactions[0].id).to.equal('6950874693022090568');
+				expect(blocks[0].transactions[0].type).to.equal(0);
+				expect(blocks[0].transactions[1]).to.be.an('object');
+				expect(blocks[0].transactions[1].id).to.equal('13831767660337349834');
+				expect(blocks[0].transactions[1].type).to.equal(1);
+
+				// Block 2
+				expect(blocks[1]).to.be.an('object');
+				expect(blocks[1].id).to.equal('7018883617995376402');
+				expect(blocks[1].height).to.equal(4);
+				expect(blocks[1].transactions).to.be.an('array');
+				expect(blocks[1].transactions[0]).to.be.an('object');
+				expect(blocks[1].transactions[0].id).to.equal('10550826199952791739');
+				expect(blocks[1].transactions[0].type).to.equal(2);
+				expect(blocks[1].transactions[1]).to.be.an('object');
+				expect(blocks[1].transactions[1].id).to.equal('3502881310841638511');
+				return expect(blocks[1].transactions[1].type).to.equal(3);
+			});
+		});
+
+		it('should generate fake signature for genesis block', async () => {
+			const genesisBlock_view_full_blocks_list = [
+				{
+					b_id: '6524861224470851795',
+					b_height: 1,
+					b_generatorPublicKey:
+						'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+					t_id: '1465651642158264047',
+					t_type: 0,
+					b_totalAmount: 100,
+					b_totalFee: 10,
+					b_reward: 1,
+					b_version: 1,
+				},
+				{
+					b_id: '6524861224470851795',
+					b_height: 1,
+					b_generatorPublicKey:
+						'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
+					t_id: '3634383815892709956',
+					t_type: 2,
+					b_totalAmount: 100,
+					b_totalFee: 10,
+					b_reward: 1,
+					b_version: 1,
+				},
+			];
+
+			const blockObject = blocksLogic.readDbRows(
+				genesisBlock_view_full_blocks_list,
+				interfaceAdaptersMock,
+				genesisBlock,
+			);
+
+			expect(blockObject).to.be.an('array');
+			expect(blockObject[0]).to.be.an('object');
+			expect(blockObject[0].id).to.equal('6524861224470851795');
+			return expect(blockObject[0].generationSignature).to.equal(
+				'0000000000000000000000000000000000000000000000000000000000000000',
+			);
+		});
+	});
+
+	describe('loadLastBlock', () => {
+		it('should return error when library.storage.entities.Block.get fails', async () => {
+			storageStub.entities.Block.get.resolves(null);
+
+			try {
+				await blocksLogic.loadLastBlock(
+					storageStub,
+					interfaceAdaptersMock,
+					genesisBlock,
+				);
+			} catch (err) {
+				expect(err.message).to.equal('Failed to load last block');
+			}
+		});
+
+		describe('sorting the block.transactions array', () => {
+			it('should return the block', async () => {
+				storageStub.entities.Block.get.resolves([...storageBlocksListRows]);
+				const block = await blocksLogic.loadLastBlock(
+					storageStub,
+					interfaceAdaptersMock,
+					genesisBlock,
+				);
+
+				expect(block).to.be.an('object');
+				expect(block.id).to.equal('13068833527549895884');
+			});
+		});
+	});
+});

--- a/framework/test/mocha/unit/modules/chain/blocks/blocks.js
+++ b/framework/test/mocha/unit/modules/chain/blocks/blocks.js
@@ -33,7 +33,7 @@ const {
 	BlocksChain,
 } = require('../../../../../../src/modules/chain/blocks/chain');
 const { Slots } = require('../../../../../../src/modules/chain/dpos');
-const blocksUtils = require('../../../../../../src/modules/chain/blocks/utils');
+const blocksLogic = require('../../../../../../src/modules/chain/blocks/block');
 
 describe('blocks', () => {
 	const interfaceAdapters = {
@@ -974,7 +974,7 @@ describe('blocks', () => {
 		const ACTIVE_DELEGATES = 101;
 
 		beforeEach(async () => {
-			sinonSandbox.stub(blocksUtils, 'loadBlocksWithOffset');
+			sinonSandbox.stub(blocksLogic, 'loadBlocksWithOffset');
 			sinonSandbox.stub(blocksInstance.blocksProcess, 'reload');
 		});
 
@@ -1052,7 +1052,7 @@ describe('blocks', () => {
 		});
 
 		it('should emit an event with proper error when loadBlocksOffset fails', async () => {
-			blocksUtils.loadBlocksWithOffset.rejects(
+			blocksLogic.loadBlocksWithOffset.rejects(
 				new Error('loadBlocksOffsetStub#ERR'),
 			);
 			try {

--- a/framework/test/mocha/unit/modules/chain/blocks/process.js
+++ b/framework/test/mocha/unit/modules/chain/blocks/process.js
@@ -506,7 +506,7 @@ describe('blocks/process', () => {
 
 		it('should call deleteLastBlock', async () => {
 			sinonSandbox
-				.stub(blocksUtils, 'loadBlockByHeight')
+				.stub(blocksLogic, 'loadBlockByHeight')
 				.resolves(beforeLastDummyBlock);
 			await blocksProcess.recoverInvalidOwnChain(lastDummyBlock, onDelete);
 			expect(blocksChainStub.deleteLastBlock).to.be.calledWith(lastDummyBlock);
@@ -514,7 +514,7 @@ describe('blocks/process', () => {
 
 		it('should call onDelete', async () => {
 			sinonSandbox
-				.stub(blocksUtils, 'loadBlockByHeight')
+				.stub(blocksLogic, 'loadBlockByHeight')
 				.resolves(beforeLastDummyBlock);
 			await blocksProcess.recoverInvalidOwnChain(lastDummyBlock, onDelete);
 			expect(onDelete.firstCall.args).to.be.eql([
@@ -525,7 +525,7 @@ describe('blocks/process', () => {
 
 		it('should call verifyBlock with the new last block', async () => {
 			sinonSandbox
-				.stub(blocksUtils, 'loadBlockByHeight')
+				.stub(blocksLogic, 'loadBlockByHeight')
 				.resolves(beforeLastDummyBlock);
 			await blocksProcess.recoverInvalidOwnChain(lastDummyBlock, onDelete);
 			expect(blocksVerifyStub.verifyBlock).to.be.calledWith(
@@ -577,7 +577,7 @@ describe('blocks/process', () => {
 			];
 			sinonSandbox.stub(blocksProcess, 'applyBlock').callsFake(block => block);
 			sinonSandbox
-				.stub(blocksUtils, 'loadBlocksWithOffset')
+				.stub(blocksLogic, 'loadBlocksWithOffset')
 				.resolves(loadedBlocks);
 		});
 
@@ -590,7 +590,7 @@ describe('blocks/process', () => {
 				onProgress,
 				10,
 			);
-			expect(blocksUtils.loadBlocksWithOffset).to.be.calledWith(
+			expect(blocksLogic.loadBlocksWithOffset).to.be.calledWith(
 				storageStub,
 				interfaceAdapters,
 				blocksProcess.genesisBlock,
@@ -639,10 +639,10 @@ describe('blocks/process', () => {
 		});
 
 		it('should call loadBlocksWithOffset second time with the next currentHeight', async () => {
-			blocksUtils.loadBlocksWithOffset
+			blocksLogic.loadBlocksWithOffset
 				.onCall(0)
 				.resolves([...loadedBlocks].slice(0, 3));
-			blocksUtils.loadBlocksWithOffset
+			blocksLogic.loadBlocksWithOffset
 				.onCall(1)
 				.resolves([...loadedBlocks].slice(3, 5));
 			await blocksProcess._rebuild(
@@ -653,7 +653,7 @@ describe('blocks/process', () => {
 				onProgress,
 				10,
 			);
-			expect(blocksUtils.loadBlocksWithOffset).to.be.calledTwice;
+			expect(blocksLogic.loadBlocksWithOffset).to.be.calledTwice;
 		});
 	});
 });

--- a/framework/test/mocha/unit/modules/chain/blocks/utils.js
+++ b/framework/test/mocha/unit/modules/chain/blocks/utils.js
@@ -17,64 +17,12 @@
 const crypto = require('crypto');
 const BigNum = require('@liskhq/bignum');
 const blocksUtils = require('../../../../../../src/modules/chain/blocks/utils');
-const blocksLogic = require('../../../../../../src/modules/chain/blocks/block');
 
 describe('blocks/utils', () => {
 	const genesisBlock = {
 		id: '6524861224470851795',
 		height: 1,
 	};
-
-	const fullBlocksListRows = [
-		{
-			b_id: '13068833527549895884',
-			b_height: 3, // Block 1
-			b_generatorPublicKey:
-				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
-			t_id: '6950874693022090568',
-			t_type: 0,
-			b_totalAmount: 100,
-			b_totalFee: 10,
-			b_reward: 1,
-			b_version: 1,
-		},
-		{
-			b_id: '13068833527549895884',
-			b_height: 3, // Block 1
-			b_generatorPublicKey:
-				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
-			t_id: '13831767660337349834',
-			t_type: 1,
-			b_totalAmount: 100,
-			b_totalFee: 10,
-			b_reward: 1,
-			b_version: 1,
-		},
-		{
-			b_id: '7018883617995376402',
-			b_height: 4, // Block 2
-			b_generatorPublicKey:
-				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
-			t_id: '10550826199952791739',
-			t_type: 2,
-			b_totalAmount: 100,
-			b_totalFee: 10,
-			b_reward: 1,
-			b_version: 1,
-		},
-		{
-			b_id: '7018883617995376402',
-			b_height: 4, // Block 2
-			b_generatorPublicKey:
-				'a24416a05bef8874fb1c638105d892162f7d5736b7a2deda318e976fd80f64e9',
-			t_id: '3502881310841638511',
-			t_type: 3,
-			b_totalAmount: 100,
-			b_totalFee: 10,
-			b_reward: 1,
-			b_version: 1,
-		},
-	];
 
 	const storageBlocksListRows = [
 		{
@@ -157,7 +105,6 @@ describe('blocks/utils', () => {
 	const lastBlock = { id: '9314232245035524467', height: 1 };
 
 	let storageStub;
-	let interfaceAdaptersMock;
 
 	beforeEach(async () => {
 		storageStub = {
@@ -173,153 +120,9 @@ describe('blocks/utils', () => {
 				},
 			},
 		};
-
-		interfaceAdaptersMock = {
-			transactions: {
-				dbRead(input) {
-					return { id: input.t_id, type: input.t_type };
-				},
-				fromBlock(input) {
-					return input;
-				},
-			},
-		};
 	});
 
 	afterEach(() => sinonSandbox.restore());
-
-	describe('readDbRows', () => {
-		beforeEach(async () => {
-			sinonSandbox.spy(blocksLogic, 'dbRead');
-		});
-
-		it('should call library.logic.block.dbRead with each block', async () => {
-			blocksUtils.readDbRows(
-				fullBlocksListRows,
-				interfaceAdaptersMock,
-				genesisBlock,
-			);
-
-			fullBlocksListRows.forEach(block => {
-				expect(blocksLogic.dbRead).to.have.callCount(4);
-				expect(blocksLogic.dbRead).to.have.been.calledWith(block);
-			});
-		});
-
-		it('should read an empty array', async () =>
-			expect(blocksUtils.readDbRows([])).to.be.an('array'));
-
-		describe('with 2 blocks each containing 2 transactions', () => {
-			let blocks;
-
-			beforeEach(async () => {
-				blocks = blocksUtils.readDbRows(
-					fullBlocksListRows,
-					interfaceAdaptersMock,
-					genesisBlock,
-				);
-				expect(blocks).to.be.an('array');
-			});
-
-			it('should read the rows correctly', async () => {
-				// Block 1
-				expect(blocks[0]).to.be.an('object');
-				expect(blocks[0].id).to.equal('13068833527549895884');
-				expect(blocks[0].height).to.equal(3);
-				expect(blocks[0].transactions).to.be.an('array');
-				expect(blocks[0].transactions[0]).to.be.an('object');
-				expect(blocks[0].transactions[0].id).to.equal('6950874693022090568');
-				expect(blocks[0].transactions[0].type).to.equal(0);
-				expect(blocks[0].transactions[1]).to.be.an('object');
-				expect(blocks[0].transactions[1].id).to.equal('13831767660337349834');
-				expect(blocks[0].transactions[1].type).to.equal(1);
-
-				// Block 2
-				expect(blocks[1]).to.be.an('object');
-				expect(blocks[1].id).to.equal('7018883617995376402');
-				expect(blocks[1].height).to.equal(4);
-				expect(blocks[1].transactions).to.be.an('array');
-				expect(blocks[1].transactions[0]).to.be.an('object');
-				expect(blocks[1].transactions[0].id).to.equal('10550826199952791739');
-				expect(blocks[1].transactions[0].type).to.equal(2);
-				expect(blocks[1].transactions[1]).to.be.an('object');
-				expect(blocks[1].transactions[1].id).to.equal('3502881310841638511');
-				return expect(blocks[1].transactions[1].type).to.equal(3);
-			});
-		});
-
-		it('should generate fake signature for genesis block', async () => {
-			const genesisBlock_view_full_blocks_list = [
-				{
-					b_id: '6524861224470851795',
-					b_height: 1,
-					b_generatorPublicKey:
-						'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
-					t_id: '1465651642158264047',
-					t_type: 0,
-					b_totalAmount: 100,
-					b_totalFee: 10,
-					b_reward: 1,
-					b_version: 1,
-				},
-				{
-					b_id: '6524861224470851795',
-					b_height: 1,
-					b_generatorPublicKey:
-						'c96dec3595ff6041c3bd28b76b8cf75dce8225173d1bd00241624ee89b50f2a8',
-					t_id: '3634383815892709956',
-					t_type: 2,
-					b_totalAmount: 100,
-					b_totalFee: 10,
-					b_reward: 1,
-					b_version: 1,
-				},
-			];
-
-			const blockObject = blocksUtils.readDbRows(
-				genesisBlock_view_full_blocks_list,
-				interfaceAdaptersMock,
-				genesisBlock,
-			);
-
-			expect(blockObject).to.be.an('array');
-			expect(blockObject[0]).to.be.an('object');
-			expect(blockObject[0].id).to.equal('6524861224470851795');
-			return expect(blockObject[0].generationSignature).to.equal(
-				'0000000000000000000000000000000000000000000000000000000000000000',
-			);
-		});
-	});
-
-	describe('loadLastBlock', () => {
-		it('should return error when library.storage.entities.Block.get fails', async () => {
-			storageStub.entities.Block.get.resolves(null);
-
-			try {
-				await blocksUtils.loadLastBlock(
-					storageStub,
-					interfaceAdaptersMock,
-					genesisBlock,
-				);
-			} catch (err) {
-				expect(err.message).to.equal('Failed to load last block');
-			}
-		});
-
-		describe('sorting the block.transactions array', () => {
-			it('should return the block', async () => {
-				storageStub.entities.Block.get.resolves([...storageBlocksListRows]);
-				const block = await blocksUtils.loadLastBlock(
-					storageStub,
-					interfaceAdaptersMock,
-					genesisBlock,
-				);
-
-				expect(block).to.be.an('object');
-				expect(block.id).to.equal('13068833527549895884');
-			});
-		});
-	});
 
 	describe('getIdSequence', () => {
 		it('should call storage.entities.Block.getFirstBlockIdOfLastRounds with proper params', async () => {


### PR DESCRIPTION
### What was the problem?
Passing block dependency to several files in the `block` folder creating circular dependency.
To solve this now, we pass the `blocksLogic` dependency.

However, as @nazarhussain indicated, we should create pure functions as util functions. Currently, they do processing and `I/O` with DB. 

### How did I solve it?
Pass `blocksLogic` dependency directly as argument.

### Review checklist

- [x] The PR resolves #4012
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
