### PR TITLE
Throw error for non-existent action and add tests - Closes #4080 #4081

### DIFF
--- a/framework/src/controller/bus.js
+++ b/framework/src/controller/bus.js
@@ -169,7 +169,7 @@ class Bus extends EventEmitter2 {
 		const action = Action.deserialize(actionData);
 
 		if (!this.actions[action.key()]) {
-			throw new Error(`Action ${action.key()} is not registered to bus.`);
+			throw new Error(`Action '${action.key()}' is not registered to bus.`);
 		}
 
 		if (action.module === CONTROLLER_IDENTIFIER) {
@@ -204,10 +204,15 @@ class Bus extends EventEmitter2 {
 	async invokePublic(actionData) {
 		const action = Action.deserialize(actionData);
 
+		// Check if action exists
+		if (!this.actions[action.key()]) {
+			throw new Error(`Action '${action.key()}' is not registered to bus.`);
+		}
+
 		// Check if action is public
 		if (!this.actions[action.key()].isPublic) {
 			throw new Error(
-				`Action ${action.key()} is not allowed because it's not public.`,
+				`Action '${action.key()}' is not allowed because it's not public.`,
 			);
 		}
 

--- a/framework/src/controller/channels/in_memory_channel.js
+++ b/framework/src/controller/channels/in_memory_channel.js
@@ -115,6 +115,13 @@ class InMemoryChannel extends BaseChannel {
 				: actionName;
 
 		if (action.module === this.moduleAlias) {
+			if (!this.actions[action.name]) {
+				throw new Error(
+					`The action '${action.name}' on module '${
+						this.moduleAlias
+					}' does not exist.`,
+				);
+			}
 			return this.actions[action.name].handler(action);
 		}
 
@@ -138,7 +145,7 @@ class InMemoryChannel extends BaseChannel {
 		if (action.module === this.moduleAlias) {
 			if (!this.actions[action.name].isPublic) {
 				throw new Error(
-					`Action ${action.name} is not allowed because it's not public.`,
+					`Action '${action.name}' is not allowed because it's not public.`,
 				);
 			}
 

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -69,6 +69,7 @@ module.exports = class Chain {
 			'app:getComponentConfig',
 			'logger',
 		);
+
 		const storageConfig = await this.channel.invoke(
 			'app:getComponentConfig',
 			'storage',

--- a/framework/test/jest/unit/specs/controller/bus.spec.js
+++ b/framework/test/jest/unit/specs/controller/bus.spec.js
@@ -139,7 +139,132 @@ describe('Bus', () => {
 	describe('#invoke', () => {
 		it.todo('should invoke controller channel action.');
 		it.todo('should invoke module channel action.');
-		it.todo('should throw error if action was not registered.');
+
+		it('should throw error if action was not registered', async () => {
+			// Arrange
+			const actionData = {
+				name: 'nonexistentaction',
+				module: 'app',
+				source: 'chain',
+				params: 'logger',
+			};
+
+			// Act && Assert
+			await expect(bus.invoke(actionData)).rejects.toBeInstanceOf(Error);
+
+			try {
+				await bus.invoke(actionData);
+			} catch (err) {
+				expect(err.message).toEqual(
+					`Action '${actionData.module}:${
+						actionData.name
+					}' is not registered to bus.`,
+				);
+			}
+		});
+
+		it('should throw error if module does not exist', async () => {
+			// Arrange
+			const actionData = {
+				name: 'getComponentConfig',
+				module: 'invalidmodule',
+				source: 'chain',
+				params: 'logger',
+			};
+
+			// Act && Assert
+			await expect(bus.invoke(actionData)).rejects.toBeInstanceOf(Error);
+
+			try {
+				await bus.invoke(actionData);
+			} catch (err) {
+				expect(err.message).toEqual(
+					`Action '${actionData.module}:${
+						actionData.name
+					}' is not registered to bus.`,
+				);
+			}
+		});
+	});
+
+	describe('#invokePublic', () => {
+		it('should throw error if action was not registered', async () => {
+			// Arrange
+			const actionData = {
+				name: 'nonexistentaction',
+				module: 'app',
+				source: 'chain',
+				params: 'logger',
+			};
+
+			// Act && Assert
+			await expect(bus.invokePublic(actionData)).rejects.toBeInstanceOf(Error);
+
+			try {
+				await bus.invoke(actionData);
+			} catch (err) {
+				expect(err.message).toEqual(
+					`Action '${actionData.module}:${
+						actionData.name
+					}' is not registered to bus.`,
+				);
+			}
+		});
+
+		it('should throw error if module does not exist', async () => {
+			// Arrange
+			const actionData = {
+				name: 'getComponentConfig',
+				module: 'invalidmodule',
+				source: 'chain',
+				params: 'logger',
+			};
+
+			// Act && Assert
+			await expect(bus.invokePublic(actionData)).rejects.toBeInstanceOf(Error);
+
+			try {
+				await bus.invoke(actionData);
+			} catch (err) {
+				expect(err.message).toEqual(
+					`Action '${actionData.module}:${
+						actionData.name
+					}' is not registered to bus.`,
+				);
+			}
+		});
+
+		it('should throw error if action is not public', async () => {
+			// Arrange
+			const moduleAlias = 'alias';
+			const actions = {
+				action1: {
+					handler: jest.fn(),
+				},
+			};
+			const actionData = {
+				name: 'action1',
+				module: moduleAlias,
+				source: 'chain',
+				params: 'logger',
+			};
+
+			// Act
+			await bus.registerChannel(moduleAlias, [], actions, channelOptions);
+
+			// Assert
+			await expect(bus.invokePublic(actionData)).rejects.toBeInstanceOf(Error);
+
+			try {
+				await bus.invokePublic(actionData);
+			} catch (err) {
+				expect(err.message).toEqual(
+					`Action '${actionData.module}:${
+						actionData.name
+					}' is not allowed because it's not public.`,
+				);
+			}
+		});
 	});
 
 	describe('#publish', () => {

--- a/framework/test/jest/unit/specs/controller/bus.spec.js
+++ b/framework/test/jest/unit/specs/controller/bus.spec.js
@@ -201,7 +201,7 @@ describe('Bus', () => {
 			await expect(bus.invokePublic(actionData)).rejects.toBeInstanceOf(Error);
 
 			try {
-				await bus.invoke(actionData);
+				await bus.invokePublic(actionData);
 			} catch (err) {
 				expect(err.message).toEqual(
 					`Action '${actionData.module}:${
@@ -224,7 +224,7 @@ describe('Bus', () => {
 			await expect(bus.invokePublic(actionData)).rejects.toBeInstanceOf(Error);
 
 			try {
-				await bus.invoke(actionData);
+				await bus.invokePublic(actionData);
 			} catch (err) {
 				expect(err.message).toEqual(
 					`Action '${actionData.module}:${


### PR DESCRIPTION
### What was the problem?
See #4070 

### How did I solve it?
Add error message and tests for non-existent actions for `invoke` and `invokePublic`.

### How to manually test it?
`npm run jest:unit -- test/jest/unit/specs/controller/bus.spec.js`
Or request a nonexisting action from chain module on startup (inside `bootstrap()` function).

### Review checklist

- [x] The PR resolves #4080 #4081 
- [x] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added - no need for now.
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated - no change for docs needed.
