### PR TITLE
Sync error on testnet - Closes #4119

### DIFF
--- a/framework/src/modules/chain/state_store/account_store.js
+++ b/framework/src/modules/chain/state_store/account_store.js
@@ -50,7 +50,11 @@ class AccountStore {
 	}
 
 	async cache(filter) {
-		const result = await this.account.get(filter, { extended: true }, this.tx);
+		const result = await this.account.get(
+			filter,
+			{ extended: true, limit: null },
+			this.tx,
+		);
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
 		return _.cloneDeep(this.data);
 	}

--- a/framework/src/modules/chain/state_store/transaction_store.js
+++ b/framework/src/modules/chain/state_store/transaction_store.js
@@ -28,7 +28,7 @@ class TransactionStore {
 	async cache(filter) {
 		const result = await this.transaction.get(
 			filter,
-			{ extended: true },
+			{ extended: true, limit: null },
 			this.tx,
 		);
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);

--- a/framework/src/modules/chain/transactions/votes_weight.js
+++ b/framework/src/modules/chain/transactions/votes_weight.js
@@ -206,35 +206,28 @@ const undo = (stateStore, transaction, exceptions = {}) => {
 
 const prepare = async (stateStore, transaction) => {
 	// Get delegate public keys whom sender voted for
-	const senderDelegatePublicKeys =
+	const senderVotedPublicKeys =
 		stateStore.account.getOrDefault(transaction.senderId)
 			.votedDelegatesPublicKeys || [];
 
 	const recipientId = getRecipientAddress(stateStore, transaction);
 
 	// Get delegate public keys whom recipient voted for
-	const recipientDelegatePublicKeys =
+	const recipientVotedPublicKeys =
 		(recipientId &&
 			stateStore.account.getOrDefault(recipientId).votedDelegatesPublicKeys) ||
 		[];
 
-	// Get unique public keys from merged list
-	const uniqPublicKeysToBeCached = [
-		...new Set([...senderDelegatePublicKeys, ...recipientDelegatePublicKeys]),
+	// Get unique public key list from merged arrays
+	const senderRecipientVotedPublicKeys = [
+		...new Set([...senderVotedPublicKeys, ...recipientVotedPublicKeys]),
 	];
 
-	/**
-	 * We are running `stateStore.account.cache` multiple times per public key instead of once with array of public keys
-	 * because StateStore uses `storage.entities.Account.get` which default limit result is 101 entries
-	 * meaning it will only cache maximum 101 accounts.
-	 */
-	return Promise.all(
-		uniqPublicKeysToBeCached
-			.map(delegatePublicKey => ({
-				address: getAddressFromPublicKey(delegatePublicKey),
-			}))
-			.map(filter => stateStore.account.cache(filter)),
-	);
+	const cacheFilter = senderRecipientVotedPublicKeys.map(publicKey => ({
+		address: getAddressFromPublicKey(publicKey),
+	}));
+
+	return stateStore.account.cache(cacheFilter);
 };
 
 module.exports = {


### PR DESCRIPTION
### What was the problem?
Syncing failing on testnet due to account not being cached in StateStore. StateStore uses `storage.entities.Account.get` which default limit result is 101 entries meaning it was only caching maximum 101 accounts.

### How did I solve it?
By adding `limit: null` to remove the limit when calling `storage.entities.Account.get`.
The same approach was introduced to `storage.entities.Transaction.get` inside StateStore to keep consistency.

### How to manually test it?
Start syncing with test. Is should pass round 134

### Review checklistd

- [ ] The PR resolves #4119
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
