### PR TITLE
Improve syncing logging - Closes #4195

### DIFF
--- a/framework/src/modules/chain/blocks/blocks.js
+++ b/framework/src/modules/chain/blocks/blocks.js
@@ -512,10 +512,6 @@ class Blocks extends EventEmitter {
 	}
 
 	async _rebuildMode(rebuildUpToRound, blocksCount) {
-		this.logger.info(
-			{ rebuildUpToRound, blocksCount },
-			'Rebuild process started',
-		);
 		if (blocksCount < this.constants.activeDelegates) {
 			throw new Error(
 				'Unable to rebuild, blockchain should contain at least one round of blocks',
@@ -529,6 +525,14 @@ class Blocks extends EventEmitter {
 				'Unable to rebuild, "--rebuild" parameter should be an integer equal to or greater than zero',
 			);
 		}
+		this.logger.info(
+			{
+				rebuildUpToRound,
+				blocksToRebuild: this.constants.activeDelegates * rebuildUpToRound,
+				currentHeight: blocksCount,
+			},
+			'Start rebuilding blockchain state',
+		);
 		const totalRounds = Math.floor(
 			blocksCount / this.constants.activeDelegates,
 		);
@@ -540,7 +544,10 @@ class Blocks extends EventEmitter {
 		this._lastBlock = await this._reload(targetHeight);
 		// Remove remaining
 		await this.storage.entities.Block.delete({ height_gt: targetHeight });
-		this.logger.info({ targetHeight, totalRounds }, 'Rebuilding finished');
+		this.logger.info(
+			{ targetHeight, totalRounds },
+			'Finished rebuilding blockchain state',
+		);
 	}
 
 	_updateLastNBlocks(block) {

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -256,7 +256,7 @@ NodeController.updateForgingStatus = async (context, next) => {
  * @param {function} next
  * @todo Add description for the function and the params
  */
-NodeController.getPooledTransactions = async function(context, next) {
+NodeController.getPooledTransactions = async (context, next) => {
 	const invalidParams = swaggerHelper.invalidParams(context.request);
 
 	if (invalidParams.length) {

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -49,46 +49,6 @@ async function _getForgingStatus(publicKey) {
 }
 
 /**
- * Get the network height
- *
- * @returns Number
- * @private
- */
-async function _getNetworkHeight() {
-	const peers = await library.channel.invoke('network:getPeers', {
-		limit: 100,
-		state: 2,
-	});
-	if (!peers || !peers.length) {
-		return 0;
-	}
-	const networkHeightCount = peers.reduce((previous, { height }) => {
-		const heightCount = previous[height] || 0;
-		previous[height] = heightCount + 1;
-		return previous;
-	}, {});
-	const heightCountPairs = Object.entries(networkHeightCount);
-	const [defaultHeight, defaultCount] = heightCountPairs[0];
-	const { height: networkHeight } = heightCountPairs.reduce(
-		(prev, [height, count]) => {
-			if (count > prev.count) {
-				return {
-					height,
-					count,
-				};
-			}
-			return prev;
-		},
-		{
-			height: defaultHeight,
-			count: defaultCount,
-		},
-	);
-
-	return parseInt(networkHeight, 10);
-}
-
-/**
  * Parse transaction instance to raw data
  *
  * @returns Object
@@ -212,7 +172,9 @@ NodeController.getStatus = async (context, next) => {
 			lastBlock,
 		} = await library.channel.invoke('chain:getNodeStatus');
 
-		const networkHeight = await _getNetworkHeight();
+		const networkHeight = await library.channel.invoke(
+			'network:getNetworkHeight',
+		);
 
 		const data = {
 			broadhash: library.applicationState.broadhash,

--- a/framework/src/modules/network/index.js
+++ b/framework/src/modules/network/index.js
@@ -70,6 +70,9 @@ module.exports = class NetworkModule extends BaseModule {
 				handler: action =>
 					this.network.actions.getUniqueOutboundConnectedPeersCount(action),
 			},
+			getNetworkHeight: {
+				handler: action => this.network.actions.getNetworkHeight(action),
+			},
 		};
 	}
 

--- a/framework/test/mocha/unit/modules/http_api/controllers/node.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/node.js
@@ -31,7 +31,6 @@ describe('node/api', () => {
 	let storageStub;
 	let configStub;
 	let getStatus;
-	let getNetworkHeight;
 
 	before(async () => {
 		channelStub = {
@@ -75,7 +74,6 @@ describe('node/api', () => {
 
 		privateLibrary = NodeController.__get__('library');
 		getStatus = NodeController.getStatus;
-		getNetworkHeight = NodeController.__get__('_getNetworkHeight');
 	});
 
 	afterEach(() => {
@@ -170,6 +168,9 @@ describe('node/api', () => {
 			beforeEach(async () => {
 				channelStub.invoke.withArgs('chain:getNodeStatus').returns(status);
 				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
+				channelStub.invoke
+					.withArgs('network:getNetworkHeight')
+					.returns(expectedStatus.networkHeight);
 			});
 
 			it('should return an object status with all properties', async () =>
@@ -202,202 +203,6 @@ describe('node/api', () => {
 					expect(err).to.be.null;
 					expect(response).to.deep.equal(expectedStatusWithoutSomeParameters);
 				}));
-		});
-	});
-
-	describe('_networkHeight', () => {
-		const MAJORITY_HEIGHT = 456;
-
-		let networkHeight;
-		describe('When there are set of majority peers with same height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 457,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 453,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 438,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return correct networkHeight based on majority', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns a blank list of peers', () => {
-			beforeEach(async () => {
-				channelStub.invoke.withArgs('network:getPeers').returns([]);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return zero when there are no peers with height', async () => {
-				expect(networkHeight).to.be.eql(0);
-			});
-		});
-
-		describe('When network:getPeers returns a list of peers with 2 different equal set of peers height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of majority with lower height', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns a list of peers with 3 different equal set of peers height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT + 2,
-					},
-					{
-						height: MAJORITY_HEIGHT + 2,
-					},
-					{
-						height: MAJORITY_HEIGHT + 2,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of majority with lower height', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns a list of peers with 2 different unequal set of peers height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of majority', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT + 1);
-			});
-		});
-
-		describe('When network:getPeers returns only one peer', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of one peer', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns majority of peers with very low height compared to others', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 1,
-					},
-					{
-						height: 1,
-					},
-					{
-						height: 1,
-					},
-					{
-						height: 1,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of the majority even though its very low compared to others', async () => {
-				expect(networkHeight).to.be.eql(1);
-			});
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
Due to the way we handle syncing, every time a few seconds we see Starting sync and Finished sync. with this log information, it's harder to know if the node actually finished syncing with the network.
### How did I solve it?
Updated log info with the relavent information.
### How to manually test it?
- Sync with Mainnet
- Rebuild against blockchain snapshot
### Review checklist

- [ ] The PR resolves #4195 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
