### PR TITLE
Update sodium-native - Closes #4105

### DIFF
--- a/elements/lisk-cryptography/package-lock.json
+++ b/elements/lisk-cryptography/package-lock.json
@@ -3850,9 +3850,9 @@
 			"dev": true
 		},
 		"sodium-native": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.5.tgz",
-			"integrity": "sha512-G1uhd4l1OexzUC/6eHIbAvoivCs9T7ncDlEWodZglPZVUOXi6jtSe7tCi25aYB06zRoOjVfE4SL+hZ4EfkyZgw==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz",
+			"integrity": "sha512-Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==",
 			"optional": true,
 			"requires": {
 				"ini": "^1.3.5",

--- a/elements/lisk-cryptography/package.json
+++ b/elements/lisk-cryptography/package.json
@@ -66,7 +66,7 @@
 		"varuint-bitcoin": "1.1.0"
 	},
 	"optionalDependencies": {
-		"sodium-native": "2.4.5"
+		"sodium-native": "2.4.6"
 	},
 	"devDependencies": {
 		"@types/jquery": "3.3.29",

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -10357,9 +10357,9 @@
 			}
 		},
 		"sodium-native": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.5.tgz",
-			"integrity": "sha512-G1uhd4l1OexzUC/6eHIbAvoivCs9T7ncDlEWodZglPZVUOXi6jtSe7tCi25aYB06zRoOjVfE4SL+hZ4EfkyZgw==",
+			"version": "2.4.6",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.6.tgz",
+			"integrity": "sha512-Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==",
 			"requires": {
 				"ini": "^1.3.5",
 				"nan": "^2.14.0",

--- a/framework/package.json
+++ b/framework/package.json
@@ -84,7 +84,7 @@
 		"randomstring": "1.1.5",
 		"redis": "2.8.0",
 		"socket.io": "2.2.0",
-		"sodium-native": "2.4.5",
+		"sodium-native": "2.4.6",
 		"swagger-node-runner": "0.7.3",
 		"sway": "2.0.5",
 		"yargs": "13.2.2",


### PR DESCRIPTION
### What was the problem?

Sodium native 2.4.5 does not support Node 12.x

### How did I solve it?

By updating to 2.4.6 which does support Node 12.x

### How to manually test it?

Build should be green.

### Review checklist

- [ ] The PR resolves #4105
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
