### PR TITLE
Fix slow http api/account - Closes #4122

### DIFF
--- a/framework/src/components/storage/sql/accounts/get.sql
+++ b/framework/src/components/storage/sql/accounts/get.sql
@@ -20,6 +20,7 @@ SELECT
 	"isDelegate"::int::boolean,
 	"secondSignature"::int::boolean,
 	"balance",
+	"asset",
 	"multimin" as "multiMin",
 	"multilifetime" as "multiLifetime",
 	"nameexist"::int::boolean as "nameExist",

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -242,6 +242,7 @@ module.exports = class Chain {
 				secondsSinceEpoch: this.slots.getTime(),
 				lastBlock: this.blocks.lastBlock,
 			}),
+			getLastBlock: async () => this.blocks.lastBlock,
 			blocks: async action => this.transport.blocks(action.params || {}),
 			blocksCommon: async action =>
 				this.transport.blocksCommon(action.params || {}),

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -122,6 +122,9 @@ module.exports = class ChainModule extends BaseModule {
 			getNodeStatus: {
 				handler: async () => this.chain.actions.getNodeStatus(),
 			},
+			getLastBlock: {
+				handler: async () => this.chain.actions.getLastBlock(),
+			},
 			blocks: {
 				handler: async action => this.chain.actions.blocks(action),
 				isPublic: true,

--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -104,14 +104,14 @@ AccountsController.getAccounts = async function(context, next) {
 		limit: params.limit.value,
 		offset: params.offset.value,
 		sort: params.sort.value,
-		extended: true,
+		extended: false,
 	};
 
 	// Remove filters with null values
 	filters = _.pickBy(filters, v => !(v === undefined || v === null));
 
 	try {
-		const { lastBlock } = await channel.invoke('chain:getNodeStatus');
+		const lastBlock = await channel.invoke('chain:getLastBlock');
 		const data = await storage.entities.Account.get(filters, options).map(
 			accountFormatter.bind(
 				null,

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -65,7 +65,7 @@ async function _getDelegates(filters, options) {
 		options,
 	);
 
-	const { lastBlock } = await channel.invoke('chain:getNodeStatus');
+	const lastBlock = await channel.invoke('chain:getLastBlock');
 
 	const supply = lastBlock.height
 		? await channel.invoke('chain:calculateSupply', {
@@ -86,7 +86,7 @@ async function _getDelegates(filters, options) {
  * @private
  */
 async function _getForgers(filters) {
-	const { lastBlock } = await channel.invoke('chain:getNodeStatus');
+	const lastBlock = await channel.invoke('chain:getLastBlock');
 
 	const lastBlockSlot = await channel.invoke('chain:getSlotNumber', {
 		epochTime: lastBlock.timestamp,

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -196,7 +196,7 @@ NodeController.getConstants = async (context, next) => {
 	}
 
 	try {
-		const { lastBlock } = await library.channel.invoke('chain:getNodeStatus');
+		const lastBlock = await library.channel.invoke('chain:getLastBlock');
 		const milestone = await library.channel.invoke('chain:calculateMilestone', {
 			height: lastBlock.height,
 		});

--- a/framework/test/mocha/unit/components/storage/entities/account.js
+++ b/framework/test/mocha/unit/components/storage/entities/account.js
@@ -105,6 +105,7 @@ describe('Account', () => {
 			'isDelegate',
 			'secondSignature',
 			'balance',
+			'asset',
 			'multiMin',
 			'multiLifetime',
 			'nameExist',

--- a/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
@@ -157,9 +157,7 @@ describe('delegates/api', () => {
 
 		beforeEach(async () => {
 			channelStub.invoke.withArgs('chain:calculateSupply').resolves('supply');
-			channelStub.invoke.withArgs('chain:getNodeStatus').resolves({
-				lastBlock,
-			});
+			channelStub.invoke.withArgs('chain:getLastBlock').resolves(lastBlock);
 			await __private.getDelegates(filters, options);
 		});
 
@@ -183,10 +181,8 @@ describe('delegates/api', () => {
 		});
 
 		it('should assign 0 to supply if lastBlock.height is 0', async () => {
-			channelStub.invoke.withArgs('chain:getNodeStatus').resolves({
-				lastBlock: {
-					height: 0,
-				},
+			channelStub.invoke.withArgs('chain:getLastBlock').resolves({
+				height: 0,
 			});
 			await __private.getDelegates();
 			expect(delegateFormatterStub).to.be.calledWith(0);
@@ -355,15 +351,13 @@ describe('delegates/api', () => {
 
 		beforeEach(() => {
 			channelStub.invoke.resolves(dummyDelegates);
-			channelStub.invoke.withArgs('chain:getNodeStatus').resolves({
-				lastBlock,
-			});
+			channelStub.invoke.withArgs('chain:getLastBlock').resolves(lastBlock);
 			return __private.getForgers(filters);
 		});
 
-		it('should call channel.invoke with chain:getNodeStatus action', async () => {
+		it('should call channel.invoke with chain:getLastBlock action', async () => {
 			expect(channelStub.invoke.getCall(0)).to.be.calledWith(
-				'chain:getNodeStatus',
+				'chain:getLastBlock',
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
`getNodeStatus` call uses transaction count and it's slow

### How did I solve it?
Change not to use `getNodeStatus` function
Also, include `asset` in default account sql and remove extended flag

### How to manually test it?
Call endpoint `/api/accounts=address=XXXL` with mainnet data

### Review checklist

- [ ] The PR resolves #4122 
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
