### PR TITLE
P2P peerBook disjoint fix and test improvements - Closes #4609 & #4599

### DIFF
--- a/elements/lisk-p2p/src/peer_book/base_list.ts
+++ b/elements/lisk-p2p/src/peer_book/base_list.ts
@@ -38,7 +38,7 @@ export interface BucketInfo {
 export class BaseList {
 	protected bucketIdToBucket: Map<number, Bucket>;
 	/* 
-		Auxilliary map for direct peerId => peerInfo lookups
+		Auxillary map for direct peerId => peerInfo lookups
 		Required because peerLists may be provided by discrete sources
 	*/
 	protected peerIdToPeerInfo: Map<string, P2PEnhancedPeerInfo>;
@@ -58,17 +58,8 @@ export class BaseList {
 			secret,
 		};
 		this.bucketIdToBucket = new Map();
-		this.initBuckets(this.bucketIdToBucket);
+		this._initBuckets();
 		this.peerIdToPeerInfo = new Map();
-	}
-
-	public initBuckets(bucketIdToBucket: Map<number, Bucket>): void {
-		// Init the Map with all the buckets
-		for (const bucketId of [
-			...new Array(this.peerListConfig.numOfBuckets).keys(),
-		]) {
-			bucketIdToBucket.set(bucketId, new Map<string, P2PEnhancedPeerInfo>());
-		}
 	}
 
 	public get peerList(): ReadonlyArray<P2PPeerInfo> {
@@ -192,7 +183,7 @@ export class BaseList {
 	protected getBucket(peerId: string): Bucket | undefined {
 		const internalPeerInfo = this.peerIdToPeerInfo.get(peerId);
 
-		if (!internalPeerInfo?.bucketId) {
+		if (typeof internalPeerInfo?.bucketId !== 'number') {
 			return undefined;
 		}
 
@@ -203,5 +194,17 @@ export class BaseList {
 		}
 
 		return bucket;
+	}
+
+	private _initBuckets(): void {
+		// Init the Map with all the buckets
+		for (const bucketId of [
+			...new Array(this.peerListConfig.numOfBuckets).keys(),
+		]) {
+			this.bucketIdToBucket.set(
+				bucketId,
+				new Map<string, P2PEnhancedPeerInfo>(),
+			);
+		}
 	}
 }

--- a/elements/lisk-p2p/src/peer_book/peer_book.ts
+++ b/elements/lisk-p2p/src/peer_book/peer_book.ts
@@ -135,16 +135,9 @@ export class PeerBook {
 		return false;
 	}
 
-	public removePeer(peerInfo: P2PPeerInfo): boolean {
-		if (this._triedPeers.getPeer(peerInfo.peerId)) {
-			return this._triedPeers.removePeer(peerInfo);
-		}
-
-		if (this._newPeers.getPeer(peerInfo.peerId)) {
-			return this._newPeers.removePeer(peerInfo);
-		}
-
-		return false;
+	public removePeer(peerInfo: P2PPeerInfo): void {
+		this._newPeers.removePeer(peerInfo);
+		this._triedPeers.removePeer(peerInfo);
 	}
 
 	public upgradePeer(peerInfo: P2PEnhancedPeerInfo): boolean {
@@ -153,7 +146,7 @@ export class PeerBook {
 		}
 
 		if (this._newPeers.hasPeer(peerInfo.peerId)) {
-			this._newPeers.removePeer(peerInfo);
+			this.removePeer(peerInfo);
 			this._triedPeers.addPeer(peerInfo);
 
 			return true;

--- a/elements/lisk-p2p/src/peer_book/tried_list.ts
+++ b/elements/lisk-p2p/src/peer_book/tried_list.ts
@@ -42,8 +42,6 @@ export class TriedList extends BaseList {
 		this._maxReconnectTries = maxReconnectTries
 			? maxReconnectTries
 			: DEFAULT_MAX_RECONNECT_TRIES;
-
-		this.initBuckets(this.bucketIdToBucket);
 	}
 
 	public get triedPeerConfig(): TriedListConfig {

--- a/elements/lisk-p2p/test/unit/peer_book/peer_book.ts
+++ b/elements/lisk-p2p/test/unit/peer_book/peer_book.ts
@@ -244,25 +244,18 @@ describe('peerBook', () => {
 		});
 
 		describe('when peer exists in the tried peers list', () => {
-			it('should return true', () => {
+			it('should be removed', () => {
 				peerBook.addPeer(samplePeers[0]);
 				peerBook.upgradePeer(samplePeers[0]);
-				expect(peerBook.removePeer(samplePeers[0])).to.be.true;
+				peerBook.removePeer(samplePeers[0]);
 				expect(peerBook.getPeer(samplePeers[0])).to.be.undefined;
 			});
 		});
 
 		describe('when peer exists in the new peers list', () => {
-			it('should return true', () => {
+			it('should be removed', () => {
 				peerBook.addPeer(samplePeers[0]);
-				expect(peerBook.removePeer(samplePeers[0])).to.be.true;
-				expect(peerBook.getPeer(samplePeers[0])).to.be.undefined;
-			});
-		});
-
-		describe('when peer does not exists in any of the peer book lists', () => {
-			it('should return false', () => {
-				expect(peerBook.removePeer(samplePeers[0])).to.be.false;
+				peerBook.removePeer(samplePeers[0]);
 				expect(peerBook.getPeer(samplePeers[0])).to.be.undefined;
 			});
 		});
@@ -400,6 +393,33 @@ describe('peerBook', () => {
 				peerBook.getRandomizedPeerList(minPeerListLength, maxPeerListLength)
 					.length,
 			).to.be.lt(maxPeerListLength + 1);
+		});
+	});
+
+	describe('when PeerBook populated and cleaned up', () => {
+		beforeEach(() => {
+			samplePeers = initPeerInfoListWithSuffix('204.123.64', 3500);
+			peerBook = new PeerBook(peerBookConfig);
+
+			samplePeers.forEach(samplePeer => {
+				if (!peerBook.hasPeer(samplePeer)) {
+					peerBook.addPeer(samplePeer);
+				}
+
+				peerBook.upgradePeer(samplePeer);
+			});
+		});
+
+		it('should return empty Peer lists', () => {
+			const AllPeers = peerBook.allPeers;
+
+			AllPeers.forEach(peer => {
+				peerBook.removePeer(peer);
+			});
+
+			expect(peerBook.newPeers).to.be.empty;
+			expect(peerBook.triedPeers).to.be.empty;
+			expect(peerBook.allPeers).to.be.empty;
 		});
 	});
 });

--- a/elements/lisk-p2p/test/unit/utils/select.ts
+++ b/elements/lisk-p2p/test/unit/utils/select.ts
@@ -353,8 +353,8 @@ describe('peer selector', () => {
 
 		describe('when there are less than 100 peers', () => {
 			it('should return peers uniformly from both lists', () => {
-				const triedPeers = initPeerInfoListWithSuffix('111.112.113', 25);
-				const newPeers = initPeerInfoListWithSuffix('111.112.114', 75);
+				const triedPeers = initPeerInfoListWithSuffix('111.112.113', 75);
+				const newPeers = initPeerInfoListWithSuffix('111.112.114', 25);
 
 				const selectedPeers = selectPeersForConnection({
 					triedPeers,
@@ -367,16 +367,11 @@ describe('peer selector', () => {
 
 				expect([...triedPeers, ...newPeers]).to.include.members(selectedPeers);
 
-				let triedCount = 0;
-				let newCount = 0;
-				for (const peer of selectedPeers) {
-					if (triedPeers.find(triedPeer => peer.peerId === triedPeer.peerId)) {
-						triedCount++;
-					}
-					newCount++;
-				}
-				expect(triedCount).to.gte(23);
-				expect(newCount).to.gte(23);
+				const verifyNewPeers = selectedPeers.filter(peerInfo =>
+					newPeers.find(newPeerInfo => newPeerInfo.peerId === peerInfo.peerId),
+				);
+
+				expect(verifyNewPeers).to.be.not.empty;
 			});
 		});
 

--- a/elements/lisk-p2p/test/unit/utils/select.ts
+++ b/elements/lisk-p2p/test/unit/utils/select.ts
@@ -392,6 +392,46 @@ describe('peer selector', () => {
 			});
 		});
 
+		describe('when math random returns above 50', () => {
+			beforeEach(function() {
+				sinon.stub(Math, 'random').returns(0.5);
+			});
+
+			afterEach(function() {
+				sandbox.restore();
+			});
+
+			it('should return only new peer list', () => {
+				const triedPeers = initPeerInfoListWithSuffix('111.112.113', 25);
+				const newPeers = initPeerInfoListWithSuffix('111.112.114', 75);
+
+				const selectedPeers = selectPeersForConnection({
+					triedPeers,
+					newPeers,
+					peerLimit: 50,
+				});
+				expect(selectedPeers)
+					.to.be.an('array')
+					.of.length(50);
+
+				expect([...triedPeers, ...newPeers]).to.include.members(selectedPeers);
+
+				let triedCount = 0;
+				let newCount = 0;
+
+				for (const peer of selectedPeers) {
+					if (triedPeers.find(triedPeer => peer.peerId === triedPeer.peerId)) {
+						triedCount++;
+					} else {
+						newCount++;
+					}
+				}
+
+				expect(triedCount).to.eql(0);
+				expect(newCount).to.eql(50);
+			});
+		});
+
 		describe('when there are multiple peer from same IP with different height', () => {
 			it('should return only unique IPs', () => {
 				let uniqIpAddresses: Array<string> = [];

--- a/elements/lisk-p2p/test/unit/utils/select.ts
+++ b/elements/lisk-p2p/test/unit/utils/select.ts
@@ -353,15 +353,17 @@ describe('peer selector', () => {
 		});
 
 		describe('when there are less than 100 peers', () => {
-			beforeEach(function() {
-				sinon.stub(Math, 'random').returns(0.499);
+			let mathRandom: sinon.SinonStub;
+			before(function() {
+				mathRandom = sinon.stub(Math, 'random');
 			});
 
-			afterEach(function() {
+			after(function() {
 				sandbox.restore();
 			});
 
 			it('should return peers uniformly from both lists', () => {
+				mathRandom.returns(0.499);
 				const triedPeers = initPeerInfoListWithSuffix('111.112.113', 25);
 				const newPeers = initPeerInfoListWithSuffix('111.112.114', 75);
 
@@ -390,18 +392,9 @@ describe('peer selector', () => {
 				expect(triedCount).to.eql(25);
 				expect(newCount).to.eql(25);
 			});
-		});
-
-		describe('when math random returns above 50', () => {
-			beforeEach(function() {
-				sinon.stub(Math, 'random').returns(0.5);
-			});
-
-			afterEach(function() {
-				sandbox.restore();
-			});
 
 			it('should return only new peer list', () => {
+				mathRandom.returns(0.5);
 				const triedPeers = initPeerInfoListWithSuffix('111.112.113', 25);
 				const newPeers = initPeerInfoListWithSuffix('111.112.114', 75);
 


### PR DESCRIPTION
### What was the problem?
- In some scenario the triedPeers and the newPeers could have same Peers and removePeer were unable to remove them neither from the PeerBook. This could happen if the bucketId were equal with 0.

### How did I solve it?
- Correct the bucketId verify statement in the `BaseList.getBucket()`
- Additionally simplified the `PeerBook.removePeer()` and change the `BaseList._initBuckets()` into private function also removed the duplicated call from the triedPeersList Class.

### How to manually test it?
- `npm run test`

### Review checklist

- [x] The PR resolves #4609 & #4599
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
