### PR TITLE
wait_for helper not updated when changing status endpoint - Closes #4553

### DIFF
--- a/framework/test/mocha/common/utils/wait_for.js
+++ b/framework/test/mocha/common/utils/wait_for.js
@@ -58,7 +58,7 @@ function blockchainReady(retries, timeout, baseUrl, doNotLogRetries, cb) {
 			.then(res => {
 				retries -= 1;
 				res = JSON.parse(res.body);
-				if (!res.data.loaded && retries >= 0) {
+				if (res.data.syncing && retries >= 0) {
 					if (!doNotLogRetries) {
 						__testContext.debug(
 							`Retrying ${totalRetries -
@@ -70,7 +70,7 @@ function blockchainReady(retries, timeout, baseUrl, doNotLogRetries, cb) {
 						fetchBlockchainStatus();
 					}, timeout);
 				}
-				if (res.data.loaded) {
+				if (!res.data.syncing) {
 					return cb();
 				}
 				return cb('Failed to load blockchain');


### PR DESCRIPTION
### What was the problem?

`wait_for` not updated when removing properties from `/api/node/status`

### How did I solve it?

by using a different property in `wait_for` to check for the HTTP API

### How to manually test it?

### Review checklist

- [ ] The PR resolves #4553
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
