### PR TITLE
If an existing peer tries to connect to us, the inbound connection is kept even though they are not added to our peer list - Closes #4170

### DIFF
--- a/elements/lisk-p2p/src/disconnect_status_codes.ts
+++ b/elements/lisk-p2p/src/disconnect_status_codes.ts
@@ -35,8 +35,10 @@ export const INCOMPATIBLE_PEER_CODE = 4104;
 export const INCOMPATIBLE_PEER_UNKNOWN_REASON =
 	'Peer is incompatible with the node for unknown reasons';
 
-// First case to follow HTTP status codes
 export const FORBIDDEN_CONNECTION = 4403;
 export const FORBIDDEN_CONNECTION_REASON = 'Peer is not allowed to connect';
+
+export const DUPLICATE_CONNECTION = 4404;
+export const DUPLICATE_CONNECTION_REASON = 'Peer has a duplicate connection';
 
 export const EVICTED_PEER_CODE = 4418;

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -29,6 +29,8 @@ import { REMOTE_RPC_GET_PEERS_LIST } from './peer';
 import { PeerBook } from './peer_directory';
 
 import {
+	DUPLICATE_CONNECTION,
+	DUPLICATE_CONNECTION_REASON,
 	FORBIDDEN_CONNECTION,
 	FORBIDDEN_CONNECTION_REASON,
 	INCOMPATIBLE_PEER_CODE,
@@ -728,7 +730,13 @@ export class P2P extends EventEmitter {
 
 				const existingPeer = this._peerPool.getPeer(peerId);
 
-				if (!existingPeer) {
+				if (existingPeer) {
+					this._disconnectSocketDueToFailedHandshake(
+						socket,
+						DUPLICATE_CONNECTION,
+						DUPLICATE_CONNECTION_REASON,
+					);
+				} else {
 					this._peerPool.addInboundPeer(incomingPeerInfo, socket);
 					this.emit(EVENT_NEW_INBOUND_PEER, incomingPeerInfo);
 					this.emit(EVENT_NEW_PEER, incomingPeerInfo);

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -136,7 +136,6 @@ export interface PeerConfig {
 	readonly maxPeerInfoSize: number;
 	readonly maxPeerDiscoveryResponseLength: number;
 	readonly secret: number;
-	readonly banTime?: number;
 }
 
 export class Peer extends EventEmitter {

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -136,6 +136,7 @@ export interface PeerConfig {
 	readonly maxPeerInfoSize: number;
 	readonly maxPeerDiscoveryResponseLength: number;
 	readonly secret: number;
+	readonly banTime?: number;
 }
 
 export class Peer extends EventEmitter {

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -189,28 +189,15 @@ export class PeerPool extends EventEmitter {
 	private readonly _peerSelectForConnection: P2PPeerSelectionForConnectionFunction;
 	private readonly _sendPeerLimit: number;
 	private readonly _outboundShuffleIntervalId: NodeJS.Timer | undefined;
-	private readonly _inboundPeerConfig: PeerConfig;
-	private readonly _outboundPeerConfig: PeerConfig;
+	private readonly _peerConfig: PeerConfig;
 
 	public constructor(peerPoolConfig: PeerPoolConfig) {
 		super();
 		this._peerMap = new Map();
 		this._peerPoolConfig = peerPoolConfig;
-		this._inboundPeerConfig = {
+		this._peerConfig = {
 			connectTimeout: this._peerPoolConfig.connectTimeout,
 			ackTimeout: this._peerPoolConfig.ackTimeout,
-			wsMaxMessageRate: this._peerPoolConfig.wsMaxMessageRate,
-			wsMaxMessageRatePenalty: this._peerPoolConfig.wsMaxMessageRatePenalty,
-			maxPeerDiscoveryResponseLength: this._peerPoolConfig
-				.maxPeerDiscoveryResponseLength,
-			maxPeerInfoSize: this._peerPoolConfig.maxPeerInfoSize,
-			rateCalculationInterval: this._peerPoolConfig.rateCalculationInterval,
-			secret: this._peerPoolConfig.secret,
-		};
-		this._outboundPeerConfig = {
-			connectTimeout: this._peerPoolConfig.connectTimeout,
-			ackTimeout: this._peerPoolConfig.ackTimeout,
-			banTime: this._peerPoolConfig.peerBanTime,
 			wsMaxMessageRate: this._peerPoolConfig.wsMaxMessageRate,
 			wsMaxMessageRatePenalty: this._peerPoolConfig.wsMaxMessageRatePenalty,
 			maxPeerDiscoveryResponseLength: this._peerPoolConfig
@@ -337,12 +324,8 @@ export class PeerPool extends EventEmitter {
 		return this._nodeInfo;
 	}
 
-	public get outboundPeerConfig(): PeerConfig {
-		return { ...this._outboundPeerConfig };
-	}
-
-	public get inboundPeerConfig(): PeerConfig {
-		return { ...this._inboundPeerConfig };
+	public get peerConfig(): PeerConfig {
+		return { ...this._peerConfig };
 	}
 
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
@@ -464,7 +447,7 @@ export class PeerPool extends EventEmitter {
 		}
 
 		const peer = new InboundPeer(peerInfo, socket, {
-			...this._inboundPeerConfig,
+			...this._peerConfig,
 		});
 
 		// Throw an error because adding a peer multiple times is a common developer error which is very difficult to identify and debug.
@@ -487,7 +470,7 @@ export class PeerPool extends EventEmitter {
 			return existingPeer;
 		}
 
-		const peer = new OutboundPeer(peerInfo, { ...this._outboundPeerConfig });
+		const peer = new OutboundPeer(peerInfo, { ...this._peerConfig });
 
 		this._peerMap.set(peer.id, peer);
 		this._bindHandlersToPeer(peer);

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -958,7 +958,7 @@ describe('Integration tests for P2P library', () => {
 				)[0] as InboundPeer;
 				firstPeerDuplicate = new OutboundPeer(
 					existingPeer.peerInfo,
-					firstP2PNode['_peerPool'].outboundPeerConfig,
+					firstP2PNode['_peerPool'].peerConfig,
 				);
 
 				firstPeerDuplicate.on(EVENT_CLOSE_OUTBOUND, (event: any) => {

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -14,7 +14,7 @@
  */
 
 import { expect } from 'chai';
-import { P2P, EVENT_REMOVE_PEER } from '../../src/index';
+import { P2P, EVENT_REMOVE_PEER, EVENT_CLOSE_OUTBOUND } from '../../src/index';
 import { wait } from '../utils/helpers';
 import { platform } from 'os';
 import {
@@ -25,7 +25,7 @@ import {
 	P2PPeerSelectionForRequestInput,
 	P2PPeerSelectionForConnectionInput,
 } from '../../src/p2p_types';
-import { InboundPeer } from '../../src/peer';
+import { InboundPeer, OutboundPeer, ConnectionState } from '../../src/peer';
 import { SCServerSocket } from 'socketcluster-server';
 import * as url from 'url';
 import cloneDeep = require('lodash.clonedeep');
@@ -121,9 +121,9 @@ describe('Integration tests for P2P library', () => {
 					seedPeers,
 					wsEngine: 'ws',
 					connectTimeout: 100,
-					ackTimeout: 200,
+					ackTimeout: 100,
 					peerBanTime: 100,
-					populatorInterval: POPULATOR_INTERVAL,
+					populatorInterval: 100,
 					maxOutboundConnections: DEFAULT_MAX_OUTBOUND_CONNECTIONS,
 					maxInboundConnections: DEFAULT_MAX_INBOUND_CONNECTIONS,
 					nodeInfo: {
@@ -148,7 +148,7 @@ describe('Integration tests for P2P library', () => {
 		describe('Peer discovery', () => {
 			it('should discover all peers in the network after a few cycles of discovery', async () => {
 				// Wait for a few cycles of discovery.
-				await wait(POPULATOR_INTERVAL * 10);
+				await wait(POPULATOR_INTERVAL * 15);
 
 				for (let p2p of p2pNodeList) {
 					const peerPorts = p2p
@@ -939,6 +939,64 @@ describe('Integration tests for P2P library', () => {
 				expect(peerPortsAfterPeerCrash).to.be.eql(
 					expectedPeerPortsAfterPeerCrash,
 				);
+			});
+		});
+
+		describe('Disconnect duplicate peers', () => {
+			let firstP2PNodeCloseEvents: Array<any> = [];
+			let firstPeerCloseEvents: Array<any> = [];
+			let firstPeerErrors: Array<any> = [];
+			let firstPeerDuplicate: OutboundPeer;
+			let firstP2PNode: P2P;
+			let existingPeer: InboundPeer;
+
+			beforeEach(async () => {
+				firstP2PNode = p2pNodeList[0];
+				firstPeerCloseEvents = [];
+				existingPeer = firstP2PNode['_peerPool'].getPeers(
+					InboundPeer,
+				)[0] as InboundPeer;
+				firstPeerDuplicate = new OutboundPeer(
+					existingPeer.peerInfo,
+					firstP2PNode['_peerPool'].outboundPeerConfig,
+				);
+
+				firstPeerDuplicate.on(EVENT_CLOSE_OUTBOUND, (event: any) => {
+					firstPeerCloseEvents.push(event);
+				});
+
+				try {
+					// This will create a connection.
+					await firstPeerDuplicate.applyNodeInfo(firstP2PNode.nodeInfo);
+				} catch (error) {
+					firstPeerErrors.push(error);
+				}
+
+				firstP2PNode.on(EVENT_CLOSE_OUTBOUND, event => {
+					firstP2PNodeCloseEvents.push(event);
+				});
+				await wait(100);
+			});
+			afterEach(() => {
+				firstPeerDuplicate.removeAllListeners(EVENT_CLOSE_OUTBOUND);
+				firstP2PNode.removeAllListeners(EVENT_CLOSE_OUTBOUND);
+				firstPeerDuplicate.disconnect();
+			});
+
+			// Simulate legacy behaviour where the node tries to connect back to an inbound peer.
+			it('should remove a peer if they try to connect but they are already connected', async () => {
+				expect(firstPeerErrors).to.have.length(1);
+				expect(firstPeerErrors[0])
+					.to.have.property('name')
+					.which.equals('BadConnectionError');
+				expect(firstPeerErrors[0])
+					.to.have.property('name')
+					.which.equals('BadConnectionError');
+				expect(firstPeerDuplicate)
+					.to.have.property('state')
+					.which.equals(ConnectionState.CLOSED);
+				// Disconnecting our new outbound socket should not cause the existing inbound peer instance to be removed.
+				expect(firstP2PNodeCloseEvents).to.be.empty;
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

In one of the `if` conditions where we refuse to add the inbound peer, we forget to disconnect their socket.

### How did I solve it?

- Disconnect the inbound socket with a relevant code/message.
- The test case related to peer discovery had to be adjusted to account for a small change in discovery time.

### How to manually test it?

A new integration test case was added.

Run `npm test`

### Review checklist

- [ ] The PR resolves #4170
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
