### PR TITLE
Improve isValidNumber function validation - Closes #3902

### DIFF
--- a/elements/lisk-transactions/src/utils/validation/validation.ts
+++ b/elements/lisk-transactions/src/utils/validation/validation.ts
@@ -153,7 +153,7 @@ export const isNumberString = (str: string) => {
 		return false;
 	}
 
-	return /^[0-9]+$/g.test(str);
+	return /^-?[0-9]+$/g.test(str);
 };
 
 export const validateNonTransferAmount = (data: string) =>

--- a/elements/lisk-transactions/test/utils/validation/validation.ts
+++ b/elements/lisk-transactions/test/utils/validation/validation.ts
@@ -30,6 +30,7 @@ import {
 	isGreaterThanMaxTransactionId,
 	isNumberString,
 	isValidInteger,
+	isValidNumber,
 	isNullByteIncluded,
 } from '../../../src/utils/validation/validation';
 
@@ -391,6 +392,20 @@ describe('validation', () => {
 
 		it('should return true when negative integer was provided', () => {
 			return expect(isValidInteger(-6)).to.be.true;
+		});
+	});
+
+	describe('#isValidNumber', () => {
+		it('should return true when number was provided', () => {
+			return expect(isValidNumber(0)).to.be.true;
+		});
+
+		it('should return true when string with number was provided', () => {
+			return expect(isValidNumber('0')).to.be.true;
+		});
+
+		it('should return false when not a number was provided', () => {
+			return expect(isValidNumber('lorem ipsum')).to.be.false;
 		});
 	});
 

--- a/elements/lisk-transactions/test/utils/validation/validation.ts
+++ b/elements/lisk-transactions/test/utils/validation/validation.ts
@@ -370,6 +370,10 @@ describe('validation', () => {
 		it('should return true when string contains only number', () => {
 			return expect(isNumberString('1234568789')).to.be.true;
 		});
+
+		it('should return true when string contains only negative number', () => {
+			return expect(isNumberString('-1234568789')).to.be.true;
+		});
 	});
 
 	describe('#isValidInteger', () => {


### PR DESCRIPTION
### What was the problem?
Expect the `isValidNumber` function inside `lisk-transactions` to return `true` when `isValidNumber('-1')`

Also expect to have tests for `isValidNumber` function.

### How did I solve it?
- Add optional `-` sign for regexp validation
- Add test block for `isValidNumber` function

### How to manually test it?
run `npm test`

### Review checklist

- [x] The PR resolves #3902
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
