### PR TITLE
PeerPool removePeer should allow code or reason as parameter - Closes #4083

### DIFF
--- a/elements/lisk-p2p/src/disconnect_status_codes.ts
+++ b/elements/lisk-p2p/src/disconnect_status_codes.ts
@@ -38,3 +38,5 @@ export const INCOMPATIBLE_PEER_UNKNOWN_REASON =
 // First case to follow HTTP status codes
 export const FORBIDDEN_CONNECTION = 4403;
 export const FORBIDDEN_CONNECTION_REASON = 'Peer is not allowed to connect';
+
+export const EVICTED_PEER_CODE = 4418;

--- a/elements/lisk-p2p/src/peer/inbound.ts
+++ b/elements/lisk-p2p/src/peer/inbound.ts
@@ -58,8 +58,10 @@ export class InboundPeer extends Peer {
 		this._handleInboundSocketError = (error: Error) => {
 			this.emit(EVENT_INBOUND_SOCKET_ERROR, error);
 		};
-		this._handleInboundSocketClose = (code, reasonString) => {
-			const reason = reasonString ? reasonString : socketErrorStatusCodes[code];
+		this._handleInboundSocketClose = (code, reasonMessage) => {
+			const reason = reasonMessage
+				? reasonMessage
+				: socketErrorStatusCodes[code];
 			if (this._pingTimeoutId) {
 				clearTimeout(this._pingTimeoutId);
 			}

--- a/elements/lisk-p2p/src/peer/inbound.ts
+++ b/elements/lisk-p2p/src/peer/inbound.ts
@@ -61,7 +61,7 @@ export class InboundPeer extends Peer {
 		this._handleInboundSocketClose = (code, reasonMessage) => {
 			const reason = reasonMessage
 				? reasonMessage
-				: socketErrorStatusCodes[code];
+				: socketErrorStatusCodes[code] || 'Unknown reason';
 			if (this._pingTimeoutId) {
 				clearTimeout(this._pingTimeoutId);
 			}

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -158,9 +158,9 @@ export class OutboundPeer extends Peer {
 
 		outboundSocket.on(
 			'close',
-			(code: number, reasonString: string | undefined) => {
-				const reason = reasonString
-					? reasonString
+			(code: number, reasonMessage: string | undefined) => {
+				const reason = reasonMessage
+					? reasonMessage
 					: socketErrorStatusCodes[code];
 				this.emit(EVENT_CLOSE_OUTBOUND, {
 					peerInfo: this._peerInfo,

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -161,7 +161,7 @@ export class OutboundPeer extends Peer {
 			(code: number, reasonMessage: string | undefined) => {
 				const reason = reasonMessage
 					? reasonMessage
-					: socketErrorStatusCodes[code];
+					: socketErrorStatusCodes[code] || 'Unknown reason';
 				this.emit(EVENT_CLOSE_OUTBOUND, {
 					peerInfo: this._peerInfo,
 					code,

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -64,6 +64,8 @@ import {
 import { getUniquePeersbyIp } from './peer_selection';
 import { constructPeerIdFromPeerInfo } from './utils';
 
+import { EVICTED_PEER_CODE } from './disconnect_status_codes';
+
 export {
 	EVENT_CLOSE_INBOUND,
 	EVENT_CLOSE_OUTBOUND,
@@ -231,13 +233,23 @@ export class PeerPool extends EventEmitter {
 		};
 		this._handlePeerCloseOutbound = (closePacket: P2PClosePacket) => {
 			const peerId = constructPeerIdFromPeerInfo(closePacket.peerInfo);
-			this.removePeer(peerId);
+			this.removePeer(
+				peerId,
+				closePacket.code,
+				`Outbound peer ${peerId} disconnected with reason: ${closePacket.reason ||
+					'Unknown reason'}`,
+			);
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CLOSE_OUTBOUND, closePacket);
 		};
 		this._handlePeerCloseInbound = (closePacket: P2PClosePacket) => {
 			const peerId = constructPeerIdFromPeerInfo(closePacket.peerInfo);
-			this.removePeer(peerId);
+			this.removePeer(
+				peerId,
+				closePacket.code,
+				`Inbound peer ${peerId} disconnected with reason: ${closePacket.reason ||
+					'Unknown reason'}`,
+			);
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CLOSE_INBOUND, closePacket);
 		};
@@ -490,7 +502,11 @@ export class PeerPool extends EventEmitter {
 		}
 
 		this._peerMap.forEach((peer: Peer) => {
-			this.removePeer(peer.id);
+			this.removePeer(
+				peer.id,
+				INTENTIONAL_DISCONNECT_STATUS_CODE,
+				`Intentionally removed peer ${peer.id}`,
+			);
 		});
 	}
 
@@ -536,13 +552,10 @@ export class PeerPool extends EventEmitter {
 		return this._peerMap.has(peerId);
 	}
 
-	public removePeer(peerId: string): boolean {
+	public removePeer(peerId: string, code: number, reason: string): boolean {
 		const peer = this._peerMap.get(peerId);
 		if (peer) {
-			peer.disconnect(
-				INTENTIONAL_DISCONNECT_STATUS_CODE,
-				`Intentionally disconnected from peer ${peerId}`,
-			);
+			peer.disconnect(code, reason);
 			this._unbindHandlersFromPeer(peer);
 		}
 
@@ -634,7 +647,11 @@ export class PeerPool extends EventEmitter {
 		if (kind === OutboundPeer) {
 			const selectedPeer = shuffle(peers)[0];
 			if (selectedPeer) {
-				this.removePeer(selectedPeer.id);
+				this.removePeer(
+					selectedPeer.id,
+					EVICTED_PEER_CODE,
+					`Evicted outbound peer ${selectedPeer.id}`,
+				);
 			}
 		}
 
@@ -642,7 +659,11 @@ export class PeerPool extends EventEmitter {
 			const evictionCandidates = this._selectPeersForEviction();
 			const peerToEvict = shuffle(evictionCandidates)[0];
 			if (peerToEvict) {
-				this.removePeer(peerToEvict.id);
+				this.removePeer(
+					peerToEvict.id,
+					EVICTED_PEER_CODE,
+					`Evicted inbound peer ${peerToEvict.id}`,
+				);
 			}
 		}
 	}

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -109,6 +109,7 @@ interface PeerPoolConfig {
 export const MAX_PEER_LIST_BATCH_SIZE = 100;
 export const MAX_PEER_DISCOVERY_PROBE_SAMPLE_SIZE = 100;
 export const EVENT_REMOVE_PEER = 'removePeer';
+export const INTENTIONAL_DISCONNECT_STATUS_CODE = 1000;
 
 export enum PROTECTION_CATEGORY {
 	NET_GROUP = 'netgroup',
@@ -538,7 +539,10 @@ export class PeerPool extends EventEmitter {
 	public removePeer(peerId: string): boolean {
 		const peer = this._peerMap.get(peerId);
 		if (peer) {
-			peer.disconnect();
+			peer.disconnect(
+				INTENTIONAL_DISCONNECT_STATUS_CODE,
+				`Intentionally disconnected from peer ${peerId}`,
+			);
 			this._unbindHandlersFromPeer(peer);
 		}
 

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -179,7 +179,7 @@ module.exports = class Network {
 
 		this.p2p.on(EVENT_CLOSE_INBOUND, closePacket => {
 			this.logger.debug(
-				`INbound connection of peer ${closePacket.peerInfo.ipAddress}:${
+				`Inbound connection of peer ${closePacket.peerInfo.ipAddress}:${
 					closePacket.peerInfo.wsPort
 				} was closed with code ${closePacket.code} and reason: ${
 					closePacket.reason


### PR DESCRIPTION
### What was the problem?

The logs did not show the disconnect reason most of the time.

### How did I solve it?

If the status reason is not provided by the other side of the socket, then use the default reason for that code from SocketCluster if it exists.

### How to manually test it?

Run tests and check against testnet.

### Review checklist

- [x] The PR resolves #4083
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
