### PR TITLE
Remove jsdoc dev dependency from framework - Closes #4612

### DIFF
--- a/framework/.eslintignore
+++ b/framework/.eslintignore
@@ -6,4 +6,3 @@ release
 ssl
 stacktrace*
 tmp
-docs/jsdoc

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -2031,23 +2031,6 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
-		"catharsis": {
-			"version": "0.8.11",
-			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-			"integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
-			}
-		},
 		"chai": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -6874,53 +6857,10 @@
 				"esprima": "^4.0.0"
 			}
 		},
-		"js2xmlparser": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
-			"integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
-			"dev": true,
-			"requires": {
-				"xmlcreate": "^1.0.1"
-			}
-		},
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-		},
-		"jsdoc": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-			"integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
-			"dev": true,
-			"requires": {
-				"babylon": "7.0.0-beta.19",
-				"bluebird": "~3.5.0",
-				"catharsis": "~0.8.9",
-				"escape-string-regexp": "~1.0.5",
-				"js2xmlparser": "~3.0.0",
-				"klaw": "~2.0.0",
-				"marked": "~0.3.6",
-				"mkdirp": "~0.5.1",
-				"requizzle": "~0.2.1",
-				"strip-json-comments": "~2.0.1",
-				"taffydb": "2.6.2",
-				"underscore": "~1.8.3"
-			},
-			"dependencies": {
-				"babylon": {
-					"version": "7.0.0-beta.19",
-					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-					"integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
-					"dev": true
-				},
-				"underscore": {
-					"version": "1.8.3",
-					"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-					"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-					"dev": true
-				}
-			}
 		},
 		"jsdom": {
 			"version": "11.12.0",
@@ -7146,15 +7086,6 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
 			"dev": true
-		},
-		"klaw": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-			"integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.9"
-			}
 		},
 		"kleur": {
 			"version": "3.0.3",
@@ -7506,12 +7437,6 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
-		},
-		"marked": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-			"dev": true
 		},
 		"math-random": {
 			"version": "1.0.4",
@@ -9382,23 +9307,6 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
 			"dev": true
 		},
-		"requizzle": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-			"integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
-			}
-		},
 		"resolve": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
@@ -11020,12 +10928,6 @@
 				}
 			}
 		},
-		"taffydb": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-			"integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-			"dev": true
-		},
 		"tar-stream": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
@@ -11738,12 +11640,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-			"dev": true
-		},
-		"xmlcreate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-			"integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
 			"dev": true
 		},
 		"xmlhttprequest-ssl": {

--- a/framework/package.json
+++ b/framework/package.json
@@ -43,9 +43,7 @@
 		"mocha:functional:get": "node test/mocha/common/lisk-mocha-runner functional:get",
 		"mocha:functional:post": "node test/mocha/common/lisk-mocha-runner functional:post",
 		"mocha:functional:put": "node test/mocha/common/lisk-mocha-runner functional:put",
-		"mocha:network": "node test/mocha/common/lisk-mocha-runner network",
-		"docs:build": "jsdoc -c docs/conf.json --verbose --pedantic",
-		"docs:serve": "http-server docs/jsdoc/"
+		"mocha:network": "node test/mocha/common/lisk-mocha-runner network"
 	},
 	"dependencies": {
 		"@liskhq/bignum": "1.3.1",
@@ -109,7 +107,6 @@
 		"jest": "24.5.0",
 		"jest-extended": "0.11.1",
 		"jest-when": "2.6.0",
-		"jsdoc": "3.5.5",
 		"mocha": "5.2.0",
 		"node-mocks-http": "1.7.3",
 		"pm2": "3.5.1",

--- a/protocol-specs/.eslintignore
+++ b/protocol-specs/.eslintignore
@@ -6,4 +6,3 @@ release
 ssl
 stacktrace*
 tmp
-docs/jsdoc

--- a/sdk/.eslintignore
+++ b/sdk/.eslintignore
@@ -6,4 +6,3 @@ release
 ssl
 stacktrace*
 tmp
-docs/jsdoc

--- a/sdk/.eslintrc.json
+++ b/sdk/.eslintrc.json
@@ -24,18 +24,6 @@
 		"operator-linebreak": "off",
 		"prefer-destructuring": "off",
 		"radix": "off",
-		"require-jsdoc": [
-			"error",
-			{
-				"require": {
-					"FunctionDeclaration": false,
-					"MethodDefinition": false,
-					"ClassDeclaration": false,
-					"ArrowFunctionExpression": false,
-					"FunctionExpression": false
-				}
-			}
-		],
 		"strict": "off",
 		"import/no-extraneous-dependencies": [
 			"error",


### PR DESCRIPTION
### What was the problem?
JSDOC dependency was not removed as its any longer used
### How did I solve it?
removed the dependency and related contents
### How to manually test it?
you should no longer see `docs:build, docs:serve`  commands under framework
### Review checklist

- [ ] The PR resolves #4612 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
