### PR TITLE
core:status command returns inconsistent output - Closes #4084

### DIFF
--- a/commander/src/commands/core/status.ts
+++ b/commander/src/commands/core/status.ts
@@ -41,9 +41,9 @@ export default class StatusCommand extends BaseCommand {
 			const instance = await describeApplication(name);
 
 			if (!instance) {
-				this.log(
-					`Lisk Core instance: ${name} doesn't exists, Please install using lisk core:install`,
-				);
+				this.print({
+					message: `Lisk Core instance: ${name} doesn't exists, Please install using lisk core:install`,
+				});
 
 				return;
 			}
@@ -52,9 +52,10 @@ export default class StatusCommand extends BaseCommand {
 			const instances = await listApplication();
 
 			if (!instances.length) {
-				this.log(
-					'Lisk Core instances not available, use lisk core:install --help',
-				);
+				this.print({
+					message:
+						'Lisk Core instances not available, use lisk core:install --help',
+				});
 			} else {
 				const toDisplay = [
 					'name',

--- a/commander/src/commands/core/status.ts
+++ b/commander/src/commands/core/status.ts
@@ -52,7 +52,7 @@ export default class StatusCommand extends BaseCommand {
 
 			if (!instance) {
 				this.print({
-					message: `Lisk Core instance: ${name} doesn't exists, Please install using lisk core:install`,
+					message: `Lisk Core instance: ${name} doesn't exists, Please install using lisk core:install --help`,
 				});
 
 				return;
@@ -64,7 +64,7 @@ export default class StatusCommand extends BaseCommand {
 			if (!instances.length) {
 				this.print({
 					message:
-						'Lisk Core instances not available, use lisk core:install --help',
+						'Lisk Core instances not available, Please install using lisk core:install --help',
 				});
 			} else {
 				const toDisplay = [

--- a/commander/src/commands/core/status.ts
+++ b/commander/src/commands/core/status.ts
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { flags as flagParser } from '@oclif/command';
 import BaseCommand from '../../base';
 import { describeApplication, listApplication } from '../../utils/core/pm2';
 
@@ -21,6 +22,15 @@ interface Args {
 }
 
 export default class StatusCommand extends BaseCommand {
+	static flags = {
+		json: flagParser.boolean({
+			hidden: true,
+		}),
+		pretty: flagParser.boolean({
+			hidden: true,
+		}),
+	};
+
 	static args = [
 		{
 			name: 'name',


### PR DESCRIPTION
### What was the problem?
lisk `core:status` may return JSON or a plain text error message (if there are no installed instances)
### How did I solve it?
Return JSON result consistently
### How to manually test it?
`lisk core:status`
### Review checklist

- [ ] The PR resolves #4084 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
