### PR TITLE
Wrong attribute description in app config schema #4167

### DIFF
--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -202,7 +202,7 @@ module.exports = {
 						'200000000', // Milestone 3
 						'100000000', // Milestone 4
 					],
-					OFFSET: 2160, // Start rewards at first block of the second round
+					OFFSET: 2160, // Start rewards at 39th block of 21st round
 					DISTANCE: 3000000, // Distance between each milestone
 				},
 			},

--- a/framework/src/controller/schema/application_config_schema.js
+++ b/framework/src/controller/schema/application_config_schema.js
@@ -202,7 +202,7 @@ module.exports = {
 						'200000000', // Milestone 3
 						'100000000', // Milestone 4
 					],
-					OFFSET: 2160, // Start rewards at 39th block of 21st round
+					OFFSET: 2160, // Start rewards at 39th block of 22nd round
 					DISTANCE: 3000000, // Distance between each milestone
 				},
 			},


### PR DESCRIPTION
### What was the problem?
Application config rewards description was incorrect
### How did I solve it?
```
Rewards starts at 2160-(101*21)=39

Where 2160 is the reward offset, 101 delegates, 21st round
```
Updated the description
### Review checklist

- [ ] The PR resolves #4167 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
