### PR TITLE
Fix broadcasting order - Closes #4521

### DIFF
--- a/framework/src/modules/chain/transport/broadcaster.js
+++ b/framework/src/modules/chain/transport/broadcaster.js
@@ -91,10 +91,10 @@ class Broadcaster {
 	 * broadcast to network.
 	 */
 	async _broadcast() {
+		this.transactionIdQueue = this.transactionIdQueue.filter(id =>
+			this.transactionPool.transactionInPool(id),
+		);
 		if (this.transactionIdQueue.length > 0) {
-			this.transactionIdQueue = this.transactionIdQueue.filter(id =>
-				this.transactionPool.transactionInPool(id),
-			);
 			const transactionIds = this.transactionIdQueue.slice(
 				0,
 				this.config.releaseLimit,

--- a/framework/test/jest/unit/specs/modules/chain/transport/transport.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/transport/transport.spec.js
@@ -133,6 +133,28 @@ describe('Transport', () => {
 			});
 		});
 
+		describe('when the transaction is not in the pool', () => {
+			it('should not broadcast after 5 sec', async () => {
+				const tx = new TransferTransaction({
+					networkIdentifier: '1234567890',
+					asset: { amount: '100', recipientId: '123L' },
+				});
+				tx.sign('signature');
+				await transport.handleBroadcastTransaction(tx);
+				transactionPoolStub.transactionInPool.mockReturnValue(false);
+				jest.advanceTimersByTime(defaultBroadcastInterval);
+				expect(channelStub.invoke).not.toHaveBeenCalledWith(
+					'network:broadcast',
+					{
+						event: 'postTransactionsAnnouncement',
+						data: {
+							transactionIds: [tx.id],
+						},
+					},
+				);
+			});
+		});
+
 		describe('when 25 transactions are given', () => {
 			it('should enqueue to the broadcaster', async () => {
 				const txs = new Array(25).fill(0).map((_, v) => {

--- a/framework/test/test_app/app.js
+++ b/framework/test/test_app/app.js
@@ -29,9 +29,9 @@ const dummyBuildVersion = '#buildVersion';
 
 const appConfig = {
 	app: {
-		version: '2.0.0',
+		version: '3.0.0',
 		minVersion: '1.0.0',
-		protocolVersion: '1.1',
+		protocolVersion: '2.0',
 		lastCommitId: dummyLastCommitId,
 		buildVersion: dummyBuildVersion,
 	},
@@ -57,7 +57,7 @@ try {
 		configurator.loadConfigFile(path.resolve(process.env.CUSTOM_CONFIG_FILE));
 	}
 
-	const config = configurator.getConfig({}, { failOnInvalidArg: false });
+	const config = configurator.getConfig(appConfig, { failOnInvalidArg: false });
 
 	// Support for PROTOCOL_VERSION only for tests
 	if (process.env.NODE_ENV === 'test' && process.env.PROTOCOL_VERSION) {


### PR DESCRIPTION
### What was the problem?
Broadcaster was checking the queue size before filtering

### How did I solve it?
Change the order of execution

### How to manually test it?
It should not send zero length response

### Review checklist

- [ ] The PR resolves #4521 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
