### PR TITLE
The rate limiter is not banning peers - Closes #4180

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -127,7 +127,7 @@ export const DEFAULT_POPULATOR_INTERVAL = 10000;
 export const DEFAULT_SEND_PEER_LIMIT = 25;
 // Max rate of WebSocket messages per second per peer.
 export const DEFAULT_WS_MAX_MESSAGE_RATE = 100;
-export const DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY = 10;
+export const DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY = 100;
 export const DEFAULT_RATE_CALCULATION_INTERVAL = 1000;
 export const DEFAULT_WS_MAX_PAYLOAD = 3048576; // Size in bytes
 

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -210,7 +210,6 @@ export class Peer extends EventEmitter {
 			this._wsMessageCount = 0;
 
 			if (this._wsMessageRate > this._peerConfig.wsMaxMessageRate) {
-				this.disconnect(FORBIDDEN_CONNECTION, FORBIDDEN_CONNECTION_REASON);
 				this.applyPenalty(this._peerConfig.wsMaxMessageRatePenalty);
 
 				return;


### PR DESCRIPTION
### What was the problem?

The rate limit penalty applyPenalty action was never banning peers because disconnecting the peer caused the score to reset to 100.

### How did I solve it?

Do not disconnect the peer, simply execute an applyPenalty of 100 to ban and disconnect the peer immediately.

### How to manually test it?

`npm run test`

### Review checklist

- [ ] The PR resolves #4180
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
