### PR TITLE
Update default connection for DB - Closes #4062

### DIFF
--- a/framework/src/components/storage/defaults/config.js
+++ b/framework/src/components/storage/defaults/config.js
@@ -81,7 +81,7 @@ const defaultConfig = {
 		user: 'lisk',
 		password: 'password',
 		min: 10,
-		max: 95,
+		max: 25,
 		poolIdleTimeout: 30000,
 		reapIntervalMillis: 1000,
 		logEvents: ['error'],


### PR DESCRIPTION
### What was the problem?
Max connection 95 per instance was too heigh to support default max connection `100`

### How did I solve it?
Update the default connection to 25 to support 4 instances.

### How to manually test it?
Start the node and observe the connection doesn't go beyond the max * 3
`psql -Atc 'SELECT count(*) FROM pg_stat_activity' `

### Review checklist

- [x] The PR resolves #4062 
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
