### PR TITLE
Investigate slow sync on introduce_bft_consensus-dpos.1 branch - Closes #4340

### DIFF
--- a/framework/src/modules/chain/components/storage/entities/round_delegates.js
+++ b/framework/src/modules/chain/components/storage/entities/round_delegates.js
@@ -75,12 +75,14 @@ class RoundDelegates extends BaseEntity {
 	/**
 	 * @returns {string[]} delegatePublicKeys
 	 */
-	async getActiveDelegatesForRound(round) {
+	async getActiveDelegatesForRound(round, tx) {
 		const [result] = await this.adapter.executeFile(
 			this.SQLs.getActiveDelegatesForRound,
 			{
 				round,
 			},
+			{},
+			tx,
 		);
 		/**
 		 * The query above returns delegatePublicKeys for the round.

--- a/framework/src/modules/chain/dpos/delegates_info.js
+++ b/framework/src/modules/chain/dpos/delegates_info.js
@@ -102,11 +102,10 @@ class DelegatesInfo {
 
 			const roundSummary = await this._summarizeRound(block, tx);
 
-			await Promise.all([
-				this._updateMissedBlocks(roundSummary, undo, tx),
-				this._updateBalanceRewardsAndFees(roundSummary, undo, tx),
-				this._updateVotedDelegatesVoteWeight(roundSummary, undo, tx),
-			]);
+			// Can NOT execute in parallel as _updateVotedDelegatesVoteWeight uses data updated on _updateBalanceRewardsAndFees
+			await this._updateMissedBlocks(roundSummary, undo, tx);
+			await this._updateBalanceRewardsAndFees(roundSummary, undo, tx);
+			await this._updateVotedDelegatesVoteWeight(roundSummary, undo, tx);
 
 			if (undo) {
 				/**

--- a/framework/src/modules/chain/dpos/delegates_info.js
+++ b/framework/src/modules/chain/dpos/delegates_info.js
@@ -137,6 +137,7 @@ class DelegatesInfo {
 	async _updateMissedBlocks(roundSummary, undo, tx) {
 		const missedBlocksDelegatePublicKeys = await this._getMissedBlocksDelegatePublicKeys(
 			roundSummary,
+			tx,
 		);
 
 		if (!missedBlocksDelegatePublicKeys.length) {
@@ -288,9 +289,10 @@ class DelegatesInfo {
 		}
 	}
 
-	async _getMissedBlocksDelegatePublicKeys({ round, uniqForgersInfo }) {
+	async _getMissedBlocksDelegatePublicKeys({ round, uniqForgersInfo }, tx) {
 		const expectedForgingPublicKeys = await this.delegatesList.getForgerPublicKeysForRound(
 			round,
+			tx,
 		);
 
 		return expectedForgingPublicKeys.filter(

--- a/framework/src/modules/chain/dpos/delegates_list.js
+++ b/framework/src/modules/chain/dpos/delegates_list.js
@@ -52,9 +52,10 @@ class DelegatesList extends EventEmitter {
 	 * Get shuffled list of active delegate public keys for a specific round -> forger public keys
 	 * @param {number} round
 	 */
-	async getForgerPublicKeysForRound(round) {
+	async getForgerPublicKeysForRound(round, tx) {
 		const delegatePublicKeys = await this.storage.entities.RoundDelegates.getActiveDelegatesForRound(
 			round,
+			tx,
 		);
 
 		if (!delegatePublicKeys.length) {
@@ -94,6 +95,7 @@ class DelegatesList extends EventEmitter {
 			{
 				round,
 			},
+			{},
 			tx,
 		);
 		await this.storage.entities.RoundDelegates.create(
@@ -111,6 +113,7 @@ class DelegatesList extends EventEmitter {
 			{
 				round_lt: round,
 			},
+			{},
 			tx,
 		);
 	}
@@ -120,6 +123,7 @@ class DelegatesList extends EventEmitter {
 			{
 				round_gt: round,
 			},
+			{},
 			tx,
 		);
 	}
@@ -131,10 +135,10 @@ class DelegatesList extends EventEmitter {
 	 * @return {Boolean} - `true`
 	 * @throw {Error} Failed to verify slot
 	 */
-	async verifyBlockForger(block) {
+	async verifyBlockForger(block, tx) {
 		const currentSlot = this.slots.getSlotNumber(block.timestamp);
 		const round = this.slots.calcRound(block.height);
-		const delegateList = await this.getForgerPublicKeysForRound(round);
+		const delegateList = await this.getForgerPublicKeysForRound(round, tx);
 
 		if (!delegateList.length) {
 			throw new Error(

--- a/framework/src/modules/chain/dpos/dpos.js
+++ b/framework/src/modules/chain/dpos/dpos.js
@@ -42,8 +42,8 @@ module.exports = class Dpos {
 		});
 	}
 
-	async getForgerPublicKeysForRound(round) {
-		return this.delegatesList.getForgerPublicKeysForRound(round);
+	async getForgerPublicKeysForRound(round, tx) {
+		return this.delegatesList.getForgerPublicKeysForRound(round, tx);
 	}
 
 	async onBlockFinalized({ height }) {
@@ -60,8 +60,8 @@ module.exports = class Dpos {
 		);
 	}
 
-	async verifyBlockForger(block) {
-		return this.delegatesList.verifyBlockForger(block);
+	async verifyBlockForger(block, tx) {
+		return this.delegatesList.verifyBlockForger(block, tx);
 	}
 
 	async apply(block, tx) {

--- a/framework/src/modules/chain/migrations/sql/20191008170600_create_mem_accounts_public_key_index.sql
+++ b/framework/src/modules/chain/migrations/sql/20191008170600_create_mem_accounts_public_key_index.sql
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+ /*
+  DESCRIPTION: Create index for mem_accounts.publicKey
+  PARAMETERS: None
+*/
+
+CREATE INDEX IF NOT EXISTS "mem_accounts_public_key" ON "mem_accounts" (ENCODE("publicKey", 'hex'));

--- a/framework/src/modules/chain/migrations/sql/20191008170800_update_mem_accounts_get_delegates_index.sql
+++ b/framework/src/modules/chain/migrations/sql/20191008170800_update_mem_accounts_get_delegates_index.sql
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+ /*
+  DESCRIPTION: Re-create mem_accounts_get_delegates index using voteWeight column instead of vote column
+  PARAMETERS: None
+*/
+
+DROP INDEX IF EXISTS "mem_accounts_get_delegates";
+
+CREATE INDEX IF NOT EXISTS "mem_accounts_get_delegates" ON "mem_accounts" ("voteWeight" DESC, ENCODE("publicKey", 'hex') ASC) WHERE "isDelegate" = 1;

--- a/framework/src/modules/chain/transactions/transactions_handlers.js
+++ b/framework/src/modules/chain/transactions/transactions_handlers.js
@@ -286,8 +286,18 @@ const undoTransactions = (storage, exceptions) => async (
 		tx,
 	});
 
-	await Promise.all(transactions.map(t => t.prepare(stateStore)));
-	await Promise.all(transactions.map(t => votesWeight.prepare(stateStore, t)));
+	// Avoid merging both prepare statements into one for...of loop as this slows down the call dramatically
+	// eslint-disable-next-line no-restricted-syntax
+	for (const transaction of transactions) {
+		// eslint-disable-next-line no-await-in-loop
+		await transaction.prepare(stateStore);
+	}
+
+	// eslint-disable-next-line no-restricted-syntax
+	for (const transaction of transactions) {
+		// eslint-disable-next-line no-await-in-loop
+		await votesWeight.prepare(stateStore, transaction);
+	}
 
 	const transactionsResponses = transactions.map(transaction => {
 		const transactionResponse = transaction.undo(stateStore);

--- a/framework/src/modules/chain/transactions/transactions_handlers.js
+++ b/framework/src/modules/chain/transactions/transactions_handlers.js
@@ -151,8 +151,18 @@ const applyTransactions = (storage, exceptions) => async (transactions, tx) => {
 		tx,
 	});
 
-	await Promise.all(transactions.map(t => t.prepare(stateStore)));
-	await Promise.all(transactions.map(t => votesWeight.prepare(stateStore, t)));
+	// Avoid merging both prepare statements into one for...of loop as this slows down the call dramatically
+	// eslint-disable-next-line no-restricted-syntax
+	for (const transaction of transactions) {
+		// eslint-disable-next-line no-await-in-loop
+		await transaction.prepare(stateStore);
+	}
+
+	// eslint-disable-next-line no-restricted-syntax
+	for (const transaction of transactions) {
+		// eslint-disable-next-line no-await-in-loop
+		await votesWeight.prepare(stateStore, transaction);
+	}
 
 	// Verify total spending of per account accumulative
 	const transactionsResponseWithSpendingErrors = verifyTotalSpending(

--- a/framework/src/modules/chain/transport/transport.js
+++ b/framework/src/modules/chain/transport/transport.js
@@ -280,6 +280,14 @@ class Transport {
 			);
 		}
 
+		// Should ignore received block if syncing
+		if (this.loaderModule.syncing()) {
+			return this.logger.debug(
+				{ id: query.block.id, height: query.block.height },
+				"Client is syncing. Can't process new block at the moment.",
+			);
+		}
+
 		const errors = validator.validate(definitions.WSBlocksBroadcast, query);
 
 		if (errors.length) {
@@ -296,16 +304,6 @@ class Transport {
 		}
 
 		const block = blocksUtils.addBlockProperties(query.block);
-
-		await this.processorModule.validate(block);
-
-		// TODO: endpoint should be protected before
-		if (this.loaderModule.syncing()) {
-			return this.logger.debug(
-				"Client is syncing. Can't receive block at the moment.",
-				block.id,
-			);
-		}
 
 		return this.processorModule.process(block);
 	}

--- a/framework/test/jest/unit/specs/modules/chain/dpos/apply.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/dpos/apply.spec.js
@@ -117,6 +117,7 @@ describe('dpos.apply()', () => {
 
 			expect(stubs.storage.entities.RoundDelegates.delete).toHaveBeenCalledWith(
 				{ round: 1 },
+				{},
 				stubs.tx,
 			);
 			expect(stubs.storage.entities.RoundDelegates.create).toHaveBeenCalledWith(
@@ -485,6 +486,7 @@ describe('dpos.apply()', () => {
 				{
 					round: nextRound,
 				},
+				{},
 				stubs.tx,
 			);
 			expect(stubs.storage.entities.RoundDelegates.create).toHaveBeenCalledWith(

--- a/framework/test/jest/unit/specs/modules/chain/dpos/undo.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/dpos/undo.spec.js
@@ -401,6 +401,7 @@ describe('dpos.undo()', () => {
 				{
 					round_gt: roundNo,
 				},
+				{},
 				stubs.tx,
 			);
 		});


### PR DESCRIPTION
### What was the problem?
When processing the last block of the round Dpos module updates the `voteWeight` of delegates that forging delegates voted for. This update was using `publicKey` as Storage filter but `publicKey` didn't have database index causing the query to take too long.

### How did I solve it?
I've created missing indexes and made some other improvements/fixes that was left out.

### How to manually test it?
Syncing with mainnet using Lisk Core branch `feature/introduce_bft_consensus` with Lisk SDK branch `4340-investigate-slow-sync`
Full sync should take less than 4 days

### Review checklist

- [ ] The PR resolves #4340
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
