### PR TITLE
Update inbound peer eviction and add advanced test coverage - Closes #4280

### DIFF
--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -80,7 +80,8 @@ interface FilterPeersOptions {
 	readonly asc: boolean;
 }
 
-const filterPeersByCategory = (
+// Returns an array of peers to be protected
+export const filterPeersByCategory = (
 	peers: Peer[],
 	options: FilterPeersOptions,
 ): Peer[] => {
@@ -88,15 +89,18 @@ const filterPeersByCategory = (
 	if (options.percentage > 1 || options.percentage < 0) {
 		return peers;
 	}
-	const peerCount = Math.ceil(peers.length * options.percentage);
+	const protectedPeerIndex = Math.max(
+		1,
+		Math.floor(peers.length * (1 - options.percentage)),
+	);
 	const sign = !!options.asc ? 1 : -1;
 
 	// tslint:disable-next-line no-any
 	return peers
-		.sort((peerA: any, peerB: any) =>
-			peerA[options.category] > peerB[options.category] ? sign : sign * -1,
+		.sort((a: any, b: any) =>
+			a[options.category] > b[options.category] ? sign : sign * -1,
 		)
-		.slice(peerCount, peers.length);
+		.slice(protectedPeerIndex, peers.length);
 };
 
 enum PROTECTION_CATEGORY {

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -103,7 +103,7 @@ export const filterPeersByCategory = (
 		.slice(protectedPeerIndex, peers.length);
 };
 
-enum PROTECTION_CATEGORY {
+export enum PROTECTION_CATEGORY {
 	NET_GROUP = 'netgroup',
 	LATENCY = 'latency',
 	RESPONSE_RATE = 'responseRate',

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -97,8 +97,8 @@ export const filterPeersByCategory = (
 
 	// tslint:disable-next-line no-any
 	return peers
-		.sort((a: any, b: any) =>
-			a[options.category] > b[options.category] ? sign : sign * -1,
+		.sort((peerA: any, peerB: any) =>
+			peerA[options.category] > peerB[options.category] ? sign : sign * -1,
 		)
 		.slice(protectedPeerIndex, peers.length);
 };

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -138,6 +138,12 @@ describe('peerPool', () => {
 		let originalPeers: Array<any> = [];
 
 		beforeEach(async () => {
+			originalPeers = [...new Array(100).keys()].map(i => ({
+				netgroup: i,
+				latency: i,
+				responseRate: i % 2 ? 0 : 1,
+				connectTime: i,
+			}));
 			(peerPool as any)._peerPoolConfig.netgroupProtectionRatio = DEFAULT_PEER_PROTECTION_FOR_NETGROUP;
 			(peerPool as any)._peerPoolConfig.latencyProtectionRatio = DEFAULT_PEER_PROTECTION_FOR_LATENCY;
 			(peerPool as any)._peerPoolConfig.productivityProtectionRatio = DEFAULT_PEER_PROTECTION_FOR_USEFULNESS;
@@ -149,12 +155,6 @@ describe('peerPool', () => {
 
 		describe('when node using default protection ratio values has 100 inbound peers', () => {
 			beforeEach(() => {
-				originalPeers = [...new Array(100).keys()].map(i => ({
-					netgroup: i,
-					latency: i,
-					responseRate: i % 2 ? 0 : 1,
-					connectTime: i,
-				}));
 				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
 			});
 
@@ -204,12 +204,6 @@ describe('peerPool', () => {
 		describe('when node with netgroup protection disabled has 100 inbound peers', () => {
 			beforeEach(() => {
 				(peerPool as any)._peerPoolConfig.netgroupProtectionRatio = 0;
-				originalPeers = [...new Array(100).keys()].map(i => ({
-					netgroup: i,
-					latency: i,
-					responseRate: i % 2 ? 0 : 1,
-					connectTime: i,
-				}));
 				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
 			});
 
@@ -223,12 +217,6 @@ describe('peerPool', () => {
 		describe('when node with latency protection disabled has 100 inbound peers', () => {
 			beforeEach(() => {
 				(peerPool as any)._peerPoolConfig.latencyProtectionRatio = 0;
-				originalPeers = [...new Array(100).keys()].map(i => ({
-					netgroup: i,
-					latency: i,
-					responseRate: i % 2 ? 0 : 1,
-					connectTime: i,
-				}));
 				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
 			});
 
@@ -242,12 +230,6 @@ describe('peerPool', () => {
 		describe('when node with usefulness protection disabled has 100 inbound peers', () => {
 			beforeEach(() => {
 				(peerPool as any)._peerPoolConfig.productivityProtectionRatio = 0;
-				originalPeers = [...new Array(100).keys()].map(i => ({
-					netgroup: i,
-					latency: i,
-					responseRate: i % 2 ? 0 : 1,
-					connectTime: i,
-				}));
 				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
 			});
 
@@ -261,7 +243,23 @@ describe('peerPool', () => {
 		describe('when node with longevity protection disabled has 100 inbound peers', () => {
 			beforeEach(() => {
 				(peerPool as any)._peerPoolConfig.longevityProtectionRatio = 0;
-				originalPeers = [...new Array(100).keys()].map(i => ({
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(85);
+			});
+		});
+
+		describe('when node has all inbound protection disabled has 10 inbound peers', () => {
+			beforeEach(() => {
+				(peerPool as any)._peerPoolConfig.netgroupProtectionRatio = 0;
+				(peerPool as any)._peerPoolConfig.latencyProtectionRatio = 0;
+				(peerPool as any)._peerPoolConfig.productivityProtectionRatio = 0;
+				(peerPool as any)._peerPoolConfig.longevityProtectionRatio = 0;
+				originalPeers = [...new Array(10).keys()].map(i => ({
 					netgroup: i,
 					latency: i,
 					responseRate: i % 2 ? 0 : 1,
@@ -270,10 +268,10 @@ describe('peerPool', () => {
 				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
 			});
 
-			it('should return expected amount of eviction candidates', async () => {
+			it('should not evict any candidates', async () => {
 				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
 
-				expect(selectedPeersForEviction.length).to.eql(85);
+				expect(selectedPeersForEviction.length).to.eql(10);
 			});
 		});
 	});

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -23,6 +23,8 @@ import {
 	selectPeersForRequest,
 	selectPeersForSend,
 } from '../../src/utils';
+// For stubbing
+import * as utils from '../../src/utils';
 import { P2PDiscoveredPeerInfo, P2PPeerInfo } from '../../src/p2p_types';
 import { Peer, ConnectionState } from '../../src/peer';
 import { initializePeerList, initializePeerInfoList } from '../utils/peers';
@@ -128,6 +130,150 @@ describe('peerPool', () => {
 
 			filteredPeers.forEach(peer => {
 				expect(peer.connectTime).to.be.lessThan(2);
+			});
+		});
+	});
+
+	describe('#_selectPeersForEviction', () => {
+		let originalPeers: Array<any> = [];
+
+		beforeEach(async () => {
+			(peerPool as any)._peerPoolConfig.netgroupProtectionRatio = DEFAULT_PEER_PROTECTION_FOR_NETGROUP;
+			(peerPool as any)._peerPoolConfig.latencyProtectionRatio = DEFAULT_PEER_PROTECTION_FOR_LATENCY;
+			(peerPool as any)._peerPoolConfig.productivityProtectionRatio = DEFAULT_PEER_PROTECTION_FOR_USEFULNESS;
+			(peerPool as any)._peerPoolConfig.longevityProtectionRatio = DEFAULT_PEER_PROTECTION_FOR_LONGEVITY;
+			sandbox
+				.stub(utils, 'constructPeerIdFromPeerInfo')
+				.returns('notAWhitelistedId');
+		});
+
+		describe('when node using default protection ratio values has 100 inbound peers', () => {
+			beforeEach(() => {
+				originalPeers = [...new Array(100).keys()].map(i => ({
+					netgroup: i,
+					latency: i,
+					responseRate: i % 2 ? 0 : 1,
+					connectTime: i,
+				}));
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(42);
+			});
+		});
+
+		describe('when node using default protection ratio values has 10 inbound peers', () => {
+			beforeEach(() => {
+				originalPeers = [...new Array(10).keys()].map(i => ({
+					netgroup: i,
+					latency: i,
+					responseRate: i % 2 ? 0 : 1,
+					connectTime: i,
+				}));
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(4);
+			});
+		});
+
+		describe('when node using default protection ratio values has 5 inbound peers', () => {
+			beforeEach(() => {
+				originalPeers = [...new Array(5).keys()].map(i => ({
+					netgroup: i,
+					latency: i,
+					responseRate: i % 2 ? 0 : 1,
+					connectTime: i,
+				}));
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(1);
+			});
+		});
+
+		describe('when node with netgroup protection disabled has 100 inbound peers', () => {
+			beforeEach(() => {
+				(peerPool as any)._peerPoolConfig.netgroupProtectionRatio = 0;
+				originalPeers = [...new Array(100).keys()].map(i => ({
+					netgroup: i,
+					latency: i,
+					responseRate: i % 2 ? 0 : 1,
+					connectTime: i,
+				}));
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(44);
+			});
+		});
+
+		describe('when node with latency protection disabled has 100 inbound peers', () => {
+			beforeEach(() => {
+				(peerPool as any)._peerPoolConfig.latencyProtectionRatio = 0;
+				originalPeers = [...new Array(100).keys()].map(i => ({
+					netgroup: i,
+					latency: i,
+					responseRate: i % 2 ? 0 : 1,
+					connectTime: i,
+				}));
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(45);
+			});
+		});
+
+		describe('when node with usefulness protection disabled has 100 inbound peers', () => {
+			beforeEach(() => {
+				(peerPool as any)._peerPoolConfig.productivityProtectionRatio = 0;
+				originalPeers = [...new Array(100).keys()].map(i => ({
+					netgroup: i,
+					latency: i,
+					responseRate: i % 2 ? 0 : 1,
+					connectTime: i,
+				}));
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(44);
+			});
+		});
+
+		describe('when node with longevity protection disabled has 100 inbound peers', () => {
+			beforeEach(() => {
+				(peerPool as any)._peerPoolConfig.longevityProtectionRatio = 0;
+				originalPeers = [...new Array(100).keys()].map(i => ({
+					netgroup: i,
+					latency: i,
+					responseRate: i % 2 ? 0 : 1,
+					connectTime: i,
+				}));
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(85);
 			});
 		});
 	});

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -201,6 +201,19 @@ describe('peerPool', () => {
 			});
 		});
 
+		describe('when node using default protection ratio values has 0 inbound peers', () => {
+			beforeEach(() => {
+				originalPeers = [];
+				sandbox.stub(peerPool, 'getPeers').returns(originalPeers as Peer[]);
+			});
+
+			it('should return expected amount of eviction candidates', async () => {
+				const selectedPeersForEviction = (peerPool as any)._selectPeersForEviction();
+
+				expect(selectedPeersForEviction.length).to.eql(0);
+			});
+		});
+
 		describe('when node with netgroup protection disabled has 100 inbound peers', () => {
 			beforeEach(() => {
 				(peerPool as any)._peerPoolConfig.netgroupProtectionRatio = 0;


### PR DESCRIPTION
### What was the problem?

- Some categories in inbound eviction process were dependent on each other causing minor change in eviction candidate results.

- There were no advanced unit tests for inbound eviction process.

### How did I solve it?

Decoupled `netgroup`, `latency` and `responseRate` peer eviction processing. 
Added required tests simulating different inbound peer scenarios.

The expected number of eviction candidates for each test are based on the following estimates derived from default protection ratios assuming 100 peers:  

`netgroup`: 4 peers, `latency`: 7 peers, `usefulness`: 7 peers, `longevity`: 41 peers



### How to manually test it?

npm run test

### Review checklist

- [ ] The PR resolves #4280 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
