### PR TITLE
Make /delegates/forgers BFT compliant - Closes #3684

### DIFF
--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -99,7 +99,7 @@ async function _getForgers(filters) {
 	});
 
 	const activeDelegates = await channel.invoke('chain:getRoundDelegates', {
-		round: currentRound,
+		round: currentRound - 2,
 	});
 
 	for (


### PR DESCRIPTION
### What was the problem?

### How did I solve it?
Use round `-2` as the offset defined in DPoS is `2`.
`framework/src/modules/chain/dpos/dpos.js:63`

### How to manually test it?
Check if the delegate list is different for each slot if you compare with and without `-2`.
Opened another issue to update all tests related to delegates here `framework/test/mocha/unit/modules/http_api/controllers/delegates.js` as they are only testing private methods.

### Review checklist

- [x] The PR resolves #3684  
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
