### PR TITLE
P2P 2.3 incompatibility with older version - Closes #4060

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -24,10 +24,7 @@ interface SCServerUpdated extends SCServer {
 	readonly isReady: boolean;
 }
 
-import {
-	REMOTE_RPC_GET_MINIMAL_PEERS_LIST,
-	REMOTE_RPC_GET_PEERS_LIST,
-} from './peer';
+import { REMOTE_RPC_GET_PEERS_LIST } from './peer';
 
 import { PeerBook } from './peer_directory';
 
@@ -230,10 +227,7 @@ export class P2P extends EventEmitter {
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerPoolRPC = (request: P2PRequest) => {
-			if (
-				request.procedure === REMOTE_RPC_GET_PEERS_LIST ||
-				request.procedure === REMOTE_RPC_GET_MINIMAL_PEERS_LIST
-			) {
+			if (request.procedure === REMOTE_RPC_GET_PEERS_LIST) {
 				this._handleGetPeersRequest(request);
 			}
 			// Re-emit the request for external use.
@@ -804,19 +798,9 @@ export class P2P extends EventEmitter {
 			Math.min(minimumPeerDiscoveryThreshold, knownPeers.length),
 		);
 
-		const selectedPeers =
-			request.procedure === REMOTE_RPC_GET_MINIMAL_PEERS_LIST
-				? this._pickRandomPeers(randomPeerCount).map(
-						(peerInfo: P2PPeerInfo): P2PPeerInfo =>
-							// Discovery process only require minmal peers data
-							({
-								ipAddress: peerInfo.ipAddress,
-								wsPort: peerInfo.wsPort,
-							}),
-				  )
-				: this._pickRandomPeers(randomPeerCount).map(
-						outgoingPeerInfoSanitization, // Sanitize the peerInfos before responding to a peer that understand old peerInfo.
-				  );
+		const selectedPeers = this._pickRandomPeers(randomPeerCount).map(
+			outgoingPeerInfoSanitization, // Sanitize the peerInfos before responding to a peer that understand old peerInfo.
+		);
 
 		const peerInfoList = {
 			success: true,

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -35,9 +35,8 @@ import { constructPeerIdFromPeerInfo, getNetgroup } from '../utils';
 import * as socketClusterClient from 'socketcluster-client';
 import { SCServerSocket } from 'socketcluster-server';
 import {
-	isLowerVersionPeer,
-	validateBasicPeersInfoList,
 	validatePeerInfo,
+	validatePeersInfoList,
 	validateProtocolMessage,
 	validateRPCRequest,
 } from '../validation';
@@ -91,7 +90,6 @@ export const REMOTE_EVENT_MESSAGE = 'remote-message';
 
 export const REMOTE_RPC_UPDATE_PEER_INFO = 'updateMyself';
 export const REMOTE_RPC_GET_NODE_INFO = 'status';
-export const REMOTE_RPC_GET_MINIMAL_PEERS_LIST = 'getPeers';
 export const REMOTE_RPC_GET_PEERS_LIST = 'list';
 
 export const DEFAULT_CONNECT_TIMEOUT = 2000;
@@ -512,12 +510,10 @@ export class Peer extends EventEmitter {
 	public async fetchPeers(): Promise<ReadonlyArray<P2PPeerInfo>> {
 		try {
 			const response: P2PResponsePacket = await this.request({
-				procedure: isLowerVersionPeer(this._peerInfo as P2PDiscoveredPeerInfo)
-					? REMOTE_RPC_GET_PEERS_LIST
-					: REMOTE_RPC_GET_MINIMAL_PEERS_LIST,
+				procedure: REMOTE_RPC_GET_PEERS_LIST,
 			});
 
-			return validateBasicPeersInfoList(response.data);
+			return validatePeersInfoList(response.data);
 		} catch (error) {
 			this.emit(EVENT_FAILED_TO_FETCH_PEERS, error);
 

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -35,6 +35,7 @@ import { constructPeerIdFromPeerInfo, getNetgroup } from '../utils';
 import * as socketClusterClient from 'socketcluster-client';
 import { SCServerSocket } from 'socketcluster-server';
 import {
+	isLowerVersionPeer,
 	validateBasicPeersInfoList,
 	validatePeerInfo,
 	validateProtocolMessage,
@@ -90,7 +91,8 @@ export const REMOTE_EVENT_MESSAGE = 'remote-message';
 
 export const REMOTE_RPC_UPDATE_PEER_INFO = 'updateMyself';
 export const REMOTE_RPC_GET_NODE_INFO = 'status';
-export const REMOTE_RPC_GET_PEERS_LIST = 'getPeers';
+export const REMOTE_RPC_GET_MINIMAL_PEERS_LIST = 'getPeers';
+export const REMOTE_RPC_GET_PEERS_LIST = 'list';
 
 export const DEFAULT_CONNECT_TIMEOUT = 2000;
 export const DEFAULT_ACK_TIMEOUT = 2000;
@@ -510,7 +512,9 @@ export class Peer extends EventEmitter {
 	public async fetchPeers(): Promise<ReadonlyArray<P2PPeerInfo>> {
 		try {
 			const response: P2PResponsePacket = await this.request({
-				procedure: REMOTE_RPC_GET_PEERS_LIST,
+				procedure: isLowerVersionPeer(this._peerInfo as P2PDiscoveredPeerInfo)
+					? REMOTE_RPC_GET_PEERS_LIST
+					: REMOTE_RPC_GET_MINIMAL_PEERS_LIST,
 			});
 
 			return validateBasicPeersInfoList(response.data);

--- a/elements/lisk-p2p/src/peer/index.ts
+++ b/elements/lisk-p2p/src/peer/index.ts
@@ -28,6 +28,7 @@ export {
 	Peer,
 	PeerConfig,
 	REMOTE_RPC_GET_PEERS_LIST,
+	REMOTE_RPC_GET_MINIMAL_PEERS_LIST,
 } from './base';
 
 export * from './inbound';

--- a/elements/lisk-p2p/src/peer/index.ts
+++ b/elements/lisk-p2p/src/peer/index.ts
@@ -28,7 +28,6 @@ export {
 	Peer,
 	PeerConfig,
 	REMOTE_RPC_GET_PEERS_LIST,
-	REMOTE_RPC_GET_MINIMAL_PEERS_LIST,
 } from './base';
 
 export * from './inbound';

--- a/elements/lisk-p2p/src/validation.ts
+++ b/elements/lisk-p2p/src/validation.ts
@@ -62,16 +62,14 @@ export const validatePeerAddress = (ip: string, wsPort: number): boolean => {
 };
 
 export const incomingPeerInfoSanitization = (
-	peerInfo: P2PPeerInfo,
+	peerInfo: ProtocolPeerInfo,
 ): P2PPeerInfo => {
 	const { ip, ...restOfPeerInfo } = peerInfo;
 
-	return ip
-		? {
-				ipAddress: ip,
-				...restOfPeerInfo,
-		  }
-		: peerInfo;
+	return {
+		ipAddress: ip,
+		...restOfPeerInfo,
+	};
 };
 
 export const outgoingPeerInfoSanitization = (
@@ -132,7 +130,9 @@ export const validateBasicPeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
 		throw new InvalidPeerError(`Invalid peer object`);
 	}
 
-	const peerInfo = incomingPeerInfoSanitization(rawPeerInfo as P2PPeerInfo);
+	const peerInfo = incomingPeerInfoSanitization(
+		rawPeerInfo as ProtocolPeerInfo,
+	);
 	if (
 		!peerInfo.ipAddress ||
 		!peerInfo.wsPort ||

--- a/elements/lisk-p2p/src/validation.ts
+++ b/elements/lisk-p2p/src/validation.ts
@@ -12,11 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import {
-	gte as isVersionGTE,
-	lt as isVersionLessThan,
-	valid as isValidVersion,
-} from 'semver';
+import { gte as isVersionGTE, valid as isValidVersion } from 'semver';
 import { isIP, isNumeric, isPort } from 'validator';
 import {
 	InvalidPeerError,
@@ -43,7 +39,6 @@ import { constructPeerIdFromPeerInfo } from './utils';
 
 const IPV4_NUMBER = 4;
 const IPV6_NUMBER = 6;
-export const IPADDRESS_FIELD_SUPPORT_VERSION = '2.3.0';
 
 interface RPCPeerListResponse {
 	readonly peers: ReadonlyArray<object>;
@@ -125,26 +120,7 @@ export const validatePeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
 	return peerInfoUpdated;
 };
 
-export const validateBasicPeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
-	if (!rawPeerInfo) {
-		throw new InvalidPeerError(`Invalid peer object`);
-	}
-
-	const peerInfo = incomingPeerInfoSanitization(
-		rawPeerInfo as ProtocolPeerInfo,
-	);
-	if (
-		!peerInfo.ipAddress ||
-		!peerInfo.wsPort ||
-		!validatePeerAddress(peerInfo.ipAddress, peerInfo.wsPort)
-	) {
-		throw new InvalidPeerError(`Invalid peer ip or port`);
-	}
-
-	return peerInfo;
-};
-
-export const validateBasicPeersInfoList = (
+export const validatePeersInfoList = (
 	rawBasicPeerInfoList: unknown,
 ): ReadonlyArray<P2PPeerInfo> => {
 	if (!rawBasicPeerInfoList) {
@@ -153,7 +129,7 @@ export const validateBasicPeersInfoList = (
 	const { peers } = rawBasicPeerInfoList as RPCPeerListResponse;
 
 	if (Array.isArray(peers)) {
-		const peerList = peers.map<P2PPeerInfo>(validateBasicPeerInfo);
+		const peerList = peers.map<P2PPeerInfo>(validatePeerInfo);
 
 		return peerList;
 	} else {
@@ -223,12 +199,6 @@ export const checkProtocolVersionCompatibility = (
 
 	return systemHardForks === peerHardForks && peerHardForks >= 1;
 };
-
-// Backwards compatibility for older peers which filed ip instead of ipAddress
-export const isLowerVersionPeer = (peerInfo: P2PDiscoveredPeerInfo): boolean =>
-	peerInfo.version
-		? isVersionLessThan(peerInfo.version, IPADDRESS_FIELD_SUPPORT_VERSION)
-		: true;
 
 export const checkPeerCompatibility = (
 	peerInfo: P2PDiscoveredPeerInfo,

--- a/elements/lisk-p2p/src/validation.ts
+++ b/elements/lisk-p2p/src/validation.ts
@@ -56,6 +56,28 @@ export const validatePeerAddress = (ip: string, wsPort: number): boolean => {
 	return true;
 };
 
+export const incomingPeerInfoSanitization = (
+	peerInfo: P2PPeerInfo,
+): P2PPeerInfo => {
+	const { ip, ...restOfPeerInfo } = peerInfo;
+
+	return {
+		ipAddress: ip,
+		...restOfPeerInfo,
+	};
+};
+
+export const outgoingPeerInfoSanitization = (
+	peerInfo: P2PPeerInfo,
+): ProtocolPeerInfo => {
+	const { ipAddress, ...restOfPeerInfo } = peerInfo;
+
+	return {
+		ip: ipAddress,
+		...restOfPeerInfo,
+	};
+};
+
 export const validatePeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
 	if (!rawPeerInfo) {
 		throw new InvalidPeerError(`Invalid peer object`);
@@ -112,7 +134,7 @@ export const validateBasicPeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
 		throw new InvalidPeerError(`Invalid peer ip or port`);
 	}
 
-	return peerInfo;
+	return incomingPeerInfoSanitization(peerInfo);
 };
 
 export const validateBasicPeersInfoList = (

--- a/elements/lisk-p2p/test/unit/validation.ts
+++ b/elements/lisk-p2p/test/unit/validation.ts
@@ -19,12 +19,15 @@ import {
 	validatePeerInfo,
 	validateRPCRequest,
 	validateProtocolMessage,
+	incomingPeerInfoSanitization,
+	outgoingPeerInfoSanitization,
 } from '../../src/validation';
 import { ProtocolPeerInfo } from '../../src/p2p_types';
 import {
 	ProtocolRPCRequestPacket,
 	ProtocolMessagePacket,
 } from '../../src/p2p_types';
+import { initializePeerInfoList } from 'utils/peers';
 
 describe('response handlers', () => {
 	describe('#validatePeerInfo', () => {
@@ -259,6 +262,36 @@ describe('response handlers', () => {
 			expect(returnedValidatedMessage)
 				.to.be.an('object')
 				.has.property('data').to.be.string;
+		});
+	});
+
+	describe('#incomingPeerInfoSanitization', () => {
+		it('should return the peerInfo with ip and convert it to ipAddress', async () => {
+			const samplePeers = initializePeerInfoList();
+			const { ipAddress, ...restOfPeerInfo } = samplePeers[0];
+			const protocolPeerInfo = {
+				ip: ipAddress,
+				...restOfPeerInfo,
+			};
+
+			expect(incomingPeerInfoSanitization(protocolPeerInfo)).eql(
+				samplePeers[0],
+			);
+		});
+	});
+
+	describe('#outgoingPeerInfoSanitization', () => {
+		it('should return the peerInfo with ip and convert it to ipAddress', async () => {
+			const samplePeers = initializePeerInfoList();
+			const { ipAddress, ...restOfPeerInfo } = samplePeers[0];
+			const protocolPeerInfo = {
+				ip: ipAddress,
+				...restOfPeerInfo,
+			};
+
+			expect(outgoingPeerInfoSanitization(samplePeers[0])).eql(
+				protocolPeerInfo,
+			);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?
The `2.3` node should work with old `2.0` and `1.x` peers. There is an incompatibility issue related to `ipAddress` vs `ip` properties in old versions. Also, the old version only supports `list` RPC to get peers list.

### How did I solve it?

- Created incoming and outgoing `peerInfo` sanitization function.
- To fetch peers call RPC based on the version if its lower than `2.3`

### How to manually test it?

`npm t` and also connect with older versions and see if it's fetching peers

### Review checklist

- [x] The PR resolves #4060 
- [x] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
