### PR TITLE
Update commander network identifier - Closes #4336

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -104,6 +104,7 @@
 		"@liskhq/lisk-cryptography": "2.3.0",
 		"@liskhq/lisk-passphrase": "2.0.3",
 		"@liskhq/lisk-transactions": "3.0.0-alpha.0",
+		"@liskhq/lisk-validator": "0.2.1",
 		"@oclif/command": "1.5.6",
 		"@oclif/config": "1.9.0",
 		"@oclif/errors": "1.2.2",

--- a/commander/src/commands/signature/create.ts
+++ b/commander/src/commands/signature/create.ts
@@ -88,7 +88,7 @@ export default class CreateCommand extends BaseCommand {
 			...transactionObject,
 			networkIdentifier,
 		});
-		const { errors } = txInstance.validate(networkIdentifier);
+		const { errors } = txInstance.validate();
 
 		if (errors.length !== 0) {
 			throw new Error('Provided transaction is invalid.');

--- a/commander/src/commands/signature/create.ts
+++ b/commander/src/commands/signature/create.ts
@@ -20,6 +20,7 @@ import { ValidationError } from '../../utils/error';
 import { flags as commonFlags } from '../../utils/flags';
 import { getInputsFromSources } from '../../utils/input';
 import { getStdIn } from '../../utils/input/utils';
+import { getNetworkIdentifierWithInput } from '../../utils/network_identifier';
 import {
 	instantiateTransaction,
 	parseTransactionString,
@@ -61,13 +62,17 @@ export default class CreateCommand extends BaseCommand {
 
 	static flags = {
 		...BaseCommand.flags,
+		networkIdentifier: flagParser.string(commonFlags.networkIdentifier),
 		passphrase: flagParser.string(commonFlags.passphrase),
 	};
 
 	async run(): Promise<void> {
 		const {
 			args,
-			flags: { passphrase: passphraseSource },
+			flags: {
+				passphrase: passphraseSource,
+				networkIdentifier: networkIdentifierSource,
+			},
 		} = this.parse(CreateCommand);
 
 		const { transaction }: Args = args;
@@ -75,8 +80,15 @@ export default class CreateCommand extends BaseCommand {
 
 		const transactionObject = parseTransactionString(transactionInput);
 
-		const txInstance = instantiateTransaction(transactionObject);
-		const { errors } = txInstance.validate();
+		const networkIdentifier = getNetworkIdentifierWithInput(
+			networkIdentifierSource,
+			this.userConfig.api.network,
+		);
+		const txInstance = instantiateTransaction({
+			...transactionObject,
+			networkIdentifier,
+		});
+		const { errors } = txInstance.validate(networkIdentifier);
 
 		if (errors.length !== 0) {
 			throw new Error('Provided transaction is invalid.');
@@ -93,10 +105,11 @@ export default class CreateCommand extends BaseCommand {
 			throw new ValidationError('No passphrase was provided.');
 		}
 
-		const result = transactions.createSignatureObject(
-			transactionObject,
+		const result = transactions.createSignatureObject({
+			transaction: transactionObject,
 			passphrase,
-		);
+			networkIdentifier,
+		});
 
 		this.print(result);
 	}

--- a/commander/src/commands/transaction/create.ts
+++ b/commander/src/commands/transaction/create.ts
@@ -99,6 +99,7 @@ export default class CreateCommand extends BaseCommand {
 		'no-signature': flagParser.boolean(commonFlags.noSignature),
 		votes: flagParser.string(commonFlags.votes),
 		unvotes: flagParser.string(commonFlags.unvotes),
+		networkIdentifier: flagParser.string(commonFlags.networkIdentifier),
 	};
 
 	async run(): Promise<void> {

--- a/commander/src/commands/transaction/create/delegate.ts
+++ b/commander/src/commands/transaction/create/delegate.ts
@@ -21,16 +21,18 @@ import {
 	getInputsFromSources,
 	InputFromSourceOutput,
 } from '../../../utils/input';
+import { getNetworkIdentifierWithInput } from '../../../utils/network_identifier';
 
 interface Args {
 	readonly username: string;
 }
 
-const processInputs = (username: string) => ({
+const processInputs = (networkIdentifier: string, username: string) => ({
 	passphrase,
 	secondPassphrase,
 }: InputFromSourceOutput) =>
 	registerDelegate({
+		networkIdentifier,
 		passphrase,
 		secondPassphrase,
 		username,
@@ -53,6 +55,7 @@ export default class DelegateCommand extends BaseCommand {
 
 	static flags = {
 		...BaseCommand.flags,
+		networkIdentifier: flagParser.string(commonFlags.networkIdentifier),
 		passphrase: flagParser.string(commonFlags.passphrase),
 		'second-passphrase': flagParser.string(commonFlags.secondPassphrase),
 		'no-signature': flagParser.boolean(commonFlags.noSignature),
@@ -62,6 +65,7 @@ export default class DelegateCommand extends BaseCommand {
 		const {
 			args,
 			flags: {
+				networkIdentifier: networkIdentifierSource,
 				passphrase: passphraseSource,
 				'second-passphrase': secondPassphraseSource,
 				'no-signature': noSignature,
@@ -69,7 +73,11 @@ export default class DelegateCommand extends BaseCommand {
 		} = this.parse(DelegateCommand);
 
 		const { username }: Args = args;
-		const processFunction = processInputs(username);
+		const networkIdentifier = getNetworkIdentifierWithInput(
+			networkIdentifierSource,
+			this.userConfig.api.network,
+		);
+		const processFunction = processInputs(networkIdentifier, username);
 
 		if (noSignature) {
 			const noSignatureResult = processFunction({

--- a/commander/src/commands/transaction/create/multisignature.ts
+++ b/commander/src/commands/transaction/create/multisignature.ts
@@ -25,6 +25,7 @@ import {
 	getInputsFromSources,
 	InputFromSourceOutput,
 } from '../../../utils/input';
+import { getNetworkIdentifierWithInput } from '../../../utils/network_identifier';
 
 interface Args {
 	readonly keysgroup: string;
@@ -33,11 +34,13 @@ interface Args {
 }
 
 const processInputs = (
+	networkIdentifier: string,
 	lifetime: number,
 	minimum: number,
 	keysgroup: ReadonlyArray<string>,
 ) => ({ passphrase, secondPassphrase }: InputFromSourceOutput) =>
 	registerMultisignature({
+		networkIdentifier,
 		passphrase,
 		secondPassphrase,
 		keysgroup,
@@ -80,6 +83,7 @@ export default class MultisignatureCommand extends BaseCommand {
 
 	static flags = {
 		...BaseCommand.flags,
+		networkIdentifier: flagParser.string(commonFlags.networkIdentifier),
 		passphrase: flagParser.string(commonFlags.passphrase),
 		'second-passphrase': flagParser.string(commonFlags.secondPassphrase),
 		'no-signature': flagParser.boolean(commonFlags.noSignature),
@@ -89,6 +93,7 @@ export default class MultisignatureCommand extends BaseCommand {
 		const {
 			args,
 			flags: {
+				networkIdentifier: networkIdentifierSource,
 				passphrase: passphraseSource,
 				'second-passphrase': secondPassphraseSource,
 				'no-signature': noSignature,
@@ -105,7 +110,12 @@ export default class MultisignatureCommand extends BaseCommand {
 
 		const transactionLifetime = parseInt(lifetime, 10);
 		const transactionMinimumConfirmations = parseInt(minimum, 10);
+		const networkIdentifier = getNetworkIdentifierWithInput(
+			networkIdentifierSource,
+			this.userConfig.api.network,
+		);
 		const processFunction = processInputs(
+			networkIdentifier,
 			transactionLifetime,
 			transactionMinimumConfirmations,
 			keysgroup,

--- a/commander/src/commands/transaction/create/second-passphrase.ts
+++ b/commander/src/commands/transaction/create/second-passphrase.ts
@@ -22,8 +22,9 @@ import {
 	getInputsFromSources,
 	InputFromSourceOutput,
 } from '../../../utils/input';
+import { getNetworkIdentifierWithInput } from '../../../utils/network_identifier';
 
-export const processInputs = () => ({
+export const processInputs = (networkIdentifier: string) => ({
 	passphrase,
 	secondPassphrase,
 }: InputFromSourceOutput) => {
@@ -32,6 +33,7 @@ export const processInputs = () => ({
 	}
 
 	return registerSecondPassphrase({
+		networkIdentifier,
 		passphrase,
 		secondPassphrase,
 	});
@@ -46,6 +48,7 @@ export default class SecondPassphraseCommand extends BaseCommand {
 
 	static flags = {
 		...BaseCommand.flags,
+		networkIdentifier: flagParser.string(commonFlags.networkIdentifier),
 		passphrase: flagParser.string(commonFlags.passphrase),
 		'second-passphrase': flagParser.string(commonFlags.secondPassphrase),
 		'no-signature': flagParser.boolean(commonFlags.noSignature),
@@ -54,13 +57,18 @@ export default class SecondPassphraseCommand extends BaseCommand {
 	async run(): Promise<void> {
 		const {
 			flags: {
+				networkIdentifier: networkIdentifierSource,
 				passphrase: passphraseSource,
 				'second-passphrase': secondPassphraseSource,
 				'no-signature': noSignature,
 			},
 		} = this.parse(SecondPassphraseCommand);
 
-		const processFunction = processInputs();
+		const networkIdentifier = getNetworkIdentifierWithInput(
+			networkIdentifierSource,
+			this.userConfig.api.network,
+		);
+		const processFunction = processInputs(networkIdentifier);
 
 		const inputs = noSignature
 			? await getInputsFromSources({

--- a/commander/src/commands/transaction/create/vote.ts
+++ b/commander/src/commands/transaction/create/vote.ts
@@ -26,12 +26,15 @@ import {
 	InputFromSourceOutput,
 } from '../../../utils/input';
 import { getData } from '../../../utils/input/utils';
+import { getNetworkIdentifierWithInput } from '../../../utils/network_identifier';
 
 const processInputs = (
+	networkIdentifier: string,
 	votes: ReadonlyArray<string>,
 	unvotes: ReadonlyArray<string>,
 ) => ({ passphrase, secondPassphrase }: InputFromSourceOutput) =>
 	castVotes({
+		networkIdentifier,
 		passphrase,
 		votes,
 		unvotes,
@@ -65,6 +68,7 @@ export default class VoteCommand extends BaseCommand {
 
 	static flags = {
 		...BaseCommand.flags,
+		networkIdentifier: flagParser.string(commonFlags.networkIdentifier),
 		passphrase: flagParser.string(commonFlags.passphrase),
 		'second-passphrase': flagParser.string(commonFlags.secondPassphrase),
 		'no-signature': flagParser.boolean(commonFlags.noSignature),
@@ -75,6 +79,7 @@ export default class VoteCommand extends BaseCommand {
 	async run(): Promise<void> {
 		const {
 			flags: {
+				networkIdentifier: networkIdentifierSource,
 				passphrase: passphraseSource,
 				'second-passphrase': secondPassphraseSource,
 				'no-signature': noSignature,
@@ -109,7 +114,15 @@ export default class VoteCommand extends BaseCommand {
 			? validatePublicKeys(processVotes(processedUnvotesInput))
 			: [];
 
-		const processFunction = processInputs(validatedVotes, validatedUnvotes);
+		const networkIdentifier = getNetworkIdentifierWithInput(
+			networkIdentifierSource,
+			this.userConfig.api.network,
+		);
+		const processFunction = processInputs(
+			networkIdentifier,
+			validatedVotes,
+			validatedUnvotes,
+		);
 
 		if (noSignature) {
 			const noSignatureResult = processFunction({

--- a/commander/src/commands/transaction/sign.ts
+++ b/commander/src/commands/transaction/sign.ts
@@ -107,7 +107,7 @@ export default class SignCommand extends BaseCommand {
 		});
 		txInstance.sign(passphrase, secondPassphrase);
 
-		const { errors } = txInstance.validate(networkIdentifier);
+		const { errors } = txInstance.validate();
 
 		if (errors.length !== 0) {
 			throw errors;

--- a/commander/src/commands/transaction/verify.ts
+++ b/commander/src/commands/transaction/verify.ts
@@ -98,20 +98,22 @@ export default class VerifyCommand extends BaseCommand {
 			...transactionObjectWithoutSignSignature
 		} = transactionObject;
 
-		const txInstance = instantiateTransaction(
-			transactionObjectWithoutSignSignature,
+		const networkIdentifier = getNetworkIdentifierWithInput(
+			networkIdentifierSource,
+			this.userConfig.api.network,
 		);
+
+		const txInstance = instantiateTransaction({
+			...transactionObjectWithoutSignSignature,
+			networkIdentifier,
+		});
 
 		const secondPublicKey = secondPublicKeySource
 			? await processSecondPublicKey(secondPublicKeySource)
 			: undefined;
 
-		const networkIdentifier = getNetworkIdentifierWithInput(
-			networkIdentifierSource,
-			this.userConfig.api.network,
-		);
 		if (!secondPublicKey) {
-			const { errors } = txInstance.validate(networkIdentifier);
+			const { errors } = txInstance.validate();
 			this.print({
 				verified: errors.length === 0,
 			});

--- a/commander/src/utils/constants.ts
+++ b/commander/src/utils/constants.ts
@@ -47,6 +47,8 @@ export const CONFIG_VARIABLES: ReadonlyArray<string> = [
 
 export const API_PROTOCOLS: ReadonlyArray<string> = ['http:', 'https:'];
 
+export const COMMUNITY_IDENTIFIER = 'Lisk';
+
 export const NETHASHES: { readonly [key: string]: string } = {
 	main: MAINNET_NETHASH,
 	test: TESTNET_NETHASH,

--- a/commander/src/utils/flags.ts
+++ b/commander/src/utils/flags.ts
@@ -74,6 +74,8 @@ const noSnapshotDescription =
 	'Install Lisk Core without a blockchain snapshot.';
 const liskVersionDescription = 'Lisk Core version.';
 const noStartDescription = 'Install Lisk Core without starting.';
+const networkIdentifierDescription =
+	'Network identifier defined for the network or main | test for the Lisk Network.';
 
 export type AlphabetLowercase =
 	| 'a'
@@ -135,6 +137,9 @@ export const flags: FlagMap = {
 	},
 	votes: {
 		description: votesDescription,
+	},
+	networkIdentifier: {
+		description: networkIdentifierDescription,
 	},
 	network: {
 		char: 'n',

--- a/commander/src/utils/network_identifier.ts
+++ b/commander/src/utils/network_identifier.ts
@@ -24,7 +24,11 @@ export const getNetworkIdentifierWithInput = (
 	if (input !== undefined && Object.keys(NETHASHES).includes(input)) {
 		return getNetworkIdentifier(NETHASHES[input], COMMUNITY_IDENTIFIER);
 	}
-	if (input !== undefined && isHexString(input)) {
+	if (input !== undefined) {
+		if (!isHexString(input)) {
+			throw new Error('Network identifier must be hex string');
+		}
+
 		return input;
 	}
 

--- a/commander/src/utils/network_identifier.ts
+++ b/commander/src/utils/network_identifier.ts
@@ -1,0 +1,38 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { getNetworkIdentifier } from '@liskhq/lisk-cryptography';
+import { isHexString } from '@liskhq/lisk-validator';
+import { COMMUNITY_IDENTIFIER, NETHASHES } from './constants';
+
+export const getNetworkIdentifierWithInput = (
+	input: string | undefined,
+	networkConfig: string | undefined,
+): string => {
+	if (input !== undefined && Object.keys(NETHASHES).includes(input)) {
+		return getNetworkIdentifier(NETHASHES[input], COMMUNITY_IDENTIFIER);
+	}
+	if (input !== undefined && isHexString(input)) {
+		return input;
+	}
+
+	if (
+		networkConfig !== undefined &&
+		Object.keys(NETHASHES).includes(networkConfig)
+	) {
+		return getNetworkIdentifier(NETHASHES[networkConfig], COMMUNITY_IDENTIFIER);
+	}
+	throw new Error('Invalid network identifier');
+};

--- a/commander/src/utils/transactions.ts
+++ b/commander/src/utils/transactions.ts
@@ -34,11 +34,11 @@ export const parseTransactionString = (transactionStr: string) => {
 
 // tslint:disable-next-line no-any
 const defaultTransactions: { readonly [key: number]: any } = {
-	0: TransferTransaction,
-	1: SecondSignatureTransaction,
-	2: DelegateTransaction,
-	3: VoteTransaction,
-	4: MultisignatureTransaction,
+	8: TransferTransaction,
+	9: SecondSignatureTransaction,
+	10: DelegateTransaction,
+	11: VoteTransaction,
+	12: MultisignatureTransaction,
 };
 
 export const instantiateTransaction = (

--- a/commander/test/commands/signature/create.test.ts
+++ b/commander/test/commands/signature/create.test.ts
@@ -22,31 +22,33 @@ import * as inputUtilsModule from '../../../src/utils/input';
 
 describe('signature:create', () => {
 	const defaultTransaction = {
+		type: 8,
 		senderPublicKey:
-			'3358a1562f9babd523a768e700bb12ad58f230f84031055802dc0ea58cef1e1b',
-		timestamp: 59353522,
-		type: 0,
+			'efaf1d977897cb60d7db9d30e8fd668dee070ac0db1fb8d184c06152a8b75f8d',
+		timestamp: 54316325,
 		asset: {
-			recipientId: '8050281191221330746L',
-			amount: '10',
+			recipientId: '18141291412139607230L',
+			amount: '1234567890',
+			data: 'random data',
 		},
 		signature:
-			'b84b95087c381ad25b5701096e2d9366ffd04037dcc941cd0747bfb0cf93111834a6c662f149018be4587e6fc4c9f5ba47aa5bbbd3dd836988f153aa8258e604',
-		id: '3694188453012384790',
+			'b88d0408318d3bf700586116046c9101535ee76d2d4b6a5903ac31f5d302094ad4b08180105ff91882482d5d62ca48ba2ed281b75134b90110e1a98aed7efe0d',
+		id: '3436168030012755419',
 	};
 	const invalidTransaction = 'invalid transaction';
 	const defaultInputs = {
-		passphrase: '123',
+		passphrase:
+			'better across runway mansion jar route valid crack panic favorite smooth sword',
 	};
 	const testnetNetworkIdentifier =
 		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 
 	const defaultSignatureObject = {
-		transactionId: '3694188453012384790',
+		transactionId: '3436168030012755419',
 		publicKey:
-			'6edfa4a73d7e2a71e61fbb80aaf6e578a9c7be779382c6d7fc99e086400c830f',
+			'6766ce280eb99e45d2cc7d9c8c852720940dab5d69f480e80477a97b4255d5d8',
 		signature:
-			'ba8250a2192cb0b70283993d4fa6c6e625a422b16829b38a6c6c14b2ad82411e2e8523abac35162e1c28d8dd35bbe7821b2945640c8baab95b00fb2525bdb807',
+			'4424342c342093f80f52f919876fc0abada5385e98e8caf211add16d1c0f5453ef6e47fa58a454128a9640f3b6e2ade618e5ee5fa8eebc4d68460d19f042050f',
 	};
 
 	const printMethodStub = sandbox.stub();

--- a/commander/test/commands/signature/create.test.ts
+++ b/commander/test/commands/signature/create.test.ts
@@ -20,7 +20,7 @@ import * as printUtils from '../../../src/utils/print';
 import * as inputUtils from '../../../src/utils/input/utils';
 import * as inputUtilsModule from '../../../src/utils/input';
 
-describe.only('signature:create', () => {
+describe('signature:create', () => {
 	const defaultTransaction = {
 		senderPublicKey:
 			'3358a1562f9babd523a768e700bb12ad58f230f84031055802dc0ea58cef1e1b',
@@ -38,6 +38,8 @@ describe.only('signature:create', () => {
 	const defaultInputs = {
 		passphrase: '123',
 	};
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 
 	const defaultSignatureObject = {
 		transactionId: '3694188453012384790',
@@ -54,7 +56,7 @@ describe.only('signature:create', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				transactions,
@@ -113,10 +115,11 @@ describe.only('signature:create', () => {
 						repeatPrompt: true,
 					},
 				});
-				expect(transactions.createSignatureObject).to.be.calledWithExactly(
-					defaultTransaction,
-					defaultInputs.passphrase,
-				);
+				expect(transactions.createSignatureObject).to.be.calledWithExactly({
+					transaction: defaultTransaction,
+					passphrase: defaultInputs.passphrase,
+					networkIdentifier: testnetNetworkIdentifier,
+				});
 				return expect(printMethodStub).to.be.calledWithExactly(
 					defaultSignatureObject,
 				);
@@ -141,10 +144,11 @@ describe.only('signature:create', () => {
 							},
 						},
 					);
-					expect(transactions.createSignatureObject).to.be.calledWithExactly(
-						defaultTransaction,
-						defaultInputs.passphrase,
-					);
+					expect(transactions.createSignatureObject).to.be.calledWithExactly({
+						transaction: defaultTransaction,
+						passphrase: defaultInputs.passphrase,
+						networkIdentifier: testnetNetworkIdentifier,
+					});
 					return expect(printMethodStub).to.be.calledWithExactly(
 						defaultSignatureObject,
 					);
@@ -193,10 +197,11 @@ describe.only('signature:create', () => {
 							},
 						},
 					);
-					expect(transactions.createSignatureObject).to.be.calledWithExactly(
-						defaultTransaction,
-						defaultInputs.passphrase,
-					);
+					expect(transactions.createSignatureObject).to.be.calledWithExactly({
+						transaction: defaultTransaction,
+						passphrase: defaultInputs.passphrase,
+						networkIdentifier: testnetNetworkIdentifier,
+					});
 					return expect(printMethodStub).to.be.calledWithExactly(
 						defaultSignatureObject,
 					);
@@ -223,10 +228,11 @@ describe.only('signature:create', () => {
 							},
 						},
 					);
-					expect(transactions.createSignatureObject).to.be.calledWithExactly(
-						defaultTransaction,
-						defaultInputs.passphrase,
-					);
+					expect(transactions.createSignatureObject).to.be.calledWithExactly({
+						transaction: defaultTransaction,
+						passphrase: defaultInputs.passphrase,
+						networkIdentifier: testnetNetworkIdentifier,
+					});
 					return expect(printMethodStub).to.be.calledWithExactly(
 						defaultSignatureObject,
 					);

--- a/commander/test/commands/signature/create.test.ts
+++ b/commander/test/commands/signature/create.test.ts
@@ -20,7 +20,7 @@ import * as printUtils from '../../../src/utils/print';
 import * as inputUtils from '../../../src/utils/input/utils';
 import * as inputUtilsModule from '../../../src/utils/input';
 
-describe('signature:create', () => {
+describe.only('signature:create', () => {
 	const defaultTransaction = {
 		senderPublicKey:
 			'3358a1562f9babd523a768e700bb12ad58f230f84031055802dc0ea58cef1e1b',
@@ -51,7 +51,11 @@ describe('signature:create', () => {
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				transactions,
 				'createSignatureObject',

--- a/commander/test/commands/transaction/create.test.ts
+++ b/commander/test/commands/transaction/create.test.ts
@@ -27,7 +27,11 @@ describe('transaction:create', () => {
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(TransferCommand, 'run', sandbox.stub())
 			.stub(SecondPassphraseCommand, 'run', sandbox.stub())
 			.stub(DelegateCommand, 'run', sandbox.stub())

--- a/commander/test/commands/transaction/create.test.ts
+++ b/commander/test/commands/transaction/create.test.ts
@@ -30,7 +30,7 @@ describe('transaction:create', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(TransferCommand, 'run', sandbox.stub())
 			.stub(SecondPassphraseCommand, 'run', sandbox.stub())

--- a/commander/test/commands/transaction/create/delegate.test.ts
+++ b/commander/test/commands/transaction/create/delegate.test.ts
@@ -35,8 +35,8 @@ describe('transaction:create:delegate', () => {
 		recipientPublicKey: null,
 		asset: {},
 	};
-	const mainnetNetworkIdentifier =
-		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 
 	const printMethodStub = sandbox.stub();
 
@@ -46,7 +46,7 @@ describe('transaction:create:delegate', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				transactions,
@@ -81,7 +81,7 @@ describe('transaction:create:delegate', () => {
 					secondPassphrase: undefined,
 				});
 				expect(transactions.registerDelegate).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					username: defaultUsername,
@@ -110,7 +110,7 @@ describe('transaction:create:delegate', () => {
 						secondPassphrase: undefined,
 					});
 					expect(transactions.registerDelegate).to.be.calledWithExactly({
-						networkIdentifier: mainnetNetworkIdentifier,
+						networkIdentifier: testnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						username: defaultUsername,
@@ -144,7 +144,7 @@ describe('transaction:create:delegate', () => {
 						},
 					});
 					expect(transactions.registerDelegate).to.be.calledWithExactly({
-						networkIdentifier: mainnetNetworkIdentifier,
+						networkIdentifier: testnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						username: defaultUsername,
@@ -165,7 +165,7 @@ describe('transaction:create:delegate', () => {
 			])
 			.it('create a transaction with the username without signature', () => {
 				expect(transactions.registerDelegate).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: undefined,
 					secondPassphrase: undefined,
 					username: defaultUsername,

--- a/commander/test/commands/transaction/create/delegate.test.ts
+++ b/commander/test/commands/transaction/create/delegate.test.ts
@@ -35,13 +35,19 @@ describe('transaction:create:delegate', () => {
 		recipientPublicKey: null,
 		asset: {},
 	};
+	const mainnetNetworkIdentifier =
+		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
 
 	const printMethodStub = sandbox.stub();
 
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				transactions,
 				'registerDelegate',
@@ -75,6 +81,7 @@ describe('transaction:create:delegate', () => {
 					secondPassphrase: undefined,
 				});
 				expect(transactions.registerDelegate).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					username: defaultUsername,
@@ -103,6 +110,7 @@ describe('transaction:create:delegate', () => {
 						secondPassphrase: undefined,
 					});
 					expect(transactions.registerDelegate).to.be.calledWithExactly({
+						networkIdentifier: mainnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						username: defaultUsername,
@@ -136,6 +144,7 @@ describe('transaction:create:delegate', () => {
 						},
 					});
 					expect(transactions.registerDelegate).to.be.calledWithExactly({
+						networkIdentifier: mainnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						username: defaultUsername,
@@ -156,6 +165,7 @@ describe('transaction:create:delegate', () => {
 			])
 			.it('create a transaction with the username without signature', () => {
 				expect(transactions.registerDelegate).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: undefined,
 					secondPassphrase: undefined,
 					username: defaultUsername,

--- a/commander/test/commands/transaction/create/multisignature.test.ts
+++ b/commander/test/commands/transaction/create/multisignature.test.ts
@@ -40,9 +40,8 @@ describe('transaction:create:multisignature', () => {
 		recipientPublicKey: null,
 		asset: {},
 	};
-	const mainnetNetworkIdentifier =
-		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
-
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 	const printMethodStub = sandbox.stub();
 	const transactionUtilStub = {
 		validatePublicKeys: sandbox.stub().returns(true),
@@ -54,7 +53,7 @@ describe('transaction:create:multisignature', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				transactions,
@@ -146,7 +145,7 @@ describe('transaction:create:multisignature', () => {
 					secondPassphrase: undefined,
 				});
 				expect(transactions.registerMultisignature).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					keysgroup: defaultKeysgroup,
@@ -180,7 +179,7 @@ describe('transaction:create:multisignature', () => {
 					secondPassphrase: undefined,
 				});
 				expect(transactions.registerMultisignature).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					keysgroup: defaultKeysgroup,
@@ -220,7 +219,7 @@ describe('transaction:create:multisignature', () => {
 						},
 					});
 					expect(transactions.registerMultisignature).to.be.calledWithExactly({
-						networkIdentifier: mainnetNetworkIdentifier,
+						networkIdentifier: testnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						keysgroup: defaultKeysgroup,
@@ -251,7 +250,7 @@ describe('transaction:create:multisignature', () => {
 					).to.be.calledWithExactly(defaultKeysgroup);
 					expect(inputUtils.getInputsFromSources).not.to.be.called;
 					expect(transactions.registerMultisignature).to.be.calledWithExactly({
-						networkIdentifier: mainnetNetworkIdentifier,
+						networkIdentifier: testnetNetworkIdentifier,
 						passphrase: undefined,
 						secondPassphrase: undefined,
 						keysgroup: defaultKeysgroup,

--- a/commander/test/commands/transaction/create/multisignature.test.ts
+++ b/commander/test/commands/transaction/create/multisignature.test.ts
@@ -40,6 +40,8 @@ describe('transaction:create:multisignature', () => {
 		recipientPublicKey: null,
 		asset: {},
 	};
+	const mainnetNetworkIdentifier =
+		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
 
 	const printMethodStub = sandbox.stub();
 	const transactionUtilStub = {
@@ -49,7 +51,11 @@ describe('transaction:create:multisignature', () => {
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				transactions,
 				'registerMultisignature',
@@ -140,6 +146,7 @@ describe('transaction:create:multisignature', () => {
 					secondPassphrase: undefined,
 				});
 				expect(transactions.registerMultisignature).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					keysgroup: defaultKeysgroup,
@@ -173,6 +180,7 @@ describe('transaction:create:multisignature', () => {
 					secondPassphrase: undefined,
 				});
 				expect(transactions.registerMultisignature).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					keysgroup: defaultKeysgroup,
@@ -212,6 +220,7 @@ describe('transaction:create:multisignature', () => {
 						},
 					});
 					expect(transactions.registerMultisignature).to.be.calledWithExactly({
+						networkIdentifier: mainnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						keysgroup: defaultKeysgroup,
@@ -242,6 +251,7 @@ describe('transaction:create:multisignature', () => {
 					).to.be.calledWithExactly(defaultKeysgroup);
 					expect(inputUtils.getInputsFromSources).not.to.be.called;
 					expect(transactions.registerMultisignature).to.be.calledWithExactly({
+						networkIdentifier: mainnetNetworkIdentifier,
 						passphrase: undefined,
 						secondPassphrase: undefined,
 						keysgroup: defaultKeysgroup,

--- a/commander/test/commands/transaction/create/second-passphrase.test.ts
+++ b/commander/test/commands/transaction/create/second-passphrase.test.ts
@@ -20,10 +20,10 @@ import * as printUtils from '../../../../src/utils/print';
 import * as inputUtils from '../../../../src/utils/input';
 
 describe('transaction:create:second-passphrase', () => {
-	const mainnetNetworkIdentifier =
-		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 	const defaultInputs = {
-		networkIdentifier: mainnetNetworkIdentifier,
+		networkIdentifier: testnetNetworkIdentifier,
 		passphrase: '123',
 		secondPassphrase: '456',
 	};
@@ -46,7 +46,7 @@ describe('transaction:create:second-passphrase', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				transactions,

--- a/commander/test/commands/transaction/create/second-passphrase.test.ts
+++ b/commander/test/commands/transaction/create/second-passphrase.test.ts
@@ -20,7 +20,10 @@ import * as printUtils from '../../../../src/utils/print';
 import * as inputUtils from '../../../../src/utils/input';
 
 describe('transaction:create:second-passphrase', () => {
+	const mainnetNetworkIdentifier =
+		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
 	const defaultInputs = {
+		networkIdentifier: mainnetNetworkIdentifier,
 		passphrase: '123',
 		secondPassphrase: '456',
 	};
@@ -40,7 +43,11 @@ describe('transaction:create:second-passphrase', () => {
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				transactions,
 				'registerSecondPassphrase',

--- a/commander/test/commands/transaction/create/transfer.test.ts
+++ b/commander/test/commands/transaction/create/transfer.test.ts
@@ -20,9 +20,12 @@ import * as printUtils from '../../../../src/utils/print';
 import * as inputUtils from '../../../../src/utils/input';
 
 describe('transaction:create:transfer', () => {
+	const mainnetNetworkIdentifier =
+		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
 	const defaultAmount = '1';
 	const defaultAddress = '123L';
 	const defaultInputs = {
+		networkIdentifier: mainnetNetworkIdentifier,
 		passphrase: '123',
 		secondPassphrase: '456',
 	};
@@ -46,7 +49,11 @@ describe('transaction:create:transfer', () => {
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				transactions,
 				'transfer',

--- a/commander/test/commands/transaction/create/transfer.test.ts
+++ b/commander/test/commands/transaction/create/transfer.test.ts
@@ -20,12 +20,12 @@ import * as printUtils from '../../../../src/utils/print';
 import * as inputUtils from '../../../../src/utils/input';
 
 describe('transaction:create:transfer', () => {
-	const mainnetNetworkIdentifier =
-		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 	const defaultAmount = '1';
 	const defaultAddress = '123L';
 	const defaultInputs = {
-		networkIdentifier: mainnetNetworkIdentifier,
+		networkIdentifier: testnetNetworkIdentifier,
 		passphrase: '123',
 		secondPassphrase: '456',
 	};
@@ -52,7 +52,7 @@ describe('transaction:create:transfer', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				transactions,

--- a/commander/test/commands/transaction/create/vote.test.ts
+++ b/commander/test/commands/transaction/create/vote.test.ts
@@ -33,8 +33,8 @@ describe('transaction:create:vote', () => {
 		'e01b6b8a9b808ec3f67a638a2d3fa0fe1a9439b91dbdde92e2839c3327bd4589',
 		'922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 	];
-	const mainnetNetworkIdentifier =
-		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 	const defaultInputs = {
 		passphrase: '123',
 		secondPassphrase: '456',
@@ -61,7 +61,7 @@ describe('transaction:create:vote', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				transactions,
@@ -107,7 +107,7 @@ describe('transaction:create:vote', () => {
 					defaultVote,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: defaultVote,
@@ -133,7 +133,7 @@ describe('transaction:create:vote', () => {
 					fileVotes,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: fileVotes,
@@ -163,7 +163,7 @@ describe('transaction:create:vote', () => {
 					defaultUnvote,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: [],
@@ -189,7 +189,7 @@ describe('transaction:create:vote', () => {
 					fileVotes,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: [],
@@ -236,7 +236,7 @@ describe('transaction:create:vote', () => {
 					defaultUnvote,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
-					networkIdentifier: mainnetNetworkIdentifier,
+					networkIdentifier: testnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: defaultVote,
@@ -267,7 +267,7 @@ describe('transaction:create:vote', () => {
 						transactionUtilStub.validatePublicKeys,
 					).to.be.calledWithExactly(defaultUnvote);
 					expect(transactions.castVotes).to.be.calledWithExactly({
-						networkIdentifier: mainnetNetworkIdentifier,
+						networkIdentifier: testnetNetworkIdentifier,
 						passphrase: undefined,
 						secondPassphrase: undefined,
 						votes: defaultVote,
@@ -305,7 +305,7 @@ describe('transaction:create:vote', () => {
 						transactionUtilStub.validatePublicKeys,
 					).to.be.calledWithExactly(defaultUnvote);
 					expect(transactions.castVotes).to.be.calledWithExactly({
-						networkIdentifier: mainnetNetworkIdentifier,
+						networkIdentifier: testnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						votes: defaultVote,
@@ -347,7 +347,7 @@ describe('transaction:create:vote', () => {
 						transactionUtilStub.validatePublicKeys,
 					).to.be.calledWithExactly(defaultUnvote);
 					expect(transactions.castVotes).to.be.calledWithExactly({
-						networkIdentifier: mainnetNetworkIdentifier,
+						networkIdentifier: testnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						votes: defaultVote,

--- a/commander/test/commands/transaction/create/vote.test.ts
+++ b/commander/test/commands/transaction/create/vote.test.ts
@@ -33,6 +33,8 @@ describe('transaction:create:vote', () => {
 		'e01b6b8a9b808ec3f67a638a2d3fa0fe1a9439b91dbdde92e2839c3327bd4589',
 		'922fbfdd596fa78269bbcadc67ec2a1cc15fc929a19c462169568d7a3df1a1aa',
 	];
+	const mainnetNetworkIdentifier =
+		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
 	const defaultInputs = {
 		passphrase: '123',
 		secondPassphrase: '456',
@@ -56,7 +58,11 @@ describe('transaction:create:vote', () => {
 	const setupStub = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				transactions,
 				'castVotes',
@@ -101,6 +107,7 @@ describe('transaction:create:vote', () => {
 					defaultVote,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: defaultVote,
@@ -126,6 +133,7 @@ describe('transaction:create:vote', () => {
 					fileVotes,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: fileVotes,
@@ -155,6 +163,7 @@ describe('transaction:create:vote', () => {
 					defaultUnvote,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: [],
@@ -180,6 +189,7 @@ describe('transaction:create:vote', () => {
 					fileVotes,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: [],
@@ -226,6 +236,7 @@ describe('transaction:create:vote', () => {
 					defaultUnvote,
 				);
 				expect(transactions.castVotes).to.be.calledWithExactly({
+					networkIdentifier: mainnetNetworkIdentifier,
 					passphrase: defaultInputs.passphrase,
 					secondPassphrase: defaultInputs.secondPassphrase,
 					votes: defaultVote,
@@ -256,6 +267,7 @@ describe('transaction:create:vote', () => {
 						transactionUtilStub.validatePublicKeys,
 					).to.be.calledWithExactly(defaultUnvote);
 					expect(transactions.castVotes).to.be.calledWithExactly({
+						networkIdentifier: mainnetNetworkIdentifier,
 						passphrase: undefined,
 						secondPassphrase: undefined,
 						votes: defaultVote,
@@ -293,6 +305,7 @@ describe('transaction:create:vote', () => {
 						transactionUtilStub.validatePublicKeys,
 					).to.be.calledWithExactly(defaultUnvote);
 					expect(transactions.castVotes).to.be.calledWithExactly({
+						networkIdentifier: mainnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						votes: defaultVote,
@@ -334,6 +347,7 @@ describe('transaction:create:vote', () => {
 						transactionUtilStub.validatePublicKeys,
 					).to.be.calledWithExactly(defaultUnvote);
 					expect(transactions.castVotes).to.be.calledWithExactly({
+						networkIdentifier: mainnetNetworkIdentifier,
 						passphrase: defaultInputs.passphrase,
 						secondPassphrase: defaultInputs.secondPassphrase,
 						votes: defaultVote,

--- a/commander/test/commands/transaction/sign.test.ts
+++ b/commander/test/commands/transaction/sign.test.ts
@@ -32,6 +32,8 @@ describe('transaction:sign', () => {
 		},
 		id: '14814738582865173524',
 	};
+	const mainnetNetworkIdentifier =
+		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
 
 	const invalidTransaction = 'invalid transaction';
 	const defaultInputs = {
@@ -63,7 +65,11 @@ describe('transaction:sign', () => {
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				inputUtils,
 				'getInputsFromSources',

--- a/commander/test/commands/transaction/sign.test.ts
+++ b/commander/test/commands/transaction/sign.test.ts
@@ -32,8 +32,8 @@ describe('transaction:sign', () => {
 		},
 		id: '14814738582865173524',
 	};
-	const mainnetNetworkIdentifier =
-		'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 
 	const invalidTransaction = 'invalid transaction';
 	const defaultInputs = {
@@ -68,7 +68,7 @@ describe('transaction:sign', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				inputUtils,

--- a/commander/test/commands/transaction/sign.test.ts
+++ b/commander/test/commands/transaction/sign.test.ts
@@ -21,44 +21,44 @@ import * as inputUtils from '../../../src/utils/input';
 
 describe('transaction:sign', () => {
 	const defaultTransaction = {
-		timestamp: 106582966,
-		type: 0,
+		type: 8,
 		senderPublicKey:
-			'a4465fd76c16fcc458448076372abf1912cc5b150663a64dffefe550f96feadd',
+			'efaf1d977897cb60d7db9d30e8fd668dee070ac0db1fb8d184c06152a8b75f8d',
+		timestamp: 54316325,
 		asset: {
-			recipientId: '123L',
-			amount: '10000000000',
-			data: undefined,
+			recipientId: '18141291412139607230L',
+			amount: '1234567890',
+			data: 'random data',
 		},
-		id: '14814738582865173524',
 	};
-	const testnetNetworkIdentifier =
-		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 
 	const invalidTransaction = 'invalid transaction';
 	const defaultInputs = {
-		passphrase: '123',
+		passphrase:
+			'wear protect skill sentence lift enter wild sting lottery power floor neglect',
 	};
 
 	const defaultInputsWithSecondPassphrase = {
 		...defaultInputs,
-		secondPassphrase: '456',
+		secondPassphrase:
+			'inherit moon normal relief spring bargain hobby join baby flash fog blood',
 	};
 
 	const defaultSignedTransaction = {
 		...defaultTransaction,
 		fee: '10000000',
-		senderId: '12475940823804898745L',
+		senderId: '2129300327344985743L',
 		signatures: [],
 		signature:
-			'bc7bbaef2cf4bb2a3b19c0958ac3b43e102cf611af1cba3928f03a6940d663976b60902a52cb29c5e01294fa873a551211bba6d9207fcd0df0fa93305cc4d503',
+			'b88d0408318d3bf700586116046c9101535ee76d2d4b6a5903ac31f5d302094ad4b08180105ff91882482d5d62ca48ba2ed281b75134b90110e1a98aed7efe0d',
+		id: '3436168030012755419',
 	};
 
 	const defaultSecondSignedTransaction = {
 		...defaultSignedTransaction,
-		id: '11148343814295761202',
+		id: '1856045075247127242',
 		signSignature:
-			'3247d8dd5de5e1a5246148c05555281e0292ac04e8bfa1fdebb9ee7411a3d8a73629e88c20b1a18b88b391869bc78bfefe78cbbbbe8a0cf8a72f1f72234cd50f',
+			'c4b0ca84aa4596401c3041a1638e670d6278e0e18949f027b3d7ede4f2f0a1685df7aec768b1a3c49acfe7ded9e7f5230998f06b0d58371bcba5a00695fb6901',
 	};
 
 	const printMethodStub = sandbox.stub();
@@ -111,7 +111,7 @@ describe('transaction:sign', () => {
 			])
 			.catch(error => {
 				return expect(error.message).to.contain(
-					'Transaction: 2567924752873475295 failed at .amount',
+					'Transaction: 6662515125650388309 failed at .amount',
 				);
 			})
 			.it('should throw an error when transaction is invalid');
@@ -166,19 +166,23 @@ describe('transaction:sign', () => {
 			.command([
 				'transaction:sign',
 				JSON.stringify(defaultTransaction),
-				'--passphrase=pass:123',
-				'--second-passphrase=pass:456',
+				`--passphrase=pass:${defaultInputs.passphrase}`,
+				`--second-passphrase=pass:${
+					defaultInputsWithSecondPassphrase.secondPassphrase
+				}`,
 			])
 			.it(
 				'should take transaction from arg and passphrase and second passphrase from flag to sign',
 				() => {
 					expect(inputUtils.getInputsFromSources).to.be.calledWithExactly({
 						passphrase: {
-							source: 'pass:123',
+							source: `pass:${defaultInputs.passphrase}`,
 							repeatPrompt: true,
 						},
 						secondPassphrase: {
-							source: 'pass:456',
+							source: `pass:${
+								defaultInputsWithSecondPassphrase.secondPassphrase
+							}`,
 							repeatPrompt: true,
 						},
 					});

--- a/commander/test/commands/transaction/verify.test.ts
+++ b/commander/test/commands/transaction/verify.test.ts
@@ -50,7 +50,11 @@ describe('transaction:verify', () => {
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
-			.stub(config, 'getConfig', sandbox.stub().returns({}))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'main' } }),
+			)
 			.stub(
 				inputUtils,
 				'getData',

--- a/commander/test/commands/transaction/verify.test.ts
+++ b/commander/test/commands/transaction/verify.test.ts
@@ -20,26 +20,31 @@ import * as inputUtils from '../../../src/utils/input/utils';
 
 describe('transaction:verify', () => {
 	const defaultTransaction = {
+		type: 8,
 		senderPublicKey:
-			'a4465fd76c16fcc458448076372abf1912cc5b150663a64dffefe550f96feadd',
-		timestamp: 66419917,
-		type: 0,
+			'efaf1d977897cb60d7db9d30e8fd668dee070ac0db1fb8d184c06152a8b75f8d',
+		timestamp: 54316325,
 		asset: {
-			recipientId: '123L',
-			amount: '10000000000',
+			recipientId: '18141291412139607230L',
+			amount: '1234567890',
+			data: 'random data',
 		},
+		fee: '10000000',
+		senderId: '2129300327344985743L',
+		signatures: [],
 		signature:
-			'96738e173a750998f4c2cdcdf7538b71854bcffd6c0dc72b3c28081ca6946322bea7ba5d8f8974fc97950014347ce379671a6eddc0d41ea6cdfb9bb7ff76be0a',
-		id: '1297455432474089551',
+			'b88d0408318d3bf700586116046c9101535ee76d2d4b6a5903ac31f5d302094ad4b08180105ff91882482d5d62ca48ba2ed281b75134b90110e1a98aed7efe0d',
+		id: '3436168030012755419',
 	};
 
 	const defaultSecondSignedTransaction = {
 		...defaultTransaction,
+		id: '1856045075247127242',
 		signSignature:
-			'96738e173a750998f4c2cdcdf7538b71854bcffd6c0dc72b3c28081ca6946322bea7ba5d8f8974fc97950014347ce379671a6eddc0d41ea6cdfb9bb7ff76be0b',
+			'c4b0ca84aa4596401c3041a1638e670d6278e0e18949f027b3d7ede4f2f0a1685df7aec768b1a3c49acfe7ded9e7f5230998f06b0d58371bcba5a00695fb6901',
 	};
 	const defaultSecondPublicKey =
-		'790049f919979d5ea42cca7b7aa0812cbae8f0db3ee39c1fe3cef18e25b67951';
+		'0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe';
 	const invalidTransaction = 'invalid transaction';
 
 	const defaultVerifyTransactionResult = {

--- a/commander/test/commands/transaction/verify.test.ts
+++ b/commander/test/commands/transaction/verify.test.ts
@@ -53,7 +53,7 @@ describe('transaction:verify', () => {
 			.stub(
 				config,
 				'getConfig',
-				sandbox.stub().returns({ api: { network: 'main' } }),
+				sandbox.stub().returns({ api: { network: 'test' } }),
 			)
 			.stub(
 				inputUtils,

--- a/commander/test/utils/network_identifier.ts
+++ b/commander/test/utils/network_identifier.ts
@@ -1,0 +1,78 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect } from 'chai';
+import { getNetworkIdentifierWithInput } from '../../src/utils/network_identifier';
+
+describe('network identifier utils', () => {
+	describe('getNetworkIdentifierWithInput', () => {
+		const mainnetNetworkIdentifier =
+			'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
+		const testnetNetworkIdentifier =
+			'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
+		const defaultNetworkIdentifier =
+			'7777777777777777777777777777777777777777777777777777777777777777';
+
+		describe('when input main is defined', () => {
+			it('should return mainnet network identifier', async () => {
+				const result = getNetworkIdentifierWithInput('main', 'test');
+				expect(result).to.eql(mainnetNetworkIdentifier);
+			});
+		});
+
+		describe('when input test is defined', () => {
+			it('should return testnet network identifier', async () => {
+				const result = getNetworkIdentifierWithInput('test', 'main');
+				expect(result).to.eql(testnetNetworkIdentifier);
+			});
+		});
+
+		describe('when input network identifier hex is defined', () => {
+			it('should return hex value', async () => {
+				const result = getNetworkIdentifierWithInput(
+					defaultNetworkIdentifier,
+					'main',
+				);
+				expect(result).to.eql(defaultNetworkIdentifier);
+			});
+		});
+
+		describe('when input is undefined and network config is main', () => {
+			it('should return mainnet network identifier', async () => {
+				const result = getNetworkIdentifierWithInput(undefined, 'main');
+				expect(result).to.eql(mainnetNetworkIdentifier);
+			});
+		});
+
+		describe('when input is undefined and network config is test', () => {
+			it('should return mainnet network identifier', async () => {
+				const result = getNetworkIdentifierWithInput(undefined, 'test');
+				expect(result).to.eql(testnetNetworkIdentifier);
+			});
+		});
+
+		describe('when input is undefined and network config is undefined', () => {
+			it('should throw error', async () => {
+				let err;
+				try {
+					getNetworkIdentifierWithInput(undefined, undefined);
+				} catch (error) {
+					err = error;
+				}
+				expect(err.message).to.equal('Invalid network identifier');
+			});
+		});
+	});
+});

--- a/commander/test/utils/network_identifier.ts
+++ b/commander/test/utils/network_identifier.ts
@@ -49,6 +49,19 @@ describe('network identifier utils', () => {
 			});
 		});
 
+		describe('when input network identifier is not valid hex string', () => {
+			it('should throw error', async () => {
+				let error;
+				try {
+					getNetworkIdentifierWithInput('zzz', 'main');
+				} catch (err) {
+					error = err;
+				}
+
+				expect(error.message).to.eql('Network identifier must be hex string');
+			});
+		});
+
 		describe('when input is undefined and network config is main', () => {
 			it('should return mainnet network identifier', async () => {
 				const result = getNetworkIdentifierWithInput(undefined, 'main');

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -543,7 +543,12 @@ export abstract class BaseTransaction {
 
 		if (secondPassphrase) {
 			this._signSignature = signData(
-				hash(transactionWithNetworkIdentifierBytes),
+				hash(
+					Buffer.concat([
+						transactionWithNetworkIdentifierBytes,
+						hexToBuffer(this._signature),
+					]),
+				),
 				secondPassphrase,
 			);
 		}

--- a/elements/lisk-transactions/test/base_transaction.ts
+++ b/elements/lisk-transactions/test/base_transaction.ts
@@ -29,6 +29,7 @@ import {
 } from './helpers';
 import { validSecondSignatureTransaction } from '../fixtures';
 import * as transferFixture from '../fixtures/transaction_network_id_and_change_order/transfer_transaction_validate.json';
+import * as transferSecondSignatureFixture from '../fixtures/transaction_network_id_and_change_order/transfer_transaction_with_second_signature_validate.json';
 import * as multisignatureFixture from '../fixtures/transaction_network_id_and_change_order/transfer_transaction_with_multi_signature_validate.json';
 import * as utils from '../src/utils';
 import { TransferTransaction } from '../src/8_transfer_transaction';
@@ -843,39 +844,50 @@ describe('Base transaction class', () => {
 	});
 
 	describe('create, sign and stringify transaction', () => {
-		const passphrase = 'secret';
-		const secondPassphrase = 'second secret';
-		const senderId = '18160565574430594874L';
-		const senderPublicKey =
-			'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
-		const signature =
-			'470f5e81589ed431cf15fb98e9659ebc04f78bd0eb418773cd6dd95ed7c8c2ee872143b46307ba730a67b8b1b80910f2108abf28ae47a84e98e6b239f3e16d01';
-		const secondSignature =
-			'377393e81deab7173c872d2d7bf0ad7982aea8c94f62ddfcae496dedfc425b9be294300e857bf3c057640274a315b9a9f5782b640c10b3ad4fc4dc231808d303';
-
 		it('should return correct senderId/senderPublicKey when sign with passphrase', () => {
-			const newTransaction = new TestTransaction({ networkIdentifier });
-			newTransaction.sign(passphrase);
+			const newTransaction = new TransferTransaction({
+				...transferSecondSignatureFixture.testCases.input.transaction,
+				networkIdentifier:
+					transferSecondSignatureFixture.testCases.input.networkIdentifier,
+			});
+			newTransaction.sign(
+				transferSecondSignatureFixture.testCases.input.account.passphrase,
+			);
 
 			const stringifiedTransaction = newTransaction.stringify();
 			const parsedResponse = JSON.parse(stringifiedTransaction);
 
-			expect(parsedResponse.senderId).to.be.eql(senderId);
-			expect(parsedResponse.senderPublicKey).to.be.eql(senderPublicKey);
-			expect(parsedResponse.signature).to.be.eql(signature);
+			expect(parsedResponse.senderPublicKey).to.be.eql(
+				transferSecondSignatureFixture.testCases.output.senderPublicKey,
+			);
+			expect(parsedResponse.signature).to.be.eql(
+				transferSecondSignatureFixture.testCases.output.signature,
+			);
 		});
 
 		it('should return correct senderId/senderPublicKey when sign with passphrase and secondPassphrase', () => {
-			const newTransaction = new TestTransaction({ networkIdentifier });
-			newTransaction.sign(passphrase, secondPassphrase);
+			const newTransaction = new TransferTransaction({
+				...transferSecondSignatureFixture.testCases.input.transaction,
+				networkIdentifier:
+					transferSecondSignatureFixture.testCases.input.networkIdentifier,
+			});
+			newTransaction.sign(
+				transferSecondSignatureFixture.testCases.input.account.passphrase,
+				transferSecondSignatureFixture.testCases.input.secondPassphrase,
+			);
 
 			const stringifiedTransaction = newTransaction.stringify();
 			const parsedResponse = JSON.parse(stringifiedTransaction);
 
-			expect(parsedResponse.senderId).to.be.eql(senderId);
-			expect(parsedResponse.senderPublicKey).to.be.eql(senderPublicKey);
-			expect(parsedResponse.signature).to.be.eql(signature);
-			expect(parsedResponse.signSignature).to.be.eql(secondSignature);
+			expect(parsedResponse.senderPublicKey).to.be.eql(
+				transferSecondSignatureFixture.testCases.output.senderPublicKey,
+			);
+			expect(parsedResponse.signature).to.be.eql(
+				transferSecondSignatureFixture.testCases.output.signature,
+			);
+			expect(parsedResponse.signSignature).to.be.eql(
+				transferSecondSignatureFixture.testCases.output.signSignature,
+			);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
- transaction:create
- transaction:verify
- transaction:sign
- signature:create
Needed network identifier to be added.

### How did I solve it?
Add `networkIdentifier` as a flag (it can specify, main | test or custom hash), if the setting does not exist, it uses `config.api.network` value (main or test).
If that doesn't exist, it will throw an error

### How to manually test it?
Create a transaction using those command, and send it to the node and observe it will be accepted.

### Review checklist

- [ ] The PR resolves #4336 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
