### PR TITLE
Application state not updated at initialization - Closes #4594

### DIFF
--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -202,6 +202,14 @@ module.exports = class Chain {
 			// After binding, it should immediately load blockchain
 			await this.processor.init(this.options.genesisBlock);
 
+			// Update Application State after processor is initialized
+			this.channel.invoke('app:updateApplicationState', {
+				height: this.blocks.lastBlock.height,
+				lastBlockId: this.blocks.lastBlock.id,
+				maxHeightPrevoted: this.blocks.lastBlock.maxHeightPrevoted || 0,
+				blockVersion: this.blocks.lastBlock.version,
+			});
+
 			this._subscribeToEvents();
 
 			this.channel.subscribe('network:bootstrap', async () => {

--- a/framework/test/mocha/unit/modules/chain/chain.js
+++ b/framework/test/mocha/unit/modules/chain/chain.js
@@ -109,6 +109,19 @@ describe('Chain', () => {
 		Chain.__set__('bootstrapStorage', stubs.initSteps.bootstrapStorage);
 		Chain.__set__('jobQueue', stubs.jobsQueue);
 
+		const Blocks = Chain.__get__('Blocks');
+		Object.defineProperty(Blocks.prototype, 'lastBlock', {
+			get: () => {
+				return {
+					height: 1,
+					id: 2,
+					version: 3,
+					maxHeightPrevoted: 4,
+				};
+			},
+		});
+		Chain.__set__('Blocks', Blocks);
+
 		// Act
 		chain = new Chain(stubs.channel, chainOptions);
 	});
@@ -331,6 +344,19 @@ describe('Chain', () => {
 
 		it('should invoke Processor.init', async () => {
 			expect(chain.processor.init).to.have.been.calledOnce;
+		});
+
+		it('should invoke "app:updateApplicationState" with correct params', () => {
+			// Assert
+			return expect(chain.channel.invoke).to.have.been.calledWith(
+				'app:updateApplicationState',
+				{
+					height: 1,
+					lastBlockId: 2,
+					blockVersion: 3,
+					maxHeightPrevoted: 4,
+				},
+			);
 		});
 
 		it('should subscribe to "app:state:updated" event', () => {


### PR DESCRIPTION
### What was the problem?
Application State was updated only when the event `chain:processor:newBlock` was published.
That means it would be outdated between the app initialization and the next block added to the chain.

### How did I solve it?
By updating the Application State after processor is initialized

### How to manually test it?
Start a single node in an isolated network with, let's say, 42 blocks in the database.
Check the Application State. It should show `height: 42`.

### Review checklist

- [ ] The PR resolves #4594
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
