### PR TITLE
P2P add protocol message limit and improved message limit penalty

### DIFF
--- a/elements/lisk-p2p/src/constants.ts
+++ b/elements/lisk-p2p/src/constants.ts
@@ -21,6 +21,8 @@ export const DEFAULT_BAN_TIME = 86400000; // Milliseconds in a day -> hours*minu
 export const DEFAULT_POPULATOR_INTERVAL = 10000;
 export const DEFAULT_FALLBACK_SEED_PEER_DISCOVERY_INTERVAL = 30000;
 export const DEFAULT_SEND_PEER_LIMIT = 16;
+// Message types
+export const RCP_REQUEST_TYPE = '/RPCRequest';
 // Max rate of WebSocket messages per second per peer.
 export const DEFAULT_WS_MAX_MESSAGE_RATE = 100;
 export const DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY = 10;

--- a/elements/lisk-p2p/src/constants.ts
+++ b/elements/lisk-p2p/src/constants.ts
@@ -24,7 +24,7 @@ export const DEFAULT_SEND_PEER_LIMIT = 16;
 // Message types
 export const RCP_REQUEST_TYPE = '/RPCRequest';
 // Max rate of WebSocket messages per second per peer.
-export const DEFAULT_WS_MAX_MESSAGE_RATE = 1000;
+export const DEFAULT_WS_MAX_MESSAGE_RATE = 100;
 export const DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY = 10;
 export const DEFAULT_RATE_CALCULATION_INTERVAL = 1000;
 export const DEFAULT_WS_MAX_PAYLOAD = 3048576; // Size in bytes

--- a/elements/lisk-p2p/src/constants.ts
+++ b/elements/lisk-p2p/src/constants.ts
@@ -24,7 +24,7 @@ export const DEFAULT_SEND_PEER_LIMIT = 16;
 // Message types
 export const RCP_REQUEST_TYPE = '/RPCRequest';
 // Max rate of WebSocket messages per second per peer.
-export const DEFAULT_WS_MAX_MESSAGE_RATE = 100;
+export const DEFAULT_WS_MAX_MESSAGE_RATE = 1000;
 export const DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY = 10;
 export const DEFAULT_RATE_CALCULATION_INTERVAL = 1000;
 export const DEFAULT_WS_MAX_PAYLOAD = 3048576; // Size in bytes

--- a/elements/lisk-p2p/src/events.ts
+++ b/elements/lisk-p2p/src/events.ts
@@ -40,6 +40,8 @@ export const EVENT_FAILED_TO_SEND_MESSAGE = 'failedToSendMessage';
 // Peer base
 export const REMOTE_SC_EVENT_RPC_REQUEST = 'rpc-request';
 export const REMOTE_SC_EVENT_MESSAGE = 'remote-message';
+
+// P2P Protocol messages
 export const REMOTE_EVENT_POST_NODE_INFO = 'postNodeInfo';
 export const REMOTE_EVENT_RPC_GET_NODE_INFO = 'getNodeInfo';
 export const REMOTE_EVENT_RPC_GET_PEERS_LIST = 'getPeers';

--- a/elements/lisk-p2p/src/events.ts
+++ b/elements/lisk-p2p/src/events.ts
@@ -49,7 +49,7 @@ export const REMOTE_EVENT_PING = 'ping';
 export const REMOTE_EVENT_PONG = 'pong';
 
 // P2P Protocol messages list
-export const PROTOCOL_REMOTE_EVENT_RCP_EVENTS: Set<string> = new Set([
+export const PROTOCOL_EVENTS_TO_RATE_LIMIT: Set<string> = new Set([
 	REMOTE_EVENT_RPC_GET_NODE_INFO,
 	REMOTE_EVENT_RPC_GET_PEERS_LIST,
 ]);

--- a/elements/lisk-p2p/src/events.ts
+++ b/elements/lisk-p2p/src/events.ts
@@ -48,6 +48,12 @@ export const REMOTE_EVENT_RPC_GET_PEERS_LIST = 'getPeers';
 export const REMOTE_EVENT_PING = 'ping';
 export const REMOTE_EVENT_PONG = 'pong';
 
+// P2P Protocol messages list
+export const PROTOCOL_REMOTE_EVENT_RCP_EVENTS: Set<string> = new Set([
+	REMOTE_EVENT_RPC_GET_NODE_INFO,
+	REMOTE_EVENT_RPC_GET_PEERS_LIST,
+]);
+
 // Inbound peer
 export const EVENT_CLOSE_INBOUND = 'closeInbound';
 export const EVENT_INBOUND_SOCKET_ERROR = 'inboundSocketError';

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -82,6 +82,7 @@ import {
 	EVENT_REQUEST_RECEIVED,
 	EVENT_UNBAN_PEER,
 	EVENT_UPDATED_PEER_INFO,
+	REMOTE_EVENT_RPC_GET_NODE_INFO,
 	REMOTE_EVENT_RPC_GET_PEERS_LIST,
 } from './events';
 import { P2PRequest } from './p2p_request';
@@ -289,8 +290,13 @@ export class P2P extends EventEmitter {
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerPoolRPC = (request: P2PRequest) => {
+			// Process protocol messages
 			if (request.procedure === REMOTE_EVENT_RPC_GET_PEERS_LIST) {
 				this._handleGetPeersRequest(request);
+			}
+
+			if (request.procedure === REMOTE_EVENT_RPC_GET_NODE_INFO) {
+				request.end(this._nodeInfo);
 			}
 
 			// Re-emit the request for external use.

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -291,12 +291,14 @@ export class P2P extends EventEmitter {
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerPoolRPC = (request: P2PRequest) => {
 			// Process protocol messages
-			if (request.procedure === REMOTE_EVENT_RPC_GET_PEERS_LIST) {
-				this._handleGetPeersRequest(request);
-			}
-
-			if (request.procedure === REMOTE_EVENT_RPC_GET_NODE_INFO) {
-				request.end(this._nodeInfo);
+			switch (request.procedure) {
+				case REMOTE_EVENT_RPC_GET_PEERS_LIST:
+					this._handleGetPeersRequest(request);
+					break;
+				case REMOTE_EVENT_RPC_GET_NODE_INFO:
+					this._handleGetNodeInfo(request);
+					break;
+				default:
 			}
 
 			// Re-emit the request for external use.
@@ -1049,6 +1051,10 @@ export class P2P extends EventEmitter {
 					? sanitizedPeerInfoList
 					: sanitizedPeerInfoList.slice(0, safeMaxPeerInfoLength),
 		});
+	}
+
+	private _handleGetNodeInfo(request: P2PRequest): void {
+		request.end(this._nodeInfo);
 	}
 
 	private _isTrustedPeer(peerId: string): boolean {

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -148,7 +148,7 @@ export class Peer extends EventEmitter {
 		this._handleRawRPC = (
 			packet: unknown,
 			respond: (responseError?: Error, responseData?: unknown) => void,
-		) => {
+		): void => {
 			// TODO later: Switch to LIP protocol format.
 			// tslint:disable-next-line:no-let
 			let rawRequest;
@@ -452,15 +452,14 @@ export class Peer extends EventEmitter {
 				this._peerConfig.wsMaxMessageRate ||
 			this._protocolRCPCounter > this._protocolRCPEvents.size
 		) {
-			// Allow to increase penalty to reduce 10 second attack window length
-			const messageRateCoeff =
+			// Allow to increase penalty based on message rate limit exceeded
+			const messageRateExceedCoeff = Math.floor(
 				this.peerInfo.internalState.wsMessageRate /
-				this._peerConfig.wsMaxMessageRate;
+					this._peerConfig.wsMaxMessageRate,
+			);
 
 			const penaltyRateMultiplier =
-				messageRateCoeff > 1
-					? messageRateCoeff / this._peerConfig.wsMaxMessageRate
-					: 1;
+				messageRateExceedCoeff > 1 ? messageRateExceedCoeff : 1;
 
 			this.applyPenalty(
 				this._peerConfig.wsMaxMessageRatePenalty * penaltyRateMultiplier,

--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -119,8 +119,8 @@ export class OutboundPeer extends Peer {
 			hostname: this.ipAddress,
 			port: this.wsPort,
 			query: querystring.stringify({
-				...this._nodeInfo,
-				options: JSON.stringify(this._nodeInfo),
+				...this._serverNodeInfo,
+				options: JSON.stringify(this._serverNodeInfo),
 			}),
 			connectTimeout,
 			ackTimeout,

--- a/elements/lisk-p2p/src/peer_pool.ts
+++ b/elements/lisk-p2p/src/peer_pool.ts
@@ -51,6 +51,7 @@ import {
 	EVENT_REQUEST_RECEIVED,
 	EVENT_UNBAN_PEER,
 	EVENT_UPDATED_PEER_INFO,
+	REMOTE_EVENT_POST_NODE_INFO,
 } from './events';
 import { P2PRequest } from './p2p_request';
 import {
@@ -303,7 +304,7 @@ export class PeerPool extends EventEmitter {
 		this._nodeInfo = nodeInfo;
 		const peerList = this.getPeers();
 		peerList.forEach(peer => {
-			this._applyNodeInfoOnPeer(peer, nodeInfo);
+			this._applyNodeInfoOnPeer(peer);
 		});
 	}
 
@@ -502,7 +503,7 @@ export class PeerPool extends EventEmitter {
 		this._peerMap.set(peer.id, peer);
 		this._bindHandlersToPeer(peer);
 		if (this._nodeInfo) {
-			this._applyNodeInfoOnPeer(peer, this._nodeInfo);
+			this._applyNodeInfoOnPeer(peer);
 		}
 		peer.connect();
 
@@ -538,7 +539,7 @@ export class PeerPool extends EventEmitter {
 		this._peerMap.set(peer.id, peer);
 		this._bindHandlersToPeer(peer);
 		if (this._nodeInfo) {
-			this._applyNodeInfoOnPeer(peer, this._nodeInfo);
+			this._applyNodeInfoOnPeer(peer);
 		}
 
 		return true;
@@ -665,9 +666,12 @@ export class PeerPool extends EventEmitter {
 		return openOutboundSlots;
 	}
 
-	private _applyNodeInfoOnPeer(peer: Peer, nodeInfo: P2PNodeInfo): void {
+	private _applyNodeInfoOnPeer(peer: Peer): void {
 		try {
-			peer.applyNodeInfo(nodeInfo);
+			peer.send({
+				event: REMOTE_EVENT_POST_NODE_INFO,
+				data: this._nodeInfo,
+			});
 		} catch (error) {
 			this.emit(EVENT_FAILED_TO_PUSH_NODE_INFO, error);
 		}

--- a/elements/lisk-p2p/test/integration/discovery.ts
+++ b/elements/lisk-p2p/test/integration/discovery.ts
@@ -275,6 +275,7 @@ describe('Network discovery', () => {
 			const customConfig = (index: number) => ({
 				maxOutboundConnections: index % 2 === 1 ? 3 : 20,
 				fallbackSeedPeerDiscoveryInterval: index === 2 ? 100 : 10000,
+				rateCalculationInterval: 100,
 				populatorInterval:
 					index === 2 ? CUSTOM_FALLBACK_SEED_DISCOVERY_INTERVAL : 10000,
 			});

--- a/elements/lisk-p2p/test/integration/discovery.ts
+++ b/elements/lisk-p2p/test/integration/discovery.ts
@@ -54,6 +54,7 @@ describe('Network discovery', () => {
 			// To capture all the initial events set network creation time to minimum 1 ms
 			const customConfig = () => ({
 				fallbackSeedPeerDiscoveryInterval: CUSTOM_FALLBACK_SEED_DISCOVERY_INTERVAL,
+				rateCalculationInterval: 100,
 			});
 
 			p2pNodeList = await createNetwork({

--- a/elements/lisk-p2p/test/integration/penalty_protocol_message_limit.ts
+++ b/elements/lisk-p2p/test/integration/penalty_protocol_message_limit.ts
@@ -13,7 +13,11 @@
  *
  */
 import { expect } from 'chai';
-import { P2P, EVENT_BAN_PEER } from '../../src/index';
+import {
+	P2P,
+	EVENT_BAN_PEER,
+	DEFAULT_WS_MAX_MESSAGE_RATE,
+} from '../../src/index';
 import {
 	createNetwork,
 	destroyNetwork,
@@ -32,7 +36,7 @@ describe('P2P protocol message limit', () => {
 			maxOutboundConnections: index % 2 === 1 ? 3 : 20,
 			fallbackSeedPeerDiscoveryInterval: index === 2 ? 100 : 10000,
 			rateCalculationInterval: 1000,
-			wsMaxMessageRatePenalty: 100,
+			wsMaxMessageRatePenalty: DEFAULT_WS_MAX_MESSAGE_RATE,
 			populatorInterval: index === 2 ? 100 : 10000,
 		});
 
@@ -58,9 +62,7 @@ describe('P2P protocol message limit', () => {
 	});
 
 	it(`should apply penalty for limit exceed`, async () => {
-		// Arrange
-
-		// Act
+		// Arrange & Act
 		await wait(100);
 
 		// Assert

--- a/elements/lisk-p2p/test/integration/penalty_protocol_message_limit.ts
+++ b/elements/lisk-p2p/test/integration/penalty_protocol_message_limit.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect } from 'chai';
+import { P2P, EVENT_BAN_PEER } from '../../src/index';
+import {
+	createNetwork,
+	destroyNetwork,
+	NETWORK_CREATION_WAIT_TIME,
+	SEED_PEER_IP,
+} from '../utils/network_setup';
+import { wait } from 'utils/helpers';
+import { constructPeerId } from '../../src/utils';
+
+describe('P2P protocol message limit', () => {
+	let p2pNodeList: ReadonlyArray<P2P> = [];
+	let bannedPeer: string = '';
+
+	beforeEach(async () => {
+		const customConfig = (index: number) => ({
+			maxOutboundConnections: index % 2 === 1 ? 3 : 20,
+			fallbackSeedPeerDiscoveryInterval: index === 2 ? 100 : 10000,
+			rateCalculationInterval: 1000,
+			wsMaxMessageRatePenalty: 100,
+			populatorInterval: index === 2 ? 100 : 10000,
+		});
+
+		p2pNodeList = await createNetwork({
+			networkDiscoveryWaitTime: 0,
+			networkSize: 3,
+			customConfig,
+		});
+
+		for (let p2p of p2pNodeList) {
+			p2p.on(EVENT_BAN_PEER, peerId => {
+				bannedPeer = peerId;
+			});
+		}
+
+		await Promise.all(p2pNodeList.map(p2p => p2p.start()));
+
+		await wait(NETWORK_CREATION_WAIT_TIME);
+	});
+
+	afterEach(async () => {
+		await destroyNetwork(p2pNodeList);
+	});
+
+	it(`should apply penalty for limit exceed`, async () => {
+		// Arrange
+
+		// Act
+		await wait(100);
+
+		// Assert
+		expect(bannedPeer).to.be.equal(
+			constructPeerId(SEED_PEER_IP, p2pNodeList[2].config.nodeInfo.wsPort),
+		);
+	});
+});

--- a/elements/lisk-p2p/test/unit/peer/base.ts
+++ b/elements/lisk-p2p/test/unit/peer/base.ts
@@ -23,6 +23,7 @@ import {
 	DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY,
 	DEFAULT_WS_MAX_MESSAGE_RATE,
 	DEFAULT_RATE_CALCULATION_INTERVAL,
+	RCP_REQUEST_TYPE,
 } from '../../../src/constants';
 import {
 	EVENT_BAN_PEER,
@@ -34,7 +35,7 @@ import {
 	EVENT_UPDATED_PEER_INFO,
 	EVENT_FAILED_PEER_INFO_UPDATE,
 	EVENT_FAILED_TO_FETCH_PEER_INFO,
-	PROTOCOL_REMOTE_EVENT_RCP_EVENTS,
+	PROTOCOL_EVENTS_TO_RATE_LIMIT,
 } from '../../../src/events';
 import { RPCResponseError } from '../../../src/errors';
 import { SCServerSocket } from 'socketcluster-server';
@@ -282,7 +283,7 @@ describe('peer/base', () => {
 			(defaultPeer as any)._socket = socket;
 			defaultPeer.request(p2pPacket);
 			expect(socket.emit).to.be.calledOnceWith(REMOTE_SC_EVENT_RPC_REQUEST, {
-				type: '/RPCRequest',
+				type: RCP_REQUEST_TYPE,
 				procedure: p2pPacket.procedure,
 				data: p2pPacket.data,
 			});
@@ -706,7 +707,7 @@ describe('peer/base', () => {
 					procedure: REMOTE_EVENT_RPC_GET_PEERS_LIST,
 				};
 				const expectedHandledEventCount =
-					PROTOCOL_REMOTE_EVENT_RCP_EVENTS.size + 1;
+					PROTOCOL_EVENTS_TO_RATE_LIMIT.size + 1;
 				const requestCount = 10;
 
 				//Act

--- a/elements/lisk-p2p/test/unit/peer/base.ts
+++ b/elements/lisk-p2p/test/unit/peer/base.ts
@@ -34,6 +34,7 @@ import {
 	EVENT_UPDATED_PEER_INFO,
 	EVENT_FAILED_PEER_INFO_UPDATE,
 	EVENT_FAILED_TO_FETCH_PEER_INFO,
+	PROTOCOL_REMOTE_EVENT_RCP_EVENTS,
 } from '../../../src/events';
 import { RPCResponseError } from '../../../src/errors';
 import { SCServerSocket } from 'socketcluster-server';
@@ -705,7 +706,7 @@ describe('peer/base', () => {
 					procedure: REMOTE_EVENT_RPC_GET_PEERS_LIST,
 				};
 				const expectedHandledEventCount =
-					(defaultPeer as any)._protocolRCPEvents.size + 1;
+					PROTOCOL_REMOTE_EVENT_RCP_EVENTS.size + 1;
 				const requestCount = 10;
 
 				//Act
@@ -729,7 +730,7 @@ describe('peer/base', () => {
 			it('should apply penalty for messagesRate exceeded', () => {
 				// Arrange
 				const reputation = defaultPeer.peerInfo.internalState.reputation;
-				const messageCount = 1001;
+				const messageCount = 101;
 
 				//Act
 				for (let i = 0; i < messageCount; i++) {
@@ -746,7 +747,7 @@ describe('peer/base', () => {
 			it('should increase penalty based on rate limit exceeded', () => {
 				// Arrange
 				const reputation = defaultPeer.peerInfo.internalState.reputation;
-				const messageCount = 2001;
+				const messageCount = 201;
 				const expectedPenalty =
 					DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY *
 					Math.floor(messageCount / DEFAULT_WS_MAX_MESSAGE_RATE);

--- a/elements/lisk-p2p/test/unit/peer/base.ts
+++ b/elements/lisk-p2p/test/unit/peer/base.ts
@@ -31,12 +31,11 @@ import {
 	EVENT_UPDATED_PEER_INFO,
 	EVENT_FAILED_PEER_INFO_UPDATE,
 	EVENT_FAILED_TO_FETCH_PEER_INFO,
-	REMOTE_EVENT_POST_NODE_INFO,
 } from '../../../src/events';
 import { RPCResponseError } from '../../../src/errors';
 import { SCServerSocket } from 'socketcluster-server';
 import { getNetgroup, constructPeerId } from '../../../src/utils';
-import { P2PNodeInfo, P2PPeerInfo } from '../../../src';
+import { P2PPeerInfo } from '../../../src';
 
 const createSocketStubInstance = () => <SCServerSocket>({
 		emit: sandbox.stub(),
@@ -46,7 +45,6 @@ const createSocketStubInstance = () => <SCServerSocket>({
 describe('peer/base', () => {
 	let defaultPeerInfo: P2PPeerInfo;
 	let peerConfig: PeerConfig;
-	let nodeInfo: P2PNodeInfo;
 	let p2pDiscoveredPeerInfo: P2PPeerInfo;
 	let defaultPeer: Peer;
 	let clock: sinon.SinonFakeTimers;
@@ -80,16 +78,6 @@ describe('peer/base', () => {
 				nonce: 'nonce',
 				advertiseAddress: true,
 			},
-		};
-		nodeInfo = {
-			os: 'os',
-			version: '1.2.0',
-			protocolVersion: '1.2',
-			nethash: 'nethash',
-			wsPort: 6001,
-			height: 100,
-			nonce: 'nonce',
-			advertiseAddress: true,
 		};
 		p2pDiscoveredPeerInfo = {
 			peerId: constructPeerId(
@@ -196,24 +184,6 @@ describe('peer/base', () => {
 				defaultPeerInfo.sharedState,
 			)));
 
-	describe('#nodeInfo', () => {
-		beforeEach(() => {
-			sandbox.stub(defaultPeer, 'request').resolves();
-		});
-
-		it('should get node info', () => {
-			const socket = createSocketStubInstance();
-			(defaultPeer as any)._socket = socket;
-			defaultPeer.applyNodeInfo(nodeInfo);
-
-			expect(defaultPeer.nodeInfo).to.eql(nodeInfo);
-			expect(socket.emit).to.be.calledOnceWithExactly(REMOTE_SC_EVENT_MESSAGE, {
-				event: REMOTE_EVENT_POST_NODE_INFO,
-				data: nodeInfo,
-			});
-		});
-	});
-
 	describe('#updatePeerInfo', () =>
 		it('should update peer info', () => {
 			defaultPeer.updatePeerInfo(p2pDiscoveredPeerInfo);
@@ -222,23 +192,6 @@ describe('peer/base', () => {
 				p2pDiscoveredPeerInfo.sharedState,
 			);
 		}));
-
-	describe('#applyNodeInfo', async () => {
-		beforeEach(() => {
-			sandbox.stub(defaultPeer, 'send').resolves();
-		});
-
-		it('should apply node info', async () => {
-			const socket = createSocketStubInstance();
-			(defaultPeer as any)._socket = socket;
-			defaultPeer.applyNodeInfo(nodeInfo);
-
-			expect(defaultPeer.send).to.be.calledOnceWithExactly({
-				event: REMOTE_EVENT_POST_NODE_INFO,
-				data: nodeInfo,
-			});
-		});
-	});
 
 	describe('#connect', () => {
 		it('should throw error if socket does not exist', () => {

--- a/elements/lisk-p2p/test/unit/peer/inbound.ts
+++ b/elements/lisk-p2p/test/unit/peer/inbound.ts
@@ -19,6 +19,7 @@ import {
 	DEFAULT_RANDOM_SECRET,
 	DEFAULT_PING_INTERVAL_MAX,
 	DEFAULT_PING_INTERVAL_MIN,
+	DEFAULT_WS_MAX_MESSAGE_RATE,
 } from '../../../src/constants';
 import {
 	REMOTE_SC_EVENT_MESSAGE,
@@ -49,7 +50,7 @@ describe('peer/inbound', () => {
 		};
 		defaultPeerConfig = {
 			rateCalculationInterval: 1000,
-			wsMaxMessageRate: 1000,
+			wsMaxMessageRate: DEFAULT_WS_MAX_MESSAGE_RATE,
 			wsMaxMessageRatePenalty: 10,
 			secret: DEFAULT_RANDOM_SECRET,
 			maxPeerInfoSize: 10000,

--- a/elements/lisk-p2p/test/unit/peer/outbound.ts
+++ b/elements/lisk-p2p/test/unit/peer/outbound.ts
@@ -25,6 +25,7 @@ import {
 	DEFAULT_RANDOM_SECRET,
 	DEFAULT_CONNECT_TIMEOUT,
 	DEFAULT_ACK_TIMEOUT,
+	DEFAULT_WS_MAX_MESSAGE_RATE,
 } from '../../../src/constants';
 import { P2PPeerInfo } from '../../../src/p2p_types';
 
@@ -48,7 +49,7 @@ describe('peer/outbound', () => {
 		};
 		defaultOutboundPeerConfig = {
 			rateCalculationInterval: 1000,
-			wsMaxMessageRate: 1000,
+			wsMaxMessageRate: DEFAULT_WS_MAX_MESSAGE_RATE,
 			wsMaxMessageRatePenalty: 10,
 			secret: DEFAULT_RANDOM_SECRET,
 			maxPeerInfoSize: 10000,

--- a/elements/lisk-p2p/test/unit/peer_pool.ts
+++ b/elements/lisk-p2p/test/unit/peer_pool.ts
@@ -50,6 +50,7 @@ import {
 	INTENTIONAL_DISCONNECT_CODE,
 	DEFAULT_SEND_PEER_LIMIT,
 	PeerKind,
+	DEFAULT_WS_MAX_MESSAGE_RATE,
 } from '../../src/constants';
 import { constructPeerId } from '../../src/utils';
 import { RequestFailError, SendFailError } from '../../src';
@@ -63,7 +64,7 @@ describe('peerPool', () => {
 		peerSelectionForSend: selectPeersForSend,
 		sendPeerLimit: DEFAULT_SEND_PEER_LIMIT,
 		wsMaxPayload: DEFAULT_WS_MAX_PAYLOAD,
-		wsMaxMessageRate: 100,
+		wsMaxMessageRate: DEFAULT_WS_MAX_MESSAGE_RATE,
 		wsMaxMessageRatePenalty: 10,
 		rateCalculationInterval: 1000,
 		peerBanTime: DEFAULT_BAN_TIME,

--- a/elements/lisk-p2p/test/utils/peers.ts
+++ b/elements/lisk-p2p/test/utils/peers.ts
@@ -12,7 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { ConnectionKind, DEFAULT_RANDOM_SECRET } from '../../src/constants';
+import {
+	ConnectionKind,
+	DEFAULT_RANDOM_SECRET,
+	DEFAULT_WS_MAX_MESSAGE_RATE,
+} from '../../src/constants';
 import { Peer } from '../../src/peer';
 import { P2PPeerInfo } from '../../src/p2p_types';
 import { assignInternalInfo } from '../../src/utils';
@@ -120,7 +124,7 @@ export const initPeerList = (): ReadonlyArray<Peer> =>
 		(peerInfo: P2PPeerInfo) =>
 			new Peer(peerInfo, {
 				rateCalculationInterval: 1000,
-				wsMaxMessageRate: 1000,
+				wsMaxMessageRate: DEFAULT_WS_MAX_MESSAGE_RATE,
 				wsMaxMessageRatePenalty: 10,
 				secret: DEFAULT_RANDOM_SECRET,
 				maxPeerInfoSize: 10000,


### PR DESCRIPTION
### What was the problem?
- LIP-0004 proposed protocol message limit were missing from the P2P libraries. 
- The current message rate limiting were still allow a 10 second wide flood-attack window. 

### How did I solve it?
- Add `_protocolRCPCounter` and logic to count and prevent P2P protocol messages flooding.
- Extend the messageRate calculation with `messageRateExceedCoeff` which allow to multiple the penalty score for `applyPenalty` this could stop flood-attack in case _immediately_.

### How to manually test it?
`npm run test`

### Review checklist

- [x] The PR resolves
- [x] All new code is covered with unit tests
- [x] Relevant integration / functional tests are added
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [x] Documentation has been added/updated
