### PR TITLE
Add index.d.ts file for lisk-sdk - Closes #4438

### DIFF
--- a/sdk/src/index.d.ts
+++ b/sdk/src/index.d.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+/* tslint:disable */
+import * as BigNum from '@liskhq/bignum';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as transactions from '@liskhq/lisk-transactions';
+
+declare const Application: any;
+declare const version: number;
+declare const systemDirs: any;
+declare const configurator: any;
+
+declare const configDevnet: any;
+declare const genesisBlockDevnet: any;
+
+export {
+	Application,
+	version,
+	systemDirs,
+	configurator,
+	BigNum,
+	cryptography,
+	transactions,
+	configDevnet,
+	genesisBlockDevnet,
+};


### PR DESCRIPTION
### What was the problem?
lisk-sdk package did not have typescript definition

### How did I solve it?
Add temporal typescript definition until we convert framework to TypeScript

### How to manually test it?
Link with the core, and check if it builds

### Review checklist

- [ ] The PR resolves #4438 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
