### PR TITLE
Integrate swagger-stats APM - Closes #4300

### DIFF
--- a/framework/src/modules/http_api/defaults/config.js
+++ b/framework/src/modules/http_api/defaults/config.js
@@ -223,7 +223,7 @@ const defaultConfig = {
 			},
 		},
 		apm: {
-			enabled: true,
+			enabled: false,
 			options: {
 				name: 'Lisk-APM',
 				uriPath: '/http-stats',

--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -523,7 +523,7 @@ Object {
       },
       "address": "0.0.0.0",
       "apm": Object {
-        "enabled": true,
+        "enabled": false,
         "options": Object {
           "name": "Lisk-APM",
           "uriPath": "/http-stats",


### PR DESCRIPTION
### What was the problem?
Missing APM after removing newrelic
### How did I solve it?
- Integrated https://swaggerstats.io/ to SDK
- Disabled APM for `Testnet` and `Mainnet` by default
### How to manually test it?
- Install SDK
- Install dependencies and build
- Run `node framework/test/test_app | npx bunyan -o short`
- Access endpoint `http://localhost:4000/lisk-stats/ui`
- Access some endpoints `siege -t2S http://localhost:4000/api/delegates`
- You should see the stats in the UI
### Review checklist

- [ ] The PR resolves #4300 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
