### PR TITLE
Remove BFT headers validation from validate detached - Closes #4511

### DIFF
--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -214,19 +214,12 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 		this.validateDetached.pipe([
 			data => this._validateVersion(data),
 			data => validateSchema(data),
-			async ({ block }) => {
-				let expectedReward = this.blocksModule.blockReward.calculateReward(
-					block.height,
-				);
-				if (!this.bftModule.isBFTProtocolCompliant(block)) {
-					expectedReward *= 0.25;
-				}
-				await this.blocksModule.validateBlockHeader(
+			async ({ block }) =>
+				this.blocksModule.validateBlockHeader(
 					block,
 					getBytes(block),
-					expectedReward,
-				);
-			},
+					block.reward, // Because it cannot calculate BFT compliance, it assumes that reward is correct
+				),
 		]);
 
 		this.forkStatus.pipe([


### PR DESCRIPTION
### What was the problem?
Validate detached shouldn't validate BFT headers
### How did I solve it?
By removing BFT header validation
### How to manually test it?

### Review checklist

- [ ] The PR resolves #4511 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
