### PR TITLE
Add logs for starting genesis block apply - Closes #4209

### DIFF
--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -241,6 +241,7 @@ class Blocks extends EventEmitter {
 			},
 		);
 		if (blocksCount === 1) {
+			this.logger.info('Applying genesis block');
 			this._lastBlock = await this._reload(blocksCount);
 			this._isActive = false;
 			return;
@@ -580,7 +581,7 @@ class Blocks extends EventEmitter {
 				this._lastBlock = block;
 				this.logger.info(
 					{ blockId: block.id, height: block.height },
-					'Rebuilding block',
+					'Rebuilt block',
 				);
 			},
 		);

--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -581,7 +581,7 @@ class Blocks extends EventEmitter {
 				this._lastBlock = block;
 				this.logger.info(
 					{ blockId: block.id, height: block.height },
-					'Rebuilt block',
+					'Reloaded block',
 				);
 			},
 		);


### PR DESCRIPTION
### What was the problem?
On mainnet, genesis block processing takes time, but it was not showing what the application is doing.

### How did I solve it?
- Add a log to show it's processing the genesis block

### How to manually test it?
- Start mainnet node from scratch

### Review checklist

- [ ] The PR resolves #4209 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
