### PR TITLE
Elements library show throw informative errors- Closes #4512

### DIFF
--- a/elements/lisk-transactions/src/utils/validation/validation.ts
+++ b/elements/lisk-transactions/src/utils/validation/validation.ts
@@ -37,6 +37,9 @@ export const validatePublicKey = (publicKey: string) => {
 };
 
 export const validateNetworkIdentifier = (networkIdentifier: string) => {
+	if (!networkIdentifier) {
+		throw new Error(`Network identifier can not be empty.`);
+	}
 	const networkIdentifierBuffer = cryptography.hexToBuffer(networkIdentifier);
 	if (networkIdentifierBuffer.length !== NETWORK_IDENTIFIER_LENGTH) {
 		throw new Error(`Invalid network identifier length: ${networkIdentifier}`);

--- a/elements/lisk-transactions/test/base_transaction.ts
+++ b/elements/lisk-transactions/test/base_transaction.ts
@@ -441,7 +441,7 @@ describe('Base transaction class', () => {
 			expect(errors).to.not.be.empty;
 		});
 
-		it.only('should throw descriptive error when networkIdentifier is missing', async () => {
+		it('should throw descriptive error when networkIdentifier is missing', async () => {
 			const transactionWithMissingNetworkIdentifier = {
 				...transferFixture.testCases.input.transaction,
 			};

--- a/elements/lisk-transactions/test/base_transaction.ts
+++ b/elements/lisk-transactions/test/base_transaction.ts
@@ -440,6 +440,22 @@ describe('Base transaction class', () => {
 
 			expect(errors).to.not.be.empty;
 		});
+
+		it.only('should throw descriptive error when networkIdentifier is missing', async () => {
+			const transactionWithMissingNetworkIdentifier = {
+				...transferFixture.testCases.input.transaction,
+			};
+
+			const transactionWithMissingNetworkIdentifierInstance = new TestTransaction(
+				transactionWithMissingNetworkIdentifier as any,
+			);
+
+			expect(() =>
+				transactionWithMissingNetworkIdentifierInstance.sign(
+					transferFixture.testCases.input.account.passphrase,
+				),
+			).to.throw('Network identifier is required to sign a transaction');
+		});
 	});
 
 	describe('#validate', () => {

--- a/elements/lisk-transactions/test/transfer.ts
+++ b/elements/lisk-transactions/test/transfer.ts
@@ -139,6 +139,17 @@ describe('#transfer transaction', () => {
 			it('second signature property should be undefined', () => {
 				return expect(transferTransaction.signSignature).to.be.undefined;
 			});
+
+			it('without network identifier it should throw a descriptive error', () => {
+				expect(() =>
+					transfer({
+						recipientId,
+						amount,
+						passphrase,
+						data: testData,
+					} as any),
+				).to.throw('Network identifier can not be empty');
+			});
 		});
 
 		describe('with data', () => {


### PR DESCRIPTION
### What was the problem?

`validateNetworkIdentifier` was not considering an empty network identifier being passed.

### How did I solve it?

By adding and extra validation for empty networkIdentifier

### How to manually test it?

- Build should be green
- Use steps to reproduce from issue

### Review checklist

- [x] The PR resolves #4512
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
