### PR TITLE
Improve performance on vote weight calculation - Closes #4340

### DIFF
--- a/framework/src/components/storage/adapters/pgp_adapter.js
+++ b/framework/src/components/storage/adapters/pgp_adapter.js
@@ -89,7 +89,6 @@ class PgpAdapter extends BaseAdapter {
 		monitor.attach(pgpOptions, this.options.logEvents);
 		monitor.setLog(info => {
 			this.logger.debug({ event: info.event }, info.text);
-			info.display = false;
 		});
 		monitor.setTheme('matrix');
 


### PR DESCRIPTION
### What was the problem?
For vote weight calculation `number of transactions * 101` for getting the address.
In worst case scenario, it will be 25 * 101 * 2.
Also, `voteWight.prepare` method was running per transaction, but in this case, it was possible to run in batch. (and in most of the cases, it will be duplicate public-key search)

### How did I solve it?
- Change `voteWeight.prepare` to take transactions
- Update getting data from account store to use public key
- Stop using immutable object creation when calculation new account state

### How to manually test it?

### Review checklist

- [ ] The PR resolves #4340 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
