### PR TITLE
Create function to compute BFT headers on block creation - Closes #4233

### DIFF
--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -148,7 +148,7 @@ class BFT extends EventEmitter {
 	 * @param delegatePubKey
 	 * @return {Promise<{prevotedConfirmedUptoHeight: number, maxHeightPreviouslyForged: (number|*)}>}
 	 */
-	async computeBlockHeadersForNewBlock(delegatePubKey) {
+	async computeHeadersForNewBlock(delegatePubKey) {
 		const blockHeaders = cloneDeep(this.finalityManager.headers.items);
 		const lastBlockForgedByDelegate = blockHeaders
 			.reverse()

--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -147,21 +147,8 @@ class BFT extends EventEmitter {
 	 * @param delegatePubKey
 	 * @return {Promise<{prevotedConfirmedUptoHeight: number, maxHeightPreviouslyForged: (number|*)}>}
 	 */
-	async computeHeadersForNewBlock(delegatePubKey) {
-		const [
-			lastBlockForgedByDelegate,
-		] = this.finalityManager.headers.items
-			.filter(blockHeader => blockHeader.delegatePublicKey === delegatePubKey)
-			.slice(-1);
-
-		const maxHeightPreviouslyForged = !lastBlockForgedByDelegate
-			? 0
-			: lastBlockForgedByDelegate.height;
-
-		return {
-			maxHeightPreviouslyForged,
-			prevotedConfirmedUptoHeight: this.finalityManager.prevotedConfirmedHeight, // It is 0 by default. No need to set default values here.
-		};
+	async computeBFTHeaderProperties(delegatePubKey) {
+		return this.finalityManager.computeBFTHeaderProperties(delegatePubKey);
 	}
 
 	/**

--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -16,7 +16,6 @@
 
 const EventEmitter = require('events');
 const assert = require('assert');
-const { cloneDeep } = require('lodash');
 const {
 	EVENT_BFT_FINALIZED_HEIGHT_CHANGED,
 	FinalityManager,
@@ -149,10 +148,11 @@ class BFT extends EventEmitter {
 	 * @return {Promise<{prevotedConfirmedUptoHeight: number, maxHeightPreviouslyForged: (number|*)}>}
 	 */
 	async computeHeadersForNewBlock(delegatePubKey) {
-		const blockHeaders = cloneDeep(this.finalityManager.headers.items);
-		const lastBlockForgedByDelegate = blockHeaders
-			.reverse()
-			.find(blockHeader => blockHeader.delegatePublicKey === delegatePubKey);
+		const [
+			lastBlockForgedByDelegate,
+		] = this.finalityManager.headers.items
+			.filter(blockHeader => blockHeader.delegatePublicKey === delegatePubKey)
+			.slice(-1);
 
 		const maxHeightPreviouslyForged = !lastBlockForgedByDelegate
 			? 0

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -353,7 +353,7 @@ class FinalityManager extends EventEmitter {
 	 * Returns the latest block that a delegate has forged
 	 * @return {BlockHeader | undefined} blockHeader
 	 */
-	_findLatestBlockForgedByDelegate(delegatePublicKey) {
+	_findLastBlockForgedByDelegate(delegatePublicKey) {
 		// Find top most block forged by same delegate
 		return this.headers
 			.top(this.processingThreshold)

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -335,7 +335,7 @@ class FinalityManager extends EventEmitter {
 	 * @return {Promise<{prevotedConfirmedUptoHeight: number, maxHeightPreviouslyForged: number}>}
 	 */
 	async computeBFTHeaderProperties(delegatePubKey) {
-		const lastBlockForgedByDelegate = this._findLatestBlockForgedByDelegate(
+		const lastBlockForgedByDelegate = this._findLastBlockForgedByDelegate(
 			delegatePubKey,
 		);
 
@@ -380,7 +380,7 @@ class FinalityManager extends EventEmitter {
 		}
 
 		// Find top most block forged by same delegate
-		const delegateLastBlock = this._findLatestBlockForgedByDelegate(
+		const delegateLastBlock = this._findLastBlockForgedByDelegate(
 			blockHeader.delegatePublicKey,
 		);
 

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -14,11 +14,6 @@
 
 'use strict';
 
-const { Mnemonic } = require('@liskhq/lisk-passphrase');
-const {
-	getAddressAndPublicKeyFromPassphrase,
-} = require('@liskhq/lisk-cryptography');
-
 const {
 	Block: blockFixture,
 } = require('../../../../../../mocha/fixtures/blocks');
@@ -388,126 +383,6 @@ describe('bft', () => {
 					403 - activeDelegates * 2,
 				);
 				expect(storageMock.entities.Block.get).toHaveBeenCalledTimes(0);
-			});
-		});
-
-		describe('computeHeadersForNewBlock()', () => {
-			let bft;
-
-			beforeEach(async () => {
-				bft = new BFT(bftParams);
-
-				storageMock.entities.Block.get.mockReset();
-				storageMock.entities.Block.get.mockReturnValue([]);
-
-				await bft.init();
-			});
-
-			it('should maxHeightPreviouslyForged and prevotedConfirmedUptoHeight properties in an object literal', async () => {
-				const headers = await bft.computeHeadersForNewBlock('aDelegatePubKey');
-
-				expect(headers).toHaveProperty('maxHeightPreviouslyForged');
-				expect(headers).toHaveProperty('prevotedConfirmedUptoHeight');
-				expect(headers).toEqual({
-					maxHeightPreviouslyForged: 0,
-					prevotedConfirmedUptoHeight: 0,
-				});
-			});
-
-			it('should compute a correct value for maxHeightPreviouslyForged, returning the height of the last block a delegate with the given public key forged a block', async () => {
-				// Arrange
-				const {
-					publicKey: forgingDelegatePubKey,
-				} = getAddressAndPublicKeyFromPassphrase(Mnemonic.generateMnemonic());
-
-				const blockHeaders = [
-					{
-						blockId: '1234567',
-						height: 1,
-						maxHeightPreviouslyForged: 0,
-						prevotedConfirmedUptoHeight: 0,
-						activeSinceRound: 0,
-						delegatePublicKey: forgingDelegatePubKey,
-					},
-					{
-						blockId: '1234568',
-						height: 2,
-						maxHeightPreviouslyForged: 0,
-						prevotedConfirmedUptoHeight: 0,
-						activeSinceRound: 0,
-						delegatePublicKey: getAddressAndPublicKeyFromPassphrase(
-							Mnemonic.generateMnemonic(),
-						).publicKey,
-					},
-					{
-						blockId: '1234569',
-						height: 3,
-						maxHeightPreviouslyForged: 1,
-						prevotedConfirmedUptoHeight: 0,
-						activeSinceRound: 0,
-						delegatePublicKey: forgingDelegatePubKey,
-					},
-				];
-
-				blockHeaders.forEach(blockHeader => {
-					bft.finalityManager.addBlockHeader(blockHeader);
-				});
-
-				// Act
-				const headers = await bft.computeHeadersForNewBlock(
-					forgingDelegatePubKey,
-				);
-
-				// Assert
-				expect(headers).toEqual({
-					maxHeightPreviouslyForged: 3,
-					prevotedConfirmedUptoHeight: 0,
-				});
-			});
-
-			it("should compute set maxHeightPreviouslyForged to 0 if it's the first time the delegate is forging a block", async () => {
-				// Arrange
-				const {
-					publicKey: forgingDelegatePubKey,
-				} = getAddressAndPublicKeyFromPassphrase(Mnemonic.generateMnemonic());
-
-				const blockHeaders = [
-					{
-						blockId: '1234568',
-						height: 1,
-						maxHeightPreviouslyForged: 0,
-						prevotedConfirmedUptoHeight: 0,
-						activeSinceRound: 0,
-						delegatePublicKey: getAddressAndPublicKeyFromPassphrase(
-							Mnemonic.generateMnemonic(),
-						).publicKey,
-					},
-					{
-						blockId: '1234569',
-						height: 2,
-						maxHeightPreviouslyForged: 0,
-						prevotedConfirmedUptoHeight: 0,
-						activeSinceRound: 0,
-						delegatePublicKey: getAddressAndPublicKeyFromPassphrase(
-							Mnemonic.generateMnemonic(),
-						).publicKey,
-					},
-				];
-
-				blockHeaders.forEach(blockHeader => {
-					bft.finalityManager.addBlockHeader(blockHeader);
-				});
-
-				// Act
-				const headers = await bft.computeHeadersForNewBlock(
-					forgingDelegatePubKey,
-				);
-
-				// Assert
-				expect(headers).toEqual({
-					maxHeightPreviouslyForged: 0,
-					prevotedConfirmedUptoHeight: 0,
-				});
 			});
 		});
 

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -14,6 +14,11 @@
 
 'use strict';
 
+const { Mnemonic } = require('@liskhq/lisk-passphrase');
+const {
+	getAddressAndPublicKeyFromPassphrase,
+} = require('@liskhq/lisk-cryptography');
+
 const {
 	Block: blockFixture,
 } = require('../../../../../../mocha/fixtures/blocks');
@@ -383,6 +388,134 @@ describe('bft', () => {
 					403 - activeDelegates * 2,
 				);
 				expect(storageMock.entities.Block.get).toHaveBeenCalledTimes(0);
+			});
+		});
+
+		describe('computeHeadersForNewBlock()', () => {
+			let bft;
+
+			beforeEach(async () => {
+				bft = new BFT(bftParams);
+
+				jest
+					.spyOn(bft, '_getLastBlockHeight')
+					.mockImplementation(() => jest.fn());
+				jest
+					.spyOn(bft, '_loadBlocksFromStorage')
+					.mockImplementation(() => jest.fn());
+
+				storageMock.entities.Block.get.mockReset();
+				storageMock.entities.Block.get.mockReturnValue([]);
+
+				bft._getLastBlockHeight.mockReturnValue(1);
+				await bft.init();
+			});
+
+			it('should maxHeightPreviouslyForged and prevotedConfirmedUptoHeight properties in an object literal', async () => {
+				const headers = await bft.computeHeadersForNewBlock('aDelegatePubKey');
+
+				expect(headers).toHaveProperty('maxHeightPreviouslyForged');
+				expect(headers).toHaveProperty('prevotedConfirmedUptoHeight');
+				expect(headers).toEqual({
+					maxHeightPreviouslyForged: 0,
+					prevotedConfirmedUptoHeight: 0,
+				});
+			});
+
+			it('should compute a correct value for maxHeightPreviouslyForged, returning the height of the last block a delegate with the given public key forged a block', async () => {
+				// Arrange
+				const {
+					publicKey: forgingDelegatePubKey,
+				} = getAddressAndPublicKeyFromPassphrase(Mnemonic.generateMnemonic());
+
+				const blockHeaders = [
+					{
+						blockId: '1234567',
+						height: 1,
+						maxHeightPreviouslyForged: 0,
+						prevotedConfirmedUptoHeight: 0,
+						activeSinceRound: 0,
+						delegatePublicKey: forgingDelegatePubKey,
+					},
+					{
+						blockId: '1234568',
+						height: 2,
+						maxHeightPreviouslyForged: 0,
+						prevotedConfirmedUptoHeight: 0,
+						activeSinceRound: 0,
+						delegatePublicKey: getAddressAndPublicKeyFromPassphrase(
+							Mnemonic.generateMnemonic(),
+						).publicKey,
+					},
+					{
+						blockId: '1234569',
+						height: 3,
+						maxHeightPreviouslyForged: 1,
+						prevotedConfirmedUptoHeight: 0,
+						activeSinceRound: 0,
+						delegatePublicKey: forgingDelegatePubKey,
+					},
+				];
+
+				blockHeaders.forEach(blockHeader => {
+					bft.finalityManager.addBlockHeader(blockHeader);
+				});
+
+				// Act
+				const headers = await bft.computeHeadersForNewBlock(
+					forgingDelegatePubKey,
+				);
+
+				// Assert
+				expect(headers).toEqual({
+					maxHeightPreviouslyForged: 3,
+					prevotedConfirmedUptoHeight: 0,
+				});
+			});
+
+			it("should compute set maxHeightPreviouslyForged to 0 if it's the first time the delegate is forging a block", async () => {
+				// Arrange
+				const {
+					publicKey: forgingDelegatePubKey,
+				} = getAddressAndPublicKeyFromPassphrase(Mnemonic.generateMnemonic());
+
+				const blockHeaders = [
+					{
+						blockId: '1234568',
+						height: 1,
+						maxHeightPreviouslyForged: 0,
+						prevotedConfirmedUptoHeight: 0,
+						activeSinceRound: 0,
+						delegatePublicKey: getAddressAndPublicKeyFromPassphrase(
+							Mnemonic.generateMnemonic(),
+						).publicKey,
+					},
+					{
+						blockId: '1234569',
+						height: 2,
+						maxHeightPreviouslyForged: 0,
+						prevotedConfirmedUptoHeight: 0,
+						activeSinceRound: 0,
+						delegatePublicKey: getAddressAndPublicKeyFromPassphrase(
+							Mnemonic.generateMnemonic(),
+						).publicKey,
+					},
+				];
+
+				blockHeaders.forEach(blockHeader => {
+					bft.finalityManager.addBlockHeader(blockHeader);
+				});
+
+				// Act
+				const headers = await bft.computeHeadersForNewBlock(
+					forgingDelegatePubKey,
+				);
+
+				// Assert
+				expect(headers).toEqual({
+					maxHeightPreviouslyForged: 0,
+					prevotedConfirmedUptoHeight: 0,
+				});
 			});
 		});
 

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -397,17 +397,9 @@ describe('bft', () => {
 			beforeEach(async () => {
 				bft = new BFT(bftParams);
 
-				jest
-					.spyOn(bft, '_getLastBlockHeight')
-					.mockImplementation(() => jest.fn());
-				jest
-					.spyOn(bft, '_loadBlocksFromStorage')
-					.mockImplementation(() => jest.fn());
-
 				storageMock.entities.Block.get.mockReset();
 				storageMock.entities.Block.get.mockReturnValue([]);
 
-				bft._getLastBlockHeight.mockReturnValue(1);
 				await bft.init();
 			});
 

--- a/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
@@ -18,6 +18,7 @@ const { Mnemonic } = require('@liskhq/lisk-passphrase');
 const {
 	getAddressAndPublicKeyFromPassphrase,
 } = require('@liskhq/lisk-cryptography');
+const { cloneDeep } = require('lodash');
 const {
 	BFTChainDisjointError,
 	BFTLowerChainBranchError,
@@ -293,6 +294,16 @@ describe('finality_manager', () => {
 					maxHeightPreviouslyForged: 0,
 					prevotedConfirmedUptoHeight: 0,
 				});
+			});
+
+			it('should not alter the content of the headers object', async () => {
+				const headersBefore = cloneDeep(finalityManager.headers);
+
+				await finalityManager.computeBFTHeaderProperties('aDelegatePubKey');
+
+				const headersAfter = finalityManager.headers;
+
+				expect(headersBefore).toEqual(headersAfter);
 			});
 
 			it('should compute a correct value for maxHeightPreviouslyForged, returning the height of the last block a delegate with the given public key forged a block', async () => {


### PR DESCRIPTION
### What was the problem?
There was no way to compute these BFT headers required for block forging.
### How did I solve it?
By implementing a function to handle this computation inside `BFT` module.
### How to manually test it?
Run Jest tests on `bft.spec.js` file.
### Review checklist

- [ ] The PR resolves #4233 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
