### PR TITLE
transaction.id should not be used before assignment - Closes #4461

### DIFF
--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -157,7 +157,7 @@ export abstract class BaseTransaction {
 	}
 
 	public get id(): string {
-		return this._id || '';
+		return this._id || 'incalculable-id';
 	}
 
 	public get senderId(): string {
@@ -186,17 +186,17 @@ export abstract class BaseTransaction {
 
 	public toJSON(): TransactionJSON {
 		const transaction = {
-			id: this.id,
+			id: this._id,
 			blockId: this.blockId,
 			height: this.height,
 			relays: this.relays,
 			confirmations: this.confirmations,
 			type: this.type,
 			timestamp: this.timestamp,
-			senderPublicKey: this.senderPublicKey,
-			senderId: this.senderId,
+			senderPublicKey: this._senderPublicKey || '',
+			senderId: this._senderPublicKey ? this.senderId : '',
 			fee: this.fee.toString(),
-			signature: this.signature,
+			signature: this._signature,
 			signSignature: this.signSignature ? this.signSignature : undefined,
 			signatures: this.signatures,
 			asset: this.assetToJSON(),

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -184,6 +184,11 @@ export abstract class BaseTransaction {
 		return this._signSignature;
 	}
 
+	/**
+	 * This method is using private versions of _id, _senderPublicKey and _signature
+	 * as we should allow for it to be called at any stage of the transaction construction
+	 */
+
 	public toJSON(): TransactionJSON {
 		const transaction = {
 			id: this._id,

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -157,11 +157,7 @@ export abstract class BaseTransaction {
 	}
 
 	public get id(): string {
-		if (!this._id) {
-			throw new Error('id is required to be set before use');
-		}
-
-		return this._id;
+		return this._id || '';
 	}
 
 	public get senderId(): string {

--- a/elements/lisk-transactions/src/utils/validation/schema.ts
+++ b/elements/lisk-transactions/src/utils/validation/schema.ts
@@ -70,14 +70,7 @@ export const transactionInterface = {
 export const baseTransaction = {
 	$id: 'lisk/base-transaction',
 	type: 'object',
-	required: [
-		'id',
-		'type',
-		'senderPublicKey',
-		'timestamp',
-		'asset',
-		'signature',
-	],
+	required: ['type', 'senderPublicKey', 'timestamp', 'asset', 'signature'],
 	properties: {
 		id: {
 			type: 'string',

--- a/elements/lisk-transactions/test/base_transaction.ts
+++ b/elements/lisk-transactions/test/base_transaction.ts
@@ -112,9 +112,6 @@ describe('Base transaction class', () => {
 			expect(transactionWithDefaultValues.receivedAt).to.be.undefined;
 			expect(transactionWithDefaultValues.relays).to.be.undefined;
 			expect(transactionWithDefaultValues.signSignature).to.be.undefined;
-			expect(() => transactionWithDefaultValues.id).to.throw(
-				'id is required to be set before use',
-			);
 			expect(() => transactionWithDefaultValues.senderId).to.throw(
 				'senderPublicKey is required to be set before use',
 			);


### PR DESCRIPTION
### What was the problem?

Transacion.id was throwing error even though not required before signing

### How did I solve it?

By making the getter return empty string if the id doesn't exist

### How to manually test it?

Build should be green

### Review checklist

- [x] The PR resolves #4461
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
