### PR TITLE
TypeError: Converting circular structure to JSON with Node 12.14.1 - Closes #4667

### DIFF
--- a/framework/src/components/storage/adapters/pgp_adapter.js
+++ b/framework/src/components/storage/adapters/pgp_adapter.js
@@ -40,15 +40,14 @@ class PgpAdapter extends BaseAdapter {
 			inTest: options.inTest,
 		});
 
-		this.options = { ...options };
-		this.logger = options.logger;
+		const { logger, ...optionsWithoutLogger } = options;
+		this.options = optionsWithoutLogger;
+		this.logger = logger;
 		this.sqlDirectory = options.sqlDirectory;
 
 		this.pgp = pgp;
 		this.db = undefined;
 		this.SQLs = {};
-
-		delete this.options.logger;
 	}
 
 	connect() {

--- a/framework/src/components/storage/adapters/pgp_adapter.js
+++ b/framework/src/components/storage/adapters/pgp_adapter.js
@@ -40,13 +40,15 @@ class PgpAdapter extends BaseAdapter {
 			inTest: options.inTest,
 		});
 
-		this.options = options;
+		this.options = { ...options };
 		this.logger = options.logger;
 		this.sqlDirectory = options.sqlDirectory;
 
 		this.pgp = pgp;
 		this.db = undefined;
 		this.SQLs = {};
+
+		delete this.options.logger;
 	}
 
 	connect() {

--- a/framework/test/mocha/unit/components/storage/adapters/pgp_adapter.js
+++ b/framework/test/mocha/unit/components/storage/adapters/pgp_adapter.js
@@ -54,8 +54,10 @@ describe('PgpAdapter', () => {
 		it('should set the parameters correctly', async () => {
 			const adapter = new PgpAdapter(validOptions);
 
-			expect(adapter.options).to.be.eql(validOptions);
-			expect(adapter.logger).to.be.eql(loggerStub);
+			const { logger, ...optionsWithoutLogger } = validOptions;
+
+			expect(adapter.options).to.be.eql(optionsWithoutLogger);
+			expect(adapter.logger).to.be.eql(logger);
 			expect(adapter.sqlDirectory).to.be.eql(validOptions.sqlDirectory);
 			expect(adapter.pgp).to.be.a('function');
 			return expect(adapter.db).to.be.undefined;


### PR DESCRIPTION
### What was the problem?

There were some changes introduced in Node `12.14.1`, which was causing circular dependency for `process.stdout`. Internally `pg-monitor` was using `JSON.stringify` on the options provided to database object. And our options contains logger, which included the `process.stdout` in Bunyan.

### How did I solve it?

Removed the `logger` from adapter options as its already assigned to instance of the adapter. 

### How to manually test it?

Use Node `12.14.1` and start the test application. 

### Review checklist

- [ ] The PR resolves #4667
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
