### PR TITLE
Fill-pool shouldn't be called when delegate is not enabled to forge or if node is syncing - Closes #4569

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -520,7 +520,6 @@ module.exports = class Chain {
 	async _forgingTask() {
 		return this.scope.sequence.add(async () => {
 			try {
-				await this.forger.beforeForge();
 				if (!this.forger.delegatesEnabled()) {
 					this.logger.debug('No delegates are enabled');
 					return;
@@ -529,6 +528,7 @@ module.exports = class Chain {
 					this.logger.debug('Client not ready to forge');
 					return;
 				}
+				await this.forger.beforeForge();
 				await this.forger.forge();
 			} catch (err) {
 				this.logger.error({ err });

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -440,6 +440,7 @@ describe('Chain', () => {
 			await chain.bootstrap();
 			sinonSandbox.stub(chain.forger, 'delegatesEnabled').returns(true);
 			sinonSandbox.stub(chain.forger, 'forge');
+			sinonSandbox.stub(chain.forger, 'beforeForge');
 			sinonSandbox.stub(chain.scope.sequence, 'add').callsFake(async fn => {
 				await fn();
 			});
@@ -458,6 +459,7 @@ describe('Chain', () => {
 				'No delegates are enabled',
 			);
 			expect(chain.scope.sequence.add).to.be.called;
+			expect(chain.forger.beforeForge).to.not.be.called;
 			expect(chain.forger.forge).to.not.be.called;
 		});
 
@@ -473,6 +475,7 @@ describe('Chain', () => {
 				'Client not ready to forge',
 			);
 			expect(chain.scope.sequence.add).to.be.called;
+			expect(chain.forger.beforeForge).to.not.be.called;
 			expect(chain.forger.forge).to.not.be.called;
 		});
 
@@ -480,6 +483,7 @@ describe('Chain', () => {
 			await chain._forgingTask();
 
 			expect(chain.scope.sequence.add).to.be.called;
+			expect(chain.forger.beforeForge).to.be.called;
 			expect(chain.forger.forge).to.be.called;
 		});
 	});


### PR DESCRIPTION
### What was the problem?
Fill-pool is called before checking if the delegate is not enabled to forge or if the node is syncing
### How did I solve it?
Checking if the delegate is enabled to forge and the node is not syncing and then calling `beforeForge` task
### How to manually test it?
Run unit test
### Review checklist

- [ ] The PR resolves #4569 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
