### PR TITLE
Setting LISK_REDIS_HOST leads to unexpected logging behaviour - Closes #4630

### DIFF
--- a/framework/src/components/cache/cache.js
+++ b/framework/src/components/cache/cache.js
@@ -18,12 +18,19 @@ const redis = require('redis');
 const { promisify } = require('util');
 
 const errorCacheDisabled = 'Cache Disabled';
+const CACHE_CONNECTION_TIMEOUT = 5000; // Five seconds
 
 class Cache {
 	constructor(options, logger) {
 		this.options = options;
 		this.logger = logger;
 		this.ready = false;
+
+		// When connect to redis server running on local machine client tries to connect
+		// through unix socket, which failed immediately if server is not running.
+		// For remote host, it connect over TCP and wait for timeout
+		// Default value for connect_timeout was 3600000, which was not triggering connection error
+		this.options.connect_timeout = CACHE_CONNECTION_TIMEOUT;
 	}
 
 	async bootstrap() {

--- a/framework/src/components/logger/defaults/config.js
+++ b/framework/src/components/logger/defaults/config.js
@@ -25,7 +25,6 @@ const defaultConfig = {
 		},
 		logFileName: {
 			type: 'string',
-			env: 'LISK_REDIS_HOST',
 		},
 		consoleLogLevel: {
 			type: 'string',


### PR DESCRIPTION
### What was the problem?

1. Env variable `LISK_REDIS_HOST` was mistakenly in logger component. 
2. Default behaviour of `Redis` library is to connect through unix socket if server running locally, which failed in case not running. For remote servers it connects over TCP and wait for connection timeout. Default value was too large so why connection timeout was never triggered. 

### How did I solve it?

Removed the unwanted use of env variable. Added timeout value for Redis to 5 seconds. 

### How to manually test it?

Run the test app with env variable `LISK_REDIS_HOST`

### Review checklist

- [ ] The PR resolves #4630
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
