### PR TITLE
Add BFT height finalized information to HTTP API - Closes #4463

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -316,6 +316,7 @@ module.exports = class Chain {
 				unconfirmedTransactions: this.transactionPool.getCount(),
 				secondsSinceEpoch: this.slots.getEpochTime(),
 				lastBlock: this.blocks.lastBlock,
+				chainMaxHeightFinalized: this.bft.finalityManager.finalizedHeight,
 			}),
 			getLastBlock: async () => ({
 				...this.blocks.lastBlock,

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -186,6 +186,7 @@ NodeController.getStatus = async (context, next) => {
 			loaded,
 			syncing,
 			lastBlock,
+			chainMaxHeightFinalized,
 		} = await library.channel.invoke('chain:getNodeStatus');
 
 		const networkHeight = await _getNetworkHeight();
@@ -194,8 +195,9 @@ NodeController.getStatus = async (context, next) => {
 			currentTime: Date.now(),
 			secondsSinceEpoch,
 			height: lastBlock.height || 0,
-			loaded,
 			networkHeight,
+			chainMaxHeightFinalized,
+			loaded,
 			syncing,
 		};
 

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -2201,9 +2201,10 @@ definitions:
     required:
       - currentTime
       - height
-      - loaded
       - networkHeight
+      - chainMaxHeightFinalized
       - secondsSinceEpoch
+      - loaded
       - syncing
     properties:
       currentTime:
@@ -2227,6 +2228,12 @@ definitions:
         description: |
           Current block height of the network.
           Represents the current number of blocks in the chain on the network.
+      chainMaxHeightFinalized:
+        type: integer
+        example: 123
+        description: |
+          The largest height with precommits by at least 68 delegates.
+          See https://github.com/LiskHQ/lips/blob/master/proposals/lip-0014.md
       secondsSinceEpoch:
         type: integer
         example: 1533558858

--- a/framework/test/mocha/unit/modules/http_api/controllers/node.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/node.js
@@ -128,6 +128,7 @@ describe('node/api', () => {
 				validated: 0,
 				received: 0,
 			},
+			chainMaxHeightFinalized: 1010,
 		};
 		const now = Date.now();
 
@@ -138,6 +139,7 @@ describe('node/api', () => {
 			networkHeight: 456,
 			syncing: false,
 			currentTime: now,
+			chainMaxHeightFinalized: 1010,
 		};
 
 		const defaultPeers = [


### PR DESCRIPTION
### What was the problem?
BFT property `chainMaxHeightFinalized` not exposed on the HTTP API

### How did I solve it?
By adding it to `node/status` endpoint

### How to manually test it?
Start the application
Access `node/status`

### Review checklist

- [ ] The PR resolves #4463
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
