### PR TITLE
P2P Disconnect from seed peers after initial discovery - Closes #4359

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -876,6 +876,8 @@ export class P2P extends EventEmitter {
 				this._sanitizedPeerLists.fixedPeers || [],
 			);
 		}, this._populatorInterval);
+
+		// Initial Populator
 		this._peerPool.triggerNewConnections(
 			this._peerBook.newPeers,
 			this._peerBook.triedPeers,
@@ -897,6 +899,14 @@ export class P2P extends EventEmitter {
 		}
 
 		return false;
+	}
+
+	private _fetchSeedPeerList(): void {
+		if (this._sanitizedPeerLists.seedPeers.length === 0) {
+			return;
+		}
+
+		this._peerPool.discoverSeedPeers(this._sanitizedPeerLists.seedPeers);
 	}
 
 	private _handleGetPeersRequest(request: P2PRequest): void {
@@ -963,9 +973,8 @@ export class P2P extends EventEmitter {
 			throw new Error('Cannot start the node because it is already active');
 		}
 
-		const newPeersToAdd = this._sanitizedPeerLists.seedPeers.concat(
-			this._sanitizedPeerLists.whitelisted,
-		);
+		const newPeersToAdd = this._sanitizedPeerLists.whitelisted;
+
 		newPeersToAdd.forEach(newPeerInfo => {
 			try {
 				this._peerBook.addPeer(newPeerInfo);
@@ -984,6 +993,8 @@ export class P2P extends EventEmitter {
 
 		// We need this check this._isActive in case the P2P library is shut down while it was in the middle of starting up.
 		if (this._isActive) {
+			// Initial Discovery SeedPeers and Disconnect
+			this._fetchSeedPeerList();
 			this._startPopulator();
 		}
 	}

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -396,6 +396,20 @@ export class PeerPool extends EventEmitter {
 		peer.send(message);
 	}
 
+	public discoverSeedPeers(seedPeers: ReadonlyArray<P2PPeerInfo>): void {
+		const seedPeersForFetch = shuffle([...seedPeers]);
+
+		seedPeersForFetch.map(peer => {
+			this.fetchPeeersAndDisconnect(peer);
+		});
+	}
+
+	public fetchPeeersAndDisconnect(peerInfo: P2PPeerInfo): void {
+		this._addOutboundPeer(peerInfo, {
+			fetchPeersAndDisconnect: true,
+		});
+	}
+
 	public triggerNewConnections(
 		newPeers: ReadonlyArray<P2PPeerInfo>,
 		triedPeers: ReadonlyArray<P2PPeerInfo>,
@@ -456,7 +470,10 @@ export class PeerPool extends EventEmitter {
 		return peer;
 	}
 
-	private _addOutboundPeer(peerInfo: P2PPeerInfo): boolean {
+	private _addOutboundPeer(
+		peerInfo: P2PPeerInfo,
+		customPeerConfig?: object,
+	): boolean {
 		if (this.hasPeer(peerInfo.peerId)) {
 			return false;
 		}
@@ -471,7 +488,10 @@ export class PeerPool extends EventEmitter {
 			return false;
 		}
 
-		const peer = new OutboundPeer(peerInfo, { ...this._peerConfig });
+		const peer = new OutboundPeer(peerInfo, {
+			...this._peerConfig,
+			...customPeerConfig,
+		});
 
 		this._peerMap.set(peer.id, peer);
 		this._bindHandlersToPeer(peer);

--- a/elements/lisk-p2p/test/integration/unseeded_network.ts
+++ b/elements/lisk-p2p/test/integration/unseeded_network.ts
@@ -22,7 +22,11 @@ describe('Unseeded network: Each node has an empty seedPeers list', () => {
 
 	beforeEach(async () => {
 		// Make sure that integration tests use real timers.
-		p2pNodeList = await createNetwork();
+		const customConfig = () => ({
+			seedPeers: [],
+		});
+
+		p2pNodeList = await createNetwork({ customConfig });
 	});
 
 	afterEach(async () => {

--- a/elements/lisk-p2p/test/unit/peer/base.ts
+++ b/elements/lisk-p2p/test/unit/peer/base.ts
@@ -50,6 +50,7 @@ describe('peer/base', () => {
 	let nodeInfo: P2PNodeInfo;
 	let p2pDiscoveredPeerInfo: P2PPeerInfo;
 	let defaultPeer: Peer;
+	let initialSeedPeer: Peer;
 	let clock: sinon.SinonFakeTimers;
 
 	beforeEach(() => {
@@ -100,6 +101,10 @@ describe('peer/base', () => {
 			internalState: undefined,
 		};
 		defaultPeer = new Peer(defaultPeerInfo, peerConfig);
+		initialSeedPeer = new Peer(defaultPeerInfo, {
+			fetchPeersAndDisconnect: true,
+			...peerConfig,
+		});
 	});
 
 	afterEach(() => {
@@ -493,32 +498,61 @@ describe('peer/base', () => {
 			];
 			sandbox.stub(defaultPeer, 'fetchPeers').resolves(discoveredPeers);
 			sandbox.stub(defaultPeer, 'emit');
+
+			sandbox.stub(initialSeedPeer, 'fetchPeers').resolves(discoveredPeers);
+			sandbox.stub(initialSeedPeer, 'emit');
+			sandbox.stub(initialSeedPeer, 'disconnect');
 		});
 
-		it('should call fetchPeers', async () => {
-			await defaultPeer.discoverPeers();
-			expect(defaultPeer.fetchPeers).to.be.calledOnce;
-		});
+		describe('when Peer is defaultPeer', () => {
+			it('should call fetchPeers', async () => {
+				await defaultPeer.discoverPeers();
+				expect(defaultPeer.fetchPeers).to.be.calledOnce;
+			});
 
-		it(`should emit ${EVENT_DISCOVERED_PEER} event 2 times`, async () => {
-			await defaultPeer.discoverPeers();
-			expect(defaultPeer.emit).to.be.calledTwice;
-		});
+			it(`should emit ${EVENT_DISCOVERED_PEER} event 2 times`, async () => {
+				await defaultPeer.discoverPeers();
+				expect(defaultPeer.emit).to.be.calledTwice;
+			});
 
-		it(`should emit ${EVENT_DISCOVERED_PEER} event with every peer info`, async () => {
-			await defaultPeer.discoverPeers();
-			expect(discoveredPeers).to.be.not.empty;
-			discoveredPeers.forEach(discoveredPeer => {
-				expect(defaultPeer.emit).to.be.calledWith(
-					EVENT_DISCOVERED_PEER,
-					discoveredPeer,
-				);
+			it(`should emit ${EVENT_DISCOVERED_PEER} event with every peer info`, async () => {
+				await defaultPeer.discoverPeers();
+				expect(discoveredPeers).to.be.not.empty;
+				discoveredPeers.forEach(discoveredPeer => {
+					expect(defaultPeer.emit).to.be.calledWith(
+						EVENT_DISCOVERED_PEER,
+						discoveredPeer,
+					);
+				});
 			});
 		});
 
-		it(`should return discoveredPeerInfoList`, async () => {
-			const discoveredPeerInfoList = await defaultPeer.discoverPeers();
-			expect(discoveredPeerInfoList).to.be.eql(discoveredPeers);
+		describe('when Peer is initialSeedPeer', () => {
+			it('should call fetchPeers', async () => {
+				await initialSeedPeer.discoverPeers();
+				expect(initialSeedPeer.fetchPeers).to.be.calledOnce;
+			});
+
+			it(`should emit ${EVENT_DISCOVERED_PEER} event 2 times`, async () => {
+				await initialSeedPeer.discoverPeers();
+				expect(initialSeedPeer.emit).to.be.calledTwice;
+			});
+
+			it(`should emit ${EVENT_DISCOVERED_PEER} event with every peer info`, async () => {
+				await initialSeedPeer.discoverPeers();
+				expect(initialSeedPeer).to.be.not.empty;
+				discoveredPeers.forEach(discoveredPeer => {
+					expect(initialSeedPeer.emit).to.be.calledWith(
+						EVENT_DISCOVERED_PEER,
+						discoveredPeer,
+					);
+				});
+			});
+
+			it('should call disconnect', async () => {
+				await initialSeedPeer.discoverPeers();
+				expect(initialSeedPeer.disconnect).to.be.calledOnce;
+			});
 		});
 	});
 


### PR DESCRIPTION
## What was the problem?

According the LIP-0004 we should disconnect from SeedPeers after we executed the initial discovery(get their PeerList).

### How did I solve it?

Add `_fetchSeedPeerList()` method into the [elements/lisk-p2p/src/p2p.ts](elements/lisk-p2p/src/p2p.ts) class which is executed before/parallel within the `_startPopulator()`. 
Extend PeerPool and Peer/Base with  `discoverSeedPeers` and  `fetchPeersAndDisconnect` functions to handle the required logic.
Remove insertion of SeedPeers from the peerBook at start-up, lately they still can be inserted into the peerBook as triedPeers from PeerPool.

### How to manually test it?

`npm run t`

### Review checklist

- [ ] The PR resolves #4359 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
