### PR TITLE
Fix syncing logic for reverting - Closes #4103

### DIFF
--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -302,7 +302,12 @@ class Blocks extends EventEmitter {
 	}
 
 	async recoverChain() {
+		const originalLastBlock = cloneDeep(this._lastBlock);
 		this._lastBlock = await this.blocksChain.deleteLastBlock(this._lastBlock);
+		this.emit(EVENT_DELETE_BLOCK, {
+			block: originalLastBlock,
+			newLastBlock: cloneDeep(this._lastBlock),
+		});
 		return this._lastBlock;
 	}
 

--- a/framework/src/modules/chain/loader.js
+++ b/framework/src/modules/chain/loader.js
@@ -370,7 +370,10 @@ class Loader {
 				failedAttemptsToLoad += 1;
 				// eslint-disable-next-line no-await-in-loop
 				await this._handleCommonBlockError(err);
-				this.logger.warn({ error: err });
+				this.logger.warn(
+					{ error: err },
+					'Failed to load blocks from the network.',
+				);
 			}
 		}
 	}
@@ -391,7 +394,6 @@ class Loader {
 				);
 			}
 		}
-		this.logger.warn({ error }, 'Failed to load blocks from the network.');
 	}
 }
 

--- a/framework/src/modules/chain/utils/error_handlers.js
+++ b/framework/src/modules/chain/utils/error_handlers.js
@@ -14,6 +14,13 @@
 
 'use strict';
 
+class CommonBlockError extends Error {
+	constructor(message, lastBlockId) {
+		super(message);
+		this.lastBlockId = lastBlockId;
+	}
+}
+
 /**
  * Converts array of errors into string
  *
@@ -44,5 +51,6 @@ function convertErrorsToString(errors) {
 }
 
 module.exports = {
+	CommonBlockError,
 	convertErrorsToString,
 };


### PR DESCRIPTION
### What was the problem?
When the chain is on fork, it doesn't rollback if it fails to fetch block from network, instead it rolls back when it fails to process

### How did I solve it?
Move the logic to the network fail.

### How to manually test it?
Build some blockchain data (around height 100), and connect to different network.

### Review checklist

- [ ] The PR resolves #4103 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
