### PR TITLE
Integration test for genesis_block.spec.js does not terminated correctly - Closes#4627

### DIFF
--- a/framework/src/components/storage/adapters/pgp_adapter.js
+++ b/framework/src/components/storage/adapters/pgp_adapter.js
@@ -112,6 +112,18 @@ class PgpAdapter extends BaseAdapter {
 		if (monitor.isAttached()) {
 			monitor.detach();
 		}
+
+		// Add physical termination of postgres connection on cleanup.
+		// By ending all connection pools created through this library initialization
+		//
+		// Pg-promise internally use the connection-pool which keeps the reference to
+		// physical connections. Multiple connection to databases can create different connection pools
+		//
+		// this.db.$pool.end()
+		//
+		// Above will trigger ending connection pool associated to instance of database
+
+		this.db.$pool.end();
 	}
 
 	executeFile(file, params = {}, options = {}, tx) {

--- a/framework/test/jest/integration/specs/modules/chain/genesis_block.spec.js
+++ b/framework/test/jest/integration/specs/modules/chain/genesis_block.spec.js
@@ -31,23 +31,16 @@ describe('genesis block', () => {
 			dbName,
 		);
 		await storage.bootstrap();
+		chainModule = await chainUtils.createAndLoadChainModule(dbName);
 	});
 
 	afterAll(async () => {
-		await chainModule.cleanup();
+		await chainModule.unload();
 		await storage.cleanup();
 	});
 
 	describe('given the application has not been initialized', () => {
 		describe('when chain module is bootstrapped', () => {
-			beforeAll(async () => {
-				chainModule = await chainUtils.createAndLoadChainModule(dbName);
-			});
-
-			afterAll(async () => {
-				await chainModule.unload();
-			});
-
 			it('should save genesis block to the database', async () => {
 				const block = await storageUtils.getBlock(storage, genesisBlock.id);
 				expect(block.id).toEqual(genesisBlock.id);
@@ -118,7 +111,7 @@ describe('genesis block', () => {
 
 			it('should have correct delegate list', async () => {
 				const delegateListFromChain = await chainUtils.getDelegateList(
-					chainModule,
+					chainModule.chain,
 					1,
 				);
 				expect(delegateListFromChain).toEqual(delegateListForTheFirstRound);
@@ -128,10 +121,6 @@ describe('genesis block', () => {
 
 	describe('given the application has been initialized previously', () => {
 		describe('when chain module is bootstrapped', () => {
-			beforeAll(async () => {
-				chainModule = await chainUtils.createAndLoadChainModule(dbName);
-			});
-
 			it('should have genesis transactions in database', async () => {
 				const block = await storageUtils.getBlock(storage, genesisBlock.id);
 				const ids = genesisBlock.transactions.map(t => t.id);
@@ -196,7 +185,7 @@ describe('genesis block', () => {
 
 			it('should have correct delegate list', async () => {
 				const delegateListFromChain = await chainUtils.getDelegateList(
-					chainModule,
+					chainModule.chain,
 					1,
 				);
 				expect(delegateListFromChain).toEqual(delegateListForTheFirstRound);

--- a/framework/test/jest/integration/utils/chain/chain.js
+++ b/framework/test/jest/integration/utils/chain/chain.js
@@ -36,7 +36,7 @@ const createChainModule = () => {
 const createAndLoadChainModule = async databaseName => {
 	const chainModule = createChainModule();
 	await chainModule.load(createMockChannel(databaseName));
-	return chainModule.chain;
+	return chainModule;
 };
 
 module.exports = {

--- a/framework/test/jest/integration/utils/channel.js
+++ b/framework/test/jest/integration/utils/channel.js
@@ -32,9 +32,7 @@ const createMockChannel = databaseName => {
 			}
 			return {};
 		}),
-		subscribe: jest.fn((event, listener) => {
-			listener({ data: {} });
-		}),
+		subscribe: jest.fn(),
 	};
 	return channel;
 };

--- a/framework/test/mocha/common/storage_sandbox.js
+++ b/framework/test/mocha/common/storage_sandbox.js
@@ -120,20 +120,6 @@ class StorageSandbox extends Storage {
 	cleanup() {
 		this.options.database = this.originalDbName;
 		super.cleanup();
-
-		// Add physical termination of postgres connection on cleanup.
-		// While writing storage test in jest, found out that test hangs even after
-		// successful execution, due to connection pool.
-		//
-		// Pg-promise internally use the connection-pool which keeps the reference to
-		// physical connections. We can't end the pool on storage.cleanup() as that
-		// cleanup can be triggered by individual module and ending the connection pool
-		// will cause exceptions to other modules which are still running
-		//
-		// On exiting application, we use process.exit() at very end, that leads to
-		// terminating the physical connections in any case. So no effect in
-		// normal execution of the application.
-		this.adapter.db.$pool.end();
 	}
 
 	_dropDB() {


### PR DESCRIPTION
### What was the problem?

Originally only `StorageSandbox` was used in the tests, which had `$pool.end()` to terminate connection. But in genesis block integration tests both `StorageSandbox` and `Storage` was used simultaneously, one was terminating the connection and other was not. In the actual application this scenario never happens because of following code. 

https://github.com/LiskHQ/lisk-sdk/blob/478030b9a2523a31c4b1af900e3d84133a89d1c6/framework/src/controller/application.js#L285

### How did I solve it?

Moved the `$pool.end()` to parent `PgpAdapter#disconnect`, that will trigger terminating connection everywhere int he application.  

### How to manually test it?

```bash
cd framework && npm run jest:integration
```

### Review checklist

- [ ] The PR resolves #4627
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
