### PR TITLE
When propagating a block with p2p.send, the block is more likely to reach inbound peers - Closes #4271

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -124,7 +124,7 @@ export const DEFAULT_NODE_HOST_IP = '0.0.0.0';
 export const DEFAULT_DISCOVERY_INTERVAL = 30000;
 export const DEFAULT_BAN_TIME = 86400;
 export const DEFAULT_POPULATOR_INTERVAL = 10000;
-export const DEFAULT_SEND_PEER_LIMIT = 25;
+export const DEFAULT_SEND_PEER_LIMIT = 24;
 // Max rate of WebSocket messages per second per peer.
 export const DEFAULT_WS_MAX_MESSAGE_RATE = 100;
 export const DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY = 100;

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -79,6 +79,7 @@ import {
 	EVENT_FAILED_TO_FETCH_PEER_INFO,
 	EVENT_FAILED_TO_FETCH_PEERS,
 	EVENT_FAILED_TO_PUSH_NODE_INFO,
+	EVENT_FAILED_TO_SEND_MESSAGE,
 	EVENT_INBOUND_SOCKET_ERROR,
 	EVENT_MESSAGE_RECEIVED,
 	EVENT_OUTBOUND_SOCKET_ERROR,
@@ -102,6 +103,7 @@ export {
 	EVENT_CONNECT_OUTBOUND,
 	EVENT_DISCOVERED_PEER,
 	EVENT_FAILED_TO_PUSH_NODE_INFO,
+	EVENT_FAILED_TO_SEND_MESSAGE,
 	EVENT_REMOVE_PEER,
 	EVENT_REQUEST_RECEIVED,
 	EVENT_MESSAGE_RECEIVED,
@@ -173,6 +175,7 @@ export class P2P extends EventEmitter {
 		discoveredPeerInfo: P2PDiscoveredPeerInfo,
 	) => void;
 	private readonly _handleFailedToPushNodeInfo: (error: Error) => void;
+	private readonly _handleFailedToSendMessage: (error: Error) => void;
 	private readonly _handleOutboundPeerConnect: (
 		peerInfo: P2PDiscoveredPeerInfo,
 	) => void;
@@ -398,6 +401,11 @@ export class P2P extends EventEmitter {
 		this._handleFailedToPushNodeInfo = (error: Error) => {
 			// Re-emit the error to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_TO_PUSH_NODE_INFO, error);
+		};
+
+		this._handleFailedToSendMessage = (error: Error) => {
+			// Re-emit the error to allow it to bubble up the class hierarchy.
+			this.emit(EVENT_FAILED_TO_SEND_MESSAGE, error);
 		};
 
 		this._handleOutboundSocketError = (error: Error) => {
@@ -951,6 +959,7 @@ export class P2P extends EventEmitter {
 			EVENT_FAILED_TO_PUSH_NODE_INFO,
 			this._handleFailedToPushNodeInfo,
 		);
+		peerPool.on(EVENT_FAILED_TO_SEND_MESSAGE, this._handleFailedToSendMessage);
 		peerPool.on(EVENT_OUTBOUND_SOCKET_ERROR, this._handleOutboundSocketError);
 		peerPool.on(EVENT_INBOUND_SOCKET_ERROR, this._handleInboundSocketError);
 		peerPool.on(EVENT_BAN_PEER, this._handleBanPeer);

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -118,6 +118,9 @@ export const MAX_PEER_DISCOVERY_PROBE_SAMPLE_SIZE = 100;
 export const EVENT_REMOVE_PEER = 'removePeer';
 export const INTENTIONAL_DISCONNECT_STATUS_CODE = 1000;
 
+// TODO: Move to events.ts.
+export const EVENT_FAILED_TO_SEND_MESSAGE = 'failedToSendMessage';
+
 // TODO: Move these to constants.ts
 export const PEER_KIND_OUTBOUND = 'outbound';
 export const PEER_KIND_INBOUND = 'inbound';
@@ -378,7 +381,11 @@ export class PeerPool extends EventEmitter {
 
 		selectedPeers.forEach((peerInfo: P2PDiscoveredPeerInfo) => {
 			const selectedPeerId = constructPeerIdFromPeerInfo(peerInfo);
-			this.sendToPeer(message, selectedPeerId);
+			try {
+				this.sendToPeer(message, selectedPeerId);
+			} catch (error) {
+				this.emit(EVENT_FAILED_TO_SEND_MESSAGE, error);
+			}
 		});
 	}
 

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -118,6 +118,10 @@ export const MAX_PEER_DISCOVERY_PROBE_SAMPLE_SIZE = 100;
 export const EVENT_REMOVE_PEER = 'removePeer';
 export const INTENTIONAL_DISCONNECT_STATUS_CODE = 1000;
 
+// TODO: Move these to constants.ts
+export const PEER_KIND_OUTBOUND = 'outbound';
+export const PEER_KIND_INBOUND = 'inbound';
+
 export enum PROTECTION_CATEGORY {
 	NET_GROUP = 'netgroup',
 	LATENCY = 'latency',
@@ -333,9 +337,15 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
+		const outboundPeerInfos = this.getUniqueOutboundConnectedPeers().map(
+			(peerInfo: P2PDiscoveredPeerInfo) => ({
+				...peerInfo,
+				kind: PEER_KIND_OUTBOUND,
+			}),
+		);
 		// This function can be customized so we should pass as much info as possible.
 		const selectedPeers = this._peerSelectForRequest({
-			peers: this.getUniqueOutboundConnectedPeers(),
+			peers: outboundPeerInfos,
 			nodeInfo: this._nodeInfo,
 			peerLimit: 1,
 			requestPacket: packet,
@@ -353,9 +363,11 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public send(message: P2PMessagePacket): void {
-		const listOfPeerInfo = [...this._peerMap.values()].map(
-			(peer: Peer) => peer.peerInfo as P2PDiscoveredPeerInfo,
-		);
+		const listOfPeerInfo = [...this._peerMap.values()].map((peer: Peer) => ({
+			...(peer.peerInfo as P2PDiscoveredPeerInfo),
+			kind:
+				peer instanceof OutboundPeer ? PEER_KIND_OUTBOUND : PEER_KIND_INBOUND,
+		}));
 		// This function can be customized so we should pass as much info as possible.
 		const selectedPeers = this._peerSelectForSend({
 			peers: listOfPeerInfo,

--- a/elements/lisk-p2p/src/peer_selection.ts
+++ b/elements/lisk-p2p/src/peer_selection.ts
@@ -63,8 +63,23 @@ export const selectPeersForRequest = (
 
 export const selectPeersForSend = (
 	input: P2PPeerSelectionForSendInput,
-): ReadonlyArray<P2PDiscoveredPeerInfo> =>
-	shuffle(input.peers).slice(0, input.peerLimit);
+): ReadonlyArray<P2PDiscoveredPeerInfo> => {
+	const shuffledPeers = shuffle(input.peers);
+	// tslint:disable: no-magic-numbers
+	const halfPeerLimit = Math.round((input.peerLimit as number) / 2);
+
+	// TODO: Get outbound string from constants.ts file.
+	const selectedOutboundPeers = shuffledPeers
+		.filter((peerInfo: P2PDiscoveredPeerInfo) => peerInfo.kind === 'outbound')
+		.slice(0, halfPeerLimit);
+
+	// TODO: Get inbound string from constants.ts file.
+	const selectedInboundPeers = shuffledPeers
+		.filter((peerInfo: P2PDiscoveredPeerInfo) => peerInfo.kind === 'inbound')
+		.slice(0, halfPeerLimit);
+
+	return selectedOutboundPeers.concat(selectedInboundPeers);
+};
 
 export const selectPeersForConnection = (
 	input: P2PPeerSelectionForConnectionInput,

--- a/elements/lisk-p2p/src/peer_selection.ts
+++ b/elements/lisk-p2p/src/peer_selection.ts
@@ -65,20 +65,38 @@ export const selectPeersForSend = (
 	input: P2PPeerSelectionForSendInput,
 ): ReadonlyArray<P2PDiscoveredPeerInfo> => {
 	const shuffledPeers = shuffle(input.peers);
+	const peerLimit = input.peerLimit as number;
 	// tslint:disable: no-magic-numbers
-	const halfPeerLimit = Math.round((input.peerLimit as number) / 2);
+	const halfPeerLimit = Math.round(peerLimit / 2);
 
 	// TODO: Get outbound string from constants.ts file.
-	const selectedOutboundPeers = shuffledPeers
-		.filter((peerInfo: P2PDiscoveredPeerInfo) => peerInfo.kind === 'outbound')
-		.slice(0, halfPeerLimit);
+	const outboundPeers = shuffledPeers.filter(
+		(peerInfo: P2PDiscoveredPeerInfo) => peerInfo.kind === 'outbound',
+	);
 
 	// TODO: Get inbound string from constants.ts file.
-	const selectedInboundPeers = shuffledPeers
-		.filter((peerInfo: P2PDiscoveredPeerInfo) => peerInfo.kind === 'inbound')
-		.slice(0, halfPeerLimit);
+	const inboundPeers = shuffledPeers.filter(
+		(peerInfo: P2PDiscoveredPeerInfo) => peerInfo.kind === 'inbound',
+	);
 
-	return selectedOutboundPeers.concat(selectedInboundPeers);
+	// tslint:disable: no-let
+	let shortestPeersList;
+	// tslint:disable: no-let
+	let longestPeersList;
+
+	if (outboundPeers.length < inboundPeers.length) {
+		shortestPeersList = outboundPeers;
+		longestPeersList = inboundPeers;
+	} else {
+		shortestPeersList = inboundPeers;
+		longestPeersList = outboundPeers;
+	}
+
+	const selectedFirstKindPeers = shortestPeersList.slice(0, halfPeerLimit);
+	const remainingPeerLimit = peerLimit - selectedFirstKindPeers.length;
+	const selectedSecondKindPeers = longestPeersList.slice(0, remainingPeerLimit);
+
+	return selectedFirstKindPeers.concat(selectedSecondKindPeers);
 };
 
 export const selectPeersForConnection = (

--- a/elements/lisk-p2p/test/integration/p2p.ts
+++ b/elements/lisk-p2p/test/integration/p2p.ts
@@ -1228,6 +1228,13 @@ describe('Integration tests for P2P library', () => {
 		) => {
 			const { peers: peersList, nodeInfo } = input;
 
+			peersList.forEach(peerInfo => {
+				// TODO: Use inbound and outbound strings from constants.ts
+				if (peerInfo.kind !== 'inbound' && peerInfo.kind !== 'outbound') {
+					throw new Error(`Invalid peer kind: ${peerInfo.kind}`);
+				}
+			});
+
 			const filteredPeers = peersList.filter(peer => {
 				if (nodeInfo && nodeInfo.height <= peer.height) {
 					const nodesModules = nodeInfo.modules

--- a/elements/lisk-p2p/test/unit/peer_selection.ts
+++ b/elements/lisk-p2p/test/unit/peer_selection.ts
@@ -43,7 +43,7 @@ describe('peer selector', () => {
 			wsPort: 5000,
 		};
 
-		it('returned array should contain an even number of inbound and outbound peers', () => {
+		it('should return an array containing an even number of inbound and outbound peers', () => {
 			const selectedPeers = selectPeersForSend({
 				peers: peerList,
 				nodeInfo,

--- a/elements/lisk-p2p/test/unit/peer_selection.ts
+++ b/elements/lisk-p2p/test/unit/peer_selection.ts
@@ -14,15 +14,60 @@
  */
 
 import { expect } from 'chai';
-import { initializePeerInfoList } from '../utils/peers';
+import {
+	initializePeerInfoList,
+	initializeLongPeerInfoList,
+} from '../utils/peers';
 import {
 	selectPeersForConnection,
 	selectPeersForRequest,
+	selectPeersForSend,
 	getUniquePeersbyIp,
 } from '../../src/peer_selection';
-import { P2PNodeInfo, P2PDiscoveredPeerInfo } from '../../src/p2p_types';
+import {
+	P2PNodeInfo,
+	P2PDiscoveredPeerInfo,
+	P2PPeerInfo,
+} from '../../src/p2p_types';
 
 describe('peer selector', () => {
+	describe('#selectPeersForSend', () => {
+		let peerList = initializeLongPeerInfoList();
+
+		const nodeInfo: P2PNodeInfo = {
+			height: 545777,
+			nethash: '73458irc3yb7rg37r7326dbt7236',
+			os: 'linux',
+			version: '1.1.1',
+			protocolVersion: '1.1',
+			wsPort: 5000,
+		};
+
+		it('returned array should contain an even number of inbound and outbound peers', () => {
+			const selectedPeers = selectPeersForSend({
+				peers: peerList,
+				nodeInfo,
+				peerLimit: 24,
+				messagePacket: { event: 'foo', data: {} },
+			});
+
+			let peerKindCounts = selectedPeers.reduce(
+				(peerKindTracker: any, peerInfo: P2PPeerInfo) => {
+					const kind = peerInfo.kind as string;
+					if (!peerKindTracker[kind]) {
+						peerKindTracker[kind] = 0;
+					}
+					peerKindTracker[kind]++;
+					return peerKindTracker;
+				},
+				{},
+			);
+
+			expect(peerKindCounts.inbound)
+				.to.equal(peerKindCounts.outbound)
+				.to.equal(12);
+		});
+	});
 	describe('#selectPeersForRequest', () => {
 		let peerList = initializePeerInfoList();
 		const nodeInfo: P2PNodeInfo = {

--- a/elements/lisk-p2p/test/utils/peers.ts
+++ b/elements/lisk-p2p/test/utils/peers.ts
@@ -67,6 +67,26 @@ export const initializePeerInfoList = (): ReadonlyArray<
 	return [peerOption1, peerOption2, peerOption3, peerOption4, peerOption5];
 };
 
+export const initializeLongPeerInfoList = (): ReadonlyArray<
+	P2PDiscoveredPeerInfo
+> => {
+	let peerInfos = [];
+	// Generate a realistic list in which 1 in 4 peers is outbound.
+	for (let i = 0; i < 120; i++) {
+		// TODO: Get inbound and outbound strings from constants.ts.
+		peerInfos.push({
+			ipAddress: `204.120.0.${i}`,
+			wsPort: 5001,
+			height: 645980,
+			kind: i % 4 === 0 ? 'outbound' : 'inbound',
+			isDiscoveredPeer: false,
+			version: '1.1.1',
+			protocolVersion: '1.1',
+		});
+	}
+	return peerInfos;
+};
+
 export const initializePeerList = (): ReadonlyArray<Peer> =>
 	initializePeerInfoList().map(
 		(peerInfo: P2PDiscoveredPeerInfo) =>


### PR DESCRIPTION
### What was the problem?

Send was not selecting an even proportion of inbound vs outbound peers. The ratio of max inbound connections vs max outbound connections was skewing the proportion of peers who received a block in favor of peers which consume more inbound connections (old peers).

### How did I solve it?

- Add a new `kind` property to each PeerInfo object which is passed to the request and send selection functions. The `kind` can be either `inbound` or `outbound`.
- Modified the default selection function to select half of its peers from inbound list and half from the outbound list.
- Lowered the `DEFAULT_SEND_PEER_LIMIT` to 24 (instead of 25; this was done to get an even number of inbound and outbound peers).

### How to manually test it?

- A new unit test was added to test the selection function.
- A new integration test was added to test that new `kind` property is present on the PeerInfo objects which are passed to the selectForSend and selectForRequest functions.

`npm test`

### Review checklist

- [ ] The PR resolves #4271 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
