### PR TITLE
Add logs for new blocks - Closes #4074

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -487,6 +487,10 @@ module.exports = class Chain {
 					block.transactions,
 				);
 			}
+			this.logger.info(
+				{ id: block.id, height: block.height },
+				'Deleted a block from the chain',
+			);
 			this.channel.publish('chain:blocks:change', block);
 		});
 
@@ -498,6 +502,14 @@ module.exports = class Chain {
 					block.transactions,
 				);
 			}
+			this.logger.info(
+				{
+					id: block.id,
+					height: block.height,
+					numberOfTransactions: block.transactions.length,
+				},
+				'New block added to the chain',
+			);
 			this.channel.publish('chain:blocks:change', block);
 		});
 
@@ -511,6 +523,10 @@ module.exports = class Chain {
 
 		this.blocks.on(EVENT_NEW_BROADHASH, ({ broadhash, height }) => {
 			this.channel.invoke('app:updateApplicationState', { broadhash, height });
+			this.logger.debug(
+				{ broadhash, height },
+				'Updating the application state',
+			);
 		});
 
 		this.transactionPool.on(EVENT_MULTISIGNATURE_SIGNATURE, signature => {


### PR DESCRIPTION
### What was the problem?
Logs were missing when new block is processed

### How did I solve it?
Add logs on the event of new blocks, deleted blocks and changing broadhash

### How to manually test it?
Start syncing with testnet and see if the logs are present.

### Review checklist

- [x] The PR resolves #4074 
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
