### PR TITLE
Fix slow account api - Closes #4122

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -248,6 +248,7 @@ module.exports = class Chain {
 				secondsSinceEpoch: this.slots.getTime(),
 				lastBlock: this.scope.modules.blocks.lastBlock.get(),
 			}),
+			getLastBlock: async () => this.scope.modules.blocks.lastBlock.get(),
 			blocks: async action =>
 				promisify(this.scope.modules.transport.shared.blocks)(
 					action.params || {}

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -116,6 +116,9 @@ module.exports = class ChainModule extends BaseModule {
 			getNodeStatus: {
 				handler: async () => this.chain.actions.getNodeStatus(),
 			},
+			getLastBlock: {
+				handler: async () => this.chain.actions.getLastBlock(),
+			},
 			blocks: {
 				handler: async action => this.chain.actions.blocks(action),
 				isPublic: true,

--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -107,7 +107,7 @@ AccountsController.getAccounts = async function(context, next) {
 	filters = _.pickBy(filters, v => !(v === undefined || v === null));
 
 	try {
-		const { lastBlock } = await channel.invoke('chain:getNodeStatus');
+		const lastBlock = await channel.invoke('chain:getLastBlock');
 		const data = await storage.entities.Account.get(filters, options).map(
 			accountFormatter.bind(
 				null,

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -164,7 +164,7 @@ async function _getDelegates(filters, options) {
 		options
 	);
 
-	const { lastBlock } = await channel.invoke('chain:getNodeStatus');
+	const lastBlock = await channel.invoke('chain:getLastBlock');
 
 	const supply = lastBlock.height
 		? await channel.invoke('chain:calculateSupply', {
@@ -185,7 +185,7 @@ async function _getDelegates(filters, options) {
  * @private
  */
 async function _getForgers(filters) {
-	const { lastBlock } = await channel.invoke('chain:getNodeStatus');
+	const lastBlock = await channel.invoke('chain:getLastBlock');
 
 	const lastBlockSlot = await channel.invoke('chain:getSlotNumber', {
 		epochTime: lastBlock.timestamp,

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -66,7 +66,7 @@ NodeController.getConstants = async (context, next) => {
 	}
 
 	try {
-		const { lastBlock } = await library.channel.invoke('chain:getNodeStatus');
+		const lastBlock = await library.channel.invoke('chain:getLastBlock');
 		const milestone = await library.channel.invoke('chain:calculateMilestone', {
 			height: lastBlock.height,
 		});

--- a/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
@@ -157,9 +157,7 @@ describe('delegates/api', () => {
 
 		beforeEach(async () => {
 			channelStub.invoke.withArgs('chain:calculateSupply').resolves('supply');
-			channelStub.invoke.withArgs('chain:getNodeStatus').resolves({
-				lastBlock,
-			});
+			channelStub.invoke.withArgs('chain:getLastBlock').resolves(lastBlock);
 			await __private.getDelegates(filters, options);
 		});
 
@@ -361,9 +359,9 @@ describe('delegates/api', () => {
 			return __private.getForgers(filters);
 		});
 
-		it('should call channel.invoke with chain:getNodeStatus action', async () => {
+		it('should call channel.invoke with chain:getLastBlock action', async () => {
 			expect(channelStub.invoke.getCall(0)).to.be.calledWith(
-				'chain:getNodeStatus'
+				'chain:getLastBlock'
 			);
 		});
 

--- a/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
@@ -181,10 +181,8 @@ describe('delegates/api', () => {
 		});
 
 		it('should assign 0 to supply if lastBlock.height is 0', async () => {
-			channelStub.invoke.withArgs('chain:getNodeStatus').resolves({
-				lastBlock: {
-					height: 0,
-				},
+			channelStub.invoke.withArgs('chain:getLastBlock').resolves({
+				height: 0,
 			});
 			await __private.getDelegates();
 			expect(delegateFormatterStub).to.be.calledWith(0);
@@ -353,9 +351,7 @@ describe('delegates/api', () => {
 
 		beforeEach(() => {
 			channelStub.invoke.resolves(dummyDelegates);
-			channelStub.invoke.withArgs('chain:getNodeStatus').resolves({
-				lastBlock,
-			});
+			channelStub.invoke.withArgs('chain:getLastBlock').resolves(lastBlock);
 			return __private.getForgers(filters);
 		});
 


### PR DESCRIPTION
### What was the problem?
`getNodeStatus` call uses transaction count and it's slow

### How did I solve it?
Change not to use `getNodeStatus` function

### How to manually test it?
Call endpoint `/api/accounts=address=XXXL` with mainnet data

### Review checklist

- [ ] The PR resolves #4122 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
