### PR TITLE
Fix event handling - Closes #4208

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -170,21 +170,30 @@ module.exports = class Chain {
 
 			// Avoid receiving blocks/transactions from the network during snapshotting process
 			if (!this.options.loading.rebuildUpToRound) {
-				this.channel.subscribe('network:event', ({ data: { event, data } }) => {
-					if (event === 'postTransactions') {
-						this.transport.postTransactions(data);
-						return;
-					}
-					if (event === 'postSignatures') {
-						this.transport.postSignatures(data);
-						return;
-					}
-					if (event === 'postBlock') {
-						this.transport.postBlock(data);
-						// eslint-disable-next-line no-useless-return
-						return;
-					}
-				});
+				this.channel.subscribe(
+					'network:event',
+					async ({ data: { event, data } }) => {
+						try {
+							if (event === 'postTransactions') {
+								await this.transport.postTransactions(data);
+								return;
+							}
+							if (event === 'postSignatures') {
+								await this.transport.postSignatures(data);
+								return;
+							}
+							if (event === 'postBlock') {
+								await this.transport.postBlock(data);
+								return;
+							}
+						} catch (error) {
+							this.logger.info(
+								{ error, event, data },
+								'Received invalid event message',
+							);
+						}
+					},
+				);
 			}
 		} catch (error) {
 			this.logger.fatal('Chain initialization', {

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -187,8 +187,8 @@ module.exports = class Chain {
 								return;
 							}
 						} catch (error) {
-							this.logger.info(
-								{ error, event, data },
+							this.logger.warn(
+								{ error, event },
 								'Received invalid event message',
 							);
 						}

--- a/framework/src/modules/chain/transport/transport.js
+++ b/framework/src/modules/chain/transport/transport.js
@@ -363,28 +363,16 @@ class Transport {
 					query,
 				},
 			);
-			throw new Error(errors);
+			throw errors;
 		}
 
 		let block;
-		let success = true;
-		try {
-			block = blocksUtils.addBlockProperties(query.block);
+		block = blocksUtils.addBlockProperties(query.block);
 
-			// Instantiate transaction classes
-			block.transactions = this.interfaceAdapters.transactions.fromBlock(block);
+		// Instantiate transaction classes
+		block.transactions = this.interfaceAdapters.transactions.fromBlock(block);
 
-			block = blocksUtils.objectNormalize(block);
-		} catch (e) {
-			success = false;
-			this.logger.debug('Block normalization failed', {
-				err: e.toString(),
-				module: 'transport',
-				block: query.block,
-			});
-
-			// TODO: If there is an error, invoke the applyPenalty action on the Network module once it is implemented.
-		}
+		block = blocksUtils.objectNormalize(block);
 		// TODO: endpoint should be protected before
 		if (this.loaderModule.syncing()) {
 			return this.logger.debug(
@@ -392,10 +380,7 @@ class Transport {
 				block.id,
 			);
 		}
-		if (success) {
-			return this.blocksModule.receiveBlockFromNetwork(block);
-		}
-		return null;
+		return this.blocksModule.receiveBlockFromNetwork(block);
 	}
 
 	/**

--- a/framework/src/modules/chain/transport/transport.js
+++ b/framework/src/modules/chain/transport/transport.js
@@ -344,13 +344,12 @@ class Transport {
 	 * @todo Add @returns tag
 	 * @todo Add description of the function
 	 */
-	async postBlock(query) {
+	async postBlock(query = {}) {
 		if (!this.constants.broadcasts.active) {
 			return this.logger.debug(
 				'Receiving blocks disabled by user through config.json',
 			);
 		}
-		query = query || {};
 
 		const errors = validator.validate(definitions.WSBlocksBroadcast, query);
 
@@ -367,8 +366,7 @@ class Transport {
 			throw errors;
 		}
 
-		let block;
-		block = blocksUtils.addBlockProperties(query.block);
+		let block = blocksUtils.addBlockProperties(query.block);
 
 		// Instantiate transaction classes
 		block.transactions = this.interfaceAdapters.transactions.fromBlock(block);

--- a/framework/src/modules/chain/transport/transport.js
+++ b/framework/src/modules/chain/transport/transport.js
@@ -363,6 +363,7 @@ class Transport {
 					query,
 				},
 			);
+			// TODO: If there is an error, invoke the applyPenalty action on the Network module once it is implemented.
 			throw errors;
 		}
 
@@ -434,6 +435,7 @@ class Transport {
 
 		if (errors.length) {
 			this.logger.debug('Invalid signatures body', errors);
+			// TODO: If there is an error, invoke the applyPenalty action on the Network module once it is implemented.
 			throw errors;
 		}
 
@@ -528,6 +530,7 @@ class Transport {
 
 		if (errors.length) {
 			this.logger.debug('Invalid transactions body', errors);
+			// TODO: If there is an error, invoke the applyPenalty action on the Network module once it is implemented.
 			throw errors;
 		}
 

--- a/framework/test/mocha/functional/ws/transport/transport.js
+++ b/framework/test/mocha/functional/ws/transport/transport.js
@@ -32,7 +32,7 @@ describe('WS transport', () => {
 		let p2p;
 
 		function postTransaction(transactionToPost) {
-			p2p.send({
+			return p2p.send({
 				event: 'postTransactions',
 				data: {
 					nonce: 'sYHEDBKcScaAAAYg',
@@ -71,6 +71,10 @@ describe('WS transport', () => {
 				postTransaction(transaction);
 				goodTransactions.push(transaction);
 				done();
+			});
+
+			it('should not crash the application', async () => {
+				await postTransaction('Invalid transaction');
 			});
 		});
 
@@ -378,6 +382,22 @@ describe('WS transport', () => {
 					}
 				});
 				await p2p.send({ event: 'postBlock', data: { block: testBlock } });
+			});
+
+			it('should not crash the application when sending the invalid block', async () => {
+				await p2p.send({
+					event: 'postBlock',
+					data: { block: { generatorPublicKey: '123' } },
+				});
+			});
+		});
+
+		describe('postSignatures', () => {
+			it('should not crash the application when sending the invalid signatures', async () => {
+				await p2p.send({
+					event: 'postSignatures',
+					data: { signatures: ['not object signature'] },
+				});
 			});
 		});
 	});

--- a/framework/test/mocha/unit/modules/chain/transport/transport.js
+++ b/framework/test/mocha/unit/modules/chain/transport/transport.js
@@ -895,19 +895,15 @@ describe('transport', () => {
 							beforeEach(async () => {
 								sinonSandbox
 									.stub(blocksModule, 'objectNormalize')
-									.throws(blockValidationError);
-								transportModule.postBlock(postBlockQuery);
+									.throws(new Error(blockValidationError));
 							});
 
-							it('should call transportModule.logger.debug with "Block normalization failed" and {err: error, module: "transport", block: query.block }', async () => {
-								expect(transportModule.logger.debug).to.be.calledWith(
-									'Block normalization failed',
-									{
-										err: blockValidationError.toString(),
-										module: 'transport',
-										block: blockMock,
-									},
-								);
+							it('should throw an error', async () => {
+								try {
+									await transportModule.postBlock(postBlockQuery);
+								} catch (err) {
+									expect(err.message).to.equal(blockValidationError);
+								}
 							});
 						});
 


### PR DESCRIPTION
### What was the problem?
- network:event was subscribed, but it shouldn't throw an error

### How did I solve it?
- wrap with try-catch, and expect the error to happen. Also, it should log.

### How to manually test it?
- Use P2P library and call the endpoint with invalid data

### Review checklist

- [ ] The PR resolves #4208 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
