### PR TITLE
Move init steps to responsible files - Closes #4297

### DIFF
--- a/framework/src/modules/chain/block_processor_v0.js
+++ b/framework/src/modules/chain/block_processor_v0.js
@@ -115,8 +115,6 @@ class BlockProcessorV0 extends BaseBlockProcessor {
 		this.constants = constants;
 		this.exceptions = exceptions;
 
-		this.init.pipe([() => this.blocksModule.init()]);
-
 		this.validate.pipe([
 			data => this._validateVersion(data),
 			data => validateSchema(data),

--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -173,7 +173,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 		this.constants = constants;
 		this.exceptions = exceptions;
 
-		this.init.pipe([() => this.blocksModule.init()]);
+		this.init.pipe([() => this.bftModule.init()]);
 
 		this.validate.pipe([
 			data => this._validateVersion(data),

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -211,7 +211,6 @@ module.exports = class Chain {
 			});
 
 			this.logger.info('Modules ready and launched');
-			await this.bft.init();
 			// After binding, it should immediately load blockchain
 			await this.processor.init(this.options.genesisBlock);
 

--- a/framework/src/modules/chain/processor/processor.js
+++ b/framework/src/modules/chain/processor/processor.js
@@ -65,7 +65,10 @@ class Processor {
 		await this._processGenesis(genesisBlock, blockProcessor, {
 			skipSave: false,
 		});
-		await blockProcessor.init.run();
+		await this.blocksModule.init();
+		for (const processor of Object.values(this.processors)) {
+			await processor.init.run();
+		}
 		this.logger.info('Blockchain ready');
 	}
 

--- a/framework/test/jest/unit/specs/modules/chain/processor/processor.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/processor/processor.spec.js
@@ -65,6 +65,7 @@ describe('processor', () => {
 			error: jest.fn(),
 		};
 		blocksModuleStub = {
+			init: jest.fn(),
 			save: jest.fn(),
 			remove: jest.fn(),
 			exists: jest.fn(),
@@ -177,6 +178,10 @@ describe('processor', () => {
 				await storageStub.entities.Block.begin.mock.calls[0][1](txStub);
 			});
 
+			it('should call blocksModule init', async () => {
+				expect(blocksModuleStub.init).toHaveBeenCalledTimes(1);
+			});
+
 			it('should check if genesis block exists', async () => {
 				expect(blocksModuleStub.exists).toHaveBeenCalledTimes(1);
 			});
@@ -207,6 +212,10 @@ describe('processor', () => {
 				await storageStub.entities.Block.begin.mock.calls[0][1](txStub);
 			});
 
+			it('should call blocksModule init', async () => {
+				expect(blocksModuleStub.init).toHaveBeenCalledTimes(1);
+			});
+
 			it('should check if genesis block exists', async () => {
 				expect(blocksModuleStub.exists).toHaveBeenCalledTimes(1);
 			});
@@ -219,6 +228,25 @@ describe('processor', () => {
 
 			it('should not save the genesis block', async () => {
 				expect(blocksModuleStub.save).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('when processor has multiple block processor registered', () => {
+			let initSteps2;
+			let blockProcessorV1;
+
+			beforeEach(async () => {
+				initSteps2 = [jest.fn(), jest.fn()];
+				blockProcessorV1 = new FakeBlockProcessorV1();
+				blockProcessorV1.init.pipe(initSteps2);
+				processor.register(blockProcessorV1);
+			});
+
+			it('should call all of the init steps', async () => {
+				await processor.init(genesisBlock);
+				for (const step of initSteps2) {
+					expect(step).toHaveBeenCalledTimes(1);
+				}
 			});
 		});
 

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -35,7 +35,6 @@ describe('Chain', () => {
 		// Arrange
 
 		sinonSandbox.stub(Processor.prototype, 'init').resolves();
-		sinonSandbox.stub(BFT.prototype, 'init').resolves();
 
 		/* Arranging Stubs start */
 		stubs.logger = {
@@ -395,10 +394,6 @@ describe('Chain', () => {
 
 		it('should invoke Processor.init', async () => {
 			expect(chain.processor.init).to.have.been.calledOnce;
-		});
-
-		it('should invoke bft.init', async () => {
-			expect(chain.bft.init).to.have.been.calledOnce;
 		});
 
 		it('should subscribe to "app:state:updated" event', () => {


### PR DESCRIPTION
### What was the problem?
BFT module was initialized at the root level, and blocks module were initialized at each block processor.

### How did I solve it?
- Move blocks module init to processor
- Move BFT initialization to block_processor_v2

### How to manually test it?
If the application runs, it should be correct

### Review checklist

- [ ] The PR resolves #4297 
- [ ] All new code is covered with unit tests
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
