### PR TITLE
Save height finalized when apply - Closes #3695

### DIFF
--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -134,12 +134,18 @@ class BFT extends EventEmitter {
 	 * Load new block to BFT
 	 *
 	 * @param {Object} block - The block which is forged
+	 * @param {Object} tx - database transaction
 	 * @return {Promise<void>}
 	 */
-	async addNewBlock(block) {
-		// We don't need async operations here as of now but can require in future
-		// and for consistency with other interfaces keeping it async
+	async addNewBlock(block, tx) {
 		this.finalityManager.addBlockHeader(extractBFTBlockHeaderFromBlock(block));
+		const { finalizedHeight } = this.finalityManager;
+		// TODO: this should be memory operation in the state store
+		return this.ChainMetaEntity.setKey(
+			META_KEYS.FINALIZED_HEIGHT,
+			finalizedHeight,
+			tx,
+		);
 	}
 
 	async verifyNewBlock(block) {

--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -211,7 +211,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 		this.apply.pipe([
 			data => this.blocksModule.verify(data),
 			data => this.blocksModule.apply(data),
-			({ block }) => this.bftModule.addNewBlock(block),
+			({ block, tx }) => this.bftModule.addNewBlock(block, tx),
 		]);
 
 		this.applyGenesis.pipe([data => this.blocksModule.applyGenesis(data)]);

--- a/framework/src/modules/chain/components/storage/entities/chain_meta.js
+++ b/framework/src/modules/chain/components/storage/entities/chain_meta.js
@@ -114,7 +114,10 @@ class ChainMeta extends BaseEntity {
 	 */
 	async setKey(key, value, tx) {
 		assert(key, 'Must provide the key to set');
-		assert(value, 'Must provide the value to set');
+		assert(
+			value !== null && value !== undefined,
+			'Must provide the value to set',
+		);
 
 		const expectedResultCount = 0;
 

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -199,6 +199,7 @@ describe('bft', () => {
 
 		describe('#addNewBlock', () => {
 			const block1 = blockFixture({ height: 1, version: '2' });
+			const lastFinalizedHeight = 5;
 
 			let bft;
 			let txStub;
@@ -206,18 +207,20 @@ describe('bft', () => {
 			beforeEach(async () => {
 				storageMock.entities.Block.get.mockReturnValue([]);
 				bft = new BFT(bftParams);
-				storageMock.entities.ChainMeta.getKey.mockReturnValue(5);
+				storageMock.entities.ChainMeta.getKey.mockReturnValue(
+					lastFinalizedHeight,
+				);
 				txStub = jest.fn();
 				await bft.init();
 				storageMock.entities.Block.get.mockClear();
 			});
 
-			describe('when valid block is added', () => {
+			describe('when valid block which does not change the finality is added', () => {
 				it('should update the latest finalized height to storage', async () => {
 					await bft.addNewBlock(block1, txStub);
 					expect(storageMock.entities.ChainMeta.setKey).toHaveBeenCalledWith(
 						'BFT.finalizedHeight',
-						5,
+						lastFinalizedHeight,
 						txStub,
 					);
 				});

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -74,6 +74,7 @@ describe('bft', () => {
 				},
 				ChainMeta: {
 					getKey: jest.fn(),
+					setKey: jest.fn(),
 				},
 			},
 		};
@@ -87,7 +88,7 @@ describe('bft', () => {
 			startingHeight,
 		};
 
-		describe('constructor()', () => {
+		describe('#constructor', () => {
 			it('should create instance of BFT', async () => {
 				expect(new BFT(bftParams)).toBeInstanceOf(BFT);
 			});
@@ -104,7 +105,7 @@ describe('bft', () => {
 			});
 		});
 
-		describe('init()', () => {
+		describe('#init', () => {
 			let bft;
 
 			beforeEach(async () => {
@@ -196,7 +197,34 @@ describe('bft', () => {
 			});
 		});
 
-		describe('deleteBlocks()', () => {
+		describe('#addNewBlock', () => {
+			const block1 = blockFixture({ height: 1, version: '2' });
+
+			let bft;
+			let txStub;
+
+			beforeEach(async () => {
+				storageMock.entities.Block.get.mockReturnValue([]);
+				bft = new BFT(bftParams);
+				storageMock.entities.ChainMeta.getKey.mockReturnValue(5);
+				txStub = jest.fn();
+				await bft.init();
+				storageMock.entities.Block.get.mockClear();
+			});
+
+			describe('when valid block is added', () => {
+				it('should update the latest finalized height to storage', async () => {
+					await bft.addNewBlock(block1, txStub);
+					expect(storageMock.entities.ChainMeta.setKey).toHaveBeenCalledWith(
+						'BFT.finalizedHeight',
+						5,
+						txStub,
+					);
+				});
+			});
+		});
+
+		describe('#deleteBlocks', () => {
 			let bft;
 
 			beforeEach(async () => {
@@ -387,7 +415,7 @@ describe('bft', () => {
 		});
 
 		// TODO: Remove tests for private methods
-		describe('_initFinalityManager()', () => {
+		describe('#_initFinalityManager', () => {
 			it('should call ChainMetaEntity.getKey to get stored finalized height', async () => {
 				const bft = new BFT(bftParams);
 				const result = await bft._initFinalityManager();
@@ -440,7 +468,7 @@ describe('bft', () => {
 			});
 		});
 
-		describe('_getLastBlockHeight()', () => {
+		describe('#_getLastBlockHeight', () => {
 			it('should call BlockEntity.get with particular parameters', async () => {
 				const bft = new BFT(bftParams);
 				storageMock.entities.Block.get.mockReturnValue([]);
@@ -481,7 +509,7 @@ describe('bft', () => {
 			});
 		});
 
-		describe('_loadBlocksFromStorage()', () => {
+		describe('#_loadBlocksFromStorage', () => {
 			const fromHeight = 0;
 			const tillHeight = 10;
 			let bft;


### PR DESCRIPTION
### What was the problem?
finalizedHeight was not saved while processing a block

### How did I solve it?
Add saving finalized logic into apply step of processing

### How to manually test it?
Keep forging until height > 202, and `select * from chain_meta;` to see if the heightFinalized is saved

### Review checklist

- [ ] The PR resolves #3695 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
