### PR TITLE
Update node version to be more flexible - Closes #4009 and #3852

### DIFF
--- a/framework/package.json
+++ b/framework/package.json
@@ -20,8 +20,8 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": "10.15.3",
-		"npm": "6.4.1"
+		"node": ">=10.4 <=10",
+		"npm": ">=6"
 	},
 	"main": "src/index.js",
 	"scripts": {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -29,7 +29,7 @@ Before running Lisk SDK, the following dependencies need to be installed in orde
 
 | Dependencies     | Version |
 | ---------------- | ------- |
-| NodeJS           | 10.15.3 |
+| NodeJS           | 10.4+   |
 | PostgreSQL       | 10+     |
 | Redis (optional) | 5+      |
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=10",
+		"node": ">=10.4 <=10",
 		"npm": ">=6"
 	},
 	"main": "src/index.js",


### PR DESCRIPTION
### What was the problem?
Framework node version was too strict

### How did I solve it?
Change to support the range of ` >= 10.4 <= 10`, and update the documentation

### Review checklist

- [x] The PR resolves #4009 and #3852 
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
