### PR TITLE
Remove typo from response - Closes #3644

### DIFF
--- a/framework/src/modules/chain/loader.js
+++ b/framework/src/modules/chain/loader.js
@@ -251,9 +251,7 @@ class Loader {
 			throw new Error('Received an invalid blocks response from the network');
 		}
 		// Check for strict equality for backwards compatibility reasons.
-		// The misspelled data.sucess is required to support v1 nodes.
-		// TODO: Remove the misspelled data.sucess === false condition once enough nodes have migrated to v2.
-		if (data.success === false || data.sucess === false) {
+		if (data.success === false) {
 			throw new CommonBlockError(
 				'Peer did not have a matching lastBlockId.',
 				lastBlock.id,


### PR DESCRIPTION
### What was the problem?
Typo was introduced in the previous release, and we had a backward compatibility code

### How did I solve it?
Removing the backward compatibility code

### Review checklist

- [ ] The PR resolves #3644 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
