### PR TITLE
Rename toJson to toJSON - Closes #3500

### DIFF
--- a/framework/src/modules/http_api/api_error.js
+++ b/framework/src/modules/http_api/api_error.js
@@ -15,7 +15,7 @@
 'use strict';
 
 /**
- * Extends standard Error with a code field and toJson function.
+ * Extends standard Error with a code field and toJSON function.
  *
  * @class
  * @memberof helpers
@@ -37,7 +37,7 @@ class ApiError extends Error {
 	 *
 	 * @returns {string}
 	 */
-	toJson() {
+	toJSON() {
 		return {
 			message: this.message,
 		};

--- a/framework/test/mocha/unit/modules/chain/blocks/verify.js
+++ b/framework/test/mocha/unit/modules/chain/blocks/verify.js
@@ -127,7 +127,7 @@ describe('blocks/verify', () => {
 
 		interfaceAdaptersMock = {
 			transactions: {
-				toJson: sinonSandbox.stub(),
+				toJSON: sinonSandbox.stub(),
 			},
 		};
 

--- a/framework/test/mocha/unit/modules/http_api/api_error.js
+++ b/framework/test/mocha/unit/modules/http_api/api_error.js
@@ -49,14 +49,14 @@ describe('helpers/apiError', () => {
 		});
 	});
 
-	describe('toJson', () => {
+	describe('toJSON', () => {
 		it('should return Object type result', done => {
-			expect(apiError.toJson()).to.be.an('Object');
+			expect(apiError.toJSON()).to.be.an('Object');
 			done();
 		});
 
 		it('should return result containing message = "Valid error message"', done => {
-			expect(apiError.toJson())
+			expect(apiError.toJSON())
 				.to.have.property('message')
 				.equal(validErrorMessage);
 			done();


### PR DESCRIPTION
### What was the problem?
`toJson` should be `toJSON` base on issue discussion

### How did I solve it?
renamed `toJson` to`toJSON `

### Review checklist

- [x] The PR resolves #3500
- [x] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
