### PR TITLE
Request from Outbound peers - Closes #4135

### DIFF
--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -311,12 +311,9 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
-		const listOfPeerInfo = [...this._peerMap.values()].map(
-			(peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo,
-		);
 		// This function can be customized so we should pass as much info as possible.
 		const selectedPeers = this._peerSelectForRequest({
-			peers: getUniquePeersbyIp(listOfPeerInfo),
+			peers: this.getUniqueOutboundConnectedPeers(),
 			nodeInfo: this._nodeInfo,
 			peerLimit: 1,
 			requestPacket: packet,

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -537,8 +537,8 @@ describe('Integration tests for P2P library', () => {
 			});
 
 			it('should make request to the network; it should reach a single peer', async () => {
-				const firstP2PNode = p2pNodeList[0];
-				const response = await firstP2PNode.request({
+				const secondP2PNode = p2pNodeList[1];
+				const response = await secondP2PNode.request({
 					procedure: 'foo',
 					data: 'bar',
 				});
@@ -554,7 +554,7 @@ describe('Integration tests for P2P library', () => {
 					.which.is.equal('bar');
 				expect(response.data)
 					.to.have.property('requestPeerId')
-					.which.is.equal(`127.0.0.1:${firstP2PNode.nodeInfo.wsPort}`);
+					.which.is.equal(`127.0.0.1:${secondP2PNode.nodeInfo.wsPort}`);
 			});
 
 			// Check for even distribution of requests across the network. Account for an error margin.
@@ -1218,7 +1218,7 @@ describe('Integration tests for P2P library', () => {
 								{
 									ipAddress: '127.0.0.1',
 									wsPort:
-										NETWORK_START_PORT + ((index - 1) % NETWORK_PEER_COUNT),
+										NETWORK_START_PORT + ((index + 1) % NETWORK_PEER_COUNT),
 								},
 						  ];
 
@@ -1286,8 +1286,8 @@ describe('Integration tests for P2P library', () => {
 			});
 
 			it('should make a request to the network; it should reach a single peer based on custom selection function', async () => {
-				const firstP2PNode = p2pNodeList[0];
-				const response = await firstP2PNode.request({
+				const secondP2PNode = p2pNodeList[1];
+				const response = await secondP2PNode.request({
 					procedure: 'foo',
 					data: 'bar',
 				});
@@ -1577,8 +1577,8 @@ describe('Integration tests for P2P library', () => {
 			});
 
 			it('should make request to the network; it should reach a single peer', async () => {
-				const firstP2PNode = p2pNodeList[0];
-				const response = await firstP2PNode.request({
+				const secondP2PNode = p2pNodeList[1];
+				const response = await secondP2PNode.request({
 					procedure: 'foo',
 					data: 'bar',
 				});
@@ -1594,7 +1594,7 @@ describe('Integration tests for P2P library', () => {
 					.which.is.equal('bar');
 				expect(response.data)
 					.to.have.property('requestPeerId')
-					.which.is.equal(`127.0.0.1:${firstP2PNode.nodeInfo.wsPort}`);
+					.which.is.equal(`127.0.0.1:${secondP2PNode.nodeInfo.wsPort}`);
 			});
 
 			// Check for even distribution of requests across the network. Account for an error margin.


### PR DESCRIPTION
### What was the problem?

We were requesting from both outbound and inbound peers, causing potential security [issue.](https://github.com/LiskHQ/lisk-sdk/issues/3972)

### How did I solve it?

Only request from outbound peers.

### How to manually test it?

Follow steps mentioned in issue #3972 . 

### Review checklist

- [x] The PR resolves #4135 
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
