### PR TITLE
Test that transaction replay is not possible among networks - Closes #4530

### DIFF
--- a/framework/test/mocha/functional/http/post/1.second_secret.js
+++ b/framework/test/mocha/functional/http/post/1.second_secret.js
@@ -130,6 +130,36 @@ describe('POST /api/transactions (type 1) register second passphrase', () => {
 				});
 		});
 
+		it('using network identifier from different network should fail', async () => {
+			const networkIdentifierOtherNetwork =
+				'91a254dc30db5eb1ce4001acde35fd5a14d62584f886d30df161e4e883220eb1';
+			const transactionFromDifferentNetwork = registerSecondPassphrase({
+				networkIdentifier: networkIdentifierOtherNetwork,
+				passphrase: accountMinimalFunds.passphrase,
+				secondPassphrase: accountMinimalFunds.secondPassphrase,
+				timeOffset: -10000,
+			});
+
+			return apiHelpers
+				.sendTransactionPromise(
+					transactionFromDifferentNetwork,
+					apiCodes.PROCESSING_ERROR,
+				)
+				.then(res => {
+					expect(res.body.message).to.be.equal(
+						'Transaction was rejected with errors',
+					);
+
+					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
+					expect(res.body.errors[0].message).to.include(
+						`Failed to validate signature ${
+							transactionFromDifferentNetwork.signature
+						}`,
+					);
+					badTransactions.push(transactionFromDifferentNetwork);
+				});
+		});
+
 		it('with minimal required amount of funds should be ok', async () => {
 			transaction = registerSecondPassphrase({
 				networkIdentifier,

--- a/framework/test/mocha/functional/http/post/2.delegate.js
+++ b/framework/test/mocha/functional/http/post/2.delegate.js
@@ -358,6 +358,28 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 			});
 		});
 
+		it('using network identifier from different network should fail', async () => {
+			const networkIdentifierOtherNetwork =
+				'91a254dc30db5eb1ce4001acde35fd5a14d62584f886d30df161e4e883220eb1';
+			const transactionFromDifferentNetwork = registerDelegate({
+				networkIdentifier: networkIdentifierOtherNetwork,
+				passphrase: account.passphrase,
+				username: account.username,
+			});
+
+			return sendTransactionPromise(
+				transactionFromDifferentNetwork,
+				apiCodes.PROCESSING_ERROR,
+			).then(res => {
+				expect(res.body.errors[0].message).to.include(
+					`Failed to validate signature ${
+						transactionFromDifferentNetwork.signature
+					}`,
+				);
+				badTransactions.push(transactionFromDifferentNetwork);
+			});
+		});
+
 		it('using valid params should be ok', async () => {
 			transaction = registerDelegate({
 				networkIdentifier,

--- a/framework/test/mocha/functional/http/post/3.votes.js
+++ b/framework/test/mocha/functional/http/post/3.votes.js
@@ -458,6 +458,28 @@ describe('POST /api/transactions (type 3) votes', () => {
 			});
 		});
 
+		it('using network identifier from different network should fail', async () => {
+			const networkIdentifierOtherNetwork =
+				'91a254dc30db5eb1ce4001acde35fd5a14d62584f886d30df161e4e883220eb1';
+			const transactionFromDifferentNetwork = castVotes({
+				networkIdentifier: networkIdentifierOtherNetwork,
+				passphrase: accountMinimalFunds.passphrase,
+				votes: [`${accountFixtures.existingDelegate.publicKey}`],
+			});
+
+			return sendTransactionPromise(
+				transactionFromDifferentNetwork,
+				apiCodes.PROCESSING_ERROR,
+			).then(res => {
+				expect(res.body.errors[0].message).to.include(
+					`Failed to validate signature ${
+						transactionFromDifferentNetwork.signature
+					}`,
+				);
+				badTransactions.push(transactionFromDifferentNetwork);
+			});
+		});
+
 		it('upvoting with minimal required amount of funds should be ok', async () => {
 			transaction = castVotes({
 				networkIdentifier,


### PR DESCRIPTION
### What was the problem?

There were no functional tests asserting that transactions of different networks can't be replayed among them.

### How did I solve it?

By adding such functional tests

### How to manually test it?

Build should be green

### Review checklist

- [x] The PR resolves #4530
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
