### PR TITLE
Fix not to evict the fixed peer - Closes #4352

### DIFF
--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -660,8 +660,10 @@ export class PeerPool extends EventEmitter {
 	}
 
 	private _selectPeersForEviction(): Peer[] {
-		const peers = [...this.getPeers(InboundPeer)].filter(peer =>
-			this._peerLists.whitelisted.every(p => p.peerId !== peer.id),
+		const peers = [...this.getPeers(InboundPeer)].filter(
+			peer =>
+				this._peerLists.whitelisted.every(p => p.peerId !== peer.id) &&
+				this._peerLists.fixedPeers.every(p => p.peerId !== peer.id),
 		);
 
 		// Cannot predict which netgroups will be protected

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -1028,13 +1028,18 @@ describe('peerPool', () => {
 		beforeEach(async () => {
 			(peerPool as any)._peerLists.whitelisted = whitelistedPeers;
 			(peerPool as any)._peerLists.fixedPeers = fixedPeers;
+			(peerPool as any)._peerPoolConfig = {
+				netgroupProtectionRatio: 0,
+				latencyProtectionRatio: 0,
+				productivityProtectionRatio: 0,
+			};
 			sandbox.stub(peerPool as any, 'getPeers').returns(defaultPeers);
 			sandbox.stub(peerPool, 'removePeer');
 		});
 
 		it('should not evict whitelisted peer', async () => {
 			(peerPool as any)._evictPeer(InboundPeer);
-			expect(peerPool.removePeer).not.to.be.calledWith(
+			expect(peerPool.removePeer).not.to.be.calledWithExactly(
 				whitelistedPeers[0].ipAddress,
 				sinon.match.any,
 				sinon.match.any,
@@ -1043,8 +1048,17 @@ describe('peerPool', () => {
 
 		it('should not evict fixed peer', async () => {
 			(peerPool as any)._evictPeer(InboundPeer);
-			expect(peerPool.removePeer).not.to.be.calledWith(
+			expect(peerPool.removePeer).not.to.be.calledWithExactly(
 				fixedPeers[0].ipAddress,
+				sinon.match.any,
+				sinon.match.any,
+			);
+		});
+
+		it('should evict a peer', async () => {
+			(peerPool as any)._evictPeer(InboundPeer);
+			expect(peerPool.removePeer).to.be.calledWithExactly(
+				defaultPeers[0].peerId,
 				sinon.match.any,
 				sinon.match.any,
 			);

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -13,6 +13,7 @@
  *
  */
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import {
 	PeerPool,
 	PROTECT_BY,
@@ -1006,7 +1007,49 @@ describe('peerPool', () => {
 		});
 	});
 
-	describe.skip('#_evictPeer', () => {});
+	describe('#_evictPeer', () => {
+		const whitelistedPeers = [
+			{ peerId: '1.2.3.4:5000', ipAddress: '1.2.3.4', wsPort: 5000 },
+		];
+		const fixedPeers = [
+			{ peerId: '5.6.7.8:5000', ipAddress: '5.6.7.8', wsPort: 5000 },
+		];
+		const defaultPeers = [
+			{
+				id: '69.123.456.78:5000',
+				peerId: '69.123.456.78:5000',
+				ipAddress: '69.123.456.78',
+				wsPort: 5000,
+			},
+			...whitelistedPeers.map(peer => ({ ...peer, id: peer.peerId })),
+			...fixedPeers.map(peer => ({ ...peer, id: peer.peerId })),
+		];
+
+		beforeEach(async () => {
+			(peerPool as any)._peerLists.whitelisted = whitelistedPeers;
+			(peerPool as any)._peerLists.fixedPeers = fixedPeers;
+			sandbox.stub(peerPool as any, 'getPeers').returns(defaultPeers);
+			sandbox.stub(peerPool, 'removePeer');
+		});
+
+		it('should not evict whitelisted peer', async () => {
+			(peerPool as any)._evictPeer(InboundPeer);
+			expect(peerPool.removePeer).not.to.be.calledWith(
+				whitelistedPeers[0].ipAddress,
+				sinon.match.any,
+				sinon.match.any,
+			);
+		});
+
+		it('should not evict fixed peer', async () => {
+			(peerPool as any)._evictPeer(InboundPeer);
+			expect(peerPool.removePeer).not.to.be.calledWith(
+				fixedPeers[0].ipAddress,
+				sinon.match.any,
+				sinon.match.any,
+			);
+		});
+	});
 
 	describe.skip('#_bindHandlersToPeer', () => {});
 });


### PR DESCRIPTION
### What was the problem?
Fixed peer had possibility to be evicted

### How did I solve it?
From the eviction, remove filter out the fixed peer before evicting

### How to manually test it?
Defined the fixed peer, and observe it's not been disconnected from inbound

### Review checklist

- [ ] The PR resolves #4352 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
