### PR TITLE
Inject nodeInfo to InboundPeer - Closes #4509

### DIFF
--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -442,6 +442,7 @@ export class PeerPool extends EventEmitter {
 
 		const peer = new InboundPeer(peerInfo, socket, {
 			...this._peerConfig,
+			serverNodeInfo: this._nodeInfo,
 		});
 		// Throw an error because adding a peer multiple times is a common developer error which is very difficult to identify and debug.
 		if (this._peerMap.has(peer.id)) {


### PR DESCRIPTION
### What was the problem?

`nodeInfo` needs to be injected into `InboundPeer`

- [x] Closes #4509 
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
