### PR TITLE
Remove internal peer info from API get peers' output - Closes #4508

### DIFF
--- a/elements/lisk-p2p/test/functional/events/connection_create.ts
+++ b/elements/lisk-p2p/test/functional/events/connection_create.ts
@@ -134,8 +134,6 @@ describe(`Connection Create`, () => {
 				os: 'darwin',
 				height: 0,
 				httpPort: 0,
-				broadhash:
-					'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
 				nonce: `O2wTkjqplHII500${index}`,
 			});
 

--- a/framework/src/modules/http_api/helpers/utils.js
+++ b/framework/src/modules/http_api/helpers/utils.js
@@ -139,12 +139,32 @@ const filterByParams = (peers, filters) => {
 const consolidatePeers = (connectedPeers = [], disconnectedPeers = []) => {
 	// Assign state 2 to the connected peers
 	const connectedList = [...connectedPeers].map(peer => {
-		const { ipAddress, options, minVersion, nethash, ...peerWithoutIp } = peer;
+		const {
+			ipAddress,
+			options,
+			minVersion,
+			nethash,
+			nonce,
+			blockVersion,
+			maxHeightPrevoted,
+			lastBlockId,
+			...peerWithoutIp
+		} = peer;
 
 		return { ip: ipAddress, ...peerWithoutIp, state: PEER_STATE_CONNECTED };
 	});
 	const disconnectedList = [...disconnectedPeers].map(peer => {
-		const { ipAddress, options, minVersion, nethash, ...peerWithoutIp } = peer;
+		const {
+			ipAddress,
+			options,
+			minVersion,
+			nethash,
+			nonce,
+			blockVersion,
+			maxHeightPrevoted,
+			lastBlockId,
+			...peerWithoutIp
+		} = peer;
 
 		return {
 			ip: ipAddress,

--- a/framework/src/modules/http_api/helpers/utils.js
+++ b/framework/src/modules/http_api/helpers/utils.js
@@ -148,10 +148,10 @@ const consolidatePeers = (connectedPeers = [], disconnectedPeers = []) => {
 			blockVersion,
 			maxHeightPrevoted,
 			lastBlockId,
-			...peerWithoutIp
+			...restOfPeerObject
 		} = peer;
 
-		return { ip: ipAddress, ...peerWithoutIp, state: PEER_STATE_CONNECTED };
+		return { ip: ipAddress, ...restOfPeerObject, state: PEER_STATE_CONNECTED };
 	});
 	const disconnectedList = [...disconnectedPeers].map(peer => {
 		const {
@@ -163,12 +163,12 @@ const consolidatePeers = (connectedPeers = [], disconnectedPeers = []) => {
 			blockVersion,
 			maxHeightPrevoted,
 			lastBlockId,
-			...peerWithoutIp
+			...restOfPeerObject
 		} = peer;
 
 		return {
 			ip: ipAddress,
-			...peerWithoutIp,
+			...restOfPeerObject,
 			state: PEER_STATE_DISCONNECTED,
 		};
 	});

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -2082,13 +2082,6 @@ definitions:
         description: |
           Network height on the peer node.
           Represents the current number of blocks in the chain on the peer node.
-      nonce:
-        type: string
-        example: sYHEDBKcScaAAAYg
-        minLength: 1
-        description: |
-          Unique Identifier for the peer.
-          Random string.
 
   Fees:
     type: object

--- a/framework/test/jest/unit/specs/controller/application_state.spec.js
+++ b/framework/test/jest/unit/specs/controller/application_state.spec.js
@@ -29,7 +29,7 @@ describe('Application State', () => {
 		httpPort: '3000',
 		minVersion: '1.0.0-beta.0',
 		protocolVersion: '1.0',
-		nethash: 'test broadhash',
+		nethash: 'test nethash',
 		maxHeightPrevoted: 0,
 		height: 1,
 		os: 'platformrelease',
@@ -42,7 +42,7 @@ describe('Application State', () => {
 		httpPort: '3000',
 		minVersion: '1.0.0-beta.0',
 		protocolVersion: '1.0',
-		nethash: 'test broadhash',
+		nethash: 'test nethash',
 		maxHeightPrevoted: 0,
 		height: 1,
 	};

--- a/framework/test/jest/unit/specs/controller/controller.spec.js
+++ b/framework/test/jest/unit/specs/controller/controller.spec.js
@@ -41,7 +41,7 @@ describe('Controller Class', () => {
 		httpPort: '3000',
 		minVersion: '1.0.0-beta.0',
 		protocolVersion: '1.0',
-		nethash: 'test broadhash',
+		nethash: 'test nethash',
 	};
 	const systemDirs = {
 		temp: `${config.tempPath}/${appLabel}/`,


### PR DESCRIPTION
### What was the problem?
Endpoint `/api/peers` reveals internal peer information

### How did I solve it?
By filtering the internal peer information

### How to manually test it?
- Start two nodes, add seed peer info to discover
- Check endpoint `/api/peers` and validate the internal peer information is not exposed
### Review checklist

- [x] The PR resolves #4508
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
