### PR TITLE
API: Node status remove network height and loaded - Closes #4543

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -298,7 +298,6 @@ module.exports = class Chain {
 					: this.slots.getSlotNumber(),
 			calcSlotRound: async action => this.slots.calcRound(action.params.height),
 			getNodeStatus: async () => ({
-				loaded: true,
 				syncing: this.synchronizer.isActive,
 				unconfirmedTransactions: this.transactionPool.getCount(),
 				secondsSinceEpoch: this.slots.getEpochTime(),

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -49,46 +49,6 @@ async function _getForgingStatus(publicKey) {
 }
 
 /**
- * Get the network height
- *
- * @returns Number
- * @private
- */
-async function _getNetworkHeight() {
-	const peers = await library.channel.invoke('network:getPeers', {
-		limit: 100,
-		state: 2,
-	});
-	if (!peers || !peers.length) {
-		return 0;
-	}
-	const networkHeightCount = peers.reduce((previous, { height }) => {
-		const heightCount = previous[height] || 0;
-		previous[height] = heightCount + 1;
-		return previous;
-	}, {});
-	const heightCountPairs = Object.entries(networkHeightCount);
-	const [defaultHeight, defaultCount] = heightCountPairs[0];
-	const { height: networkHeight } = heightCountPairs.reduce(
-		(prev, [height, count]) => {
-			if (count > prev.count) {
-				return {
-					height,
-					count,
-				};
-			}
-			return prev;
-		},
-		{
-			height: defaultHeight,
-			count: defaultCount,
-		},
-	);
-
-	return parseInt(networkHeight, 10);
-}
-
-/**
  * Description of the function.
  *
  * @class
@@ -182,21 +142,16 @@ NodeController.getStatus = async (context, next) => {
 	try {
 		const {
 			secondsSinceEpoch,
-			loaded,
 			syncing,
 			lastBlock,
 			chainMaxHeightFinalized,
 		} = await library.channel.invoke('chain:getNodeStatus');
 
-		const networkHeight = await _getNetworkHeight();
-
 		const data = {
 			currentTime: Date.now(),
 			secondsSinceEpoch,
 			height: lastBlock.height || 0,
-			networkHeight,
 			chainMaxHeightFinalized,
-			loaded,
 			syncing,
 		};
 

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -2198,10 +2198,8 @@ definitions:
     required:
       - currentTime
       - height
-      - networkHeight
       - chainMaxHeightFinalized
       - secondsSinceEpoch
-      - loaded
       - syncing
     properties:
       currentTime:
@@ -2215,16 +2213,6 @@ definitions:
         description: |
           Current block height of the node.
           Represents the current number of blocks in the chain on the node.
-      loaded:
-        type: boolean
-        example: true
-        description: True if the blockchain loaded.
-      networkHeight:
-        type: integer
-        example: 123
-        description: |
-          Current block height of the network.
-          Represents the current number of blocks in the chain on the network.
       chainMaxHeightFinalized:
         type: integer
         example: 123

--- a/framework/test/mocha/unit/modules/http_api/controllers/node.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/node.js
@@ -31,7 +31,6 @@ describe('node/api', () => {
 	let storageStub;
 	let configStub;
 	let getStatus;
-	let getNetworkHeight;
 
 	before(async () => {
 		channelStub = {
@@ -72,7 +71,6 @@ describe('node/api', () => {
 
 		privateLibrary = NodeController.__get__('library');
 		getStatus = NodeController.getStatus;
-		getNetworkHeight = NodeController.__get__('_getNetworkHeight');
 	});
 
 	afterEach(() => {
@@ -119,7 +117,6 @@ describe('node/api', () => {
 			lastBlock: {
 				height: 1187,
 			},
-			loaded: true,
 			syncing: false,
 			unconfirmedTransactions: {
 				ready: 0,
@@ -135,27 +132,10 @@ describe('node/api', () => {
 		const expectedStatus = {
 			secondsSinceEpoch: 89742345,
 			height: 1187,
-			loaded: true,
-			networkHeight: 456,
 			syncing: false,
 			currentTime: now,
 			chainMaxHeightFinalized: 1010,
 		};
-
-		const defaultPeers = [
-			{
-				height: 456,
-			},
-			{
-				height: 457,
-			},
-			{
-				height: 456,
-			},
-			{
-				height: 453,
-			},
-		];
 
 		beforeEach(async () => {
 			sinonSandbox.stub(Date, 'now').returns(now);
@@ -164,7 +144,6 @@ describe('node/api', () => {
 		describe('when chain:getNodeStatus answers with all parameters', () => {
 			beforeEach(async () => {
 				channelStub.invoke.withArgs('chain:getNodeStatus').returns(status);
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
 			});
 
 			it('should return an object status with all properties', async () =>
@@ -181,13 +160,11 @@ describe('node/api', () => {
 			beforeEach(async () => {
 				statusWithoutSomeParameters = _.cloneDeep(status);
 				statusWithoutSomeParameters.lastBlock.height = undefined;
-				statusWithoutSomeParameters.networkHeight = undefined;
 				expectedStatusWithoutSomeParameters = _.cloneDeep(expectedStatus);
 				expectedStatusWithoutSomeParameters.height = 0;
 				channelStub.invoke
 					.withArgs('chain:getNodeStatus')
 					.returns(statusWithoutSomeParameters);
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
 			});
 
 			it('should return an object status with some properties to 0', async () =>
@@ -195,202 +172,6 @@ describe('node/api', () => {
 					expect(err).to.be.null;
 					expect(response).to.deep.equal(expectedStatusWithoutSomeParameters);
 				}));
-		});
-	});
-
-	describe('_networkHeight', () => {
-		const MAJORITY_HEIGHT = 456;
-
-		let networkHeight;
-		describe('When there are set of majority peers with same height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 457,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 453,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 438,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return correct networkHeight based on majority', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns a blank list of peers', () => {
-			beforeEach(async () => {
-				channelStub.invoke.withArgs('network:getPeers').returns([]);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return zero when there are no peers with height', async () => {
-				expect(networkHeight).to.be.eql(0);
-			});
-		});
-
-		describe('When network:getPeers returns a list of peers with 2 different equal set of peers height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of majority with lower height', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns a list of peers with 3 different equal set of peers height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT + 2,
-					},
-					{
-						height: MAJORITY_HEIGHT + 2,
-					},
-					{
-						height: MAJORITY_HEIGHT + 2,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of majority with lower height', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns a list of peers with 2 different unequal set of peers height', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-					{
-						height: MAJORITY_HEIGHT + 1,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of majority', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT + 1);
-			});
-		});
-
-		describe('When network:getPeers returns only one peer', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of one peer', async () => {
-				expect(networkHeight).to.be.eql(MAJORITY_HEIGHT);
-			});
-		});
-
-		describe('When network:getPeers returns majority of peers with very low height compared to others', () => {
-			beforeEach(async () => {
-				const defaultPeers = [
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: MAJORITY_HEIGHT,
-					},
-					{
-						height: 1,
-					},
-					{
-						height: 1,
-					},
-					{
-						height: 1,
-					},
-					{
-						height: 1,
-					},
-				];
-				channelStub.invoke.withArgs('network:getPeers').returns(defaultPeers);
-				networkHeight = await getNetworkHeight();
-			});
-
-			it('should return height of the majority even though its very low compared to others', async () => {
-				expect(networkHeight).to.be.eql(1);
-			});
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
API node status shows network height, which is a partial mesh network, which is not the full network height, in the previous protocol both networkHeight and loaded properties made relevant. With BFT and Partial mesh p2p network these properties no longer valid
### How did I solve it?
- Remove networkHeight and loaded from `api/node/status
- Remove networkHeight calculation from framework
### How to manually test it?
- Run unit test for node status endpoint
### Review checklist

- [ ] The PR resolves #4543 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
