### PR TITLE
LISK_API_PUBLIC=false does not work - Closes#4631

### DIFF
--- a/framework/src/controller/validator/keywords/env/index.js
+++ b/framework/src/controller/validator/keywords/env/index.js
@@ -55,7 +55,7 @@ const compile = (schema, parentSchema) => {
 			}
 		}
 
-		if (variableValue) {
+		if (variableValue !== undefined) {
 			object[key] = envVariable.formatter
 				? envVariable.formatter(variableValue)
 				: variableValue;

--- a/framework/test/jest/unit/specs/controller/helpers/validator/keywords/env.spec.js
+++ b/framework/test/jest/unit/specs/controller/helpers/validator/keywords/env.spec.js
@@ -75,7 +75,26 @@ describe('validator keyword "env"', () => {
 		expect(data.prop1).toBe(999);
 	});
 
-	it('should accept env variable if specified as boolean and format accordingly', () => {
+	it('should accept env variable if specified as boolean "true" and format accordingly', () => {
+		const envSchemaWithOutFormatter = {
+			type: 'object',
+			properties: {
+				prop1: {
+					type: 'boolean',
+					env: 'PROP1',
+				},
+			},
+		};
+
+		const data = { prop1: 'false' };
+		process.env.PROP1 = 'true';
+
+		validator.validate(envSchemaWithOutFormatter, data);
+
+		expect(data.prop1).toBe(true);
+	});
+
+	it('should accept env variable if specified as boolean "false" and format accordingly', () => {
 		const envSchemaWithOutFormatter = {
 			type: 'object',
 			properties: {
@@ -87,11 +106,11 @@ describe('validator keyword "env"', () => {
 		};
 
 		const data = { prop1: 'true' };
-		process.env.PROP1 = 'true';
+		process.env.PROP1 = 'false';
 
 		validator.validate(envSchemaWithOutFormatter, data);
 
-		expect(data.prop1).toBe(true);
+		expect(data.prop1).toBe(false);
 	});
 
 	it('should format the value of env variable if specified as an object', () => {


### PR DESCRIPTION
### What was the problem?

There was a value check on existence of value which was falsify with a false value. 

### How did I solve it?

Updated the check to check if value is not undefined. 

### How to manually test it?

Added the missing unit test for that case, can be run through `nom run jest:unit`

### Review checklist

- [ ] The PR resolves #4631
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
