### PR TITLE
Lisk core upgrade to latest version using Lisk commander failed - Closes #4037

### DIFF
--- a/commander/src/commands/core/install.ts
+++ b/commander/src/commands/core/install.ts
@@ -18,7 +18,7 @@ import * as fsExtra from 'fs-extra';
 import Listr from 'listr';
 import * as os from 'os';
 import BaseCommand from '../../base';
-import { NETWORK, SNAPSHOT_URL } from '../../utils/constants';
+import { NETWORK, RELEASE_URL, SNAPSHOT_URL } from '../../utils/constants';
 import {
 	createDirectory,
 	generateEnvConfig,
@@ -26,6 +26,7 @@ import {
 	getVersionToInstall,
 	isSupportedOS,
 	liskInstall,
+	liskLatestUrl,
 	liskSnapshotUrl,
 	validateNetwork,
 	validateNotARootUser,
@@ -65,6 +66,7 @@ interface Options {
 	readonly liskTarSHA256Url: string;
 	readonly liskTarUrl: string;
 	readonly version: string;
+	readonly latestUrl: string;
 }
 
 const validatePrerequisite = (installPath: string): void => {
@@ -103,14 +105,16 @@ const installOptions = async (
 ): Promise<Options> => {
 	const installPath = liskInstall(installationPath);
 	const installDir = `${installPath}/${name}/`;
+	const latestUrl = releaseUrl || liskLatestUrl(RELEASE_URL, network);
+
 	const installVersion: string = await getVersionToInstall(
 		network,
 		liskVersion,
-		releaseUrl,
+		latestUrl,
 	);
 
 	const { version, liskTarUrl, liskTarSHA256Url } = await getReleaseInfo(
-		releaseUrl,
+		latestUrl,
 		network,
 		installVersion,
 	);
@@ -120,6 +124,7 @@ const installOptions = async (
 		version,
 		liskTarUrl,
 		liskTarSHA256Url,
+		latestUrl,
 	};
 };
 
@@ -225,12 +230,12 @@ export default class InstallCommand extends BaseCommand {
 						{
 							title: 'Validate root user, flags, prerequisites',
 							task: async ctx => {
-								const { installDir, releaseUrl } = ctx.options;
+								const { installDir, latestUrl } = ctx.options;
 								validateNotARootUser();
 								validateFlags(flags as Flags);
 								validatePrerequisite(installDir);
 								if (liskVersion) {
-									await validateVersion(releaseUrl, liskVersion);
+									await validateVersion(latestUrl, liskVersion);
 									ctx.options.version = liskVersion;
 								}
 							},

--- a/commander/src/commands/core/install.ts
+++ b/commander/src/commands/core/install.ts
@@ -110,7 +110,7 @@ const installOptions = async (
 	const installVersion: string = await getVersionToInstall(
 		network,
 		liskVersion,
-		latestUrl,
+		releaseUrl,
 	);
 
 	const { version, liskTarUrl, liskTarSHA256Url } = await getReleaseInfo(

--- a/commander/src/commands/core/upgrade.ts
+++ b/commander/src/commands/core/upgrade.ts
@@ -18,12 +18,14 @@ import * as fsExtra from 'fs-extra';
 import Listr from 'listr';
 import semver from 'semver';
 import BaseCommand from '../../base';
+import { RELEASE_URL } from '../../utils/constants';
 import { isCacheRunning, startCache, stopCache } from '../../utils/core/cache';
 import {
 	backupLisk,
 	generateEnvConfig,
 	getDownloadedFileInfo,
 	getVersionToInstall,
+	liskLatestUrl,
 	upgradeLisk,
 	validateVersion,
 } from '../../utils/core/commons';
@@ -125,7 +127,9 @@ export default class UpgradeCommand extends BaseCommand {
 							`Upgrade version:${upgradeVersion} should be greater than current version: ${currentVersion}`,
 						);
 					}
-					await validateVersion(releaseUrl, upgradeVersion);
+					const latestUrl = releaseUrl || liskLatestUrl(RELEASE_URL, network);
+
+					await validateVersion(latestUrl, upgradeVersion);
 				},
 			},
 			{


### PR DESCRIPTION
### What was the problem?
Commands lisk core `install` and `upgrade` failed due to missing default release URL
### How did I solve it?
Handled default release URL for `install` and `upgrade`
### How to manually test it?
```
cd commander;
npm run build;
./bin/run core:install --network=testnet --no-snapshot --lisk-version=2.0.0-rc.0 lisk-testnet
./bin/run core:status lisk-testnet
./bin/run core:stop lisk-testnet
./bin/run core:start lisk-testnet
./bin/run core:restart lisk-testnet
./bin/run core:upgrade --lisk-version=2.0.1-rc.0 lisk-testnet
./bin/run core:status
./bin/run core:logs lisk-testnet
```
### Review checklist

- [x] The PR resolves #4037 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
