### PR TITLE
Validate Asset should return full path on error - Closes #4388

### DIFF
--- a/commander/test/commands/transaction/sign.test.ts
+++ b/commander/test/commands/transaction/sign.test.ts
@@ -111,7 +111,7 @@ describe('transaction:sign', () => {
 			])
 			.catch(error => {
 				return expect(error.message).to.contain(
-					'Transaction: 6662515125650388309 failed at .amount',
+					'Transaction: 6662515125650388309 failed at .asset.amount',
 				);
 			})
 			.it('should throw an error when transaction is invalid');

--- a/elements/lisk-transactions/src/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/8_transfer_transaction.ts
@@ -151,7 +151,7 @@ export class TransferTransaction extends BaseTransaction {
 				new TransactionError(
 					'Amount must be a valid number in string format.',
 					this.id,
-					'.amount',
+					'asset.amount',
 					this.asset.amount.toString(),
 				),
 			);

--- a/elements/lisk-transactions/src/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/8_transfer_transaction.ts
@@ -151,7 +151,7 @@ export class TransferTransaction extends BaseTransaction {
 				new TransactionError(
 					'Amount must be a valid number in string format.',
 					this.id,
-					'asset.amount',
+					'.asset.amount',
 					this.asset.amount.toString(),
 				),
 			);

--- a/elements/lisk-transactions/test/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/test/8_transfer_transaction.ts
@@ -163,6 +163,9 @@ describe('Transfer transaction class', () => {
 					'message',
 					`Amount must be a valid number in string format.`,
 				);
+			expect(errors[0])
+				.to.be.instanceof(TransactionError)
+				.and.to.have.property('dataPath', `asset.amount`);
 		});
 
 		it('should return error with invalid asset', async () => {

--- a/elements/lisk-transactions/test/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/test/8_transfer_transaction.ts
@@ -165,7 +165,7 @@ describe('Transfer transaction class', () => {
 				);
 			expect(errors[0])
 				.to.be.instanceof(TransactionError)
-				.and.to.have.property('dataPath', `asset.amount`);
+				.and.to.have.property('dataPath', `.asset.amount`);
 		});
 
 		it('should return error with invalid asset', async () => {


### PR DESCRIPTION
### What was the problem?

If there was an error in the amount of a transfer transaction the path in the error message was incomplete.

### How did I solve it?

- By correcting the path
- adding an extra assertion in the transfer tests

### How to manually test it?

Build should be green

### Review checklist

- [x] The PR resolves #4388
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
