### PR TITLE
Undo did not call bft module to delete block - Closes #4320

### DIFF
--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -216,7 +216,10 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 
 		this.applyGenesis.pipe([data => this.blocksModule.applyGenesis(data)]);
 
-		this.undo.pipe([data => this.blocksModule.undo(data)]);
+		this.undo.pipe([
+			data => this.blocksModule.undo(data),
+			({ block }) => this.bftModule.deleteBlocks([block]),
+		]);
 
 		this.create.pipe([
 			// Getting the BFT header (maxHeightPreviouslyForged and prevotedConfirmedUptoHeight)


### PR DESCRIPTION
### What was the problem?
bft.deleteBlocks was not called while undoing the block

### How did I solve it?
Call in the v2 block_processor while undoing

### How to manually test it?
block processor test needs to be added.

### Review checklist

- [ ] The PR resolves #4320 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Documentation has been added/updated
