### PR TITLE
State store inconsistent return value - Closes #4317

### DIFF
--- a/framework/src/modules/chain/state_store/account_store.js
+++ b/framework/src/modules/chain/state_store/account_store.js
@@ -51,7 +51,7 @@ class AccountStore {
 	async cache(filter) {
 		const result = await this.account.get(filter, { extended: true }, this.tx);
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
-		return _.cloneDeep(this.data);
+		return _.cloneDeep(result);
 	}
 
 	createSnapshot() {

--- a/framework/src/modules/chain/state_store/transaction_store.js
+++ b/framework/src/modules/chain/state_store/transaction_store.js
@@ -32,7 +32,7 @@ class TransactionStore {
 			this.tx,
 		);
 		this.data = _.uniqBy([...this.data, ...result], this.primaryKey);
-		return result;
+		return _.cloneDeep(result);
 	}
 
 	add(element) {


### PR DESCRIPTION
As mentionned into LiskHQ#4317 the return values of the state store are inconsistent. This tiny patch fixes it.