### PR TITLE
Fix invalid use of callback

### DIFF
--- a/framework/src/modules/chain/submodules/loader.js
+++ b/framework/src/modules/chain/submodules/loader.js
@@ -226,14 +226,18 @@ __private.getSignaturesFromNetwork = async function() {
 						modules.multisignatures
 					)
 				);
-				// eslint-disable-next-line no-await-in-loop
-				await processSignature({
-					signature,
-					transactionId: signature.transactionId,
-				});
+				try {
+					// eslint-disable-next-line no-await-in-loop
+					await processSignature({
+						signature,
+						transactionId: signature.transactionId,
+					});
+				} catch (error) {
+					return setImmediate(addSequenceCb, error);
+				}
 			}
 		}
-		addSequenceCb();
+		return addSequenceCb();
 	});
 };
 


### PR DESCRIPTION
### What was the problem?
Sequence was expecting the callback to be called, but it was throwing.
This was solved by changing sequence to async await in 2.2, but it still exists in 2.0.1.

### How did I solve it?
Try catch the async-await and call the callback.

### Review checklist
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
