### PR TITLE
Return full common block instead of ID property - Closes #4307

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -330,7 +330,7 @@ module.exports = class Chain {
 					action.params.ids,
 				);
 
-				return commonBlock || null;
+				return commonBlock;
 			},
 		};
 	}

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -316,10 +316,13 @@ module.exports = class Chain {
 				if (valid.length) {
 					const err = valid;
 					const error = `${err[0].message}: ${err[0].path}`;
-					this.logger.debug('getHighestCommonBlock request validation failed', {
-						err: error,
-						req: action.params,
-					});
+					this.logger.debug(
+						{
+							err: error,
+							req: action.params,
+						},
+						'getHighestCommonBlock request validation failed',
+					);
 					throw new Error(error);
 				}
 

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -307,22 +307,19 @@ module.exports = class Chain {
 			}),
 			getLastBlock: async () => this.blocks.lastBlock,
 			blocks: async action => this.transport.blocks(action.params || {}),
-			getHighestCommonBlockId: async action => {
+			getHighestCommonBlock: async action => {
 				const valid = validator.validate(
-					definitions.getHighestCommonBlockIdRequest,
+					definitions.getHighestCommonBlockRequest,
 					action.params,
 				);
 
 				if (valid.length) {
 					const err = valid;
 					const error = `${err[0].message}: ${err[0].path}`;
-					this.logger.debug(
-						'getHighestCommonBlockId request validation failed',
-						{
-							err: error,
-							req: action.params,
-						},
-					);
+					this.logger.debug('getHighestCommonBlock request validation failed', {
+						err: error,
+						req: action.params,
+					});
 					throw new Error(error);
 				}
 
@@ -330,7 +327,7 @@ module.exports = class Chain {
 					action.params.ids,
 				);
 
-				return commonBlock ? commonBlock.id : null;
+				return commonBlock || null;
 			},
 		};
 	}

--- a/framework/src/modules/chain/index.js
+++ b/framework/src/modules/chain/index.js
@@ -136,9 +136,9 @@ class ChainModule extends BaseModule {
 				handler: async action => this.chain.actions.blocks(action),
 				isPublic: true,
 			},
-			getHighestCommonBlockId: {
+			getHighestCommonBlock: {
 				handler: async action =>
-					this.chain.actions.getHighestCommonBlockId(action),
+					this.chain.actions.getHighestCommonBlock(action),
 				isPublic: true,
 			},
 		};

--- a/framework/src/modules/chain/schema/definitions.js
+++ b/framework/src/modules/chain/schema/definitions.js
@@ -99,8 +99,8 @@ module.exports = {
 			type: 'object',
 		},
 	},
-	getHighestCommonBlockIdRequest: {
-		id: 'getHighestCommonBlockIdRequest',
+	getHighestCommonBlockRequest: {
+		id: 'getHighestCommonBlockRequest',
 		type: 'object',
 		required: ['ids'],
 		properties: {

--- a/framework/test/mocha/functional/ws/transport/transport.js
+++ b/framework/test/mocha/functional/ws/transport/transport.js
@@ -303,7 +303,7 @@ describe('WS transport', () => {
 					},
 				});
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(data));
-				expect(data).to.be.null;
+				expect(data).to.be.undefined;
 			});
 		});
 

--- a/framework/test/mocha/functional/ws/transport/transport.js
+++ b/framework/test/mocha/functional/ws/transport/transport.js
@@ -204,12 +204,12 @@ describe('WS transport', () => {
 			});
 		});
 
-		describe('getHighestCommonBlockId', () => {
+		describe('getHighestCommonBlock', () => {
 			it('using no params should fail', async () => {
 				let res;
 				try {
 					const { data } = await p2p.request({
-						procedure: 'getHighestCommonBlockId',
+						procedure: 'getHighestCommonBlock',
 					});
 					res = data;
 				} catch (err) {
@@ -227,7 +227,7 @@ describe('WS transport', () => {
 				let res;
 				try {
 					res = await p2p.request({
-						procedure: 'getHighestCommonBlockId',
+						procedure: 'getHighestCommonBlock',
 						data: { ids: ['1', '2', '2'] },
 					});
 				} catch (err) {
@@ -246,7 +246,7 @@ describe('WS transport', () => {
 				let res;
 				try {
 					res = await p2p.request({
-						procedure: 'getHighestCommonBlockId',
+						procedure: 'getHighestCommonBlock',
 						data: { ids: [] },
 					});
 				} catch (err) {
@@ -265,7 +265,7 @@ describe('WS transport', () => {
 				let res;
 				try {
 					res = await p2p.request({
-						procedure: 'getHighestCommonBlockId',
+						procedure: 'getHighestCommonBlock',
 						data: { ids: ['abcde', '1'] },
 					});
 				} catch (err) {
@@ -282,7 +282,7 @@ describe('WS transport', () => {
 				let res;
 				try {
 					res = await p2p.request({
-						procedure: 'getHighestCommonBlockId',
+						procedure: 'getHighestCommonBlock',
 						data: { ids: '1,2,3,4,5,6' },
 					});
 				} catch (err) {
@@ -297,18 +297,18 @@ describe('WS transport', () => {
 
 			it('using ids which include genesisBlock.id should be ok', async () => {
 				const { data } = await p2p.request({
-					procedure: 'getHighestCommonBlockId',
+					procedure: 'getHighestCommonBlock',
 					data: {
 						ids: [__testContext.config.genesisBlock.id.toString(), '2', '3'],
 					},
 				});
 				__testContext.debug('> Error / Response:'.grey, JSON.stringify(data));
-				expect(data).to.equal(__testContext.config.genesisBlock.id.toString());
+				expect(data).to.equal(__testContext.config.genesisBlock);
 			});
 
 			it('using ["1","2","3"] should return an empty array (no common blocks)', async () => {
 				const { data } = await p2p.request({
-					procedure: 'getHighestCommonBlockId',
+					procedure: 'getHighestCommonBlock',
 					data: {
 						ids: ['1', '2', '3'],
 					},

--- a/framework/test/mocha/functional/ws/transport/transport.js
+++ b/framework/test/mocha/functional/ws/transport/transport.js
@@ -295,17 +295,6 @@ describe('WS transport', () => {
 				}
 			});
 
-			it('using ids which include genesisBlock.id should be ok', async () => {
-				const { data } = await p2p.request({
-					procedure: 'getHighestCommonBlock',
-					data: {
-						ids: [__testContext.config.genesisBlock.id.toString(), '2', '3'],
-					},
-				});
-				__testContext.debug('> Error / Response:'.grey, JSON.stringify(data));
-				expect(data).to.equal(__testContext.config.genesisBlock);
-			});
-
 			it('using ["1","2","3"] should return an empty array (no common blocks)', async () => {
 				const { data } = await p2p.request({
 					procedure: 'getHighestCommonBlock',

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -175,7 +175,7 @@ describe('Chain', () => {
 						ids: ['1', '2'],
 					},
 				});
-				expect(response).to.be.null;
+				expect(response).to.be.undefined;
 			});
 
 			it('should return the block id if commonBlock has been found', async () => {

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -186,7 +186,7 @@ describe('Chain', () => {
 				const response = await chain.actions.getHighestCommonBlock({
 					params: { ids: ['1', '2'] },
 				});
-				expect(response).to.equal({ id: '123', height: '1' });
+				expect(response).to.deep.equal({ id: '123', height: '1' });
 			});
 
 			it('should call blocks.getHighestCommonBlock with proper arguments', async () => {});

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -145,20 +145,20 @@ describe('Chain', () => {
 			};
 		});
 
-		describe('getHighestCommonBlockId', () => {
+		describe('getHighestCommonBlock', () => {
 			const actionQuery = {
 				params: { ids: ['1', '1'] },
 			};
 
 			it('should validate the request and return a validation error and debug log it if it fails', async () => {
 				try {
-					await chain.actions.getHighestCommonBlockId(actionQuery);
+					await chain.actions.getHighestCommonBlock(actionQuery);
 				} catch (error) {
 					expect(error.message).to.equal(
 						'should NOT have duplicate items (items ## 1 and 0 are identical): undefined',
 					);
 					expect(chain.logger.debug).to.be.calledWith(
-						'getHighestCommonBlockId request validation failed',
+						'getHighestCommonBlock request validation failed',
 						{
 							err:
 								'should NOT have duplicate items (items ## 1 and 0 are identical): undefined',
@@ -170,7 +170,7 @@ describe('Chain', () => {
 
 			it('should return null if commonBlock has not been found', async () => {
 				chain.scope.modules.blocks.getHighestCommonBlock.returns(undefined);
-				const response = await chain.actions.getHighestCommonBlockId({
+				const response = await chain.actions.getHighestCommonBlock({
 					params: {
 						ids: ['1', '2'],
 					},
@@ -183,10 +183,10 @@ describe('Chain', () => {
 					id: '123',
 					height: '1',
 				});
-				const response = await chain.actions.getHighestCommonBlockId({
+				const response = await chain.actions.getHighestCommonBlock({
 					params: { ids: ['1', '2'] },
 				});
-				expect(response).to.equal('123');
+				expect(response).to.equal({ id: '123', height: '1' });
 			});
 
 			it('should call blocks.getHighestCommonBlock with proper arguments', async () => {});

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -158,12 +158,12 @@ describe('Chain', () => {
 						'should NOT have duplicate items (items ## 1 and 0 are identical): undefined',
 					);
 					expect(chain.logger.debug).to.be.calledWith(
-						'getHighestCommonBlock request validation failed',
 						{
 							err:
 								'should NOT have duplicate items (items ## 1 and 0 are identical): undefined',
 							req: actionQuery.params,
 						},
+						'getHighestCommonBlock request validation failed',
 					);
 				}
 			});
@@ -186,7 +186,7 @@ describe('Chain', () => {
 				const response = await chain.actions.getHighestCommonBlock({
 					params: { ids: ['1', '2'] },
 				});
-				expect(response).to.deep.equal({ id: '123', height: '1' });
+				expect(response).to.eql({ id: '123', height: '1' });
 			});
 
 			it('should call blocks.getHighestCommonBlock with proper arguments', async () => {});


### PR DESCRIPTION
### What was the problem?
Refer to #4307
### How did I solve it?
Returning the full block instead of only its ID.
### How to manually test it?
Run `blocks.spec.js`
### Review checklist

- [ ] The PR resolves #4307
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
