### PR TITLE
Add back nodeInfo, peerLimit and requestPacket fields to _peerSelectForRequest function - Closes #4142

### DIFF
--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -314,8 +314,12 @@ export class PeerPool extends EventEmitter {
 		const listOfPeerInfo = [...this._peerMap.values()].map(
 			(peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo,
 		);
+		// This function can be customized so we should pass as much info as possible.
 		const selectedPeers = this._peerSelectForRequest({
 			peers: getUniquePeersbyIp(listOfPeerInfo),
+			nodeInfo: this._nodeInfo,
+			peerLimit: 1,
+			requestPacket: packet,
 		});
 
 		if (selectedPeers.length <= 0) {
@@ -333,6 +337,7 @@ export class PeerPool extends EventEmitter {
 		const listOfPeerInfo = [...this._peerMap.values()].map(
 			(peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo,
 		);
+		// This function can be customized so we should pass as much info as possible.
 		const selectedPeers = this._peerSelectForSend({
 			peers: listOfPeerInfo,
 			nodeInfo: this._nodeInfo,
@@ -397,6 +402,8 @@ export class PeerPool extends EventEmitter {
 			this._maxOutboundConnections -
 			disconnectedFixedPeers.length -
 			outboundCount;
+
+		// This function can be customized so we should pass as much info as possible.
 		const peersToConnect = this._peerSelectForConnection({
 			newPeers: disconnectedNewPeers,
 			triedPeers: disconnectedTriedPeers,

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -2037,7 +2037,7 @@ describe('Integration tests for P2P library', () => {
 	describe('Network with peer inbound eviction protection for connectTime enabled', () => {
 		const NETWORK_PEER_COUNT_WITH_LIMIT = 10;
 		const MAX_INBOUND_CONNECTIONS = 3;
-		const POPULATOR_INTERVAL_WITH_LIMIT = 150;
+		const POPULATOR_INTERVAL_WITH_LIMIT = 100;
 		beforeEach(async () => {
 			p2pNodeList = [...new Array(NETWORK_PEER_COUNT_WITH_LIMIT).keys()].map(
 				index => {
@@ -2047,14 +2047,15 @@ describe('Integration tests for P2P library', () => {
 							ipAddress: '127.0.0.1',
 							wsPort:
 								NETWORK_START_PORT +
-								((index + 1) % NETWORK_PEER_COUNT_WITH_LIMIT),
+								((index - 1 + NETWORK_PEER_COUNT_WITH_LIMIT) %
+									NETWORK_PEER_COUNT_WITH_LIMIT),
 						},
 					];
 
 					const nodePort = NETWORK_START_PORT + index;
 					return new P2P({
 						connectTimeout: 100,
-						ackTimeout: 5000,
+						ackTimeout: 200,
 						seedPeers,
 						wsEngine: 'ws',
 						populatorInterval: POPULATOR_INTERVAL_WITH_LIMIT,
@@ -2068,7 +2069,7 @@ describe('Integration tests for P2P library', () => {
 							nethash:
 								'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
 							version: '1.0.1',
-							protocolVersion: '1.0.1',
+							protocolVersion: '1.1',
 							minVersion: '1.0.0',
 							os: platform(),
 							height: 0,
@@ -2081,11 +2082,11 @@ describe('Integration tests for P2P library', () => {
 			);
 
 			// Start nodes incrementally to make inbound eviction behavior predictable
-			p2pNodeList.forEach(async p2p => {
-				await wait(500);
-				p2p.start();
-			});
-			await wait(1500);
+			for (const p2p of p2pNodeList) {
+				await wait(100);
+				await p2p.start();
+			}
+			await wait(500);
 		});
 
 		afterEach(async () => {
@@ -2101,13 +2102,12 @@ describe('Integration tests for P2P library', () => {
 			// Due to randomization from shuffling and timing of the nodes
 			// This test may experience some instability and not always evict.
 			it('should not evict earliest connected peers', async () => {
-				// We watch middle node for more predictable connection behavior
-				const middleNode = p2pNodeList[5];
-				const inboundPeers = middleNode['_peerPool']
+				const firstNode = p2pNodeList[0];
+				const inboundPeers = firstNode['_peerPool']
 					.getPeers(InboundPeer)
 					.map(peer => peer.wsPort);
 				expect(inboundPeers).to.satisfy(
-					(n: Number[]) => n.includes(5003) || n.includes(5004),
+					(n: Number[]) => n.includes(5001) || n.includes(5002),
 				);
 			});
 		});

--- a/elements/lisk-p2p/test/unit/peer_selection.ts
+++ b/elements/lisk-p2p/test/unit/peer_selection.ts
@@ -40,32 +40,60 @@ describe('peer selector', () => {
 			});
 
 			it('should return an array without optional arguments', () => {
-				return expect(selectPeersForRequest({ peers: peerList })).to.be.an(
-					'array',
-				);
+				return expect(
+					selectPeersForRequest({
+						peers: peerList,
+						peerLimit: 1,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
+				).to.be.an('array');
 			});
 
 			it('should return an array', () => {
 				return expect(
-					selectPeersForRequest({ peers: peerList, nodeInfo }),
+					selectPeersForRequest({
+						peers: peerList,
+						nodeInfo,
+						peerLimit: 1,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
 				).to.be.an('array');
 			});
 
 			it('returned array should contain good peers according to algorithm', () => {
-				return expect(selectPeersForRequest({ peers: peerList, nodeInfo }))
+				return expect(
+					selectPeersForRequest({
+						peers: peerList,
+						nodeInfo,
+						peerLimit: 5,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
+				)
 					.and.be.an('array')
 					.and.of.length(5);
 			});
 
 			it('return empty peer list for no peers as an argument', () => {
-				return expect(selectPeersForRequest({ peers: [], nodeInfo }))
+				return expect(
+					selectPeersForRequest({
+						peers: [],
+						nodeInfo,
+						peerLimit: 1,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
+				)
 					.and.be.an('array')
 					.and.to.be.eql([]);
 			});
 
 			it('should return an array having one good peer', () => {
 				return expect(
-					selectPeersForRequest({ peers: peerList, nodeInfo, peerLimit: 1 }),
+					selectPeersForRequest({
+						peers: peerList,
+						nodeInfo,
+						peerLimit: 1,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
 				)
 					.and.be.an('array')
 					.and.of.length(1);
@@ -73,21 +101,38 @@ describe('peer selector', () => {
 
 			it('should return an array having 2 good peers', () => {
 				return expect(
-					selectPeersForRequest({ peers: peerList, nodeInfo, peerLimit: 2 }),
+					selectPeersForRequest({
+						peers: peerList,
+						nodeInfo,
+						peerLimit: 2,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
 				)
 					.and.be.an('array')
 					.and.of.length(2);
 			});
 
 			it('should return an array having all good peers', () => {
-				return expect(selectPeersForRequest({ peers: peerList, nodeInfo }))
+				return expect(
+					selectPeersForRequest({
+						peers: peerList,
+						nodeInfo,
+						peerLimit: 5,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
+				)
 					.and.be.an('array')
 					.and.of.length(5);
 			});
 
 			it('should return an array of equal length equal to requested number of peers', () => {
 				return expect(
-					selectPeersForRequest({ peers: peerList, nodeInfo, peerLimit: 3 }),
+					selectPeersForRequest({
+						peers: peerList,
+						nodeInfo,
+						peerLimit: 3,
+						requestPacket: { procedure: 'foo', data: {} },
+					}),
 				)
 					.and.be.an('array')
 					.and.of.length(3);
@@ -108,6 +153,7 @@ describe('peer selector', () => {
 						peers: lowHeightPeers,
 						nodeInfo,
 						peerLimit: 2,
+						requestPacket: { procedure: 'foo', data: {} },
 					}),
 				)
 					.and.be.an('array')
@@ -125,6 +171,7 @@ describe('peer selector', () => {
 				const selectedPeers = selectPeersForConnection({
 					triedPeers: [],
 					newPeers: [],
+					peerLimit: 20,
 				});
 				expect(selectedPeers).to.be.an('array').empty;
 			});
@@ -135,6 +182,7 @@ describe('peer selector', () => {
 				const selectedPeers = selectPeersForConnection({
 					triedPeers: peerList,
 					newPeers: [],
+					peerLimit: 20,
 				});
 				expect(selectedPeers)
 					.to.be.an('array')

--- a/elements/lisk-p2p/test/unit/peer_selection.ts
+++ b/elements/lisk-p2p/test/unit/peer_selection.ts
@@ -39,29 +39,27 @@ describe('peer selector', () => {
 				peerList = initializePeerInfoList();
 			});
 
-			it('should return an array without optional arguments', () => {
-				return expect(
+			it('should return an array without optional arguments', () =>
+				expect(
 					selectPeersForRequest({
 						peers: peerList,
 						peerLimit: 1,
 						requestPacket: { procedure: 'foo', data: {} },
 					}),
-				).to.be.an('array');
-			});
+				).to.be.an('array'));
 
-			it('should return an array', () => {
-				return expect(
+			it('should return an array', () =>
+				expect(
 					selectPeersForRequest({
 						peers: peerList,
 						nodeInfo,
 						peerLimit: 1,
 						requestPacket: { procedure: 'foo', data: {} },
 					}),
-				).to.be.an('array');
-			});
+				).to.be.an('array'));
 
-			it('returned array should contain good peers according to algorithm', () => {
-				return expect(
+			it('returned array should contain good peers according to algorithm', () =>
+				expect(
 					selectPeersForRequest({
 						peers: peerList,
 						nodeInfo,
@@ -70,11 +68,10 @@ describe('peer selector', () => {
 					}),
 				)
 					.and.be.an('array')
-					.and.of.length(5);
-			});
+					.and.of.length(5));
 
-			it('return empty peer list for no peers as an argument', () => {
-				return expect(
+			it('return empty peer list for no peers as an argument', () =>
+				expect(
 					selectPeersForRequest({
 						peers: [],
 						nodeInfo,
@@ -83,11 +80,10 @@ describe('peer selector', () => {
 					}),
 				)
 					.and.be.an('array')
-					.and.to.be.eql([]);
-			});
+					.and.to.be.eql([]));
 
-			it('should return an array having one good peer', () => {
-				return expect(
+			it('should return an array having one good peer', () =>
+				expect(
 					selectPeersForRequest({
 						peers: peerList,
 						nodeInfo,
@@ -96,11 +92,10 @@ describe('peer selector', () => {
 					}),
 				)
 					.and.be.an('array')
-					.and.of.length(1);
-			});
+					.and.of.length(1));
 
-			it('should return an array having 2 good peers', () => {
-				return expect(
+			it('should return an array having 2 good peers', () =>
+				expect(
 					selectPeersForRequest({
 						peers: peerList,
 						nodeInfo,
@@ -109,11 +104,10 @@ describe('peer selector', () => {
 					}),
 				)
 					.and.be.an('array')
-					.and.of.length(2);
-			});
+					.and.of.length(2));
 
-			it('should return an array having all good peers', () => {
-				return expect(
+			it('should return an array having all good peers', () =>
+				expect(
 					selectPeersForRequest({
 						peers: peerList,
 						nodeInfo,
@@ -122,11 +116,10 @@ describe('peer selector', () => {
 					}),
 				)
 					.and.be.an('array')
-					.and.of.length(5);
-			});
+					.and.of.length(5));
 
-			it('should return an array of equal length equal to requested number of peers', () => {
-				return expect(
+			it('should return an array of equal length equal to requested number of peers', () =>
+				expect(
 					selectPeersForRequest({
 						peers: peerList,
 						nodeInfo,
@@ -135,8 +128,7 @@ describe('peer selector', () => {
 					}),
 				)
 					.and.be.an('array')
-					.and.of.length(3);
-			});
+					.and.of.length(3));
 		});
 
 		describe('peers with lower blockheight', () => {


### PR DESCRIPTION
### What was the problem?

- Some useful fields were removed from the custom selection function which limits the ability of the P2P library to do advanced routing of requests.
- There was an issue with the integration test related to peer eviction which made it brittle because the peers would not be started sequentially as was intended.

### How did I solve it?

- Added back missing fields when calling the selectForRequest function.
- Fixed the integration test case so that each peer would wait one after another. Also, made each successive node point to the previous node instead of the next one (since the next one hasn't launched yet).

### How to manually test it?

`npm test`

### Review checklist

- [x] The PR resolves #4142
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
