### PR TITLE
Chain state store finalize () does not return the promise - Closes #4652

### DIFF
--- a/framework/src/modules/chain/blocks/state_store/chain_state_store.js
+++ b/framework/src/modules/chain/blocks/state_store/chain_state_store.js
@@ -62,8 +62,7 @@ class ChainStateStore {
 		if (this.updatedKeys.size === 0) {
 			return;
 		}
-
-		Promise.all(
+		await Promise.all(
 			Array.from(this.updatedKeys).map(key =>
 				this.chainState.setKey(key, this.data[key], this.tx),
 			),

--- a/framework/test/jest/unit/specs/modules/chain/blocks/state_store_chain_state.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/blocks/state_store_chain_state.spec.js
@@ -92,5 +92,18 @@ describe('state store / chain_state', () => {
 				undefined,
 			);
 		});
+
+		it('should handle promise rejection', async () => {
+			// Prepare
+			storageStub.entities.ChainState.setKey.mockImplementation(() =>
+				Promise.reject(new Error('Fake storage layer error')),
+			);
+			// Act
+			await stateStore.chainState.set('key3', 'value3');
+			// Assert
+			return expect(stateStore.chainState.finalize()).rejects.toThrow(
+				'Fake storage layer error',
+			);
+		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

finalize() was not awaiting for promise resolution so an error in the storage layer would cause an unhandled rejection

### How did I solve it?

- by awaiting the promise resolution
- by adding a test to check in case of storage layer error the promise is returned 

### How to manually test it?

- `npm run jest:unit test/jest/unit/specs/modules/chain/blocks/state_store_chain_state.spec.js`
- check the code

### Review checklist

- [ ] The PR resolves #4652
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
