### PR TITLE
Add default implementation for verifyAgainstTransactions - Closes #4238

### DIFF
--- a/elements/lisk-transactions/README.md
+++ b/elements/lisk-transactions/README.md
@@ -84,7 +84,7 @@ The invert of `applyAsset`. Roll-back all of the changes to the accounts done in
 
 #### Additional methods
 
-To increase your application's performance, you should override the following functions: `verifyAgainstTransactions`, `assetFromSync`, `fromSync`.
+To increase your application's performance, you can override the following function: `verifyAgainstTransactions`.
 
 The BaseTransaction provides the default implementation of the methods revolving around the signatures. As your application matures you can provide the custom ways of how your a transaction's signature is derived: `sign`, `getBytes`, `assetToBytes`.
 

--- a/elements/lisk-transactions/src/0_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/0_transfer_transaction.ts
@@ -76,13 +76,6 @@ export class TransferTransaction extends BaseTransaction {
 		]);
 	}
 
-	// tslint:disable-next-line prefer-function-over-method
-	protected verifyAgainstTransactions(
-		_: ReadonlyArray<TransactionJSON>,
-	): ReadonlyArray<TransactionError> {
-		return [];
-	}
-
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(transferAssetFormatSchema, this.asset);
 		const errors = convertToAssetError(

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -132,9 +132,6 @@ export abstract class BaseTransaction {
 	protected abstract undoAsset(
 		store: StateStore,
 	): ReadonlyArray<TransactionError>;
-	protected abstract verifyAgainstTransactions(
-		transactions: ReadonlyArray<TransactionJSON>,
-	): ReadonlyArray<TransactionError>;
 
 	public constructor(rawTransaction: unknown) {
 		const tx = (typeof rawTransaction === 'object' && rawTransaction !== null
@@ -322,6 +319,13 @@ export abstract class BaseTransaction {
 					(this.constructor as typeof BaseTransaction).FEE.toString(),
 			  )
 			: undefined;
+	}
+
+	// tslint:disable-next-line prefer-function-over-method
+	protected verifyAgainstTransactions(
+		_: ReadonlyArray<TransactionJSON>,
+	): ReadonlyArray<TransactionError> {
+		return [];
 	}
 
 	public verifyAgainstOtherTransactions(

--- a/elements/lisk-transactions/test/helpers/test_transaction_class.ts
+++ b/elements/lisk-transactions/test/helpers/test_transaction_class.ts
@@ -52,10 +52,6 @@ export class TestTransaction extends BaseTransaction {
 
 		return [];
 	}
-
-	public assetFromSync(raw: any) {
-		return { data: raw };
-	}
 }
 
 export class TestTransactionBasicImpl extends BaseTransaction {
@@ -71,17 +67,5 @@ export class TestTransactionBasicImpl extends BaseTransaction {
 
 	public undoAsset() {
 		return [];
-	}
-
-	public verifyAgainstTransactions(
-		transactions: ReadonlyArray<TransactionJSON>,
-	): ReadonlyArray<TransactionError> {
-		transactions.forEach(() => true);
-
-		return [];
-	}
-
-	public assetFromSync(raw: any) {
-		return { data: raw };
 	}
 }


### PR DESCRIPTION
### What was the problem?
The issue describes to add a default implementation `assetSync` and `verifyAgainstTransactions`. As Shu already had removed `assetSync`, we only needed to add a default implementation for `verifyAgainstTransactions`. And remove the default we added for transactions that did not implement this (only `TransferTransaction`).

### How did I solve it?
Add a default implementation inside `BaseTransaction`.

### How to manually test it?
Verify compilation errors (no errors) for test class extended from `BaseTransaction` -> `elements/lisk-transactions/test/helpers/test_transaction_class.ts`

### Review checklist

- [ ] The PR resolves #4238 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
