### PR TITLE
Trying to upgrade non-existing instance does not return non-zero exit code - Closes #3928

### DIFF
--- a/commander/src/commands/core/status.ts
+++ b/commander/src/commands/core/status.ts
@@ -41,11 +41,9 @@ export default class StatusCommand extends BaseCommand {
 			const instance = await describeApplication(name);
 
 			if (!instance) {
-				this.log(
+				throw new Error(
 					`Lisk Core instance: ${name} doesn't exists, Please install using lisk core:install`,
 				);
-
-				return;
 			}
 			this.print(instance);
 		} else {

--- a/commander/src/commands/core/upgrade.ts
+++ b/commander/src/commands/core/upgrade.ts
@@ -96,11 +96,9 @@ export default class UpgradeCommand extends BaseCommand {
 		const instance = await describeApplication(name);
 
 		if (!instance) {
-			this.log(
+			throw new Error(
 				`Lisk Core instance: ${name} doesn't exists.\nTo upgrade first install using lisk core:install and then run lisk core:upgrade`,
 			);
-
-			return;
 		}
 
 		const {


### PR DESCRIPTION
### What was the problem?
Trying to upgrade non-existing instance does not return non-zero exit code
### How did I solve it?
Returning non-zero code for `non-existing` instance
### How to manually test it?
`lisk core:status idontexist`
`lisk core:upgrade meneither`
### Review checklist

- [ ] The PR resolves #3928 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
