### PR TITLE
Integrate swagger-stats APM - Closes #4300

### DIFF
--- a/framework/README.md
+++ b/framework/README.md
@@ -117,6 +117,17 @@ npm run jest:<testType>
 npm run jest:<testType> -- [testPathPattern] [jestCliOptions]
 ```
 
+### API Performance and APM
+
+To access the API Peformance of your Lisk Instance, navigate to `http://localhost:4000/http-stats/ui`, the APM is enabled by default to all environment except `testnet` and `mainnet`. The APM doesn't store any of the performance metrics, neither it forwards to any external services. The stats is served until the instance is up and running, once the instance is restarted it will not hold any stats.
+
+To access the stats, follow the steps below:
+
+```
+node test/test_app | npx bunyan
+Access: http://localhost:4000/http-stats/ui
+```
+
 ## Contribution
 
 To test the changes in framework you can run,

--- a/framework/README.md
+++ b/framework/README.md
@@ -119,7 +119,7 @@ npm run jest:<testType> -- [testPathPattern] [jestCliOptions]
 
 ### API Performance and APM
 
-To access the API Peformance of your Lisk Instance, navigate to `http://localhost:4000/http-stats/ui`, the APM is enabled by default to all environment except `testnet` and `mainnet`. The APM doesn't store any of the performance metrics, neither it forwards to any external services. The stats is served until the instance is up and running, once the instance is restarted it will not hold any stats.
+To access the API Peformance of your Lisk Instance, navigate to `http://localhost:4000/http-stats/ui`. The APM is enabled by default to all environments except `testnet` and `mainnet`. The APM doesn't store any of the performance metrics, neither it forwards to any external services. The stats are served from the point on the instance is up and running, once the instance is restarted it will not hold any stats.
 
 To access the stats, follow the steps below:
 

--- a/framework/README.md
+++ b/framework/README.md
@@ -2,11 +2,7 @@
 
 # Lisk Framework
 
-[![Build Status](https://jenkins.lisk.io/buildStatus/icon?job=lisk-core/development)](https://jenkins.lisk.io/job/lisk-core/job/development)
-[![Coverage Status](https://coveralls.io/repos/github/LiskHQ/lisk/badge.svg?branch=development)](https://coveralls.io/github/LiskHQ/lisk?branch=development)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
-<a href="https://david-dm.org/LiskHQ/lisk"><img src="https://david-dm.org/LiskHQ/lisk.svg" alt="Dependency Status"></a>
-<a href="https://david-dm.org/LiskHQ/lisk/?type=dev"><img src="https://david-dm.org/LiskHQ/lisk/dev-status.svg" alt="devDependency Status"></a>
 
 ## What is Lisk Framework
 

--- a/framework/README.md
+++ b/framework/README.md
@@ -119,7 +119,7 @@ npm run jest:<testType> -- [testPathPattern] [jestCliOptions]
 
 ### API Performance and APM
 
-To access the API Peformance of your Lisk Instance, navigate to `http://localhost:4000/http-stats/ui`. The APM is enabled by default to all environments except `testnet` and `mainnet`. The APM doesn't store any of the performance metrics, neither it forwards to any external services. The stats are served from the point on the instance is up and running, once the instance is restarted it will not hold any stats.
+To access the API Peformance of your Lisk Instance, navigate to `http://localhost:4000/http-stats/ui`. The APM doesn't store any of the performance metrics, neither it forwards to any external services. The stats are served from the point on the instance is up and running, once the instance is restarted it will not hold any stats.
 
 To access the stats, follow the steps below:
 

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -7854,11 +7854,6 @@
 			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
 			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
 		},
-		"natives": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-			"integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -10951,7 +10946,6 @@
 				"cookies": "^0.7.1",
 				"debug": "^3.1.0",
 				"moment": "^2.19.3",
-				"natives": "^1.1.6",
 				"path-to-regexp": "^2.1.0",
 				"prom-client": "^11.0.0",
 				"qs": "^6.7.0",

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -1646,6 +1646,14 @@
 			"resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
 			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
 		},
+		"basic-auth": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+			"requires": {
+				"safe-buffer": "5.1.2"
+			}
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1667,6 +1675,11 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
+		},
+		"bintrees": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+			"integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
 		},
 		"bip39": {
 			"version": "2.5.0",
@@ -2500,6 +2513,15 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
 			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+		},
+		"cookies": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.3.tgz",
+			"integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
+			"requires": {
+				"depd": "~1.1.2",
+				"keygrip": "~1.0.3"
+			}
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -7126,6 +7148,11 @@
 				"verror": "1.10.0"
 			}
 		},
+		"keygrip": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
+			"integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
+		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -7745,8 +7772,7 @@
 		"moment": {
 			"version": "2.23.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-			"integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==",
-			"dev": true
+			"integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
 		},
 		"moment-timezone": {
 			"version": "0.5.26",
@@ -7827,6 +7853,11 @@
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
 			"integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+		},
+		"natives": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+			"integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -8910,6 +8941,14 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
+		},
+		"prom-client": {
+			"version": "11.5.3",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
+			"integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+			"requires": {
+				"tdigest": "^0.1.1"
+			}
 		},
 		"promptly": {
 			"version": "2.2.0",
@@ -10903,6 +10942,118 @@
 			"resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
 			"integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
 		},
+		"swagger-stats": {
+			"version": "0.95.11",
+			"resolved": "https://registry.npmjs.org/swagger-stats/-/swagger-stats-0.95.11.tgz",
+			"integrity": "sha512-RpE6NEofecAURwUm8Qfh2/IOkaselhHS/qQdTsowPuNrjSk7jkNF+JCqQLIM4xhIFX0i43sARDEmopi0cXLevA==",
+			"requires": {
+				"basic-auth": "^2.0.0",
+				"cookies": "^0.7.1",
+				"debug": "^3.1.0",
+				"moment": "^2.19.3",
+				"natives": "^1.1.6",
+				"path-to-regexp": "^2.1.0",
+				"prom-client": "^11.0.0",
+				"qs": "^6.7.0",
+				"request": "^2.85.0",
+				"send": "^0.17.1",
+				"uuid": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"http-errors": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+					"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.4",
+						"setprototypeof": "1.1.1",
+						"statuses": ">= 1.5.0 < 2",
+						"toidentifier": "1.0.0"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+				},
+				"mime": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"path-to-regexp": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+					"integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+				},
+				"qs": {
+					"version": "6.9.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
+					"integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
+				},
+				"send": {
+					"version": "0.17.1",
+					"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+					"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+					"requires": {
+						"debug": "2.6.9",
+						"depd": "~1.1.2",
+						"destroy": "~1.0.4",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"etag": "~1.8.1",
+						"fresh": "0.5.2",
+						"http-errors": "~1.7.2",
+						"mime": "1.6.0",
+						"ms": "2.1.1",
+						"on-finished": "~2.3.0",
+						"range-parser": "~1.2.1",
+						"statuses": "~1.5.0"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"requires": {
+								"ms": "2.0.0"
+							},
+							"dependencies": {
+								"ms": {
+									"version": "2.0.0",
+									"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+									"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+								}
+							}
+						},
+						"ms": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+						}
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+					"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+				}
+			}
+		},
 		"sway": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/sway/-/sway-2.0.5.tgz",
@@ -11063,6 +11214,14 @@
 					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
 					"dev": true
 				}
+			}
+		},
+		"tdigest": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+			"integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+			"requires": {
+				"bintrees": "1.0.1"
 			}
 		},
 		"test-exclude": {
@@ -11250,6 +11409,11 @@
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
 			}
+		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
 		},
 		"tough-cookie": {
 			"version": "2.4.3",

--- a/framework/package.json
+++ b/framework/package.json
@@ -84,6 +84,7 @@
 		"socket.io": "2.2.0",
 		"sodium-native": "2.4.6",
 		"swagger-node-runner": "0.7.3",
+		"swagger-stats": "0.95.11",
 		"sway": "2.0.5",
 		"yargs": "13.2.2",
 		"z-schema": "3.24.2"

--- a/framework/src/modules/http_api/defaults/config.js
+++ b/framework/src/modules/http_api/defaults/config.js
@@ -226,7 +226,7 @@ const defaultConfig = {
 			enabled: true,
 			options: {
 				name: 'Lisk-APM',
-				uriPath: '/lisk-stats',
+				uriPath: '/http-stats',
 			},
 		},
 	},

--- a/framework/src/modules/http_api/defaults/config.js
+++ b/framework/src/modules/http_api/defaults/config.js
@@ -153,6 +153,27 @@ const defaultConfig = {
 			},
 			required: ['access'],
 		},
+		apm: {
+			type: 'object',
+			properties: {
+				enabled: {
+					type: 'boolean',
+				},
+				options: {
+					type: 'object',
+					properties: {
+						name: {
+							type: 'string',
+						},
+						uriPath: {
+							type: 'string',
+						},
+					},
+					required: ['name', 'uriPath'],
+				},
+			},
+			required: ['enabled', 'options'],
+		},
 	},
 	required: [
 		'httpPort',
@@ -199,6 +220,13 @@ const defaultConfig = {
 		forging: {
 			access: {
 				whiteList: ['127.0.0.1'],
+			},
+		},
+		apm: {
+			enabled: true,
+			options: {
+				name: 'Lisk-APM',
+				uriPath: '/lisk-stats',
 			},
 		},
 	},

--- a/framework/src/modules/http_api/init_steps/setup_servers.js
+++ b/framework/src/modules/http_api/init_steps/setup_servers.js
@@ -20,6 +20,7 @@ const express = require('express');
 const http = require('http');
 const https = require('https');
 const socketIO = require('socket.io');
+const swStats = require('swagger-stats');
 
 module.exports = ({ components: { logger }, config }) => {
 	const expressApp = express();
@@ -38,6 +39,16 @@ module.exports = ({ components: { logger }, config }) => {
 
 	if (config.trustProxy) {
 		expressApp.enable('trust proxy');
+	}
+
+	if (config.apm.enabled) {
+		expressApp.use(
+			swStats.getMiddleware({
+				name: config.apm.options.name,
+				uriPath: config.apm.options.uriPath,
+			}),
+		);
+		logger.info('Enabled Lisk APM');
 	}
 
 	const httpServer = http.createServer(expressApp);

--- a/framework/src/modules/http_api/init_steps/setup_servers.js
+++ b/framework/src/modules/http_api/init_steps/setup_servers.js
@@ -42,13 +42,14 @@ module.exports = ({ components: { logger }, config }) => {
 	}
 
 	if (config.apm.enabled) {
+		const { name, uriPath } = config.apm.options;
 		expressApp.use(
 			swStats.getMiddleware({
-				name: config.apm.options.name,
-				uriPath: config.apm.options.uriPath,
+				name,
+				uriPath,
 			}),
 		);
-		logger.info('Enabled Lisk APM');
+		logger.info({ 'service-name': name, uriPath }, 'Enabled Lisk APM');
 	}
 
 	const httpServer = http.createServer(expressApp);

--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -522,6 +522,13 @@ Object {
         ],
       },
       "address": "0.0.0.0",
+      "apm": Object {
+        "enabled": true,
+        "options": Object {
+          "name": "Lisk-APM",
+          "uriPath": "/http-stats",
+        },
+      },
       "enabled": true,
       "forging": Object {
         "access": Object {

--- a/framework/test/mocha/unit/modules/http_api/init_steps/setup_servers.js
+++ b/framework/test/mocha/unit/modules/http_api/init_steps/setup_servers.js
@@ -38,6 +38,9 @@ describe('init_steps/setup_servers', () => {
 		config: {
 			coverage: false,
 			trustProxy: false,
+			apm: {
+				enable: false,
+			},
 			ssl: {
 				enabled: false,
 				options: {


### PR DESCRIPTION
### What was the problem?
Missing APM after removing newrelic
### How did I solve it?
Integrated https://swaggerstats.io/ to SDK
### How to manually test it?
- Install SDK
- Install dependencies and build
- Run `node framework/test/test_app | npx bunyan -o short`
- Access endpoint `http://localhost:4000/lisk-stats/ui`
- Access some endpoints `siege -t2S http://localhost:4000/api/delegates`
- You should see the stats in the UI
### Review checklist

- [ ] The PR resolves #4300 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
