### PR TITLE
Replace rounds.generateDelegateList by dpos.getRoundDelegates - Closes #4152

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -225,11 +225,8 @@ module.exports = class Chain {
 				this.blocks.blockReward.calculateMilestone(action.params.height),
 			calculateReward: action =>
 				this.blocks.blockReward.calculateReward(action.params.height),
-			generateDelegateList: async action =>
-				this.rounds.generateDelegateList(
-					action.params.round,
-					action.params.source,
-				),
+			getRoundDelegates: async action =>
+				this.dpos.getRoundDelegates(action.params.round),
 			updateForgingStatus: async action =>
 				this.forger.updateForgingStatus(
 					action.params.publicKey,
@@ -463,7 +460,7 @@ module.exports = class Chain {
 			storage: this.storage,
 			sequence: this.scope.sequence,
 			slots: this.slots,
-			roundsModule: this.rounds,
+			dposModule: this.dpos,
 			transactionPoolModule: this.transactionPool,
 			blocksModule: this.blocks,
 			peersModule: this.peers,

--- a/framework/src/modules/chain/forger.js
+++ b/framework/src/modules/chain/forger.js
@@ -32,13 +32,13 @@ const {
  * @todo Add description for the params
  */
 const getDelegateKeypairForCurrentSlot = async (
-	rounds,
+	dposModule,
 	keypairs,
 	currentSlot,
 	round,
 	numOfActiveDelegates,
 ) => {
-	const activeDelegates = await rounds.generateDelegateList(round);
+	const activeDelegates = await dposModule.getRoundDelegates(round);
 
 	const currentSlotIndex = currentSlot % numOfActiveDelegates;
 	const currentSlotDelegate = activeDelegates[currentSlotIndex];
@@ -71,7 +71,7 @@ class Forger {
 		// Unique requirements
 		slots,
 		// Modules
-		roundsModule,
+		dposModule,
 		transactionPoolModule,
 		blocksModule,
 		peersModule,
@@ -101,7 +101,7 @@ class Forger {
 			maxTransactionsPerBlock,
 		};
 
-		this.roundsModule = roundsModule;
+		this.dposModule = dposModule;
 		this.peersModule = peersModule;
 		this.transactionPoolModule = transactionPoolModule;
 		this.blocksModule = blocksModule;
@@ -318,7 +318,7 @@ class Forger {
 		try {
 			// eslint-disable-next-line no-use-before-define
 			delegateKeypair = await exportedInterfaces.getDelegateKeypairForCurrentSlot(
-				this.roundsModule,
+				this.dposModule,
 				this.keypairs,
 				currentSlot,
 				round,

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -81,8 +81,8 @@ class ChainModule extends BaseModule {
 			calculateReward: {
 				handler: action => this.chain.actions.calculateReward(action),
 			},
-			generateDelegateList: {
-				handler: action => this.chain.actions.generateDelegateList(action),
+			getRoundDelegates: {
+				handler: action => this.chain.actions.getRoundDelegates(action),
 			},
 			updateForgingStatus: {
 				handler: async action => this.chain.actions.updateForgingStatus(action),

--- a/framework/src/modules/chain/rounds/rounds.js
+++ b/framework/src/modules/chain/rounds/rounds.js
@@ -376,11 +376,6 @@ class Rounds {
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	generateDelegateList(round, source, tx) {
-		return library.delegates.generateDelegateList(round, source, tx);
-	}
-
-	// eslint-disable-next-line class-methods-use-this
 	fork(block, cause) {
 		return library.delegates.fork(block, cause);
 	}

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -99,7 +99,7 @@ async function _getForgers(filters) {
 	});
 
 	const activeDelegates = await channel.invoke('chain:getRoundDelegates', {
-		currentRound,
+		round: currentRound,
 	});
 
 	for (

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -94,12 +94,12 @@ async function _getForgers(filters) {
 	const currentSlot = await channel.invoke('chain:getSlotNumber');
 	const forgerKeys = [];
 
-	const round = await channel.invoke('chain:calcSlotRound', {
+	const currentRound = await channel.invoke('chain:calcSlotRound', {
 		height: lastBlock.height + 1,
 	});
 
-	const activeDelegates = await channel.invoke('chain:generateDelegateList', {
-		round,
+	const activeDelegates = await channel.invoke('chain:getRoundDelegates', {
+		currentRound,
 	});
 
 	for (
@@ -277,7 +277,7 @@ function DelegatesController(scope) {
  * @param {function} next
  * @todo Add description for the function and the params
  */
-DelegatesController.getDelegates = async function(context, next) {
+DelegatesController.getDelegates = async (context, next) => {
 	const invalidParams = swaggerHelper.invalidParams(context.request);
 
 	if (invalidParams.length) {
@@ -329,7 +329,7 @@ DelegatesController.getDelegates = async function(context, next) {
  * @param {function} next
  * @todo Add description for the function and the params
  */
-DelegatesController.getForgers = async function(context, next) {
+DelegatesController.getForgers = async (context, next) => {
 	const { params } = context.request.swagger;
 
 	const filters = {
@@ -345,7 +345,7 @@ DelegatesController.getForgers = async function(context, next) {
 	}
 };
 
-DelegatesController.getForgingStatistics = async function(context, next) {
+DelegatesController.getForgingStatistics = async (context, next) => {
 	const { params } = context.request.swagger;
 
 	const filters = {

--- a/framework/test/jest/integration/utils/chain/delegate.js
+++ b/framework/test/jest/integration/utils/chain/delegate.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const getDelegateList = async (chainModule, round) =>
-	chainModule.rounds.generateDelegateList(round);
+	chainModule.dpos.getRoundDelegates(round);
 
 module.exports = {
 	getDelegateList,

--- a/framework/test/mocha/common/application.js
+++ b/framework/test/mocha/common/application.js
@@ -165,7 +165,7 @@ const initStepsForTest = {
 			logger: scope.components.logger,
 			storage: scope.components.storage,
 			slots: scope.slots,
-			roundsModule: modules.rounds,
+			dposModule: modules.dpos,
 			transactionPoolModule: modules.transactionPool,
 			blocksModule: modules.blocks,
 			peersModule: modules.peers,

--- a/framework/test/mocha/integration/app.js
+++ b/framework/test/mocha/integration/app.js
@@ -300,8 +300,8 @@ describe('app', () => {
 			let delegatesList;
 
 			before(() => {
-				return library.modules.rounds
-					.generateDelegateList(1, null)
+				return library.modules.dpos
+					.getRoundDelegates(1)
 					.then(_delegatesList => {
 						delegatesList = _delegatesList;
 					});

--- a/framework/test/mocha/integration/blocks/process/on_receive_block.js
+++ b/framework/test/mocha/integration/blocks/process/on_receive_block.js
@@ -29,9 +29,6 @@ const blockVersion = require('../../../../../src/modules/chain/blocks/block_vers
 const genesisDelegates = require('../../../data/genesis_delegates.json')
 	.delegates;
 const application = require('../../../common/application');
-const {
-	getKeysSortByVote,
-} = require('../../../../../src/modules/chain/rounds/delegates');
 
 const { ACTIVE_DELEGATES, BLOCK_SLOT_WINDOW } = global.constants;
 
@@ -126,12 +123,10 @@ describe('integration test (blocks) - process receiveBlockFromNetwork()', () => 
 		function getNextForger(offset, seriesCb) {
 			offset = !offset ? 0 : offset;
 			const round = slots.calcRound(last_block.height + 1);
-			library.modules.rounds
-				.generateDelegateList(round, getKeysSortByVote)
-				.then(delegateList => {
-					const nextForger = delegateList[(slot + offset) % ACTIVE_DELEGATES];
-					return seriesCb(nextForger);
-				});
+			library.modules.dpos.getRoundDelegates(round).then(delegateList => {
+				const nextForger = delegateList[(slot + offset) % ACTIVE_DELEGATES];
+				return seriesCb(nextForger);
+			});
 		}
 
 		async.waterfall(
@@ -211,8 +206,8 @@ describe('integration test (blocks) - process receiveBlockFromNetwork()', () => 
 		const lastBlock = library.modules.blocks.lastBlock;
 		const round = slots.calcRound(lastBlock.height);
 
-		return library.modules.rounds
-			.generateDelegateList(round, null)
+		return library.modules.dpos
+			.getRoundDelegates(round)
 			.then(list => {
 				const delegatePublicKey = list[slot % ACTIVE_DELEGATES];
 				return getKeypair(

--- a/framework/test/mocha/integration/blocks/verify/verify.js
+++ b/framework/test/mocha/integration/blocks/verify/verify.js
@@ -90,8 +90,8 @@ function getValidKeypairForSlot(library, slot) {
 	const lastBlock = genesisBlock;
 	const round = slots.calcRound(lastBlock.height);
 
-	return library.modules.rounds
-		.generateDelegateList(round, null)
+	return library.modules.dpos
+		.getRoundDelegates(round)
 		.then(list => {
 			const delegatePublicKey = list[slot % ACTIVE_DELEGATES];
 			const passphrase = _.find(genesisDelegates, delegate => {
@@ -108,7 +108,7 @@ describe('blocks/verify', () => {
 	let library;
 	let blocksProcess;
 	let blocks;
-	let rounds;
+	let dpos;
 	let storage;
 
 	before(done => {
@@ -121,7 +121,7 @@ describe('blocks/verify', () => {
 			(err, scope) => {
 				blocksProcess = scope.modules.blocks.blocksProcess;
 				blocks = scope.modules.blocks;
-				rounds = scope.modules.rounds;
+				dpos = scope.modules.dpos;
 				storage = scope.components.storage;
 
 				// Set current block version to 0
@@ -300,7 +300,7 @@ describe('blocks/verify', () => {
 					if (err) {
 						return done(err);
 					}
-					return rounds.generateDelegateList(1, null).then(() => done());
+					return dpos.getRoundDelegates(1).then(() => done());
 				},
 			);
 		});

--- a/framework/test/mocha/integration/common.js
+++ b/framework/test/mocha/integration/common.js
@@ -45,8 +45,8 @@ function getDelegateForSlot(library, slot, cb) {
 	library.modules.forger
 		.loadDelegates()
 		.then(() => {
-			library.modules.rounds
-				.generateDelegateList(round)
+			library.modules.dpos
+				.getRoundDelegates(round)
 				.then(list => {
 					const delegatePublicKey = list[slot % ACTIVE_DELEGATES];
 					return cb(null, delegatePublicKey);

--- a/framework/test/mocha/integration/rounds.js
+++ b/framework/test/mocha/integration/rounds.js
@@ -376,7 +376,7 @@ describe('rounds', () => {
 				return Promise.join(
 					getMemAccounts(),
 					getDelegates(),
-					library.modules.rounds.generateDelegateList(tick.before.round, null),
+					library.modules.dpos.getRoundDelegates(tick.before.round),
 					Queries.getDelegatesOrderedByVote(),
 					(_accounts, _delegates, _delegatesList, _delegatesOrderedByVote) => {
 						tick.before.accounts = _.cloneDeep(_accounts);
@@ -400,9 +400,8 @@ describe('rounds', () => {
 							return Promise.join(
 								getMemAccounts(),
 								getDelegates(),
-								library.modules.rounds.generateDelegateList(
+								library.modules.dpos.getRoundDelegates(
 									slots.calcRound(tick.after.block.height + 1),
-									null,
 								),
 								Queries.getDelegatesOrderedByVote(),
 								(
@@ -586,9 +585,8 @@ describe('rounds', () => {
 			return Promise.join(
 				getMemAccounts(),
 				getDelegates(),
-				library.modules.rounds.generateDelegateList(
+				library.modules.dpos.getRoundDelegates(
 					slots.calcRound(lastBlock.height),
-					null,
 				),
 				(_accounts, _delegates, _delegatesList) => {
 					// Get genesis accounts address - should be senderId from first transaction
@@ -751,11 +749,11 @@ describe('rounds', () => {
 
 			it('should generate a different delegate list than one generated at the beginning of round 1', async () => {
 				const lastBlock = library.modules.blocks.lastBlock;
-				return library.modules.rounds
-					.generateDelegateList(slots.calcRound(lastBlock.height + 1), null)
-					.then(delegatesList => {
-						expect(delegatesList).to.not.deep.equal(round.delegatesList);
-					});
+				const delegatesList = await library.modules.dpos.getRoundDelegates(
+					slots.calcRound(lastBlock.height + 1),
+				);
+
+				return expect(delegatesList).to.not.deep.equal(round.delegatesList);
 			});
 		});
 
@@ -806,11 +804,8 @@ describe('rounds', () => {
 
 			it('delegates list should be equal to one generated at the beginning of round 1', async () => {
 				const freshLastBlock = library.modules.blocks.lastBlock;
-				return library.modules.rounds
-					.generateDelegateList(
-						slots.calcRound(freshLastBlock.height + 1),
-						null,
-					)
+				return library.modules.dpos
+					.getRoundDelegates(slots.calcRound(freshLastBlock.height + 1))
 					.then(delegatesList => {
 						expect(delegatesList).to.deep.equal(round.delegatesList);
 					});
@@ -837,8 +832,8 @@ describe('rounds', () => {
 
 			it('delegates list should be equal to one generated at the beginning of round 1', async () => {
 				const lastBlock = library.modules.blocks.lastBlock;
-				return library.modules.rounds
-					.generateDelegateList(slots.calcRound(lastBlock.height + 1), null)
+				return library.modules.dpos
+					.getRoundDelegates(slots.calcRound(lastBlock.height + 1))
 					.then(delegatesList => {
 						expect(delegatesList).to.deep.equal(round.delegatesList);
 					});
@@ -923,11 +918,8 @@ describe('rounds', () => {
 			describe('after round finish', () => {
 				it('delegates list should be different than one generated at the beginning of round 1', async () => {
 					const freshLastBlock = library.modules.blocks.lastBlock;
-					return library.modules.rounds
-						.generateDelegateList(
-							slots.calcRound(freshLastBlock.height + 1),
-							null,
-						)
+					return library.modules.dpos
+						.getRoundDelegates(slots.calcRound(freshLastBlock.height + 1))
 						.then(delegatesList => {
 							expect(delegatesList).to.not.deep.equal(round.delegatesList);
 						});
@@ -950,11 +942,8 @@ describe('rounds', () => {
 						.then(newLastBlock => {
 							library.modules.blocks._lastBlock = newLastBlock;
 							const freshLastBlock = library.modules.blocks.lastBlock;
-							return library.modules.rounds
-								.generateDelegateList(
-									slots.calcRound(freshLastBlock.height),
-									null,
-								)
+							return library.modules.dpos
+								.getRoundDelegates(slots.calcRound(freshLastBlock.height))
 								.then(delegatesList => {
 									expect(delegatesList).to.deep.equal(round.delegatesList);
 								});
@@ -1058,9 +1047,8 @@ describe('rounds', () => {
 
 					return Promise.join(
 						getDelegates(),
-						library.modules.rounds.generateDelegateList(
+						library.modules.dpos.getRoundDelegates(
 							slots.calcRound(lastBlock.height + 1),
-							null,
 						),
 						(_delegates, _delegatesList) => {
 							delegatesList = _delegatesList;
@@ -1113,8 +1101,8 @@ describe('rounds', () => {
 						.then(newLastBlock => {
 							library.modules.blocks._lastBlock = newLastBlock;
 							lastBlock = library.modules.blocks.lastBlock;
-							return library.modules.rounds
-								.generateDelegateList(slots.calcRound(lastBlock.height), null)
+							return library.modules.dpos
+								.getRoundDelegates(slots.calcRound(lastBlock.height))
 								.then(delegatesList => {
 									expect(delegatesList).to.deep.equal(round.delegatesList);
 								});

--- a/framework/test/mocha/integration/rounds.js
+++ b/framework/test/mocha/integration/rounds.js
@@ -1074,11 +1074,15 @@ describe('rounds', () => {
 					return expect(delegatesList).to.not.deep.equal(round.delegatesList);
 				});
 
-				it('unvoted delegate should not be on list', async () => {
+				// TODO: to be unskiped on https://github.com/LiskHQ/lisk-sdk/issues/4147
+				// eslint-disable-next-line mocha/no-skipped-tests
+				it.skip('unvoted delegate should not be on list', async () => {
 					return expect(delegatesList).to.not.contain(lastBlockForger);
 				});
 
-				it('delegate who replaced unvoted one should be on list', async () => {
+				// TODO: to be unskiped on https://github.com/LiskHQ/lisk-sdk/issues/4147
+				// eslint-disable-next-line mocha/no-skipped-tests
+				it.skip('delegate who replaced unvoted one should be on list', async () => {
 					return expect(delegatesList).to.contain(tmpAccount.publicKey);
 				});
 

--- a/framework/test/mocha/integration/rounds.js
+++ b/framework/test/mocha/integration/rounds.js
@@ -804,11 +804,10 @@ describe('rounds', () => {
 
 			it('delegates list should be equal to one generated at the beginning of round 1', async () => {
 				const freshLastBlock = library.modules.blocks.lastBlock;
-				return library.modules.dpos
-					.getRoundDelegates(slots.calcRound(freshLastBlock.height + 1))
-					.then(delegatesList => {
-						expect(delegatesList).to.deep.equal(round.delegatesList);
-					});
+				const delegatesList = await library.modules.dpos.getRoundDelegates(
+					slots.calcRound(freshLastBlock.height + 1),
+				);
+				return expect(delegatesList).to.deep.equal(round.delegatesList);
 			});
 		});
 
@@ -832,11 +831,10 @@ describe('rounds', () => {
 
 			it('delegates list should be equal to one generated at the beginning of round 1', async () => {
 				const lastBlock = library.modules.blocks.lastBlock;
-				return library.modules.dpos
-					.getRoundDelegates(slots.calcRound(lastBlock.height + 1))
-					.then(delegatesList => {
-						expect(delegatesList).to.deep.equal(round.delegatesList);
-					});
+				const delegatesList = await library.modules.dpos.getRoundDelegates(
+					slots.calcRound(lastBlock.height + 1),
+				);
+				return expect(delegatesList).to.deep.equal(round.delegatesList);
 			});
 		});
 
@@ -918,11 +916,10 @@ describe('rounds', () => {
 			describe('after round finish', () => {
 				it('delegates list should be different than one generated at the beginning of round 1', async () => {
 					const freshLastBlock = library.modules.blocks.lastBlock;
-					return library.modules.dpos
-						.getRoundDelegates(slots.calcRound(freshLastBlock.height + 1))
-						.then(delegatesList => {
-							expect(delegatesList).to.not.deep.equal(round.delegatesList);
-						});
+					const delegatesList = await library.modules.dpos.getRoundDelegates(
+						slots.calcRound(freshLastBlock.height + 1),
+					);
+					return expect(delegatesList).to.not.deep.equal(round.delegatesList);
 				});
 
 				it('forger of last block of previous round should have vote = 0', async () => {
@@ -937,17 +934,15 @@ describe('rounds', () => {
 
 			describe('after last block of round is deleted', () => {
 				it('delegates list should be equal to one generated at the beginning of round 1', async () => {
-					return library.modules.blocks.blocksChain
-						.deleteLastBlock(library.modules.blocks.lastBlock)
-						.then(newLastBlock => {
-							library.modules.blocks._lastBlock = newLastBlock;
-							const freshLastBlock = library.modules.blocks.lastBlock;
-							return library.modules.dpos
-								.getRoundDelegates(slots.calcRound(freshLastBlock.height))
-								.then(delegatesList => {
-									expect(delegatesList).to.deep.equal(round.delegatesList);
-								});
-						});
+					const newLastBlock = await library.modules.blocks.blocksChain.deleteLastBlock(
+						library.modules.blocks.lastBlock,
+					);
+					library.modules.blocks._lastBlock = newLastBlock;
+					const freshLastBlock = library.modules.blocks.lastBlock;
+					const delegatesList = await library.modules.dpos.getRoundDelegates(
+						slots.calcRound(freshLastBlock.height),
+					);
+					return expect(delegatesList).to.deep.equal(round.delegatesList);
 				});
 
 				it('expected forger of last block of round should have proper votes again', async () => {
@@ -1100,17 +1095,15 @@ describe('rounds', () => {
 
 			describe('after last block of round is deleted', () => {
 				it('delegates list should be equal to one generated at the beginning of round 1', async () => {
-					return library.modules.blocks.blocksChain
-						.deleteLastBlock(library.modules.blocks.lastBlock)
-						.then(newLastBlock => {
-							library.modules.blocks._lastBlock = newLastBlock;
-							lastBlock = library.modules.blocks.lastBlock;
-							return library.modules.dpos
-								.getRoundDelegates(slots.calcRound(lastBlock.height))
-								.then(delegatesList => {
-									expect(delegatesList).to.deep.equal(round.delegatesList);
-								});
-						});
+					const newLastBlock = await library.modules.blocks.blocksChain.deleteLastBlock(
+						library.modules.blocks.lastBlock,
+					);
+					library.modules.blocks._lastBlock = newLastBlock;
+					lastBlock = library.modules.blocks.lastBlock;
+					const delegatesList = await library.modules.dpos.getRoundDelegates(
+						slots.calcRound(lastBlock.height),
+					);
+					return expect(delegatesList).to.deep.equal(round.delegatesList);
 				});
 
 				it('last block height should be at height 100', async () => {

--- a/framework/test/mocha/unit/modules/chain/forger.js
+++ b/framework/test/mocha/unit/modules/chain/forger.js
@@ -69,8 +69,8 @@ describe('forge', () => {
 					calcRound: sinonSandbox.stub(),
 					getRealTime: sinonSandbox.stub(),
 				},
-				roundsModule: {
-					generateDelegateList: sinonSandbox.stub(),
+				dposModule: {
+					getRoundDelegates: sinonSandbox.stub(),
 				},
 				transactionPoolModule: {
 					getUnconfirmedTransactionList: sinonSandbox.stub(),
@@ -973,7 +973,7 @@ describe('forge', () => {
 		let genesis1Keypair;
 		let genesis2Keypair;
 		let genesis3Keypair;
-		let delegatesModuleStub;
+		let dposModuleStub;
 
 		beforeEach(async () => {
 			const genesis1KeypairBuffer = getPrivateAndPublicKeyBytesFromPassphrase(
@@ -1002,8 +1002,8 @@ describe('forge', () => {
 			forgeModule.keypairs[genesis2.publicKey] = genesis2Keypair;
 			forgeModule.keypairs[genesis3.publicKey] = genesis3Keypair;
 
-			delegatesModuleStub = {
-				generateDelegateList: sinonSandbox.stub(),
+			dposModuleStub = {
+				getRoundDelegates: sinonSandbox.stub(),
 			};
 		});
 
@@ -1012,12 +1012,12 @@ describe('forge', () => {
 			const currentSlot = 35;
 			const round = 1;
 
-			delegatesModuleStub.generateDelegateList
+			dposModuleStub.getRoundDelegates
 				.withArgs(round)
 				.resolves(delegatesRoundsList[round]);
 
 			const { publicKey, privateKey } = await getDelegateKeypairForCurrentSlot(
-				delegatesModuleStub,
+				dposModuleStub,
 				forgeModule.keypairs,
 				currentSlot,
 				round,
@@ -1032,12 +1032,10 @@ describe('forge', () => {
 			const currentSlot = 578;
 			const round = 2;
 
-			delegatesModuleStub.generateDelegateList.resolves(
-				delegatesRoundsList[round],
-			);
+			dposModuleStub.getRoundDelegates.resolves(delegatesRoundsList[round]);
 
 			const { publicKey, privateKey } = await getDelegateKeypairForCurrentSlot(
-				delegatesModuleStub,
+				dposModuleStub,
 				forgeModule.keypairs,
 				currentSlot,
 				round,
@@ -1052,12 +1050,10 @@ describe('forge', () => {
 			const currentSlot = 1051;
 			const round = 3;
 
-			delegatesModuleStub.generateDelegateList.resolves(
-				delegatesRoundsList[round],
-			);
+			dposModuleStub.getRoundDelegates.resolves(delegatesRoundsList[round]);
 
 			const { publicKey, privateKey } = await getDelegateKeypairForCurrentSlot(
-				delegatesModuleStub,
+				dposModuleStub,
 				forgeModule.keypairs,
 				currentSlot,
 				round,
@@ -1073,12 +1069,10 @@ describe('forge', () => {
 			const currentSlot = 1;
 			const round = 4;
 
-			delegatesModuleStub.generateDelegateList.resolves(
-				delegatesRoundsList[round],
-			);
+			dposModuleStub.getRoundDelegates.resolves(delegatesRoundsList[round]);
 
 			const keyPair = await getDelegateKeypairForCurrentSlot(
-				delegatesModuleStub,
+				dposModuleStub,
 				forgeModule.keypairs,
 				currentSlot,
 				round,
@@ -1087,17 +1081,17 @@ describe('forge', () => {
 			expect(keyPair).to.be.null;
 		});
 
-		it('should return error when `generateDelegateList` fails', async () => {
+		it('should return error when `getRoundDelegates` fails', async () => {
 			const currentSlot = 1;
 			const round = 4;
 
-			const expectedError = new Error('generateDelegateList error');
+			const expectedError = new Error('getRoundDelegates error');
 
-			delegatesModuleStub.generateDelegateList.rejects(expectedError);
+			dposModuleStub.getRoundDelegates.rejects(expectedError);
 
 			try {
 				await getDelegateKeypairForCurrentSlot(
-					delegatesModuleStub,
+					dposModuleStub,
 					forgeModule.keypairs,
 					currentSlot,
 					round,

--- a/framework/test/mocha/unit/modules/chain/submodules/rounds.js
+++ b/framework/test/mocha/unit/modules/chain/submodules/rounds.js
@@ -73,21 +73,6 @@ describe('rounds', () => {
 		storageStubs,
 	);
 
-	const bindings = {
-		components: {
-			cache: {
-				isReady: sinon.stub(),
-				removeByPattern: sinon.stub(),
-			},
-		},
-		modules: {
-			rounds: {
-				generateDelegateList: sinon.stub(),
-				clearDelegateListCache: sinon.stub(),
-			},
-		},
-	};
-
 	const validScope = {
 		components: { logger, storage },
 		channel: {
@@ -112,12 +97,6 @@ describe('rounds', () => {
 
 	beforeEach(done => {
 		scope = _.cloneDeep(validScope);
-
-		bindings.modules.rounds.generateDelegateList.resolves([
-			'delegate1',
-			'delegate2',
-			'delegate3',
-		]);
 
 		sinonSandbox.stub(cryptography, 'getAddressFromPublicKey');
 		cryptography.getAddressFromPublicKey

--- a/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
@@ -367,9 +367,9 @@ describe('delegates/api', () => {
 			);
 		});
 
-		it('should call channel.invoke with chain:generateDelegateList action', async () => {
+		it('should call channel.invoke with chain:getRoundDelegates action', async () => {
 			expect(channelStub.invoke.getCall(4)).to.be.calledWith(
-				'chain:generateDelegateList',
+				'chain:getRoundDelegates',
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
`rounds.generateDelegateList` still being used in the codebase

### How did I solve it?
By replacing every use of `rounds.generateDelegateList` by `dpos.getRoundDelegates`.

During the replacement, it was identified an issue with `dpos.getRoundDelegates` -> https://github.com/LiskHQ/lisk-sdk/issues/4147
Because of this issue, two tests were skipped and should be unskipped as part of its fix.

### How to manually test it?
Green build
Should sync on testnet at least up to height 10000

### Review checklist

- [x] The PR resolves #4152
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
