### PR TITLE
Remove signature loading - Closes #4268

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -564,7 +564,7 @@ module.exports = class Chain {
 	}
 
 	_startLoader() {
-		this.loader.loadTransactions();
+		this.loader.loadUnconfirmedTransactions();
 		if (!this.options.syncing.active) {
 			return;
 		}

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -564,7 +564,7 @@ module.exports = class Chain {
 	}
 
 	_startLoader() {
-		this.loader.loadTransactionsAndSignatures();
+		this.loader.loadTransactions();
 		if (!this.options.syncing.active) {
 			return;
 		}

--- a/framework/src/modules/chain/loader.js
+++ b/framework/src/modules/chain/loader.js
@@ -91,11 +91,11 @@ class Loader {
 	/**
 	 * Pulls Transactions
 	 */
-	async loadTransactions() {
+	async loadUnconfirmedTransactions() {
 		await new Promise(resolve => {
 			async.retry(
 				this.retries,
-				async () => this._getTransactionsFromNetwork(),
+				async () => this._getUnconfirmedTransactionsFromNetwork(),
 				err => {
 					if (err) {
 						this.logger.error('Unconfirmed transactions loader', err);
@@ -165,7 +165,7 @@ class Loader {
 	 * @returns {setImmediateCallback} cb, err
 	 * @todo Add description for the params
 	 */
-	async _getTransactionsFromNetwork() {
+	async _getUnconfirmedTransactionsFromNetwork() {
 		this.logger.info('Loading transactions from the network');
 
 		// TODO: Add target module to procedure name. E.g. chain:getTransactions

--- a/framework/test/jest/unit/specs/modules/chain/loader.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/loader.spec.js
@@ -23,7 +23,7 @@ const {
 } = require('../../../utils/registered_transactions');
 
 describe('Loader', () => {
-	describe('#_getTransactionsFromNetwork', () => {
+	describe('#_getUnconfirmedTransactionsFromNetwork', () => {
 		let loader;
 		let channelStub;
 		let transactionPoolModuleStub;
@@ -89,7 +89,7 @@ describe('Loader', () => {
 			it('should not throw an error', async () => {
 				let error;
 				try {
-					await loader._getTransactionsFromNetwork();
+					await loader._getUnconfirmedTransactionsFromNetwork();
 				} catch (err) {
 					error = err;
 				}
@@ -97,7 +97,7 @@ describe('Loader', () => {
 			});
 
 			it('should process the transaction with transactionPoolModule', async () => {
-				await loader._getTransactionsFromNetwork();
+				await loader._getUnconfirmedTransactionsFromNetwork();
 				expect(
 					transactionPoolModuleStub.processUnconfirmedTransaction,
 				).toHaveBeenCalledTimes(1);
@@ -113,7 +113,7 @@ describe('Loader', () => {
 			it('should throw an error', async () => {
 				let error;
 				try {
-					await loader._getTransactionsFromNetwork();
+					await loader._getUnconfirmedTransactionsFromNetwork();
 				} catch (err) {
 					error = err;
 				}

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -548,7 +548,7 @@ describe('Chain', () => {
 	describe('#_startLoader', () => {
 		beforeEach(async () => {
 			await chain.bootstrap();
-			sinonSandbox.stub(chain.loader, 'loadTransactionsAndSignatures');
+			sinonSandbox.stub(chain.loader, 'loadTransactions');
 		});
 
 		it('should return if syncing.active in config is set to false', async () => {
@@ -564,7 +564,7 @@ describe('Chain', () => {
 
 		it('should load transactions and signatures', async () => {
 			chain._startLoader();
-			expect(chain.loader.loadTransactionsAndSignatures).to.be.called;
+			expect(chain.loader.loadTransactions).to.be.called;
 		});
 
 		it('should register a task in Jobs Queue named "nextSync" with a designated interval', async () => {

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -548,7 +548,7 @@ describe('Chain', () => {
 	describe('#_startLoader', () => {
 		beforeEach(async () => {
 			await chain.bootstrap();
-			sinonSandbox.stub(chain.loader, 'loadTransactions');
+			sinonSandbox.stub(chain.loader, 'loadUnconfirmedTransactions');
 		});
 
 		it('should return if syncing.active in config is set to false', async () => {
@@ -564,7 +564,7 @@ describe('Chain', () => {
 
 		it('should load transactions and signatures', async () => {
 			chain._startLoader();
-			expect(chain.loader.loadTransactions).to.be.called;
+			expect(chain.loader.loadUnconfirmedTransactions).to.be.called;
 		});
 
 		it('should register a task in Jobs Queue named "nextSync" with a designated interval', async () => {


### PR DESCRIPTION
### What was the problem?
On the startup, signature endpoint was called, but it was never successful.
When signature is received from the network, it will be injected in the transaction.
Therefore, when we start up the node and get the transactions, signatures will be there already if it was propagated.

### How did I solve it?
Remove the signatures fetch on startup.

### How to manually test it?
Observe no error while connecting to the network where it has the multisignature in the pool.

### Review checklist

- [ ] The PR resolves #4268 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
