### PR TITLE
P2P update DEFAULT_BAN_TIME in ms

### DIFF
--- a/elements/lisk-p2p/src/constants.ts
+++ b/elements/lisk-p2p/src/constants.ts
@@ -17,7 +17,7 @@ import { getRandomBytes } from '@liskhq/lisk-cryptography';
 // General P2P constants
 export const DEFAULT_NODE_HOST_IP = '0.0.0.0';
 export const DEFAULT_LOCALHOST_IP = '127.0.0.1';
-export const DEFAULT_BAN_TIME = 86400;
+export const DEFAULT_BAN_TIME = 86400000; // Milliseconds in a day -> hours*minutes*seconds*milliseconds
 export const DEFAULT_POPULATOR_INTERVAL = 10000;
 export const DEFAULT_SEND_PEER_LIMIT = 16;
 // Max rate of WebSocket messages per second per peer.
@@ -33,7 +33,7 @@ export const DEFAULT_RANDOM_SECRET = getRandomBytes(
 
 export const DEFAULT_MAX_OUTBOUND_CONNECTIONS = 20;
 export const DEFAULT_MAX_INBOUND_CONNECTIONS = 100;
-export const DEFAULT_OUTBOUND_SHUFFLE_INTERVAL = 300000;
+export const DEFAULT_OUTBOUND_SHUFFLE_INTERVAL = 300000; // Milliseconds 5 minute
 export const DEFAULT_PEER_PROTECTION_FOR_NETGROUP = 0.034;
 export const DEFAULT_PEER_PROTECTION_FOR_LATENCY = 0.068;
 export const DEFAULT_PEER_PROTECTION_FOR_USEFULNESS = 0.068;
@@ -66,7 +66,7 @@ export const DEFAULT_PING_INTERVAL_MIN = 20000;
 // Peer directory constants
 export const DEFAULT_NEW_BUCKET_COUNT = 128;
 export const DEFAULT_NEW_BUCKET_SIZE = 32;
-export const DEFAULT_EVICTION_THRESHOLD_TIME = 86400000; // Milliseconds in a day -> hours*minutes*seconds*milliseconds;
+export const DEFAULT_EVICTION_THRESHOLD_TIME = 86400000; // Milliseconds in a day -> hours*minutes*seconds*milliseconds
 export const DEFAULT_TRIED_BUCKET_COUNT = 64;
 export const DEFAULT_TRIED_BUCKET_SIZE = 32;
 export const DEFAULT_MAX_RECONNECT_TRIES = 3;

--- a/elements/lisk-p2p/test/utils/network_setup.ts
+++ b/elements/lisk-p2p/test/utils/network_setup.ts
@@ -81,6 +81,7 @@ export const createNetwork = async ({
 		const p2pConfig = {
 			connectTimeout: DEFAULT_CONNECTION_TIMEOUT,
 			ackTimeout: DEFAULT_ACK_TIMEOUT,
+			peerBanTime: 5000, // avoid timeOut stuck, TODO: Cleanup unban timer properly
 			rateCalculationInterval: RATE_CALCULATION_INTERVAL,
 			seedPeers: defaultSeedPeers,
 			wsEngine: WEB_SOCKET_ENGINE,

--- a/elements/lisk-p2p/test/utils/network_setup.ts
+++ b/elements/lisk-p2p/test/utils/network_setup.ts
@@ -81,7 +81,6 @@ export const createNetwork = async ({
 		const p2pConfig = {
 			connectTimeout: DEFAULT_CONNECTION_TIMEOUT,
 			ackTimeout: DEFAULT_ACK_TIMEOUT,
-			peerBanTime: 5000, // avoid timeOut stuck, TODO: Cleanup unban timer properly
 			rateCalculationInterval: RATE_CALCULATION_INTERVAL,
 			seedPeers: defaultSeedPeers,
 			wsEngine: WEB_SOCKET_ENGINE,

--- a/framework/src/modules/network/defaults/config.js
+++ b/framework/src/modules/network/defaults/config.js
@@ -154,7 +154,7 @@ const defaultConfig = {
 		wsPort: 5000,
 		address: '0.0.0.0',
 		discoveryInterval: 30000,
-		peerBanTime: 86400,
+		peerBanTime: 86400000,
 		populatorInterval: 10000,
 		seedPeers: [],
 		blacklistedPeers: [],

--- a/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
+++ b/framework/test/jest/unit/specs/controller/__snapshots__/application.spec.js.snap
@@ -585,7 +585,7 @@ Object {
       "maxPeerDiscoveryResponseLength": 1000,
       "maxPeerInfoSize": 20480,
       "outboundShuffleInterval": 300000,
-      "peerBanTime": 86400,
+      "peerBanTime": 86400000,
       "peerDiscoveryResponseLength": 1000,
       "populatorInterval": 10000,
       "seedPeers": Array [


### PR DESCRIPTION
### What was the problem?
- After executing P2P banPeer request the ban expired earlier than expected. 

### How did I solve it?
- Modify `DEFAULT_BAN_TIME = 86400;` to `DEFAULT_BAN_TIME = 86400000;` which is the correct value of 1 day in milliseconds. Also related default configurations are modified.

### How to manually test it?
- `npm run test`

### Review checklist

- [x] The PR resolves #4561
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
