### PR TITLE
Prettier fails to apply format for lisk-sdk - Closes #4614

### DIFF
--- a/commander/.prettierignore
+++ b/commander/.prettierignore
@@ -2,6 +2,7 @@
 LICENSE
 .gitkeep
 mocha.opts
+tsconfig.tsbuildinfo
 
 # rc files
 .*rc
@@ -20,3 +21,4 @@ mocha.opts
 .nyc_output/
 coverage/
 dist/
+tmp/

--- a/commander/src/utils/core/cache.ts
+++ b/commander/src/utils/core/cache.ts
@@ -48,7 +48,9 @@ export const startCache = async (
 ): Promise<string> => {
 	const { redisPort } = (await describeApplication(name)) as PM2ProcessInstance;
 
-	const { stderr }: ExecResult = await exec(
+	const {
+		stderr,
+	}: ExecResult = await exec(
 		`${REDIS_BIN} ${REDIS_CONFIG} --port ${redisPort}`,
 		{ cwd: installDir },
 	);

--- a/commander/src/utils/core/database.ts
+++ b/commander/src/utils/core/database.ts
@@ -45,7 +45,9 @@ const isDbRunning = async (
 	installDir: string,
 	port: string,
 ): Promise<boolean> => {
-	const { stderr }: ExecResult = await exec(
+	const {
+		stderr,
+	}: ExecResult = await exec(
 		`${PG_CTL} --pgdata ${DB_DATA} --options '-F -p ${port}' status`,
 		{ cwd: installDir },
 	);
@@ -60,7 +62,9 @@ export const initDB = async (installDir: string): Promise<string> => {
 
 	const { stderr }: ExecResult = await exec(
 		`${PG_CTL} initdb --pgdata ${DB_DATA}`,
-		{ cwd: installDir },
+		{
+			cwd: installDir,
+		},
 	);
 
 	if (!stderr) {
@@ -80,7 +84,9 @@ export const startDatabase = async (
 		return DATABASE_START_SUCCESS;
 	}
 
-	const { stderr }: ExecResult = await exec(
+	const {
+		stderr,
+	}: ExecResult = await exec(
 		`${PG_CTL} --wait --pgdata ${DB_DATA} --log ${DB_LOG_FILE} --options "-F -p ${dbPort}" start`,
 		{ cwd: installDir },
 	);
@@ -162,7 +168,9 @@ export const stopDatabase = async (
 		return DATABASE_STATUS;
 	}
 
-	const { stderr }: ExecResult = await exec(
+	const {
+		stderr,
+	}: ExecResult = await exec(
 		`${PG_CTL} --pgdata ${DB_DATA} --log ${DB_LOG_FILE} stop`,
 		{ cwd: installDir },
 	);
@@ -188,7 +196,9 @@ export const restoreSnapshot = async (
 		}: LiskConfig = await getLiskConfig(installDir, network);
 		const { dbPort } = (await describeApplication(name)) as PM2ProcessInstance;
 
-		const { stderr }: ExecResult = await exec(
+		const {
+			stderr,
+		}: ExecResult = await exec(
 			`gunzip --force --stdout --quiet ${snapshotFilePath} | ${PG_BIN}/psql --username ${user} --dbname ${database} --port ${dbPort};`,
 			{ cwd: installDir },
 		);

--- a/commander/src/utils/core/pm2.ts
+++ b/commander/src/utils/core/pm2.ts
@@ -247,9 +247,9 @@ const extractProcessDetails = (
 	};
 };
 
-export const listApplication = async (): Promise<
-	ReadonlyArray<PM2ProcessInstance>
-> => {
+export const listApplication = async (): Promise<ReadonlyArray<
+	PM2ProcessInstance
+>> => {
 	await connectPM2();
 	const applications = (await listPM2()) as ReadonlyArray<PM2ProcessInstance>;
 	disconnect();

--- a/commander/test/_global_hooks.ts
+++ b/commander/test/_global_hooks.ts
@@ -3,9 +3,7 @@ import lockfile from 'lockfile';
 afterEach(() => sandbox.restore());
 
 after(() => {
-	const configLockfilePath = `${
-		process.env.LISK_COMMANDER_CONFIG_DIR
-	}/config.lock`;
+	const configLockfilePath = `${process.env.LISK_COMMANDER_CONFIG_DIR}/config.lock`;
 
 	return lockfile.unlockSync(configLockfilePath);
 });

--- a/commander/test/commands/transaction/sign.test.ts
+++ b/commander/test/commands/transaction/sign.test.ts
@@ -167,9 +167,7 @@ describe('transaction:sign', () => {
 				'transaction:sign',
 				JSON.stringify(defaultTransaction),
 				`--passphrase=pass:${defaultInputs.passphrase}`,
-				`--second-passphrase=pass:${
-					defaultInputsWithSecondPassphrase.secondPassphrase
-				}`,
+				`--second-passphrase=pass:${defaultInputsWithSecondPassphrase.secondPassphrase}`,
 			])
 			.it(
 				'should take transaction from arg and passphrase and second passphrase from flag to sign',
@@ -180,9 +178,7 @@ describe('transaction:sign', () => {
 							repeatPrompt: true,
 						},
 						secondPassphrase: {
-							source: `pass:${
-								defaultInputsWithSecondPassphrase.secondPassphrase
-							}`,
+							source: `pass:${defaultInputsWithSecondPassphrase.secondPassphrase}`,
 							repeatPrompt: true,
 						},
 					});

--- a/elements/lisk-api-client/src/api_resource.ts
+++ b/elements/lisk-api-client/src/api_resource.ts
@@ -71,27 +71,25 @@ export class APIResource {
 	): Promise<APIResponse> {
 		const request = Axios.request(req)
 			.then((res: AxiosResponse) => res.data)
-			.catch(
-				(error: AxiosError): void => {
-					if (error.response) {
-						const { status } = error.response;
-						if (error.response.data) {
-							const {
-								error: errorString,
-								errors,
-								message,
-							}: APIErrorResponse = error.response.data;
-							throw new APIError(
-								message || errorString || 'An unknown error has occurred.',
-								status,
-								errors,
-							);
-						}
-						throw new APIError('An unknown error has occurred.', status);
+			.catch((error: AxiosError): void => {
+				if (error.response) {
+					const { status } = error.response;
+					if (error.response.data) {
+						const {
+							error: errorString,
+							errors,
+							message,
+						}: APIErrorResponse = error.response.data;
+						throw new APIError(
+							message || errorString || 'An unknown error has occurred.',
+							status,
+							errors,
+						);
 					}
-					throw error;
-				},
-			);
+					throw new APIError('An unknown error has occurred.', status);
+				}
+				throw error;
+			});
 
 		if (retry) {
 			return request.catch(async (err: Error) =>

--- a/elements/lisk-p2p/src/errors.ts
+++ b/elements/lisk-p2p/src/errors.ts
@@ -106,9 +106,7 @@ export class RequestFailError extends Error {
 		this.peerId = peerId || '';
 		this.peerVersion = peerVersion || '';
 		this.message = peerId
-			? `${this.message}: Peer Id: ${this.peerId}: Peer Version: ${
-					this.peerVersion
-			  }`
+			? `${this.message}: Peer Id: ${this.peerId}: Peer Version: ${this.peerVersion}`
 			: message;
 	}
 }

--- a/elements/lisk-p2p/src/p2p_request.ts
+++ b/elements/lisk-p2p/src/p2p_request.ts
@@ -58,9 +58,7 @@ export class P2PRequest {
 		) => {
 			if (this._wasResponseSent) {
 				throw new RPCResponseAlreadySentError(
-					`A response has already been sent for the request procedure <<${
-						options.procedure
-					}>>`,
+					`A response has already been sent for the request procedure <<${options.procedure}>>`,
 				);
 			}
 			this._wasResponseSent = true;

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -475,9 +475,11 @@ export class PeerPool extends EventEmitter {
 			peerLimit,
 		});
 
-		[...peersToConnect, ...disconnectedFixedPeers].forEach(
-			(peerInfo: P2PPeerInfo) =>
-				this._addOutboundPeer(peerInfo, this._nodeInfo as P2PNodeInfo),
+		[
+			...peersToConnect,
+			...disconnectedFixedPeers,
+		].forEach((peerInfo: P2PPeerInfo) =>
+			this._addOutboundPeer(peerInfo, this._nodeInfo as P2PNodeInfo),
 		);
 	}
 

--- a/elements/lisk-p2p/src/utils/validate.ts
+++ b/elements/lisk-p2p/src/utils/validate.ts
@@ -132,9 +132,7 @@ export const validatePeerInfo = (
 		!validatePeerAddress(peerInfo.ipAddress, peerInfo.wsPort)
 	) {
 		throw new InvalidPeerInfoError(
-			`Invalid peer ipAddress or port for peer with ip: ${
-				peerInfo.ipAddress
-			} and wsPort ${peerInfo.wsPort}`,
+			`Invalid peer ipAddress or port for peer with ip: ${peerInfo.ipAddress} and wsPort ${peerInfo.wsPort}`,
 		);
 	}
 

--- a/elements/lisk-p2p/test/functional/blacklist_whitelist_fixed_peers.ts
+++ b/elements/lisk-p2p/test/functional/blacklist_whitelist_fixed_peers.ts
@@ -321,9 +321,7 @@ describe('Blacklisted/fixed/whitelisted peers', () => {
 
 		it('should not be possible to ban them', async () => {
 			const peerPenalty = {
-				peerId: `${whitelistedPeers[0].ipAddress}:${
-					whitelistedPeers[0].wsPort
-				}`,
+				peerId: `${whitelistedPeers[0].ipAddress}:${whitelistedPeers[0].wsPort}`,
 				penalty: 100,
 			};
 

--- a/elements/lisk-p2p/test/unit/p2p_request.ts
+++ b/elements/lisk-p2p/test/unit/p2p_request.ts
@@ -117,9 +117,7 @@ describe('p2p_request', () => {
 		it('should throw error when sending another request', () =>
 			expect(() => request.end('hello')).to.throw(
 				RPCResponseAlreadySentError,
-				`A response has already been sent for the request procedure <<${
-					requestOptions.procedure
-				}>>`,
+				`A response has already been sent for the request procedure <<${requestOptions.procedure}>>`,
 			));
 	});
 

--- a/elements/lisk-p2p/test/unit/utils/misc.ts
+++ b/elements/lisk-p2p/test/unit/utils/misc.ts
@@ -94,9 +94,7 @@ describe('utils/misc', () => {
 	});
 
 	describe('#getNetgroup', () => {
-		it(`should throw an error if network is equal to ${
-			NETWORK.NET_OTHER
-		}`, () => {
+		it(`should throw an error if network is equal to ${NETWORK.NET_OTHER}`, () => {
 			expect(() =>
 				getNetgroup('wrong ipAddress', DEFAULT_RANDOM_SECRET),
 			).to.throw('IP address is unsupported.');
@@ -179,9 +177,7 @@ describe('utils/misc', () => {
 				.within(0, MAX_NEW_BUCKETS);
 		});
 
-		it(`should throw an error if network is equal to ${
-			NETWORK.NET_OTHER
-		}`, () => {
+		it(`should throw an error if network is equal to ${NETWORK.NET_OTHER}`, () => {
 			expect(() =>
 				getBucketId({
 					secret,

--- a/elements/lisk-transaction-pool/test/unit/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_pool.ts
@@ -152,8 +152,9 @@ describe('transaction pool', () => {
 			existsInPoolStub.returns(false);
 			receviedQueueSizeStub.returns(maxTransactionsPerQueue - 1);
 			addTransactionToQueue(queueName, transactions[0]);
-			expect(transactionPool.queues.received
-				.enqueueOne as sinon.SinonStub).to.be.calledWith(transactions[0]);
+			expect(
+				transactionPool.queues.received.enqueueOne as sinon.SinonStub,
+			).to.be.calledWith(transactions[0]);
 		});
 
 		it('should return false for isFull and alreadyExists if the transaction does not exist and queue is not full', async () => {
@@ -557,10 +558,9 @@ describe('transaction pool', () => {
 			expect(checkerStubs.checkTransactionForId.getCall(1)).to.be.calledWith(
 				validTransactions,
 			);
-			expect(transactionPool.queues.received
-				.removeFor as sinon.SinonStub).to.be.calledWith(
-				checkForTransactionValidTransactionId,
-			);
+			expect(
+				transactionPool.queues.received.removeFor as sinon.SinonStub,
+			).to.be.calledWith(checkForTransactionValidTransactionId);
 			expect(transactionPool.queues.validated.enqueueMany).to.be.calledWith(
 				validTransactions,
 			);
@@ -658,10 +658,9 @@ describe('transaction pool', () => {
 			expect(checkerStubs.checkTransactionForId.getCall(1)).to.be.calledWith(
 				verifiableTransactions,
 			);
-			expect(transactionPool.queues.validated
-				.removeFor as sinon.SinonStub).to.be.calledWith(
-				checkForTransactionVerifiableTransactionId,
-			);
+			expect(
+				transactionPool.queues.validated.removeFor as sinon.SinonStub,
+			).to.be.calledWith(checkForTransactionVerifiableTransactionId);
 			expect(transactionPool.queues.verified.enqueueMany).to.be.calledWith(
 				verifiableTransactions,
 			);
@@ -694,10 +693,9 @@ describe('transaction pool', () => {
 			expect(checkerStubs.checkTransactionForId.getCall(2)).to.be.calledWith(
 				pendingTransactions,
 			);
-			expect(transactionPool.queues.validated
-				.removeFor as sinon.SinonStub).to.be.calledWith(
-				checkForTransactionPendingTransactionId,
-			);
+			expect(
+				transactionPool.queues.validated.removeFor as sinon.SinonStub,
+			).to.be.calledWith(checkForTransactionPendingTransactionId);
 			expect(transactionPool.queues.pending.enqueueMany).to.be.calledWith(
 				pendingTransactions,
 			);

--- a/elements/lisk-transactions/src/11_vote_transaction.ts
+++ b/elements/lisk-transactions/src/11_vote_transaction.ts
@@ -127,26 +127,23 @@ export class VoteTransaction extends BaseTransaction {
 			.map(tx => new VoteTransaction(tx));
 		const publicKeys = this.asset.votes.map(vote => vote.substring(1));
 
-		return sameTypeTransactions.reduce(
-			(previous, tx) => {
-				const conflictingVotes = tx.asset.votes
-					.map(vote => vote.substring(1))
-					.filter(publicKey => publicKeys.includes(publicKey));
-				if (conflictingVotes.length > 0) {
-					return [
-						...previous,
-						new TransactionError(
-							`Transaction includes conflicting votes: ${conflictingVotes.toString()}`,
-							this.id,
-							'.asset.votes',
-						),
-					];
-				}
+		return sameTypeTransactions.reduce((previous, tx) => {
+			const conflictingVotes = tx.asset.votes
+				.map(vote => vote.substring(1))
+				.filter(publicKey => publicKeys.includes(publicKey));
+			if (conflictingVotes.length > 0) {
+				return [
+					...previous,
+					new TransactionError(
+						`Transaction includes conflicting votes: ${conflictingVotes.toString()}`,
+						this.id,
+						'.asset.votes',
+					),
+				];
+			}
 
-				return previous;
-			},
-			[] as ReadonlyArray<TransactionError>,
-		);
+			return previous;
+		}, [] as ReadonlyArray<TransactionError>);
 	}
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
@@ -223,9 +220,7 @@ export class VoteTransaction extends BaseTransaction {
 		if (votedDelegatesPublicKeys.length > MAX_VOTE_PER_ACCOUNT) {
 			errors.push(
 				new TransactionError(
-					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${
-						votedDelegatesPublicKeys.length
-					}.`,
+					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${votedDelegatesPublicKeys.length}.`,
 					this.id,
 					'.asset.votes',
 					votedDelegatesPublicKeys.length.toString(),
@@ -260,9 +255,7 @@ export class VoteTransaction extends BaseTransaction {
 		if (votedDelegatesPublicKeys.length > MAX_VOTE_PER_ACCOUNT) {
 			errors.push(
 				new TransactionError(
-					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${
-						votedDelegatesPublicKeys.length
-					}.`,
+					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${votedDelegatesPublicKeys.length}.`,
 					this.id,
 					'.asset.votes',
 					votedDelegatesPublicKeys.length.toString(),

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -380,9 +380,7 @@ export abstract class BaseTransaction {
 		) {
 			return createResponse(this.id, [
 				new TransactionError(
-					`Public Key '${
-						signatureObject.publicKey
-					}' is not a member for account '${account.address}'.`,
+					`Public Key '${signatureObject.publicKey}' is not a member for account '${account.address}'.`,
 					this.id,
 				),
 			]);
@@ -392,9 +390,7 @@ export abstract class BaseTransaction {
 		if (this.signatures.includes(signatureObject.signature)) {
 			return createResponse(this.id, [
 				new TransactionError(
-					`Signature '${
-						signatureObject.signature
-					}' already present in transaction.`,
+					`Signature '${signatureObject.signature}' already present in transaction.`,
 					this.id,
 				),
 			]);

--- a/elements/lisk-transactions/src/errors.ts
+++ b/elements/lisk-transactions/src/errors.ts
@@ -36,9 +36,7 @@ export class TransactionError extends Error {
 	}
 
 	public toString(): string {
-		const defaultMessage = `Transaction: ${this.id} failed at ${
-			this.dataPath
-		}: ${this.message}`;
+		const defaultMessage = `Transaction: ${this.id} failed at ${this.dataPath}: ${this.message}`;
 		const withActual = this.actual
 			? `${defaultMessage}, actual: ${this.actual}`
 			: defaultMessage;
@@ -65,9 +63,7 @@ export class TransactionPendingError extends TransactionError {
 	}
 
 	public toString(): string {
-		return `Transaction: ${this.id} failed at ${this.dataPath}: ${
-			this.message
-		} `;
+		return `Transaction: ${this.id} failed at ${this.dataPath}: ${this.message} `;
 	}
 }
 

--- a/elements/lisk-transactions/test/base_transaction.ts
+++ b/elements/lisk-transactions/test/base_transaction.ts
@@ -710,9 +710,7 @@ describe('Base transaction class', () => {
 				store,
 				multisigMember,
 			);
-			const expectedError = `Signature '${
-				multisignatureFixture.testCases.output.signatures[0]
-			}' already present in transaction.`;
+			const expectedError = `Signature '${multisignatureFixture.testCases.output.signatures[0]}' already present in transaction.`;
 
 			expect(status).to.eql(Status.FAIL);
 			expect(errors[0].message).to.be.eql(expectedError);
@@ -744,11 +742,7 @@ describe('Base transaction class', () => {
 				multisigMember,
 			);
 
-			const expectedError = `Public Key '${
-				multisigMember.publicKey
-			}' is not a member for account '${
-				defaultMultisignatureAccount.address
-			}'.`;
+			const expectedError = `Public Key '${multisigMember.publicKey}' is not a member for account '${defaultMultisignatureAccount.address}'.`;
 
 			expect(status).to.eql(Status.FAIL);
 			expect(errors[0].message).to.be.eql(expectedError);
@@ -810,9 +804,7 @@ describe('Base transaction class', () => {
 				.to.be.instanceof(TransactionError)
 				.and.to.have.property(
 					'message',
-					`Account does not have enough LSK: ${
-						defaultSenderAccount.address
-					}, balance: 0`,
+					`Account does not have enough LSK: ${defaultSenderAccount.address}, balance: 0`,
 				);
 		});
 	});

--- a/framework/.prettierignore
+++ b/framework/.prettierignore
@@ -16,6 +16,8 @@ mocha.opts
 
 # project specific paths
 test/mocha/.coverage-unit/
+logs/
+tmp/
 
 .DS_Store
 .log

--- a/framework/src/controller/channels/child_process_channel.js
+++ b/framework/src/controller/channels/child_process_channel.js
@@ -50,9 +50,7 @@ class ChildProcessChannel extends BaseChannel {
 
 		// Channel RPC Server is only required if the module has actions
 		if (this.actionsList.length > 0) {
-			this.rpcSocketPath = `unix://${socketsPath.root}/${
-				this.moduleAlias
-			}_rpc.sock`;
+			this.rpcSocketPath = `unix://${socketsPath.root}/${this.moduleAlias}_rpc.sock`;
 
 			this.rpcSocket = axon.socket('rep');
 			this.rpcSocket.bind(this.rpcSocketPath);

--- a/framework/src/controller/channels/in_memory_channel.js
+++ b/framework/src/controller/channels/in_memory_channel.js
@@ -66,9 +66,7 @@ class InMemoryChannel extends BaseChannel {
 		if (action.module === this.moduleAlias) {
 			if (!this.actions[action.name]) {
 				throw new Error(
-					`The action '${action.name}' on module '${
-						this.moduleAlias
-					}' does not exist.`,
+					`The action '${action.name}' on module '${this.moduleAlias}' does not exist.`,
 				);
 			}
 			return this.actions[action.name].handler(action);

--- a/framework/src/controller/validator/keywords/env/index.js
+++ b/framework/src/controller/validator/keywords/env/index.js
@@ -47,9 +47,7 @@ const compile = (schema, parentSchema) => {
 				case 'boolean':
 					if (!['true', 'false'].includes(variableValue.toLowerCase())) {
 						throw new Error(
-							`Failed to apply value for option ${
-								envVariable.name
-							}, use "true" or "false"`,
+							`Failed to apply value for option ${envVariable.name}, use "true" or "false"`,
 						);
 					}
 

--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -255,9 +255,7 @@ class BFT extends EventEmitter {
 			const activeHeights = minActiveHeightsOfDelegates[row.generatorPublicKey];
 			if (!activeHeights) {
 				throw new Error(
-					`Minimum active heights were not found for delegate "${
-						row.generatorPublicKey
-					}".`,
+					`Minimum active heights were not found for delegate "${row.generatorPublicKey}".`,
 				);
 			}
 

--- a/framework/src/modules/chain/chain.js
+++ b/framework/src/modules/chain/chain.js
@@ -96,11 +96,7 @@ module.exports = class Chain {
 				this.options.forging.waitThreshold >= this.options.constants.BLOCK_TIME
 			) {
 				throw Error(
-					`modules.chain.forging.waitThreshold=${
-						this.options.forging.waitThreshold
-					} is greater or equal to app.genesisConfig.BLOCK_TIME=${
-						this.options.constants.BLOCK_TIME
-					}. It impacts the forging and propagation of blocks. Please use a smaller value for modules.chain.forging.waitThreshold`,
+					`modules.chain.forging.waitThreshold=${this.options.forging.waitThreshold} is greater or equal to app.genesisConfig.BLOCK_TIME=${this.options.constants.BLOCK_TIME}. It impacts the forging and propagation of blocks. Please use a smaller value for modules.chain.forging.waitThreshold`,
 				);
 			}
 

--- a/framework/src/modules/chain/dpos/delegates_list.js
+++ b/framework/src/modules/chain/dpos/delegates_list.js
@@ -136,9 +136,7 @@ class DelegatesList {
 
 		if (!delegateList.length) {
 			throw new Error(
-				`Failed to verify slot: ${currentSlot} for block ID: ${
-					block.id
-				} - No delegateList was found`,
+				`Failed to verify slot: ${currentSlot} for block ID: ${block.id} - No delegateList was found`,
 			);
 		}
 
@@ -162,9 +160,7 @@ class DelegatesList {
 			}
 
 			throw new Error(
-				`Failed to verify slot: ${currentSlot}. Block ID: ${
-					block.id
-				}. Block Height: ${block.height}`,
+				`Failed to verify slot: ${currentSlot}. Block ID: ${block.id}. Block Height: ${block.height}`,
 			);
 		}
 

--- a/framework/src/modules/chain/forger/forger.js
+++ b/framework/src/modules/chain/forger/forger.js
@@ -162,9 +162,7 @@ class Forger {
 			return;
 		}
 		this.logger.info(
-			`Loading ${
-				encryptedList.length
-			} delegates using encrypted passphrases from config`,
+			`Loading ${encryptedList.length} delegates using encrypted passphrases from config`,
 		);
 
 		for (const encryptedItem of encryptedList) {
@@ -175,9 +173,7 @@ class Forger {
 					this.config.forging.defaultPassword,
 				);
 			} catch (error) {
-				const decryptionError = `Invalid encryptedPassphrase for publicKey: ${
-					encryptedItem.publicKey
-				}. ${error.message}`;
+				const decryptionError = `Invalid encryptedPassphrase for publicKey: ${encryptedItem.publicKey}. ${error.message}`;
 				this.logger.error(decryptionError);
 				throw decryptionError;
 			}
@@ -194,9 +190,7 @@ class Forger {
 
 			if (keypair.publicKey.toString('hex') !== encryptedItem.publicKey) {
 				throw new Error(
-					`Invalid encryptedPassphrase for publicKey: ${
-						encryptedItem.publicKey
-					}. Public keys do not match`,
+					`Invalid encryptedPassphrase for publicKey: ${encryptedItem.publicKey}. Public keys do not match`,
 				);
 			}
 

--- a/framework/src/modules/chain/synchronizer/fast_chain_switching_mechanism.js
+++ b/framework/src/modules/chain/synchronizer/fast_chain_switching_mechanism.js
@@ -171,11 +171,7 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		if (highestCommonBlock.height < this.bft.finalizedHeight) {
 			throw new ApplyPenaltyAndRestartError(
 				peerId,
-				`Common block height ${
-					highestCommonBlock.height
-				} is lower than the finalized height of the chain ${
-					this.bft.finalizedHeight
-				}`,
+				`Common block height ${highestCommonBlock.height} is lower than the finalized height of the chain ${this.bft.finalizedHeight}`,
 			);
 		}
 
@@ -209,9 +205,7 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		if (!blocks || !blocks.length) {
 			throw new ApplyPenaltyAndRestartError(
 				peerId,
-				`Peer didn't return any requested block within IDs ${
-					highestCommonBlock.id
-				} and ${receivedBlock.id}`,
+				`Peer didn't return any requested block within IDs ${highestCommonBlock.id} and ${receivedBlock.id}`,
 			);
 		}
 
@@ -364,15 +358,17 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		const heightList = this._computeLastTwoRoundsHeights();
 
 		while (numberOfRequests < requestLimit) {
-			const blockIds = (await this.storage.entities.Block.get(
-				{
-					height_in: heightList,
-				},
-				{
-					sort: 'height:asc',
-					limit: heightList.length,
-				},
-			)).map(block => block.id);
+			const blockIds = (
+				await this.storage.entities.Block.get(
+					{
+						height_in: heightList,
+					},
+					{
+						sort: 'height:asc',
+						limit: heightList.length,
+					},
+				)
+			).map(block => block.id);
 
 			// Request the highest common block with the previously computed list
 			// to the given peer

--- a/framework/src/modules/chain/synchronizer/synchronizer.js
+++ b/framework/src/modules/chain/synchronizer/synchronizer.js
@@ -43,9 +43,7 @@ class Synchronizer {
 		for (const mechanism of this.mechanisms) {
 			assert(
 				typeof mechanism.isValidFor === 'function',
-				`Mechanism ${
-					mechanism.constructor.name
-				} should implement "isValidFor" method`,
+				`Mechanism ${mechanism.constructor.name} should implement "isValidFor" method`,
 			);
 			assert(
 				typeof mechanism.run === 'function',

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -95,10 +95,12 @@ async function _getForgers(filters) {
 		}
 	}
 
-	const forgers = (await storage.entities.Account.get(
-		{ isDelegate: true, publicKey_in: forgerKeys },
-		{ limit: null },
-	))
+	const forgers = (
+		await storage.entities.Account.get(
+			{ isDelegate: true, publicKey_in: forgerKeys },
+			{ limit: null },
+		)
+	)
 		.map(({ username, address, publicKey }) => ({
 			username,
 			address,

--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -137,7 +137,10 @@ NodeController.getForgingStatus = async (context, next) => {
 	try {
 		const forgingStatus = await _getForgingStatus(publicKey.value);
 		if (forging && typeof forging.value === 'boolean') {
-			return next(null, forgingStatus.filter(f => f.forging === forging.value));
+			return next(
+				null,
+				forgingStatus.filter(f => f.forging === forging.value),
+			);
 		}
 		return next(null, forgingStatus);
 	} catch (err) {

--- a/framework/src/modules/network/network.js
+++ b/framework/src/modules/network/network.js
@@ -268,9 +268,7 @@ module.exports = class Network {
 
 		this.p2p.on(EVENT_REQUEST_RECEIVED, async request => {
 			this.logger.trace(
-				`EVENT_REQUEST_RECEIVED: Received inbound request for procedure ${
-					request.procedure
-				}`,
+				`EVENT_REQUEST_RECEIVED: Received inbound request for procedure ${request.procedure}`,
 			);
 			// If the request has already been handled internally by the P2P library, we ignore.
 			if (request.wasResponseSent) {
@@ -287,9 +285,7 @@ module.exports = class Network {
 					peerId: request.peerId,
 				});
 				this.logger.trace(
-					`Peer request fulfilled event: Responded to peer request ${
-						request.procedure
-					}`,
+					`Peer request fulfilled event: Responded to peer request ${request.procedure}`,
 				);
 				request.end(result); // Send the response back to the peer.
 			} catch (error) {
@@ -304,9 +300,7 @@ module.exports = class Network {
 
 		this.p2p.on(EVENT_MESSAGE_RECEIVED, async packet => {
 			this.logger.trace(
-				`EVENT_MESSAGE_RECEIVED: Received inbound message from ${
-					packet.peerId
-				} for event ${packet.event}`,
+				`EVENT_MESSAGE_RECEIVED: Received inbound message from ${packet.peerId} for event ${packet.event}`,
 			);
 			this.channel.publish('network:event', packet);
 		});

--- a/framework/test/jest/integration/utils/storage.js
+++ b/framework/test/jest/integration/utils/storage.js
@@ -56,9 +56,7 @@ class StorageSandbox extends Storage {
 	constructor(dbConfig) {
 		if (!process.env.NODE_ENV || process.env.NODE_ENV !== 'test') {
 			throw new Error(
-				`storage_sandbox is meant to be run in test environment only. NODE_ENV is: ${
-					process.env.NODE_ENV
-				}`,
+				`storage_sandbox is meant to be run in test environment only. NODE_ENV is: ${process.env.NODE_ENV}`,
 			);
 		}
 		super(dbConfig, {});

--- a/framework/test/jest/unit/specs/controller/channels/child_process_channel.spec.js
+++ b/framework/test/jest/unit/specs/controller/channels/child_process_channel.spec.js
@@ -243,9 +243,7 @@ describe('ChildProcessChannel Channel', () => {
 			expect(() =>
 				childProcessChannel.publish(invalidEventName, () => {}),
 			).toThrow(
-				`Event "${invalidEventName}" not registered in "${
-					params.moduleAlias
-				}" module.`,
+				`Event "${invalidEventName}" not registered in "${params.moduleAlias}" module.`,
 			);
 		});
 

--- a/framework/test/jest/unit/specs/controller/channels/in_memory_channel.spec.js
+++ b/framework/test/jest/unit/specs/controller/channels/in_memory_channel.spec.js
@@ -182,9 +182,7 @@ describe('InMemoryChannel Channel', () => {
 			expect(() => {
 				inMemoryChannel.publish(eventName);
 			}).toThrow(
-				`Event "${eventName}" not registered in "${
-					inMemoryChannel.moduleAlias
-				}" module.`,
+				`Event "${eventName}" not registered in "${inMemoryChannel.moduleAlias}" module.`,
 			);
 		});
 

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft_finality_manager_protocol_specs.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft_finality_manager_protocol_specs.spec.js
@@ -42,11 +42,7 @@ describe('FinalityManager', () => {
 				});
 
 				scenario.testCases.forEach(testCase => {
-					it(`should have accurate information when ${
-						testCase.input.delegateName
-					} forge block at height = ${
-						testCase.input.blockHeader.height
-					}`, async () => {
+					it(`should have accurate information when ${testCase.input.delegateName} forge block at height = ${testCase.input.blockHeader.height}`, async () => {
 						myBft.addBlockHeader(testCase.input.blockHeader);
 
 						expect(myBft.preCommits).toEqual(testCase.output.preCommits);

--- a/framework/test/jest/unit/specs/modules/chain/dpos/verifyBlockForger.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/dpos/verifyBlockForger.spec.js
@@ -171,9 +171,7 @@ describe('dpos.verifyBlockForger()', () => {
 
 		// Act && Assert
 		const error = new Error(
-			`Failed to verify slot: ${expectedSlot}. Block ID: ${
-				block.id
-			}. Block Height: ${block.height}`,
+			`Failed to verify slot: ${expectedSlot}. Block ID: ${block.id}. Block Height: ${block.height}`,
 		);
 		await expect(dpos.verifyBlockForger(block)).rejects.toEqual(error);
 	});

--- a/framework/test/mocha/common/modules_loader.js
+++ b/framework/test/mocha/common/modules_loader.js
@@ -21,7 +21,7 @@ const { createLoggerComponent } = require('../../../src/components/logger');
 const jobsQueue = require('../../../src/modules/chain/utils/jobs_queue');
 
 // TODO: Remove this file
-const modulesLoader = new function() {
+const modulesLoader = new (function() {
 	this.storage = null;
 	this.logger = createLoggerComponent(__testContext.config.components.logger);
 
@@ -186,6 +186,6 @@ const modulesLoader = new function() {
 			cb,
 		);
 	};
-}();
+})();
 
 module.exports = modulesLoader;

--- a/framework/test/mocha/common/storage_sandbox.js
+++ b/framework/test/mocha/common/storage_sandbox.js
@@ -74,9 +74,7 @@ class StorageSandbox extends Storage {
 	constructor(dbConfig, dbName) {
 		if (!process.env.NODE_ENV || process.env.NODE_ENV !== 'test') {
 			throw new Error(
-				`storage_sandbox is meant to be run in test environment only. NODE_ENV is: ${
-					process.env.NODE_ENV
-				}`,
+				`storage_sandbox is meant to be run in test environment only. NODE_ENV is: ${process.env.NODE_ENV}`,
 			);
 		}
 
@@ -188,9 +186,7 @@ class TestStorageSandbox extends Storage {
 	constructor(dbConfig, entityStubs) {
 		if (!process.env.NODE_ENV || process.env.NODE_ENV !== 'test') {
 			throw new Error(
-				`storage_sandbox is meant to be run in test environment only. NODE_ENV is: ${
-					process.env.NODE_ENV
-				}`,
+				`storage_sandbox is meant to be run in test environment only. NODE_ENV is: ${process.env.NODE_ENV}`,
 			);
 		}
 

--- a/framework/test/mocha/functional/http/get/peers.js
+++ b/framework/test/mocha/functional/http/get/peers.js
@@ -123,9 +123,7 @@ describe('GET /peers', () => {
 	describe('pass data from a real peer', () => {
 		const PEER_STATE_CONNECTED = 'connected';
 
-		it(`using a valid httpPort = ${
-			validHeaders.httpPort
-		} should return the result`, async () => {
+		it(`using a valid httpPort = ${validHeaders.httpPort} should return the result`, async () => {
 			return peersEndpoint
 				.makeRequest({ httpPort: validHeaders.httpPort }, 200)
 				.then(res => {
@@ -133,9 +131,7 @@ describe('GET /peers', () => {
 				});
 		});
 
-		it(`using state = ${
-			validHeaders.state
-		} should return the result`, async () => {
+		it(`using state = ${validHeaders.state} should return the result`, async () => {
 			return peersEndpoint
 				.makeRequest({ state: PEER_STATE_CONNECTED }, 200)
 				.then(res => {
@@ -143,9 +139,7 @@ describe('GET /peers', () => {
 				});
 		});
 
-		it(`using version = "${
-			validHeaders.version
-		}" should return the result`, async () => {
+		it(`using version = "${validHeaders.version}" should return the result`, async () => {
 			return peersEndpoint
 				.makeRequest({ version: validHeaders.version }, 200)
 				.then(res => {
@@ -153,9 +147,7 @@ describe('GET /peers', () => {
 				});
 		});
 
-		it(`using protocolVersion = "${
-			validHeaders.protocolVersion
-		}" should return the result`, async () => {
+		it(`using protocolVersion = "${validHeaders.protocolVersion}" should return the result`, async () => {
 			return peersEndpoint
 				.makeRequest({ protocolVersion: validHeaders.protocolVersion }, 200)
 				.then(res => {

--- a/framework/test/mocha/functional/http/get/transactions.js
+++ b/framework/test/mocha/functional/http/get/transactions.js
@@ -226,9 +226,7 @@ describe('GET /api/transactions', () => {
 							blockId: '1',
 							senderId: `${accountFixtures.genesis.address},${account.address}`,
 							senderPublicKey: accountFixtures.genesis.publicKey,
-							recipientPublicKey: `${accountFixtures.genesis.publicKey},${
-								account.publicKey
-							}`,
+							recipientPublicKey: `${accountFixtures.genesis.publicKey},${account.publicKey}`,
 							sort: 'amount:asc',
 						},
 						400,

--- a/framework/test/mocha/functional/http/post/0.transfer.js
+++ b/framework/test/mocha/functional/http/post/0.transfer.js
@@ -229,9 +229,7 @@ describe('POST /api/transactions (type 0) transfer funds', () => {
 
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.include(
-					`Failed to validate signature ${
-						transactionFromDifferentNetwork.signature
-					}`,
+					`Failed to validate signature ${transactionFromDifferentNetwork.signature}`,
 				);
 				badTransactions.push(transactionFromDifferentNetwork);
 			});

--- a/framework/test/mocha/functional/http/post/1.second_secret.js
+++ b/framework/test/mocha/functional/http/post/1.second_secret.js
@@ -122,9 +122,7 @@ describe('POST /api/transactions (type 1) register second passphrase', () => {
 				.sendTransactionPromise(transaction, apiCodes.PROCESSING_ERROR)
 				.then(res => {
 					expect(res.body.errors[0].message).to.be.equal(
-						`Account does not have enough LSK: ${
-							accountNoFunds.address
-						}, balance: 0`,
+						`Account does not have enough LSK: ${accountNoFunds.address}, balance: 0`,
 					);
 					badTransactions.push(transaction);
 				});
@@ -152,9 +150,7 @@ describe('POST /api/transactions (type 1) register second passphrase', () => {
 
 					expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 					expect(res.body.errors[0].message).to.include(
-						`Failed to validate signature ${
-							transactionFromDifferentNetwork.signature
-						}`,
+						`Failed to validate signature ${transactionFromDifferentNetwork.signature}`,
 					);
 					badTransactions.push(transactionFromDifferentNetwork);
 				});

--- a/framework/test/mocha/functional/http/post/2.delegate.js
+++ b/framework/test/mocha/functional/http/post/2.delegate.js
@@ -126,9 +126,7 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
-					`Account does not have enough LSK: ${
-						accountNoFunds.address
-					}, balance: 0`,
+					`Account does not have enough LSK: ${accountNoFunds.address}, balance: 0`,
 				);
 				badTransactions.push(transaction);
 			});
@@ -372,9 +370,7 @@ describe('POST /api/transactions (type 2) register delegate', () => {
 				apiCodes.PROCESSING_ERROR,
 			).then(res => {
 				expect(res.body.errors[0].message).to.include(
-					`Failed to validate signature ${
-						transactionFromDifferentNetwork.signature
-					}`,
+					`Failed to validate signature ${transactionFromDifferentNetwork.signature}`,
 				);
 				badTransactions.push(transactionFromDifferentNetwork);
 			});

--- a/framework/test/mocha/functional/http/post/3.votes.js
+++ b/framework/test/mocha/functional/http/post/3.votes.js
@@ -303,9 +303,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 				passphrase: delegateAccount.passphrase,
 				unvotes: [`${accountFixtures.existingDelegate.publicKey}`],
 			});
-			transaction.asset.votes[0] = `+1${
-				accountFixtures.existingDelegate.publicKey
-			}`;
+			transaction.asset.votes[0] = `+1${accountFixtures.existingDelegate.publicKey}`;
 			transaction = elements.redoVoteTransactionSignature(
 				transaction,
 				networkIdentifier,
@@ -428,9 +426,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
-					`Account does not have enough LSK: ${
-						accountNoFunds.address
-					}, balance: 0`,
+					`Account does not have enough LSK: ${accountNoFunds.address}, balance: 0`,
 				);
 				badTransactions.push(transaction);
 			});
@@ -472,9 +468,7 @@ describe('POST /api/transactions (type 3) votes', () => {
 				apiCodes.PROCESSING_ERROR,
 			).then(res => {
 				expect(res.body.errors[0].message).to.include(
-					`Failed to validate signature ${
-						transactionFromDifferentNetwork.signature
-					}`,
+					`Failed to validate signature ${transactionFromDifferentNetwork.signature}`,
 				);
 				badTransactions.push(transactionFromDifferentNetwork);
 			});

--- a/framework/test/mocha/functional/http/post/4.multisignature.js
+++ b/framework/test/mocha/functional/http/post/4.multisignature.js
@@ -477,9 +477,7 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 				});
 			});
 
-			it(`using min greater than maximum(${
-				MULTISIG_CONSTRAINTS.MIN.MAXIMUM
-			}) should fail`, async () => {
+			it(`using min greater than maximum(${MULTISIG_CONSTRAINTS.MIN.MAXIMUM}) should fail`, async () => {
 				transaction = createInvalidRegisterMultisignatureTransaction({
 					networkIdentifier,
 					passphrase: scenarios.max_members_max_min.account.passphrase,
@@ -504,9 +502,7 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 				});
 			});
 
-			it(`using min less than minimum(${
-				MULTISIG_CONSTRAINTS.MIN.MINIMUM
-			}) should fail`, async () => {
+			it(`using min less than minimum(${MULTISIG_CONSTRAINTS.MIN.MINIMUM}) should fail`, async () => {
 				transaction = createInvalidRegisterMultisignatureTransaction({
 					networkIdentifier,
 					passphrase: scenarios.max_members.account.passphrase,
@@ -533,9 +529,7 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 		});
 
 		describe('lifetime', () => {
-			it(`using greater than maximum(${
-				MULTISIG_CONSTRAINTS.LIFETIME.MAXIMUM
-			}) should fail`, async () => {
+			it(`using greater than maximum(${MULTISIG_CONSTRAINTS.LIFETIME.MAXIMUM}) should fail`, async () => {
 				transaction = createInvalidRegisterMultisignatureTransaction({
 					networkIdentifier,
 					passphrase: scenarios.regular.account.passphrase,
@@ -560,9 +554,7 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 				});
 			});
 
-			it(`using less than minimum(${
-				MULTISIG_CONSTRAINTS.LIFETIME.MINIMUM
-			}) should fail`, async () => {
+			it(`using less than minimum(${MULTISIG_CONSTRAINTS.LIFETIME.MINIMUM}) should fail`, async () => {
 				transaction = createInvalidRegisterMultisignatureTransaction({
 					networkIdentifier,
 					passphrase: scenarios.regular.account.passphrase,
@@ -602,9 +594,7 @@ describe('POST /api/transactions (type 4) register multisignature', () => {
 				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
-					`Account does not have enough LSK: ${
-						scenarios.no_funds.account.address
-					}, balance: 0`,
+					`Account does not have enough LSK: ${scenarios.no_funds.account.address}, balance: 0`,
 				);
 				badTransactions.push(scenario.multiSigTransaction);
 			});

--- a/framework/test/mocha/functional/http/post/5.dapps.js
+++ b/framework/test/mocha/functional/http/post/5.dapps.js
@@ -1140,9 +1140,7 @@ describe.skip('POST /api/transactions (type 5) register dapp', () => {
 				);
 				expect(res.body.code).to.be.eql(apiCodes.PROCESSING_ERROR);
 				expect(res.body.errors[0].message).to.be.equal(
-					`Account does not have enough LSK: ${
-						accountNoFunds.address
-					}, balance: 0`,
+					`Account does not have enough LSK: ${accountNoFunds.address}, balance: 0`,
 				);
 				badTransactions.push(transaction);
 			});

--- a/framework/test/mocha/integration/blocks/process/on_receive_block.js
+++ b/framework/test/mocha/integration/blocks/process/on_receive_block.js
@@ -168,9 +168,7 @@ describe('integration test (blocks) - process receiveBlockFromNetwork()', () => 
 						.then(() => {
 							last_block = library.modules.blocks.lastBlock;
 							__testContext.debug(
-								`New last block height: ${
-									last_block.height
-								} New last block ID: ${last_block.id}`,
+								`New last block height: ${last_block.height} New last block ID: ${last_block.id}`,
 							);
 							return waterFallCb();
 						})

--- a/framework/test/mocha/integration/blocks/verify/verify.js
+++ b/framework/test/mocha/integration/blocks/verify/verify.js
@@ -428,9 +428,7 @@ describe('blocks/verify', () => {
 					await library.modules.processor.process(block2);
 				} catch (err) {
 					expect(err.message).equal(
-						`Failed to verify slot: 3377288. Block ID: ${
-							block2.id
-						}. Block Height: ${block2.height}`,
+						`Failed to verify slot: 3377288. Block ID: ${block2.id}. Block Height: ${block2.height}`,
 					);
 				}
 			});
@@ -515,9 +513,7 @@ describe('blocks/verify', () => {
 						await library.modules.processor.process(firstBlock);
 					} catch (err) {
 						expect(err[0].message).to.equal(
-							`Account does not have enough LSK: ${
-								account.address
-							}, balance: 0`,
+							`Account does not have enough LSK: ${account.address}, balance: 0`,
 						);
 					}
 				});

--- a/framework/test/mocha/integration/common.js
+++ b/framework/test/mocha/integration/common.js
@@ -213,9 +213,7 @@ function forge(library, cb) {
 						last_block = library.modules.blocks.lastBlock;
 						library.modules.transactionPool._resetPool();
 						__testContext.debug(
-							`		New last block height: ${last_block.height} New last block ID: ${
-								last_block.id
-							}`,
+							`		New last block height: ${last_block.height} New last block ID: ${last_block.id}`,
 						);
 						seriesCb();
 					})
@@ -248,11 +246,7 @@ function addTransaction(library, transaction, cb) {
 		: transaction.asset.amount.dividedBy(NORMALIZER).toFixed();
 	const feeNormalized = transaction.fee.dividedBy(NORMALIZER).toFixed();
 	__testContext.debug(
-		`Enqueue transaction ID: ${
-			transaction.id
-		}, Amount: ${amountNormalized}, Fee: ${feeNormalized}, Sender: ${
-			transaction.senderId
-		}, Recipient: ${transaction.recipientId}`,
+		`Enqueue transaction ID: ${transaction.id}, Amount: ${amountNormalized}, Fee: ${feeNormalized}, Sender: ${transaction.senderId}, Recipient: ${transaction.recipientId}`,
 	);
 	library.modules.transactionPool
 		.processUnconfirmedTransaction(transaction)

--- a/framework/test/mocha/integration/rounds.js
+++ b/framework/test/mocha/integration/rounds.js
@@ -549,9 +549,7 @@ describe('rounds', () => {
 					}
 
 					__testContext.debug(
-						`	Processing block ${blocksProcessed} of ${blocksToForge} with ${
-							transactions.length
-						} transactions`,
+						`	Processing block ${blocksProcessed} of ${blocksToForge} with ${transactions.length} transactions`,
 					);
 					tickAndValidate(transactions);
 					untilCb();
@@ -1037,9 +1035,7 @@ describe('rounds', () => {
 						}
 
 						__testContext.debug(
-							`	Processing block ${blocksProcessed} of ${blocksToForge} with ${
-								transactions.length
-							} transactions`,
+							`	Processing block ${blocksProcessed} of ${blocksToForge} with ${transactions.length} transactions`,
 						);
 						tickAndValidate(transactions);
 						untilCb();
@@ -1093,9 +1089,7 @@ describe('rounds', () => {
 						}
 
 						__testContext.debug(
-							`	Processing block ${blocksProcessed} of ${blocksToForge} with ${
-								transactions.length
-							} transactions`,
+							`	Processing block ${blocksProcessed} of ${blocksToForge} with ${transactions.length} transactions`,
 						);
 						tickAndValidate(transactions);
 

--- a/framework/test/mocha/integration/transactions/0.0.address_collision.js
+++ b/framework/test/mocha/integration/transactions/0.0.address_collision.js
@@ -185,11 +185,7 @@ describe('integration test (type 0) - address collision', () => {
 									expect(res).to.be.undefined;
 									expect(err).to.be.not.null;
 									expect(err).to.equal(
-										`Transaction: ${
-											secondTransactionWithData.id
-										} failed at .senderPublicKey: Invalid sender publicKey, actual: ${
-											publicKeys[1]
-										}, expected: ${publicKeys[0]}`,
+										`Transaction: ${secondTransactionWithData.id} failed at .senderPublicKey: Invalid sender publicKey, actual: ${publicKeys[1]}, expected: ${publicKeys[0]}`,
 									);
 									seriesCb();
 								},

--- a/framework/test/mocha/integration/transactions/0_0_transfer.js
+++ b/framework/test/mocha/integration/transactions/0_0_transfer.js
@@ -126,11 +126,7 @@ describe('integration test (type 0) - double transfers', () => {
 				it('adding to pool transfer for same account should fail', done => {
 					localCommon.addTransaction(library, transaction2, err => {
 						expect(err).to.be.equal(
-							`Transaction: ${
-								transaction2.id
-							} failed at .balance: Account does not have enough LSK: ${
-								account.address
-							}, balance: 99.9`,
+							`Transaction: ${transaction2.id} failed at .balance: Account does not have enough LSK: ${account.address}, balance: 99.9`,
 						);
 						done();
 					});

--- a/framework/test/mocha/integration/transactions/1_second_signature/1_1_second_signature.js
+++ b/framework/test/mocha/integration/transactions/1_second_signature/1_1_second_signature.js
@@ -118,12 +118,8 @@ describe('integration test (type 1) - double second signature registrations', ()
 		it('adding to pool second signature registration for same account should fail', done => {
 			localCommon.addTransaction(library, transaction2, err => {
 				const expectedErrors = [
-					`Transaction: ${
-						transaction2.id
-					} failed at .signSignature: Missing signSignature`,
-					`Transaction: ${
-						transaction2.id
-					} failed at .secondPublicKey: Register second signature only allowed once per account.`,
+					`Transaction: ${transaction2.id} failed at .signSignature: Missing signSignature`,
+					`Transaction: ${transaction2.id} failed at .secondPublicKey: Register second signature only allowed once per account.`,
 				];
 				expect(err).to.equal(expectedErrors.join(','));
 				done();

--- a/framework/test/mocha/integration/transactions/1_second_signature/1_X_second_signature_unconfirmed.js
+++ b/framework/test/mocha/integration/transactions/1_second_signature/1_X_second_signature_unconfirmed.js
@@ -83,11 +83,7 @@ describe('integration test (type 1) - sending transactions on top of unconfirmed
 							transactionSecondSignature,
 							err => {
 								expect(err).to.equal(
-									`Transaction: ${
-										transactionSecondSignature.id
-									} failed at .id: Transaction is already processed: ${
-										transactionSecondSignature.id
-									}`,
+									`Transaction: ${transactionSecondSignature.id} failed at .id: Transaction is already processed: ${transactionSecondSignature.id}`,
 								);
 								done();
 							},
@@ -116,12 +112,8 @@ describe('integration test (type 1) - sending transactions on top of unconfirmed
 							loadedTransaction => {
 								localCommon.addTransaction(library, loadedTransaction, err => {
 									const expectedErrors = [
-										`Transaction: ${
-											loadedTransaction.id
-										} failed at .signSignature: Sender does not have a secondPublicKey`,
-										`Transaction: ${
-											loadedTransaction.id
-										} failed at .signatures: Missing signatures `,
+										`Transaction: ${loadedTransaction.id} failed at .signSignature: Sender does not have a secondPublicKey`,
+										`Transaction: ${loadedTransaction.id} failed at .signatures: Missing signatures `,
 									];
 									expect(err).to.equal(
 										expectedErrors.join(','),
@@ -142,9 +134,7 @@ describe('integration test (type 1) - sending transactions on top of unconfirmed
 							loadedTransaction => {
 								localCommon.addTransaction(library, loadedTransaction, err => {
 									expect(err).to.equal(
-										`Transaction: ${
-											loadedTransaction.id
-										} failed at .signSignature: Sender does not have a secondPublicKey`,
+										`Transaction: ${loadedTransaction.id} failed at .signSignature: Sender does not have a secondPublicKey`,
 									);
 									done();
 								});

--- a/framework/test/mocha/integration/transactions/1_second_signature/1_X_second_signature_validated.js
+++ b/framework/test/mocha/integration/transactions/1_second_signature/1_X_second_signature_validated.js
@@ -109,12 +109,8 @@ describe('integration test (type 1) - checking validated second signature regist
 			});
 			localCommon.addTransaction(library, auxTransaction, err => {
 				const expectedErrors = [
-					`Transaction: ${
-						auxTransaction.id
-					} failed at .signSignature: Missing signSignature`,
-					`Transaction: ${
-						auxTransaction.id
-					} failed at .secondPublicKey: Register second signature only allowed once per account.`,
+					`Transaction: ${auxTransaction.id} failed at .signSignature: Missing signSignature`,
+					`Transaction: ${auxTransaction.id} failed at .secondPublicKey: Register second signature only allowed once per account.`,
 				];
 				expect(err).to.equal(expectedErrors.join(','));
 				done();
@@ -139,18 +135,12 @@ describe('integration test (type 1) - checking validated second signature regist
 								localCommon.addTransaction(library, loadedTransaction, err => {
 									if (key !== 'MULTI') {
 										expect(err).to.equal(
-											`Transaction: ${
-												loadedTransaction.id
-											} failed at .signSignature: Missing signSignature`,
+											`Transaction: ${loadedTransaction.id} failed at .signSignature: Missing signSignature`,
 										);
 									} else {
 										const expectedErrors = [
-											`Transaction: ${
-												loadedTransaction.id
-											} failed at .signSignature: Missing signSignature`,
-											`Transaction: ${
-												loadedTransaction.id
-											} failed at .signatures: Missing signatures `,
+											`Transaction: ${loadedTransaction.id} failed at .signSignature: Missing signSignature`,
+											`Transaction: ${loadedTransaction.id} failed at .signatures: Missing signatures `,
 										];
 										expect(err).to.equal(expectedErrors.join(','));
 									}

--- a/framework/test/mocha/integration/transactions/2_delegates/1_same_account_same_username.js
+++ b/framework/test/mocha/integration/transactions/2_delegates/1_same_account_same_username.js
@@ -139,9 +139,7 @@ describe('integration test (type 2) - double delegate registrations', () => {
 						});
 						localCommon.addTransaction(library, transaction2, err => {
 							expect(err).to.equal(
-								`Transaction: ${
-									transaction2.id
-								} failed at .asset.username: Account is already a delegate`,
+								`Transaction: ${transaction2.id} failed at .asset.username: Account is already a delegate`,
 							);
 							done();
 						});

--- a/framework/test/mocha/integration/transactions/2_delegates/2_same_account_different_usernames.js
+++ b/framework/test/mocha/integration/transactions/2_delegates/2_same_account_different_usernames.js
@@ -139,9 +139,7 @@ describe('integration test (type 2) - double delegate registrations', () => {
 						});
 						localCommon.addTransaction(library, transaction2, err => {
 							expect(err).to.equal(
-								`Transaction: ${
-									transaction2.id
-								} failed at .asset.username: Account is already a delegate`,
+								`Transaction: ${transaction2.id} failed at .asset.username: Account is already a delegate`,
 							);
 							done();
 						});

--- a/framework/test/mocha/integration/transactions/2_delegates/3_different_accounts_same_username.js
+++ b/framework/test/mocha/integration/transactions/2_delegates/3_different_accounts_same_username.js
@@ -145,9 +145,7 @@ describe('integration test (type 2) - double delegate registrations', () => {
 					it('adding to pool delegate registration with already registered username should fail', done => {
 						localCommon.addTransaction(library, transaction2, err => {
 							expect(err).to.equal(
-								`Transaction: ${
-									transaction2.id
-								} failed at .asset.username: Username is not unique.`,
+								`Transaction: ${transaction2.id} failed at .asset.username: Username is not unique.`,
 							);
 							done();
 						});
@@ -162,9 +160,7 @@ describe('integration test (type 2) - double delegate registrations', () => {
 						});
 						localCommon.addTransaction(library, transaction3, err => {
 							expect(err).to.equal(
-								`Transaction: ${
-									transaction3.id
-								} failed at .asset.username: Account is already a delegate`,
+								`Transaction: ${transaction3.id} failed at .asset.username: Account is already a delegate`,
 							);
 							done();
 						});

--- a/framework/test/mocha/integration/transactions/2_delegates/4_different_accounts_different_usernames.js
+++ b/framework/test/mocha/integration/transactions/2_delegates/4_different_accounts_different_usernames.js
@@ -152,12 +152,8 @@ describe('integration test (type 2) - double delegate registrations', () => {
 						});
 						localCommon.addTransaction(library, transaction3, err => {
 							const expectedErrors = [
-								`Transaction: ${
-									transaction3.id
-								} failed at .asset.username: Username is not unique.`,
-								`Transaction: ${
-									transaction3.id
-								} failed at .asset.username: Account is already a delegate`,
+								`Transaction: ${transaction3.id} failed at .asset.username: Username is not unique.`,
+								`Transaction: ${transaction3.id} failed at .asset.username: Account is already a delegate`,
 							];
 							expect(err).to.equal(expectedErrors.join(','));
 							done();

--- a/framework/test/mocha/integration/transactions/3_3_votes.js
+++ b/framework/test/mocha/integration/transactions/3_3_votes.js
@@ -128,9 +128,7 @@ describe('integration test (type 3) - voting with duplicate submissions', () => 
 				it('adding to pool upvoting transaction to same delegate from same account should fail', done => {
 					localCommon.addTransaction(library, transaction2, err => {
 						expect(err).to.equal(
-							`Transaction: ${transaction2.id} failed at .asset.votes: ${
-								accountFixtures.existingDelegate.publicKey
-							} is already voted.`,
+							`Transaction: ${transaction2.id} failed at .asset.votes: ${accountFixtures.existingDelegate.publicKey} is already voted.`,
 						);
 						done();
 					});
@@ -216,9 +214,7 @@ describe('integration test (type 3) - voting with duplicate submissions', () => 
 						});
 						localCommon.addTransaction(library, transaction5, err => {
 							expect(err).to.equal(
-								`Transaction: ${transaction5.id} failed at .asset.votes: ${
-									accountFixtures.existingDelegate.publicKey
-								} is not voted.`,
+								`Transaction: ${transaction5.id} failed at .asset.votes: ${accountFixtures.existingDelegate.publicKey} is not voted.`,
 							);
 							done();
 						});

--- a/framework/test/mocha/integration/transactions/4_multisignature/4_4_multisignature.js
+++ b/framework/test/mocha/integration/transactions/4_multisignature/4_4_multisignature.js
@@ -153,12 +153,8 @@ describe('integration test (type 4) - double multisignature registrations', () =
 			});
 			localCommon.addTransaction(library, multiSignatureToSameAccount, err => {
 				const expectedErrors = [
-					`Transaction: ${
-						multiSignatureToSameAccount.id
-					} failed at .signatures: Missing signatures `,
-					`Transaction: ${
-						multiSignatureToSameAccount.id
-					} failed at .signatures: Register multisignature only allowed once per account.`,
+					`Transaction: ${multiSignatureToSameAccount.id} failed at .signatures: Missing signatures `,
+					`Transaction: ${multiSignatureToSameAccount.id} failed at .signatures: Register multisignature only allowed once per account.`,
 				];
 				expect(err).to.equal(expectedErrors.join(','));
 				done();

--- a/framework/test/mocha/integration/transactions/4_multisignature/4_X_multisignature_validated.js
+++ b/framework/test/mocha/integration/transactions/4_multisignature/4_X_multisignature_validated.js
@@ -126,12 +126,8 @@ describe('integration test (type 4) - checking registered multisignature transac
 			});
 			localCommon.addTransaction(library, multiSignatureToSameAccount, err => {
 				const expectedErrors = [
-					`Transaction: ${
-						multiSignatureToSameAccount.id
-					} failed at .signatures: Missing signatures `,
-					`Transaction: ${
-						multiSignatureToSameAccount.id
-					} failed at .signatures: Register multisignature only allowed once per account.`,
+					`Transaction: ${multiSignatureToSameAccount.id} failed at .signatures: Missing signatures `,
+					`Transaction: ${multiSignatureToSameAccount.id} failed at .signatures: Register multisignature only allowed once per account.`,
 				];
 				expect(err).to.equal(expectedErrors.join(','));
 				done();

--- a/framework/test/mocha/integration/transactions/4_multisignature/duplicate_signatures.js
+++ b/framework/test/mocha/integration/transactions/4_multisignature/duplicate_signatures.js
@@ -510,9 +510,7 @@ describe('duplicate_signatures', () => {
 							});
 							expect(results[valueIndex].value).to.be.undefined;
 							expect(results[errorIndex].error[0].message).to.eql(
-								`Signature '${
-									signatures[0].signature
-								}' already present in transaction.`,
+								`Signature '${signatures[0].signature}' already present in transaction.`,
 							);
 							expect(results[2].value).to.be.undefined;
 

--- a/framework/test/mocha/network/network.js
+++ b/framework/test/mocha/network/network.js
@@ -248,9 +248,7 @@ class Network {
 			waitFor.blockchainReady(
 				retries,
 				timeout,
-				`http://${configuration.modules.http_api.address}:${
-					configuration.modules.http_api.httpPort
-				}`,
+				`http://${configuration.modules.http_api.address}:${configuration.modules.http_api.httpPort}`,
 				!logRetries,
 				err => {
 					if (err) {
@@ -299,9 +297,7 @@ class Network {
 		return new Promise((resolve, reject) => {
 			waitFor.blocks(
 				blocksToWait,
-				`http://${configuration.modules.http_api.address}:${
-					configuration.modules.http_api.httpPort
-				}`,
+				`http://${configuration.modules.http_api.address}:${configuration.modules.http_api.httpPort}`,
 				err => {
 					if (err) {
 						return reject(

--- a/framework/test/mocha/network/setup/config.js
+++ b/framework/test/mocha/network/setup/config.js
@@ -123,9 +123,7 @@ const config = {
 		const configReducer = (pm2Config, configuration) => {
 			const index = pm2Config.apps.length;
 			// eslint-disable-next-line no-param-reassign
-			configuration.components.storage.database = `${
-				configuration.components.storage.database
-			}_${index}`;
+			configuration.components.storage.database = `${configuration.components.storage.database}_${index}`;
 			try {
 				if (!fs.existsSync(`${__dirname}/../configs/`)) {
 					fs.mkdirSync(`${__dirname}/../configs/`);
@@ -136,9 +134,7 @@ const config = {
 				);
 			} catch (ex) {
 				throw new Error(
-					`Failed to write PM2 config for node ${index} to file system because of exception: ${
-						ex.message
-					}`,
+					`Failed to write PM2 config for node ${index} to file system because of exception: ${ex.message}`,
 				);
 			}
 

--- a/framework/test/mocha/network/setup/shell.js
+++ b/framework/test/mocha/network/setup/shell.js
@@ -23,9 +23,7 @@ module.exports = {
 			configurations,
 			(configuration, index, eachCb) => {
 				child_process.exec(
-					`dropdb ${configuration.components.storage.database}; createdb ${
-						configuration.components.storage.database
-					}`,
+					`dropdb ${configuration.components.storage.database}; createdb ${configuration.components.storage.database}`,
 					eachCb,
 				);
 			},

--- a/framework/test/mocha/network/utils/http.js
+++ b/framework/test/mocha/network/utils/http.js
@@ -158,9 +158,7 @@ module.exports = {
 			.then(res => {
 				if (res.status !== apiCodes.OK) {
 					throw new Error(
-						`Failed to enable forging for delegate with publicKey: ${
-							keys.publicKey
-						}`,
+						`Failed to enable forging for delegate with publicKey: ${keys.publicKey}`,
 					);
 				}
 				return JSON.parse(res.body).data[0];

--- a/framework/test/mocha/setup.js
+++ b/framework/test/mocha/setup.js
@@ -84,9 +84,7 @@ testContext.config.genesisBlock = _.cloneDeep(app.genesisBlock);
 testContext.consoleLogLevel =
 	process.env.LOG_LEVEL || config.components.logger.consoleLogLevel;
 
-testContext.baseUrl = `http://${config.modules.http_api.address}:${
-	config.modules.http_api.httpPort
-}`;
+testContext.baseUrl = `http://${config.modules.http_api.address}:${config.modules.http_api.httpPort}`;
 testContext.api = supertest(testContext.baseUrl);
 
 _.mixin(

--- a/framework/test/mocha/unit/components/storage/entities/account.js
+++ b/framework/test/mocha/unit/components/storage/entities/account.js
@@ -518,9 +518,7 @@ describe('Account', () => {
 			it('should always return "publicKey" as "encode(publicKey, \'hex\')"', async () => {
 				const accounts = await AccountEntity.get(filters, options);
 				const rawKey = await adapter.execute(
-					`SELECT "publicKey" FROM mem_accounts WHERE "address" = '${
-						validAccount.address
-					}'`,
+					`SELECT "publicKey" FROM mem_accounts WHERE "address" = '${validAccount.address}'`,
 				);
 
 				expect(accounts[0].publicKey).to.be.eql(
@@ -531,9 +529,7 @@ describe('Account', () => {
 			it('should always return "secondPublicKey" as "encode(secondPublicKey, \'hex\')"', async () => {
 				const accounts = await AccountEntity.get(filters, options);
 				const rawKey = await adapter.execute(
-					`SELECT "secondPublicKey" FROM mem_accounts WHERE "address" = '${
-						validAccount.address
-					}'`,
+					`SELECT "secondPublicKey" FROM mem_accounts WHERE "address" = '${validAccount.address}'`,
 				);
 
 				expect(accounts[0].secondPublicKey).to.be.eql(

--- a/framework/test/mocha/unit/modules/chain/forger.js
+++ b/framework/test/mocha/unit/modules/chain/forger.js
@@ -238,9 +238,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Unsupported state or unable to authenticate data`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Unsupported state or unable to authenticate data`,
 				);
 			});
 
@@ -256,9 +254,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Unsupported state or unable to authenticate data`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Unsupported state or unable to authenticate data`,
 				);
 			});
 
@@ -275,9 +271,7 @@ describe('forge', () => {
 				// TODO: Update the expectation after fixing
 				// https://github.com/LiskHQ/lisk-elements/issues/1162
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Encrypted passphrase to parse must have only one value per key.`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Encrypted passphrase to parse must have only one value per key.`,
 				);
 			});
 
@@ -314,9 +308,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Unsupported state or unable to authenticate data`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Unsupported state or unable to authenticate data`,
 				);
 			});
 
@@ -353,9 +345,7 @@ describe('forge', () => {
 				// TODO: Update the expectation after fixing
 				// https://github.com/LiskHQ/lisk-elements/issues/1162
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Encrypted passphrase to parse must have only one value per key.`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Encrypted passphrase to parse must have only one value per key.`,
 				);
 			});
 
@@ -392,9 +382,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Unsupported state or unable to authenticate data`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Unsupported state or unable to authenticate data`,
 				);
 			});
 
@@ -431,9 +419,7 @@ describe('forge', () => {
 				// TODO: Update the expectation after fixing
 				// https://github.com/LiskHQ/lisk-elements/issues/1162
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Encrypted passphrase to parse must have only one value per key.`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Encrypted passphrase to parse must have only one value per key.`,
 				);
 			});
 
@@ -470,9 +456,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Unsupported state or unable to authenticate data`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Unsupported state or unable to authenticate data`,
 				);
 			});
 
@@ -509,9 +493,7 @@ describe('forge', () => {
 				// TODO: Update the expectation after fixing
 				// https://github.com/LiskHQ/lisk-elements/issues/1162
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Encrypted passphrase to parse must have only one value per key.`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Encrypted passphrase to parse must have only one value per key.`,
 				);
 			});
 
@@ -548,9 +530,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Unsupported state or unable to authenticate data`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Unsupported state or unable to authenticate data`,
 				);
 			});
 
@@ -586,9 +566,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Tag must be 16 bytes.`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Tag must be 16 bytes.`,
 				);
 			});
 
@@ -623,9 +601,7 @@ describe('forge', () => {
 				forgeModule.config.forging.delegates = [accountDetails];
 
 				return expect(forgeModule.loadDelegates()).to.be.rejectedWith(
-					`Invalid encryptedPassphrase for publicKey: ${
-						accountDetails.publicKey
-					}. Public keys do not match`,
+					`Invalid encryptedPassphrase for publicKey: ${accountDetails.publicKey}. Public keys do not match`,
 				);
 			});
 

--- a/framework/test/mocha/unit/modules/chain/transactions/transactions_handlers.js
+++ b/framework/test/mocha/unit/modules/chain/transactions/transactions_handlers.js
@@ -87,9 +87,9 @@ describe('transactions', () => {
 	describe('#checkAllowedTransactions', () => {
 		it('should return a proper response format', async () => {
 			// Act
-			const response = transactionHandlers.checkAllowedTransactions(dummyState)(
-				[trs1],
-			);
+			const response = transactionHandlers.checkAllowedTransactions(
+				dummyState,
+			)([trs1]);
 
 			// Assert
 			expect(response).to.have.deep.property('transactionsResponses', [
@@ -109,9 +109,9 @@ describe('transactions', () => {
 			};
 
 			// Act
-			const response = transactionHandlers.checkAllowedTransactions(dummyState)(
-				[disallowedTransaction],
-			);
+			const response = transactionHandlers.checkAllowedTransactions(
+				dummyState,
+			)([disallowedTransaction]);
 
 			// Assert
 			expect(response.transactionsResponses.length).to.equal(1);
@@ -128,9 +128,7 @@ describe('transactions', () => {
 				Error,
 			);
 			expect(response.transactionsResponses[0].errors[0].message).to.equal(
-				`Transaction type ${
-					disallowedTransaction.type
-				} is currently not allowed.`,
+				`Transaction type ${disallowedTransaction.type} is currently not allowed.`,
 			);
 		});
 
@@ -139,9 +137,9 @@ describe('transactions', () => {
 			const { matcher, ...transactionWithoutMatcherImpl } = trs1;
 
 			// Act
-			const response = transactionHandlers.checkAllowedTransactions(dummyState)(
-				[transactionWithoutMatcherImpl],
-			);
+			const response = transactionHandlers.checkAllowedTransactions(
+				dummyState,
+			)([transactionWithoutMatcherImpl]);
 
 			// Assert
 			expect(response.transactionsResponses.length).to.equal(1);
@@ -164,9 +162,9 @@ describe('transactions', () => {
 			};
 
 			// Act
-			const response = transactionHandlers.checkAllowedTransactions(dummyState)(
-				[allowedTransaction],
-			);
+			const response = transactionHandlers.checkAllowedTransactions(
+				dummyState,
+			)([allowedTransaction]);
 
 			// Assert
 			expect(response.transactionsResponses.length).to.equal(1);
@@ -223,9 +221,7 @@ describe('transactions', () => {
 				Error,
 			);
 			expect(response.transactionsResponses[1].errors[0].message).to.equal(
-				`Transaction type ${
-					testTransactions[1].type
-				} is currently not allowed.`,
+				`Transaction type ${testTransactions[1].type} is currently not allowed.`,
 			);
 		});
 	});

--- a/framework/test/mocha/unit/modules/chain/transport/transport.js
+++ b/framework/test/mocha/unit/modules/chain/transport/transport.js
@@ -411,9 +411,7 @@ describe('transport', () => {
 				let processUnconfirmedTransactionError;
 
 				beforeEach(async () => {
-					processUnconfirmedTransactionError = `Transaction is already processed: ${
-						transaction.id
-					}`;
+					processUnconfirmedTransactionError = `Transaction is already processed: ${transaction.id}`;
 
 					transportModule.transactionPoolModule.processUnconfirmedTransaction.rejects(
 						[new Error(processUnconfirmedTransactionError)],

--- a/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
@@ -176,7 +176,9 @@ describe('delegates/api', () => {
 		it('should call channel.invoke with chain:calculateSupply action if lastBlock.height is not 0', async () => {
 			expect(channelStub.invoke).to.be.calledWithExactly(
 				'chain:calculateSupply',
-				{ height: dummyBlock.height },
+				{
+					height: dummyBlock.height,
+				},
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
The prettier fails apply the format as certain directory and files are not ignored
### How did I solve it?
Fixed the prettierignore and applied outdated prettier changes 
### How to manually test it?
`npm run format`
### Review checklist

- [ ] The PR resolves #4614 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
