### PR TITLE
Remove transactions data from node status endpoint - Closes #4294

### DIFF
--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -18,7 +18,6 @@ const _ = require('lodash');
 const checkIpInList = require('../helpers/check_ip_in_list');
 const apiCodes = require('../api_codes');
 const swaggerHelper = require('../helpers/swagger');
-const { CACHE_KEYS_TRANSACTION_COUNT } = require('../../../components/cache');
 
 const { EPOCH_TIME, FEES } = global.constants;
 
@@ -87,47 +86,6 @@ async function _getNetworkHeight() {
 	);
 
 	return parseInt(networkHeight, 10);
-}
-
-/**
- * Get count of confirmedTransaction from cache
- *
- * @returns Number
- * @private
- */
-async function _getConfirmedTransactionCount() {
-	// if cache is ready, then get cache and return
-	if (library.components.cache.ready) {
-		try {
-			const data = await library.components.cache.getJsonForKey(
-				CACHE_KEYS_TRANSACTION_COUNT,
-			);
-			if (data && data.confirmed !== null && data.confirmed !== undefined) {
-				return data.confirmed;
-			}
-		} catch (error) {
-			library.components.logger.debug("Transaction count wasn't cached");
-		}
-	}
-	const confirmed = await library.components.storage.entities.Transaction.count();
-	// only update cache if ready
-	if (library.components.cache.ready) {
-		try {
-			await library.components.cache.setJsonForKey(
-				CACHE_KEYS_TRANSACTION_COUNT,
-				{
-					confirmed,
-				},
-			);
-		} catch (error) {
-			// Ignore error and just put warn
-			library.components.logger.debug(
-				error,
-				'Failed to cache Transaction count',
-			);
-		}
-	}
-	return confirmed;
 }
 
 /**

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -251,22 +251,10 @@ NodeController.getStatus = async (context, next) => {
 			secondsSinceEpoch,
 			loaded,
 			syncing,
-			unconfirmedTransactions,
 			lastBlock,
 		} = await library.channel.invoke('chain:getNodeStatus');
 
-		// get confirmed count from cache or chain
-
-		const [confirmed, networkHeight] = await Promise.all([
-			_getConfirmedTransactionCount(),
-			_getNetworkHeight(),
-		]);
-		const total =
-			confirmed +
-			Object.values(unconfirmedTransactions).reduce(
-				(prev, current) => prev + current,
-				0,
-			);
+		const networkHeight = await _getNetworkHeight();
 
 		const data = {
 			broadhash: library.applicationState.broadhash,
@@ -277,11 +265,6 @@ NodeController.getStatus = async (context, next) => {
 			loaded,
 			networkHeight,
 			syncing,
-			transactions: {
-				confirmed,
-				...unconfirmedTransactions,
-				total,
-			},
 		};
 
 		return next(null, data);

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -2262,7 +2262,6 @@ definitions:
       - networkHeight
       - secondsSinceEpoch
       - syncing
-      - transactions
     properties:
       broadhash:
         type: string
@@ -2308,46 +2307,6 @@ definitions:
         type: boolean
         example: false
         description: True if the node syncing with other peers.
-      transactions:
-        type: object
-        required:
-          - ready
-          - pending
-          - verified
-          - confirmed
-          - validated
-          - received
-          - total
-        description: Transactions known to the node.
-        properties:
-          ready:
-            type: integer
-            example: 5
-            description: Number of unconfirmed Transactions known to the node.
-          pending:
-            type: integer
-            example: 2
-            description: Number of pending Transactions known to the node.
-          verified:
-            type: integer
-            example: 3
-            description: Number of verified Transactions known to the node.
-          confirmed:
-            type: integer
-            example: 5
-            description: Number of confirmed Transactions known to the node.
-          validated:
-            type: integer
-            example: 5
-            description: Number of validated Transactions known to the node.
-          received:
-            type: integer
-            example: 5
-            description: Number of received Transactions known to the node.
-          total:
-            type: integer
-            example: 15
-            description: Number of total Transactions known to the node.
 
   TransactionError:
     type: object

--- a/framework/test/mocha/unit/modules/http_api/controllers/node.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/node.js
@@ -144,15 +144,6 @@ describe('node/api', () => {
 			loaded: true,
 			networkHeight: 456,
 			syncing: false,
-			transactions: {
-				confirmed: confirmedTransactions,
-				ready: 0,
-				verified: 0,
-				pending: 0,
-				validated: 0,
-				received: 0,
-				total: 10,
-			},
 			currentTime: now,
 		};
 


### PR DESCRIPTION
### What was the problem?
API `node/status` returns transactions count which can be accessed using specific endpoint

### How did I solve it?
- Remove `total` and `confirmed` value computation from `getStatus` method
- Remove `transactions` key from response data

### How to manually test it?
`npm run mocha`

### Review checklist

- [x] The PR resolves #4294
- [x] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
