### PR TITLE
Fix selection for eviction - Closes #4067

### DIFF
--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -590,7 +590,7 @@ export class PeerPool extends EventEmitter {
 					percentage: this._peerPoolConfig.latencyProtectionRatio,
 					asc: true,
 			  })
-			: peers;
+			: filteredPeersByNetgroup;
 		if (filteredPeersByLatency.length <= 1) {
 			return filteredPeersByLatency;
 		}


### PR DESCRIPTION
### What was the problem?

At latency stage, if latency protection not set, selected peers were reverting back to original peers instead of the peers from the prior filtering stage

### How did I solve it?

Passed down filtered peers correctly

### How to manually test it?

npm t

### Review checklist

- [x] The PR resolves #4067
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
