### PR TITLE
Fix applying penalty on transaction processing error - Closes #4528

### DIFF
--- a/framework/src/modules/chain/transport/errors.js
+++ b/framework/src/modules/chain/transport/errors.js
@@ -15,9 +15,11 @@
 'use strict';
 
 class InvalidTransactionError extends Error {
-	constructor(message, id) {
+	constructor(message, id, errors) {
 		super(message);
+		this.message = message;
 		this.id = id;
+		this.errors = errors;
 	}
 }
 

--- a/framework/src/modules/chain/transport/errors.js
+++ b/framework/src/modules/chain/transport/errors.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+class InvalidTransactionError extends Error {
+	constructor(message, id) {
+		super(message);
+		this.id = id;
+	}
+}
+
+module.exports = {
+	InvalidTransactionError,
+};

--- a/framework/src/modules/chain/transport/transport.js
+++ b/framework/src/modules/chain/transport/transport.js
@@ -447,8 +447,8 @@ class Transport {
 			};
 		} catch (err) {
 			return {
-				message: err.message || 'Transaction was rejected with errors',
-				errors: err,
+				message: 'Transaction was rejected with errors',
+				errors: err.errors || err,
 			};
 		}
 	}
@@ -575,7 +575,7 @@ class Transport {
 			}
 		} catch (errors) {
 			const errString = convertErrorsToString(errors);
-			const err = new InvalidTransactionError(errString, id);
+			const err = new InvalidTransactionError(errString, id, errors);
 			this.logger.error(
 				{
 					err,

--- a/framework/test/jest/unit/specs/modules/chain/transport/transport.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/transport/transport.spec.js
@@ -44,6 +44,7 @@ describe('Transport', () => {
 		loggerStub = {
 			info: jest.fn(),
 			warn: jest.fn(),
+			error: jest.fn(),
 			debug: jest.fn(),
 		};
 		storageStub = {
@@ -940,7 +941,7 @@ describe('Transport', () => {
 				);
 			});
 
-			it('should apply penalty when processUnconfirmedTransaction fails', async () => {
+			it('should not apply penalty when processUnconfirmedTransaction fails', async () => {
 				const error = new Error('validate error');
 				transactionPoolStub.processUnconfirmedTransaction.mockRejectedValue(
 					error,
@@ -949,7 +950,7 @@ describe('Transport', () => {
 					validTransactionsRequest,
 					defaultPeerId,
 				);
-				expect(channelStub.invoke).toHaveBeenCalledWith(
+				expect(channelStub.invoke).not.toHaveBeenCalledWith(
 					'network:applyPenalty',
 					{
 						peerId: defaultPeerId,

--- a/framework/test/mocha/integration/matcher.js
+++ b/framework/test/mocha/integration/matcher.js
@@ -281,8 +281,8 @@ describe('matcher', () => {
 				expect(
 					scope.modules.transactionPool.transactionInPool(rawTransaction.id),
 				).to.be.false;
-				expect(err[0]).to.be.instanceOf(Error);
-				expect(err[0].message).to.equal(
+				expect(err).to.be.instanceOf(Error);
+				expect(err.message).to.contain(
 					`Transaction type ${CUSTOM_TRANSACTION_TYPE} is currently not allowed.`,
 				);
 			}

--- a/framework/test/mocha/unit/modules/chain/transport/transport.js
+++ b/framework/test/mocha/unit/modules/chain/transport/transport.js
@@ -400,8 +400,8 @@ describe('transport', () => {
 				});
 
 				it('should call the call back with error message', async () => {
-					expect(errorResult).to.be.an('array');
-					errorResult.forEach(anError => {
+					expect(errorResult.errors).to.be.an('array');
+					errorResult.errors.forEach(anError => {
 						expect(anError).to.be.instanceOf(TransactionError);
 					});
 				});


### PR DESCRIPTION
### What was the problem?
If transaction fails on the processing, it was applying the penalty.
However, transaction processing can fail in various reason.
- not synced
- already processed
- etc

### How did I solve it?
- Create error type for invalid transaction
- Only apply error in case of this error

### How to manually test it?
Try to send already processed transaction

### Review checklist

- [ ] The PR resolves #4528 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
