### PR TITLE
Solve JavaScript heap out of memory - Closes #4183

### DIFF
--- a/framework/src/modules/chain/transactions/transactions_handlers.js
+++ b/framework/src/modules/chain/transactions/transactions_handlers.js
@@ -115,6 +115,7 @@ const applyGenesisTransactions = storage => async (
 		tx,
 	});
 
+	// Avoid merging both prepare statements into one for...of loop as this slows down the call dramatically
 	// eslint-disable-next-line no-restricted-syntax
 	for (const transaction of transactions) {
 		// eslint-disable-next-line no-await-in-loop

--- a/framework/src/modules/chain/transactions/transactions_handlers.js
+++ b/framework/src/modules/chain/transactions/transactions_handlers.js
@@ -115,8 +115,17 @@ const applyGenesisTransactions = storage => async (
 		tx,
 	});
 
-	await Promise.all(transactions.map(t => t.prepare(stateStore)));
-	await Promise.all(transactions.map(t => votesWeight.prepare(stateStore, t)));
+	// eslint-disable-next-line no-restricted-syntax
+	for (const transaction of transactions) {
+		// eslint-disable-next-line no-await-in-loop
+		await transaction.prepare(stateStore);
+	}
+
+	// eslint-disable-next-line no-restricted-syntax
+	for (const transaction of transactions) {
+		// eslint-disable-next-line no-await-in-loop
+		await votesWeight.prepare(stateStore, transaction);
+	}
 
 	const transactionsResponses = transactions.map(transaction => {
 		const transactionResponse = transaction.apply(stateStore);

--- a/framework/src/modules/chain/transactions/votes_weight.js
+++ b/framework/src/modules/chain/transactions/votes_weight.js
@@ -223,13 +223,13 @@ const prepare = async (stateStore, transaction) => {
 		...new Set([...senderVotedPublicKeys, ...recipientVotedPublicKeys]),
 	];
 
-	const cacheFilter = senderRecipientVotedPublicKeys.map(publicKey => ({
-		publicKey,
-	}));
-
-	if (cacheFilter.length === 0) {
+	if (senderRecipientVotedPublicKeys.length === 0) {
 		return true;
 	}
+
+	const cacheFilter = senderRecipientVotedPublicKeys.map(publicKey => ({
+		address: getAddressFromPublicKey(publicKey),
+	}));
 
 	return stateStore.account.cache(cacheFilter);
 };

--- a/framework/src/modules/chain/transactions/votes_weight.js
+++ b/framework/src/modules/chain/transactions/votes_weight.js
@@ -224,8 +224,12 @@ const prepare = async (stateStore, transaction) => {
 	];
 
 	const cacheFilter = senderRecipientVotedPublicKeys.map(publicKey => ({
-		address: getAddressFromPublicKey(publicKey),
+		publicKey,
 	}));
+
+	if (cacheFilter.length === 0) {
+		return true;
+	}
 
 	return stateStore.account.cache(cacheFilter);
 };


### PR DESCRIPTION
### What was the problem?
It crashes with the following error:

> FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

### How did I solve it?
Separate both prepare statements, use `for ... of`, and skip caching for genesis block (preventing 8k DB calls -> causing the issue previously).

### How to manually test it?
Start application and see if it runs correctly.

### Review checklist

- [x] The PR resolves #4183 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
