### PR TITLE
HTTP API whitelists do not always work as expected - Closes #4629

### DIFF
--- a/framework/src/controller/validator/keywords/formatters.js
+++ b/framework/src/controller/validator/keywords/formatters.js
@@ -21,9 +21,16 @@ module.exports = {
 				const [ip, wsPort] = peer.split(':');
 				return {
 					ip,
-					wsPort: wsPort || 5000,
+					wsPort: parseInt(wsPort, 10) || 5000,
 				};
 			});
+		}
+		return [];
+	},
+
+	stringToIpList: value => {
+		if (typeof value === 'string') {
+			return value.split(',');
 		}
 		return [];
 	},

--- a/framework/src/modules/http_api/defaults/config.js
+++ b/framework/src/modules/http_api/defaults/config.js
@@ -47,7 +47,7 @@ const defaultConfig = {
 					type: 'array',
 					env: {
 						variable: 'LISK_API_WHITELIST',
-						formatter: 'stringToIpPortSet',
+						formatter: 'stringToIpList',
 					},
 				},
 			},
@@ -144,7 +144,7 @@ const defaultConfig = {
 							type: 'array',
 							env: {
 								variable: 'LISK_FORGING_WHITELIST',
-								formatter: 'stringToIpPortSet',
+								formatter: 'stringToIpList',
 							},
 						},
 					},

--- a/framework/test/jest/unit/specs/controller/helpers/validator/keywords/formatters.spec.js
+++ b/framework/test/jest/unit/specs/controller/helpers/validator/keywords/formatters.spec.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+const {
+	stringToIpPortSet,
+	stringToIpList,
+	stringToDelegateList,
+} = require('../../../../../../../../src/controller/validator/keywords/formatters');
+
+describe('formatters', () => {
+	describe('stringToIpPortSet', () => {
+		it('should return empty array if given argument is not string', async () => {
+			// Arrange
+			const input = 123;
+			const expectedOutput = [];
+
+			// Act
+			const output = stringToIpPortSet(input);
+
+			// Assert
+			expect(output).toEqual(expectedOutput);
+		});
+
+		it('should return list of "ip" and "wsPort" objects for given string value', async () => {
+			// Arrange
+			const input = '127.0.0.1:123,192.168.0.1:8000';
+			const expectedOutput = [
+				{ ip: '127.0.0.1', wsPort: 123 },
+				{ ip: '192.168.0.1', wsPort: 8000 },
+			];
+
+			// Act
+			const output = stringToIpPortSet(input);
+
+			// Assert
+			expect(output).toEqual(expectedOutput);
+		});
+
+		it('should return use 5000 was wsPort if not available in given argument', async () => {
+			// Arrange
+			const input = '127.0.0.1,192.168.0.1:';
+			const expectedOutput = [
+				{ ip: '127.0.0.1', wsPort: 5000 },
+				{ ip: '192.168.0.1', wsPort: 5000 },
+			];
+
+			// Act
+			const output = stringToIpPortSet(input);
+
+			// Assert
+			expect(output).toEqual(expectedOutput);
+		});
+	});
+
+	describe('stringToIpList', () => {
+		it('should return empty array if given argument is not string', async () => {
+			// Arrange
+			const input = 123;
+			const expectedOutput = [];
+
+			// Act
+			const output = stringToIpList(input);
+
+			// Assert
+			expect(output).toEqual(expectedOutput);
+		});
+
+		it('should return list IPs for given string value', async () => {
+			// Arrange
+			const input = '127.0.0.1,192.168.0.1';
+			const expectedOutput = ['127.0.0.1', '192.168.0.1'];
+
+			// Act
+			const output = stringToIpList(input);
+
+			// Assert
+			expect(output).toEqual(expectedOutput);
+		});
+	});
+
+	describe('stringToDelegateList', () => {
+		it('should return empty array if given argument is not string', async () => {
+			// Arrange
+			const input = 123;
+			const expectedOutput = [];
+
+			// Act
+			const output = stringToDelegateList(input);
+
+			// Assert
+			expect(output).toEqual(expectedOutput);
+		});
+
+		it('should return list of "publicKey" and "encryptedPassphrase" objects for given string value', async () => {
+			// Arrange
+			const input = 'key1|pass1,key2|pass2';
+			const expectedOutput = [
+				{ publicKey: 'key1', encryptedPassphrase: 'pass1' },
+				{ publicKey: 'key2', encryptedPassphrase: 'pass2' },
+			];
+
+			// Act
+			const output = stringToDelegateList(input);
+
+			// Assert
+			expect(output).toEqual(expectedOutput);
+		});
+	});
+});

--- a/framework/test/jest/unit/specs/controller/helpers/validator/keywords/formatters.spec.js
+++ b/framework/test/jest/unit/specs/controller/helpers/validator/keywords/formatters.spec.js
@@ -22,7 +22,7 @@ const {
 
 describe('formatters', () => {
 	describe('stringToIpPortSet', () => {
-		it('should return empty array if given argument is not string', async () => {
+		it('should return empty array if given argument is not string', () => {
 			// Arrange
 			const input = 123;
 			const expectedOutput = [];
@@ -34,7 +34,7 @@ describe('formatters', () => {
 			expect(output).toEqual(expectedOutput);
 		});
 
-		it('should return list of "ip" and "wsPort" objects for given string value', async () => {
+		it('should return list of "ip" and "wsPort" objects for given string value', () => {
 			// Arrange
 			const input = '127.0.0.1:123,192.168.0.1:8000';
 			const expectedOutput = [
@@ -49,7 +49,7 @@ describe('formatters', () => {
 			expect(output).toEqual(expectedOutput);
 		});
 
-		it('should return use 5000 was wsPort if not available in given argument', async () => {
+		it('should return use 5000 was wsPort if not available in given argument', () => {
 			// Arrange
 			const input = '127.0.0.1,192.168.0.1:';
 			const expectedOutput = [
@@ -66,7 +66,7 @@ describe('formatters', () => {
 	});
 
 	describe('stringToIpList', () => {
-		it('should return empty array if given argument is not string', async () => {
+		it('should return empty array if given argument is not string', () => {
 			// Arrange
 			const input = 123;
 			const expectedOutput = [];
@@ -78,7 +78,7 @@ describe('formatters', () => {
 			expect(output).toEqual(expectedOutput);
 		});
 
-		it('should return list IPs for given string value', async () => {
+		it('should return list IPs for given string value', () => {
 			// Arrange
 			const input = '127.0.0.1,192.168.0.1';
 			const expectedOutput = ['127.0.0.1', '192.168.0.1'];
@@ -92,7 +92,7 @@ describe('formatters', () => {
 	});
 
 	describe('stringToDelegateList', () => {
-		it('should return empty array if given argument is not string', async () => {
+		it('should return empty array if given argument is not string', () => {
 			// Arrange
 			const input = 123;
 			const expectedOutput = [];
@@ -104,7 +104,7 @@ describe('formatters', () => {
 			expect(output).toEqual(expectedOutput);
 		});
 
-		it('should return list of "publicKey" and "encryptedPassphrase" objects for given string value', async () => {
+		it('should return list of "publicKey" and "encryptedPassphrase" objects for given string value', () => {
 			// Arrange
 			const input = 'key1|pass1,key2|pass2';
 			const expectedOutput = [


### PR DESCRIPTION
### What was the problem?
The configuration specification for http_api module were using  `stringToIpPortSet` formatter.

### How did I solve it?

Created new formatter `stringToIpList` and updated the configuration spec for http_api module. 

### How to manually test it?

Added few tests as well, so can be tested with `nom run jest:unit`

### Review checklist

- [ ] The PR resolves #4629
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
