### PR TITLE
Implement verify blockslot forger - Closes #4144

### DIFF
--- a/framework/src/modules/chain/dpos/delegates_list.js
+++ b/framework/src/modules/chain/dpos/delegates_list.js
@@ -111,12 +111,12 @@ class DelegatesList extends EventEmitter {
 
 		if (!delegateList.length) {
 			throw new Error(
-				`Failed to verify slot: ${currentSlot} - No delegateList was found`,
+				`Failed to verify slot: ${currentSlot} for block ID: ${block.id} - No delegateList was found`,
 			);
 		}
 
-		// Get delegate key that forged this block
-		const delegatePubKey = delegateList[currentSlot % this.activeDelegates];
+		// Get delegate public key that was supposed to forge the block
+		const expectedForgerPublicKey = delegateList[currentSlot % this.activeDelegates];
 
 		// Verify if forger exists and matches the generatorPublicKey on block
 		if (!delegatePubKey || block.generatorPublicKey !== delegatePubKey) {

--- a/framework/src/modules/chain/dpos/delegates_list.js
+++ b/framework/src/modules/chain/dpos/delegates_list.js
@@ -111,15 +111,21 @@ class DelegatesList extends EventEmitter {
 
 		if (!delegateList.length) {
 			throw new Error(
-				`Failed to verify slot: ${currentSlot} for block ID: ${block.id} - No delegateList was found`,
+				`Failed to verify slot: ${currentSlot} for block ID: ${
+					block.id
+				} - No delegateList was found`,
 			);
 		}
 
 		// Get delegate public key that was supposed to forge the block
-		const expectedForgerPublicKey = delegateList[currentSlot % this.activeDelegates];
+		const expectedForgerPublicKey =
+			delegateList[currentSlot % this.activeDelegates];
 
 		// Verify if forger exists and matches the generatorPublicKey on block
-		if (!delegatePubKey || block.generatorPublicKey !== delegatePubKey) {
+		if (
+			!expectedForgerPublicKey ||
+			block.generatorPublicKey !== expectedForgerPublicKey
+		) {
 			throw new Error(`Failed to verify slot: ${currentSlot}`);
 		}
 

--- a/framework/src/modules/chain/dpos/delegates_list.js
+++ b/framework/src/modules/chain/dpos/delegates_list.js
@@ -119,11 +119,11 @@ class DelegatesList extends EventEmitter {
 		const delegatePubKey = delegateList[currentSlot % this.activeDelegates];
 
 		// Verify if forger exists and matches the generatorPublicKey on block
-		if (delegatePubKey && block.generatorPublicKey === delegatePubKey) {
-			return true;
+		if (!delegatePubKey || block.generatorPublicKey !== delegatePubKey) {
+			throw new Error(`Failed to verify slot: ${currentSlot}`);
 		}
 
-		throw new Error(`Failed to verify slot: ${currentSlot}`);
+		return true;
 	}
 }
 

--- a/framework/src/modules/chain/dpos/delegates_list.js
+++ b/framework/src/modules/chain/dpos/delegates_list.js
@@ -101,6 +101,8 @@ class DelegatesList extends EventEmitter {
 	 * Validates if block was forged by correct delegate
 	 *
 	 * @param {Object} block
+	 * @return {Boolean} - `true`
+	 * @throw {Error} Failed to verify slot
 	 */
 	async verifyBlockForger(block) {
 		const currentSlot = this.slots.getSlotNumber(block.timestamp);

--- a/framework/src/modules/chain/dpos/dpos.js
+++ b/framework/src/modules/chain/dpos/dpos.js
@@ -28,7 +28,13 @@ module.exports = class Dpos {
 	}) {
 		this.finalizedBlockRound = 0;
 		this.slots = slots;
-		this.delegatesList = new DelegatesList({ storage, logger, exceptions });
+		this.delegatesList = new DelegatesList({
+			storage,
+			logger,
+			slots,
+			activeDelegates,
+			exceptions,
+		});
 		this.delegatesInfo = new DelegatesInfo({
 			storage,
 			slots,
@@ -60,6 +66,10 @@ module.exports = class Dpos {
 		await this.delegatesList.deleteDelegateListUntilRound(
 			disposableDelegateList,
 		);
+	}
+
+	async verifyBlockForger(block) {
+		return this.delegatesList.verifyBlockForger(block);
 	}
 
 	async apply(block, tx) {

--- a/framework/test/jest/unit/specs/modules/chain/dpos/verifyBlockForger.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/dpos/verifyBlockForger.spec.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const { Dpos, Slots } = require('../../../../../../../src/modules/chain/dpos');
+const { constants } = require('../../../../utils');
+const { delegatePublicKeys } = require('./round_delegates');
+
+describe('dpos.verifyBlockForger()', () => {
+	describe('When DPoS returns correct delegate list', () => {
+		const stubs = {};
+		let dpos;
+		let slots;
+
+		beforeEach(() => {
+			// Arrange
+			stubs.storage = {
+				entities: {
+					RoundDelegates: {
+						getRoundDelegates: jest.fn().mockReturnValue(delegatePublicKeys),
+					},
+				},
+			};
+
+			stubs.logger = {
+				debug: jest.fn(),
+				log: jest.fn(),
+				error: jest.fn(),
+			};
+
+			slots = new Slots({
+				epochTime: constants.EPOCH_TIME,
+				interval: constants.BLOCK_TIME,
+				blocksPerRound: constants.ACTIVE_DELEGATES,
+			});
+
+			dpos = new Dpos({
+				slots,
+				...stubs,
+				activeDelegates: constants.ACTIVE_DELEGATES,
+			});
+		});
+
+		it('should resolve with "true" when block is forged by correct delegate', async () => {
+			// Arrange
+			const block = {
+				height: 302,
+				timestamp: 23450,
+				generatorPublicKey:
+					'6fb2e0882cd9d895e1e441b9f9be7f98e877aa0a16ae230ee5caceb7a1b896ae',
+			};
+
+			// Act
+			const result = await dpos.verifyBlockForger(block);
+
+			// Assert
+			expect(result).toBeTrue();
+		});
+
+		it('should throw error if block is forged by incorrect delegate', async () => {
+			// Arrange
+			const block = {
+				height: 302,
+				timestamp: 23450,
+				generatorPublicKey: 'xxx',
+			};
+
+			const expectedSlot = slots.getSlotNumber(block.timestamp);
+
+			// Act && Assert
+			const error = new Error(`Failed to verify slot: ${expectedSlot}`);
+			await expect(dpos.verifyBlockForger(block)).rejects.toEqual(error);
+		});
+	});
+
+	describe('When DPoS returns empty delegate list', () => {
+		const stubs = {};
+		let dpos;
+		let slots;
+
+		beforeEach(() => {
+			// Arrange
+			stubs.storage = {
+				entities: {
+					RoundDelegates: {
+						getRoundDelegates: jest.fn().mockReturnValue([]),
+						create: jest.fn(),
+					},
+					Account: {
+						get: jest.fn().mockReturnValue([]),
+					},
+				},
+			};
+
+			stubs.logger = {
+				debug: jest.fn(),
+				log: jest.fn(),
+				error: jest.fn(),
+			};
+
+			slots = new Slots({
+				epochTime: constants.EPOCH_TIME,
+				interval: constants.BLOCK_TIME,
+				blocksPerRound: constants.ACTIVE_DELEGATES,
+			});
+
+			dpos = new Dpos({
+				slots,
+				...stubs,
+				activeDelegates: constants.ACTIVE_DELEGATES,
+			});
+		});
+
+		it('should throw error if no delegate list is found', async () => {
+			// Arrange
+			const block = {
+				height: 302,
+				timestamp: 23450,
+				generatorPublicKey: 'xxx',
+			};
+
+			const expectedSlot = slots.getSlotNumber(block.timestamp);
+
+			// Act && Assert
+			const error = new Error(
+				`Failed to verify slot: ${expectedSlot} - No delegateList was found`,
+			);
+			await expect(dpos.verifyBlockForger(block)).rejects.toEqual(error);
+		});
+	});
+});

--- a/framework/test/jest/unit/specs/modules/chain/dpos/verifyBlockForger.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/dpos/verifyBlockForger.spec.js
@@ -93,6 +93,7 @@ describe('dpos.verifyBlockForger()', () => {
 			[],
 		);
 		const block = {
+			id: 'myid',
 			height: 302,
 			timestamp: 23450,
 			generatorPublicKey: 'xxx',
@@ -102,7 +103,9 @@ describe('dpos.verifyBlockForger()', () => {
 
 		// Act && Assert
 		const error = new Error(
-			`Failed to verify slot: ${expectedSlot} - No delegateList was found`,
+			`Failed to verify slot: ${expectedSlot} for block ID: ${
+				block.id
+			} - No delegateList was found`,
 		);
 		await expect(dpos.verifyBlockForger(block)).rejects.toEqual(error);
 	});


### PR DESCRIPTION
### What was the problem?
Dpos module should expose a method to validate if a given block was forged by the expected delegate.

### How did I solve it?
Add functionality inside `framework/src/modules/chain/dpos/delegates_list.js` to verify if the block was forged by the right delegate public key.

### How to manually test it?
`npm run jest:unit -- test/jest/unit/specs/modules/chain/dpos/verifyBlockForger.spec.js`

### Review checklist

- [x] The PR resolves #4144 
- [x] All new code is covered with unit tests
- ~[ ] Relevant integration / functional tests are added~
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
