### PR TITLE
API node/status/forging filter doesn't work as expected - Closes #4091

### DIFF
--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -219,10 +219,13 @@ NodeController.getForgingStatus = async (context, next) => {
 		context.statusCode = apiCodes.FORBIDDEN;
 		return next(new Error('Access Denied'));
 	}
-	const publicKey = context.request.swagger.params.publicKey.value;
+	const { publicKey, forging } = context.request.swagger.params;
 
 	try {
-		const forgingStatus = await _getForgingStatus(publicKey);
+		const forgingStatus = await _getForgingStatus(publicKey.value);
+		if (forging && typeof forging.value === 'boolean') {
+			return next(null, forgingStatus.filter(f => f.forging === forging.value));
+		}
 		return next(null, forgingStatus);
 	} catch (err) {
 		return next(err);

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -1190,7 +1190,7 @@ parameters:
     in: query
     description: Forging status to filter
     type: boolean
-    format: bool
+
 definitions:
   Meta:
     type: object

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -384,6 +384,7 @@ paths:
         - application/json
       parameters:
         - $ref: '#/parameters/publicKey'
+        - $ref: '#/parameters/forging'
       responses:
         200:
           description: Search results matching criteria
@@ -1184,7 +1185,12 @@ parameters:
     description: Ending unix timestamp
     type: integer
     minimum: 1
-
+  forging:
+    name: forging
+    in: query
+    description: Forging status to filter
+    type: boolean
+    format: bool
 definitions:
   Meta:
     type: object

--- a/framework/test/mocha/functional/http/get/node/node.js
+++ b/framework/test/mocha/functional/http/get/node/node.js
@@ -167,6 +167,23 @@ describe('GET /node', () => {
 					expect(res.body.data[0].forging).to.be.true;
 				});
 			});
+
+			it('using invalid forging value should fail', async () => {
+				return forgingEndpoint.makeRequest({ forging: null }, 400).then(res => {
+					expectSwaggerParamError(res, 'forging');
+				});
+			});
+
+			it('should return only forging delegates', async () => {
+				return forgingEndpoint.makeRequest({ forging: true }, 200).then(res => {
+					expect(res.body.data.length).to.be.eql(
+						__testContext.config.modules.chain.forging.delegates.length,
+					);
+					expect(
+						res.body.data.filter(d => d.forging === false).length,
+					).to.be.eql(0);
+				});
+			});
 		});
 	});
 });

--- a/framework/test/mocha/functional/http/put/node.js
+++ b/framework/test/mocha/functional/http/put/node.js
@@ -119,12 +119,18 @@ describe('PUT /node/status/forging', () => {
 			forging: true,
 		};
 
-		return updateForgingEndpoint
-			.makeRequest({ data: params }, 200)
+		updateForgingEndpoint.makeRequest({ data: params }, 200).then(res => {
+			expect(res.body.data).to.have.length(1);
+			expect(res.body.data[0].publicKey).to.be.eql(validDelegate.publicKey);
+			expect(res.body.data[0].forging).to.be.eql(true);
+		});
+
+		return forgingStatusEndpoint
+			.makeRequest({ forging: false }, 200)
 			.then(res => {
-				expect(res.body.data).to.have.length(1);
-				expect(res.body.data[0].publicKey).to.be.eql(validDelegate.publicKey);
-				expect(res.body.data[0].forging).to.be.eql(true);
+				expect(res.body.data.filter(d => d.forging === true).length).to.be.eql(
+					0,
+				);
 			});
 	});
 


### PR DESCRIPTION
### What was the problem?
API `node/status/forging` was not filtering according to forging status.
### How did I solve it?
Filtering the response based on forging status parameter.
### How to manually test it?
- Start the node, enable forging all nodes
- http://localhost:4000/api/node/status/forging?forging=false (should get zero results)
- Disable a few delegates
- http://localhost:4000/api/node/status/forging?forging=false (should get all disabled delegates)

### Review checklist

- [x] The PR resolves #4091 
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
