### PR TITLE
Fix processor block save ordering - Closes #4668

### DIFF
--- a/framework/src/modules/chain/processor/processor.js
+++ b/framework/src/modules/chain/processor/processor.js
@@ -304,11 +304,6 @@ class Processor {
 				});
 			}
 
-			if (!skipSave) {
-				// TODO: After moving everything to state store, save should get the state store and finalize the state store
-				await this.blocksModule.save(blockJSON, tx);
-			}
-
 			// Apply should always be executed after save as it performs database calculations
 			// i.e. Dpos.apply expects to have this processing block in the database
 			await processor.apply.run({
@@ -318,6 +313,11 @@ class Processor {
 				stateStore,
 				tx,
 			});
+
+			if (!skipSave) {
+				// TODO: After moving everything to state store, save should get the state store and finalize the state store
+				await this.blocksModule.save(blockJSON, tx);
+			}
 
 			if (removeFromTempTable) {
 				await this.blocksModule.removeBlockFromTempTable(block.id, tx);

--- a/framework/test/jest/unit/specs/modules/chain/dpos/apply.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/dpos/apply.spec.js
@@ -307,6 +307,7 @@ describe('dpos.apply()', () => {
 				reward: rewardPerDelegate,
 				height: 809 + i,
 			}));
+
 			forgedBlocks.splice(forgedBlocks.length - 1);
 
 			lastBlockOfTheRoundNine = {

--- a/framework/test/jest/unit/specs/modules/chain/processor/processor.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/processor/processor.spec.js
@@ -487,15 +487,17 @@ describe('processor', () => {
 			});
 
 			it('should emit newBlock event for the block', async () => {
-				expect(
-					channelStub.publish,
-				).toHaveBeenCalledWith('chain:processor:newBlock', { block: blockV0 });
+				expect(channelStub.publish).toHaveBeenCalledWith(
+					'chain:processor:newBlock',
+					{ block: blockV0 },
+				);
 			});
 
 			it('should emit broadcast event for the block', async () => {
-				expect(
-					channelStub.publish,
-				).toHaveBeenCalledWith('chain:processor:broadcast', { block: blockV0 });
+				expect(channelStub.publish).toHaveBeenCalledWith(
+					'chain:processor:broadcast',
+					{ block: blockV0 },
+				);
 			});
 		});
 
@@ -708,15 +710,17 @@ describe('processor', () => {
 			});
 
 			it('should broadcast with the block', async () => {
-				expect(
-					channelStub.publish,
-				).toHaveBeenCalledWith('chain:processor:broadcast', { block: blockV0 });
+				expect(channelStub.publish).toHaveBeenCalledWith(
+					'chain:processor:broadcast',
+					{ block: blockV0 },
+				);
 			});
 
 			it('should emit newBlock event with the block', async () => {
-				expect(
-					channelStub.publish,
-				).toHaveBeenCalledWith('chain:processor:newBlock', { block: blockV0 });
+				expect(channelStub.publish).toHaveBeenCalledWith(
+					'chain:processor:newBlock',
+					{ block: blockV0 },
+				);
 			});
 		});
 	});
@@ -986,7 +990,7 @@ describe('processor', () => {
 
 			it('should apply the block', async () => {
 				applySteps.forEach(step => {
-					expect(step).not.toHaveBeenCalled();
+					expect(step).toHaveBeenCalled();
 				});
 			});
 


### PR DESCRIPTION
### What was the problem?

Block processor was saving block before applying it, causing invalid tx to be included.

### How did I solve it?

Reordered so apply is called first, then save.

### How to manually test it?

`npm run jest:unit apply.spec`

### Review checklist

- [ ] The PR resolves #4668 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
