### PR TITLE
Add network ready event - Closes #4090

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -117,6 +117,7 @@ export {
 export const EVENT_NEW_INBOUND_PEER = 'newInboundPeer';
 export const EVENT_FAILED_TO_ADD_INBOUND_PEER = 'failedToAddInboundPeer';
 export const EVENT_NEW_PEER = 'newPeer';
+export const EVENT_NETWORK_READY = 'networkReady';
 
 export const DEFAULT_NODE_HOST_IP = '0.0.0.0';
 export const DEFAULT_DISCOVERY_INTERVAL = 30000;
@@ -154,6 +155,7 @@ export class P2P extends EventEmitter {
 	private readonly _sanitizedPeerLists: PeerLists;
 	private readonly _httpServer: http.Server;
 	private _isActive: boolean;
+	private _hasConnected: boolean;
 	private readonly _peerBook: PeerBook;
 	private readonly _bannedPeers: Set<string>;
 	private readonly _populatorInterval: number;
@@ -212,6 +214,7 @@ export class P2P extends EventEmitter {
 		);
 		this._config = config;
 		this._isActive = false;
+		this._hasConnected = false;
 		this._peerBook = new PeerBook({
 			secret: config.secret ? config.secret : DEFAULT_RANDOM_SECRET,
 		});
@@ -382,6 +385,9 @@ export class P2P extends EventEmitter {
 				}
 				// Re-emit the message to allow it to bubble up the class hierarchy.
 				this.emit(EVENT_DISCOVERED_PEER, detailedPeerInfo);
+				if (this._isNetworkReady()) {
+					this.emit(EVENT_NETWORK_READY);
+				}
 			}
 		};
 
@@ -768,6 +774,16 @@ export class P2P extends EventEmitter {
 		}
 	}
 
+	private _isNetworkReady(): boolean {
+		if (!this._hasConnected && this._peerPool.getConnectedPeers().length > 0) {
+			this._hasConnected = true;
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private _pickRandomPeers(count: number): ReadonlyArray<P2PPeerInfo> {
 		const peerList: ReadonlyArray<P2PPeerInfo> = this._peerBook.getAllPeers(); // Peers whose values has been updated at least once.
 
@@ -857,6 +873,7 @@ export class P2P extends EventEmitter {
 			throw new Error('Cannot stop the node because it is not active');
 		}
 		this._isActive = false;
+		this._hasConnected = false;
 		this._stopPopulator();
 		this._peerPool.removeAllPeers();
 		await this._stopPeerServer();

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -261,6 +261,9 @@ export class P2P extends EventEmitter {
 
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CONNECT_OUTBOUND, peerInfo);
+			if (this._isNetworkReady()) {
+				this.emit(EVENT_NETWORK_READY);
+			}
 		};
 
 		this._handleOutboundPeerConnectAbort = (peerInfo: P2PPeerInfo) => {
@@ -385,9 +388,6 @@ export class P2P extends EventEmitter {
 				}
 				// Re-emit the message to allow it to bubble up the class hierarchy.
 				this.emit(EVENT_DISCOVERED_PEER, detailedPeerInfo);
-				if (this._isNetworkReady()) {
-					this.emit(EVENT_NETWORK_READY);
-				}
 			}
 		};
 

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -309,9 +309,9 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
-		const listOfPeerInfo = [...this._peerMap.values()].map(
-			(peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo,
-		);
+		const listOfPeerInfo = [...this._peerMap.values()]
+			.filter(p => p.state === ConnectionState.OPEN)
+			.map((peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo);
 		const selectedPeers = this._peerSelectForRequest({
 			peers: getUniquePeersbyIp(listOfPeerInfo),
 			nodeInfo: this._nodeInfo,

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -311,9 +311,9 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
-		const listOfPeerInfo = [...this._peerMap.values()]
-			.filter(p => p.state === ConnectionState.OPEN)
-			.map((peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo);
+		const listOfPeerInfo = [...this._peerMap.values()].map(
+			(peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo,
+		);
 		const selectedPeers = this._peerSelectForRequest({
 			peers: getUniquePeersbyIp(listOfPeerInfo),
 		});

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -182,7 +182,6 @@ export class PeerPool extends EventEmitter {
 	private readonly _maxOutboundConnections: number;
 	private readonly _maxInboundConnections: number;
 	private readonly _peerSelectForSend: P2PPeerSelectionForSendFunction;
-	private readonly _peerSelectForRequest: P2PPeerSelectionForRequestFunction;
 	private readonly _peerSelectForConnection: P2PPeerSelectionForConnectionFunction;
 	private readonly _sendPeerLimit: number;
 	private readonly _outboundShuffleIntervalId: NodeJS.Timer | undefined;
@@ -192,7 +191,6 @@ export class PeerPool extends EventEmitter {
 		this._peerMap = new Map();
 		this._peerPoolConfig = peerPoolConfig;
 		this._peerSelectForSend = peerPoolConfig.peerSelectionForSend;
-		this._peerSelectForRequest = peerPoolConfig.peerSelectionForRequest;
 		this._peerSelectForConnection = peerPoolConfig.peerSelectionForConnection;
 		this._maxOutboundConnections = peerPoolConfig.maxOutboundConnections;
 		this._maxInboundConnections = peerPoolConfig.maxInboundConnections;
@@ -312,19 +310,12 @@ export class PeerPool extends EventEmitter {
 		const listOfPeerInfo = [...this._peerMap.values()]
 			.filter(p => p.state === ConnectionState.OPEN)
 			.map((peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo);
-		const selectedPeers = this._peerSelectForRequest({
-			peers: getUniquePeersbyIp(listOfPeerInfo),
-			nodeInfo: this._nodeInfo,
-			peerLimit: 1,
-			requestPacket: packet,
-		});
 
-		if (selectedPeers.length <= 0) {
-			throw new RequestFailError(
-				'Request failed due to no peers found in peer selection',
-			);
+		if (listOfPeerInfo.length <= 0) {
+			throw new RequestFailError('Request failed due to no connected peers');
 		}
-		const selectedPeerId = constructPeerIdFromPeerInfo(selectedPeers[0]);
+		const selectedPeer = shuffle(listOfPeerInfo)[0];
+		const selectedPeerId = constructPeerIdFromPeerInfo(selectedPeer);
 
 		return this.requestFromPeer(packet, selectedPeerId);
 	}

--- a/elements/lisk-p2p/test/unit/peer_selection.ts
+++ b/elements/lisk-p2p/test/unit/peer_selection.ts
@@ -54,7 +54,7 @@ describe('peer selector', () => {
 			it('returned array should contain good peers according to algorithm', () => {
 				return expect(selectPeersForRequest({ peers: peerList, nodeInfo }))
 					.and.be.an('array')
-					.and.of.length(3);
+					.and.of.length(5);
 			});
 
 			it('return empty peer list for no peers as an argument', () => {
@@ -82,7 +82,7 @@ describe('peer selector', () => {
 			it('should return an array having all good peers', () => {
 				return expect(selectPeersForRequest({ peers: peerList, nodeInfo }))
 					.and.be.an('array')
-					.and.of.length(3);
+					.and.of.length(5);
 			});
 
 			it('should return an array of equal length equal to requested number of peers', () => {
@@ -102,7 +102,7 @@ describe('peer selector', () => {
 				peer => peer.height < nodeInfo.height,
 			);
 
-			it('should return an array with 0 good peers', () => {
+			it('should return an array with 1 good peer', () => {
 				return expect(
 					selectPeersForRequest({
 						peers: lowHeightPeers,
@@ -111,7 +111,7 @@ describe('peer selector', () => {
 					}),
 				)
 					.and.be.an('array')
-					.and.of.length(0);
+					.and.of.length(1);
 			});
 		});
 	});

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -160,9 +160,12 @@ module.exports = class Chain {
 			this._subscribeToEvents();
 
 			this.channel.subscribe('network:bootstrap', async () => {
-				this._startLoader();
 				this._calculateConsensus();
 				await this._startForging();
+			});
+
+			this.channel.subscribe('network:ready', async () => {
+				this._startLoader();
 			});
 
 			// Avoid receiving blocks/transactions from the network during snapshotting process

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -82,7 +82,6 @@ module.exports = class NetworkModule extends BaseModule {
 	async load(channel) {
 		this.network = new Network(this.options);
 		await this.network.bootstrap(channel);
-		channel.publish('network:bootstrap');
 	}
 
 	async unload() {

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -49,7 +49,7 @@ module.exports = class NetworkModule extends BaseModule {
 	}
 
 	get events() {
-		return ['bootstrap', 'event'];
+		return ['bootstrap', 'event', 'ready'];
 	}
 
 	get actions() {
@@ -82,6 +82,7 @@ module.exports = class NetworkModule extends BaseModule {
 	async load(channel) {
 		this.network = new Network(this.options);
 		await this.network.bootstrap(channel);
+		channel.publish('network:bootstrap');
 	}
 
 	async unload() {

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -17,6 +17,7 @@
 const { getRandomBytes } = require('@liskhq/lisk-cryptography');
 const {
 	P2P,
+	EVENT_NETWORK_READY,
 	EVENT_NEW_INBOUND_PEER,
 	EVENT_CLOSE_INBOUND,
 	EVENT_CLOSE_OUTBOUND,
@@ -166,6 +167,10 @@ module.exports = class Network {
 		});
 
 		// ---- START: Bind event handlers ----
+		this.p2p.on(EVENT_NETWORK_READY, () => {
+			this.logger.debug('Network has connected to peers');
+			this.channel.publish('network:bootstrap');
+		});
 
 		this.p2p.on(EVENT_CLOSE_OUTBOUND, closePacket => {
 			this.logger.debug(

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -174,7 +174,7 @@ module.exports = class Network {
 		// ---- START: Bind event handlers ----
 		this.p2p.on(EVENT_NETWORK_READY, () => {
 			this.logger.debug('Node connected to the network');
-			this.channel.publish('network:bootstrap');
+			this.channel.publish('network:ready');
 		});
 
 		this.p2p.on(EVENT_CLOSE_OUTBOUND, closePacket => {

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -168,7 +168,7 @@ module.exports = class Network {
 
 		// ---- START: Bind event handlers ----
 		this.p2p.on(EVENT_NETWORK_READY, () => {
-			this.logger.debug('Network has connected to peers');
+			this.logger.debug('Node connected to the network');
 			this.channel.publish('network:bootstrap');
 		});
 


### PR DESCRIPTION
### What was the problem?

Node was attempting to load transactions and signatures before it was connected to any peers on p2p network. This caused an error message: `RequestFailError: Request failed due to no peers found in peer selection`.

### How did I solve it?

1. Created `EVENT_NETWORK_READY` which the network module listens for before publishing `network:bootstrap` and calling `loader.loadTransactionsAndSignatures`.

2. `peerSelectForRequest` now simply shuffles peerList and selects one, instead of using height histogram. 

### How to manually test it?

Start 2.3.0 node and connect to testnet. Observe that there is no `RequestFailError`.

### Review checklist

- [x] The PR resolves #4090 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
