### PR TITLE
Implement isEmpty and truncate for temp_block - Closes #3776

### DIFF
--- a/framework/src/modules/chain/components/storage/entities/temp_block.js
+++ b/framework/src/modules/chain/components/storage/entities/temp_block.js
@@ -220,7 +220,7 @@ class TempBlock extends BaseEntity {
 	isEmpty(tx = null) {
 		return this.adapter
 			.executeFile(this.SQLs.isEmpty, {}, {}, tx)
-			.then(result => (result[0] ? result[0].bool : true));
+			.then(([result]) => (result ? result.bool : true));
 	}
 }
 

--- a/framework/src/modules/chain/components/storage/entities/temp_block.js
+++ b/framework/src/modules/chain/components/storage/entities/temp_block.js
@@ -219,8 +219,8 @@ class TempBlock extends BaseEntity {
 	 */
 	isEmpty(tx = null) {
 		return this.adapter
-			.executeFile(this.SQLs.isEmpty, {}, { expectedResultCount: 1 }, tx)
-			.then(result => result.bool);
+			.executeFile(this.SQLs.isEmpty, {}, {}, tx)
+			.then(result => (result[0] ? result[0].bool : true));
 	}
 }
 

--- a/framework/src/modules/chain/components/storage/entities/temp_block.js
+++ b/framework/src/modules/chain/components/storage/entities/temp_block.js
@@ -28,6 +28,8 @@ const sqlFiles = {
 	create: 'temp_block/create.sql',
 	delete: 'temp_block/delete.sql',
 	get: 'temp_block/get.sql',
+	truncate: 'temp_block/truncate.sql',
+	isEmpty: 'temp_block/isEmpty.sql',
 };
 
 /**
@@ -192,6 +194,33 @@ class TempBlock extends BaseEntity {
 				tx,
 			)
 			.then(result => result);
+	}
+
+	/**
+	 * Delete all rows in table
+	 *
+	 * @param {Object} [tx]
+	 * @returns {Promise.<boolean, Error>}
+	 */
+	truncate(tx = null) {
+		return this.adapter.executeFile(
+			this.SQLs.truncate,
+			{},
+			{ expectedResultCount: 0 },
+			tx,
+		);
+	}
+
+	/**
+	 * Check if table is empty (true)
+	 *
+	 * @param {Object} [tx]
+	 * @returns {Promise.<boolean, Error>}
+	 */
+	isEmpty(tx = null) {
+		return this.adapter
+			.executeFile(this.SQLs.isEmpty, {}, { expectedResultCount: 1 }, tx)
+			.then(result => result.bool);
 	}
 }
 

--- a/framework/src/modules/chain/components/storage/sql/temp_block/isEmpty.sql
+++ b/framework/src/modules/chain/components/storage/sql/temp_block/isEmpty.sql
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+/*
+  DESCRIPTION: Return false if temp_block contains records, otherwise true.
+
+  PARAMETERS: none
+*/
+
+SELECT false FROM temp_block LIMIT 1;

--- a/framework/src/modules/chain/components/storage/sql/temp_block/truncate.sql
+++ b/framework/src/modules/chain/components/storage/sql/temp_block/truncate.sql
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+/*
+  DESCRIPTION: Clear table temp_block
+  ONLY makes sure that only this table gets truncated
+
+  PARAMETERS: none
+*/
+
+TRUNCATE TABLE ONLY temp_block

--- a/framework/test/jest/integration/specs/modules/chain/components/storage/entities/block_temp.spec.js
+++ b/framework/test/jest/integration/specs/modules/chain/components/storage/entities/block_temp.spec.js
@@ -32,7 +32,7 @@ describe('TempBlock', () => {
 		config.components.storage,
 		'lisk_test_chain_module_storage_temp_block',
 	);
-	const validSQLs = ['create', 'delete', 'get'];
+	const validSQLs = ['create', 'delete', 'get', 'truncate', 'isEmpty'];
 	const validFields = ['id', 'height', 'fullBlock'];
 	const validFilters = [
 		'id',
@@ -244,10 +244,17 @@ describe('TempBlock', () => {
 	});
 
 	describe('isEmpty', () => {
-		it('should check if table is empty', async () => {
+		it('should return false if table is not empty', async () => {
 			const isEmpty = await TempBlockEntity.isEmpty();
 
 			expect(isEmpty).toEqual(false); // Row 1 and Row 2
+		});
+
+		it('should return true if table is empty', async () => {
+			await TempBlockEntity.truncate();
+			const isEmpty = await TempBlockEntity.isEmpty();
+
+			expect(isEmpty).toEqual(true);
 		});
 	});
 });

--- a/framework/test/jest/integration/specs/modules/chain/components/storage/entities/block_temp.spec.js
+++ b/framework/test/jest/integration/specs/modules/chain/components/storage/entities/block_temp.spec.js
@@ -243,8 +243,8 @@ describe('TempBlock', () => {
 		});
 	});
 
-	describe('count', () => {
-		it('should count all rows in table', async () => {
+	describe('isEmpty', () => {
+		it('should check if table is empty', async () => {
 			const isEmpty = await TempBlockEntity.isEmpty();
 
 			expect(isEmpty).toEqual(false); // Row 1 and Row 2

--- a/framework/test/jest/integration/specs/modules/chain/components/storage/entities/block_temp.spec.js
+++ b/framework/test/jest/integration/specs/modules/chain/components/storage/entities/block_temp.spec.js
@@ -234,4 +234,20 @@ describe('TempBlock', () => {
 			await expect(TempBlockEntity.delete({ height })).resolves.toBeNull();
 		});
 	});
+
+	describe('truncate', () => {
+		it('should truncate all rows from table', async () => {
+			await TempBlockEntity.truncate();
+
+			expect(await TempBlockEntity.get()).toEqual([]);
+		});
+	});
+
+	describe('count', () => {
+		it('should count all rows in table', async () => {
+			const isEmpty = await TempBlockEntity.isEmpty();
+
+			expect(isEmpty).toEqual(false); // Row 1 and Row 2
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?
Need functionality for truncating the `temp_block` table and checking if the table is`isEmpty`. 

### How did I solve it?
Added functionality in `temp_block` entity in `chain` and added relevant integration tests.
[Related PR](https://github.com/LiskHQ/lisk-sdk/pull/4019/files).

### How to manually test it?
Run `npm run jest:integration -- test/jest/integration/specs/modules/chain/components/storage/entities/block_temp.spec.js`

### Review checklist

- [x] The PR resolves #3776 
- [x] All new code is covered with ~unit tests~ integration tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
