### PR TITLE
Protocol Spec for vote transactions generate different output - Closes #4686

### DIFF
--- a/protocol-specs/generator_outputs/block_processing_votes/invalid_block_processing_vote_all_delegates_in_one_transaction.json
+++ b/protocol-specs/generator_outputs/block_processing_votes/invalid_block_processing_vote_all_delegates_in_one_transaction.json
@@ -19,19 +19,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -41,6 +28,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -175,15 +175,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -344,8 +344,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -359,19 +359,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -381,6 +368,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -515,15 +515,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -684,8 +684,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -699,19 +699,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -721,6 +708,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -855,15 +855,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1024,8 +1024,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -1039,19 +1039,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -1061,6 +1048,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1195,15 +1195,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1364,8 +1364,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{
@@ -3499,19 +3499,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -3521,6 +3508,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3655,15 +3655,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3824,8 +3824,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -3839,19 +3839,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -3861,6 +3848,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3995,15 +3995,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4164,8 +4164,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -4179,19 +4179,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -4201,6 +4188,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4335,15 +4335,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4504,8 +4504,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -4519,19 +4519,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -4541,6 +4528,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4675,15 +4675,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4844,8 +4844,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{

--- a/protocol-specs/generator_outputs/block_processing_votes/invalid_block_processing_vote_already_voted_delegate.json
+++ b/protocol-specs/generator_outputs/block_processing_votes/invalid_block_processing_vote_already_voted_delegate.json
@@ -19,19 +19,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -41,6 +28,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -175,15 +175,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -344,8 +344,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -359,19 +359,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -381,6 +368,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -515,15 +515,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -684,8 +684,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -699,19 +699,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -721,6 +708,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -855,15 +855,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1024,8 +1024,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -1039,19 +1039,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -1061,6 +1048,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1195,15 +1195,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1364,8 +1364,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{
@@ -3399,19 +3399,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -3421,6 +3408,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3555,15 +3555,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3724,8 +3724,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -3739,19 +3739,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -3761,6 +3748,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3895,15 +3895,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4064,8 +4064,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -4079,19 +4079,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -4101,6 +4088,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4235,15 +4235,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4404,8 +4404,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -4419,19 +4419,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -4441,6 +4428,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4575,15 +4575,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4744,8 +4744,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{

--- a/protocol-specs/generator_outputs/block_processing_votes/invalid_block_processing_vote_no_delegate.json
+++ b/protocol-specs/generator_outputs/block_processing_votes/invalid_block_processing_vote_no_delegate.json
@@ -19,19 +19,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -41,6 +28,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -175,15 +175,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -344,8 +344,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -359,19 +359,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -381,6 +368,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -515,15 +515,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -684,8 +684,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -699,19 +699,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -721,6 +708,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -855,15 +855,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1024,8 +1024,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -1039,19 +1039,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -1061,6 +1048,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1195,15 +1195,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1364,8 +1364,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{
@@ -3363,7 +3363,7 @@
 				"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 				"transactions": [
 					{
-						"id": "6405055682160148916",
+						"id": "16096788547053154961",
 						"amount": "0",
 						"type": 3,
 						"timestamp": 102702700,
@@ -3371,17 +3371,17 @@
 						"senderId": "2222471382442610527L",
 						"recipientId": "",
 						"fee": "100000000",
-						"signature": "66b2b20bb9b891e5ae8c517b345ceafe1ae55693ae78f6a9a48943d4e8c57ec967b2320b0121a1078cdc2ff6d3622278765396b1a6755b7b6a21d5dddc191103",
+						"signature": "76c9dfa5784ed35513eadb84e2c4b08e9ee0a2f4e016ee0bdedc4854eb42473ae638cd7e1cc3806135dd881f853286b92087337132414e0ee606c676cde7d105",
 						"signatures": [],
 						"asset": {
 							"votes": [
-								"+b286fad526bfe9b2ef55f9d394ee8032b9102743aa8b220c338ebc8b677bef43"
+								"+b2b98de6f89d708a11af0bf5866db860f0889161e27af5b6bd7bbc9ad2cd797b"
 							]
 						}
 					}
 				],
-				"payloadHash": "b4c1c01d3554e358b9062445f09662c7cbdd032a46aba7d17cdf0cf329a084e5",
-				"blockSignature": "30093d5565d09c926948f8a352e74b873f68f16a716319b25125ab4993e3d0eb51d68a73dd83ab4f74ce001015e1f4aeb8eaf81299694edfc17c0195424ac906",
+				"payloadHash": "91f2ad2be64763dfb1adac92d20eb1e5c12acde310a8e1ea5130abb0f507edde",
+				"blockSignature": "723bca3baa680dc93dec33fa13011b8d978fbfacc54ec37a47f2f4367c5a7312604f23487dd0955ef4cfc7854f899f81a912cc16cddf2ac0e8eacc4120795f05",
 				"height": 7
 			}
 		],
@@ -3399,19 +3399,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -3421,6 +3408,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3555,15 +3555,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3724,8 +3724,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -3739,19 +3739,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -3761,6 +3748,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3895,15 +3895,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4064,8 +4064,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -4079,19 +4079,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -4101,6 +4088,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4235,15 +4235,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4404,8 +4404,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -4419,19 +4419,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -4441,6 +4428,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4575,15 +4575,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4744,8 +4744,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{

--- a/protocol-specs/generator_outputs/block_processing_votes/valid_block_processing_vote_all_delegates.json
+++ b/protocol-specs/generator_outputs/block_processing_votes/valid_block_processing_vote_all_delegates.json
@@ -19,19 +19,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -41,6 +28,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -175,15 +175,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -344,8 +344,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -359,19 +359,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -381,6 +368,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -515,15 +515,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -684,8 +684,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -699,19 +699,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -721,6 +708,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -855,15 +855,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1024,8 +1024,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -1039,19 +1039,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -1061,6 +1048,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1195,15 +1195,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -1364,8 +1364,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{
@@ -3547,19 +3547,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "4436319808547332365",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "11595026565287740051L",
-							"fee": "10000000",
-							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "17408074499624623184",
 							"amount": "9900000000",
 							"type": 0,
@@ -3569,6 +3556,19 @@
 							"recipientId": "2003981962043442425L",
 							"fee": "10000000",
 							"signature": "e24698c4dbc04259bc0176f459e69a67024e023c01e96b692f4817e5372ea81d7babebdc945cd825cdbc86bdf6e9eb473e28fd5426b560e9c1c5bd4b6e59a30b",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "18214470982603750134",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "18181157191600196376L",
+							"fee": "10000000",
+							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3703,15 +3703,15 @@
 							"asset": {}
 						},
 						{
-							"id": "18214470982603750134",
+							"id": "4436319808547332365",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "18181157191600196376L",
+							"recipientId": "11595026565287740051L",
 							"fee": "10000000",
-							"signature": "a63c05c92e966bee1a23861bc7ebe18e6021f90beadea5ad222934d728a709f6140dc01dfe686bc2cb3c7d7608f535f16d26388a44f860fcd0d860cf94c6c90a",
+							"signature": "20fd5fd97ef1dc5f41b04072ace7c5bf9050a334737ac01671eb1bcc60b8cbb9ea7802259f9de8d133c8c170c2494a39dc31a9a12437a243dfad74ade9466d0b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -3872,8 +3872,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "61b97f6bf8e9b5bfef5843436e779e0dcd2a79164d5e64efb64d350f7c59f635",
-					"blockSignature": "8717878ba59b000238515f123f5ccabea8bc7d22a3958bcdb6ea0915a6ee8a5754587c8a8ba3af6ca353a8c311f6145f573ed1f7739943ec4dba6ac7bb8a9d0a",
+					"payloadHash": "14d44ba469eada0eb841a9880ae043b11fc65c8ade1ac6ea177a9bc92bfd8743",
+					"blockSignature": "4410a381b8ff4ffee6085956da481db8d6932b9c7d12f5578eea9d01364a49ba0f16b98e10f19f07c3481249dfd555f1c14a73177fccb7062d169abc7b0de20b",
 					"height": 2
 				},
 				{
@@ -3887,19 +3887,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "13782360517805908541",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "6214967903930344618L",
-							"fee": "10000000",
-							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "8025799438374852533",
 							"amount": "9900000000",
 							"type": 0,
@@ -3909,6 +3896,19 @@
 							"recipientId": "11231201826468807624L",
 							"fee": "10000000",
 							"signature": "5b74278a1e0a776bc0554848b581b20a51dfeb7dfaca0a66e052ed6f8a650b6bdf2b279bf63ca86cb9a46d03df93a6df9f38ec0bbc93725bedef946b11787f02",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "14272182229476900895",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "9528507096611161860L",
+							"fee": "10000000",
+							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4043,15 +4043,15 @@
 							"asset": {}
 						},
 						{
-							"id": "14272182229476900895",
+							"id": "13782360517805908541",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "9528507096611161860L",
+							"recipientId": "6214967903930344618L",
 							"fee": "10000000",
-							"signature": "e23287eb64154d806bbfcdf490b5fd1a2f0905e8349cb77829c50cd953b8a5874fe83b89605783167e5990421168403964fb4ac78b2695e7b974f12f66ae550c",
+							"signature": "5f1a0da17ccb5528dd7b14633edfc10129e0b90bf12b66fe28183ec8536846bd4d77cce07a8fd5ffa24977afd6a2c4472e7f6224731d7ecc82054ca2b345740d",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4212,8 +4212,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "b481e6800f96a22fd6c7a45cf179b0c10a89ea9cdecedd5bd6077b67dfed4b04",
-					"blockSignature": "883118e15bfbe30d6b47a6eaa99eb6f46515499adc9fb582c8bda1c56295f4e8154c86d1b41ee241d8f0f2d2217312c202aa767218872d9eba56c90026e75c04",
+					"payloadHash": "67397a64ceb1a63a922c05cbb30314b74ebc3f0543f680a8112aefc7de9e28a1",
+					"blockSignature": "d8b44216b45d49827bed075134960c64de6483d177cc7a6b427657baa8ead24b09380fa46e30a1edc9b81ed4bfc637b5193d83261a20f9a1ddbcc38afc20710e",
 					"height": 3
 				},
 				{
@@ -4227,19 +4227,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10633224528200373805",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "3038510178697972178L",
-							"fee": "10000000",
-							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "11696576473815207568",
 							"amount": "9900000000",
 							"type": 0,
@@ -4249,6 +4236,19 @@
 							"recipientId": "1081724521551096934L",
 							"fee": "10000000",
 							"signature": "3caa9eaf46f2d49ff4decac3b72035bc5c48f94e2d128edc34e22c5cf58099d653be989e6c9f626a73ac072c7258b92a8c07a56b359cc603dd8d6dafc879bf0e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "17236572932986835261",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "11776976371460504977L",
+							"fee": "10000000",
+							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4383,15 +4383,15 @@
 							"asset": {}
 						},
 						{
-							"id": "17236572932986835261",
+							"id": "10633224528200373805",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "11776976371460504977L",
+							"recipientId": "3038510178697972178L",
 							"fee": "10000000",
-							"signature": "9a761f32980dc9ba7b808de9a2fc8bf42a4e1ec421a43cb2580e637575266a5a489c2019576eec808472c2e70d83071ce4298c30c3406a28c88d9a795b36e10b",
+							"signature": "893c37cb6ad3f508ba36772aac4444ad49147b830ad5f63c6711a8d8f36790e6c8302c9899d14c5f8fcbfbb33e6cc2a2209b97a24095b76b0eb19d66bb46450e",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4552,8 +4552,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "248f775e21b32c76b7e0615743a714aba2051a5918da9cfe6033ff9841f348c5",
-					"blockSignature": "481921b729189d7739f8052e2a59036375cf8c4d71037c5f05058758988cf3412699daeac0ce25c09d6f21ce04a1727b56b6bd48c2c5dc1476a90cacb7538e0b",
+					"payloadHash": "a08bae56b0612aff995c55d8a895c63c6c570e47937c89d06b392708410292ca",
+					"blockSignature": "dc01979d4dc4ffdf59b9845b1173342ec7f61723d2306ac9a76748f44e8d32b7e4e5b3d3a70bb037dd809fc455a49733c4d53c0879317c41419359135fdcf004",
 					"height": 4
 				},
 				{
@@ -4567,19 +4567,6 @@
 					"generatorPublicKey": "e6d075e3e396673c853210f74f8fe6db5e814c304bb9cd7f362018881a21f76c",
 					"transactions": [
 						{
-							"id": "10488150576653287671",
-							"amount": "9900000000",
-							"type": 0,
-							"timestamp": 102702700,
-							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
-							"senderId": "16313739661670634666L",
-							"recipientId": "7806545753492919148L",
-							"fee": "10000000",
-							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
-							"signatures": [],
-							"asset": {}
-						},
-						{
 							"id": "7752400059973634657",
 							"amount": "9900000000",
 							"type": 0,
@@ -4589,6 +4576,19 @@
 							"recipientId": "309766985700168161L",
 							"fee": "10000000",
 							"signature": "cb87f949c1def0964006a4c534ead0deb95c79f58f5c4508d1b8c5a4c768d8bd467fe0ca37a898ffbd0874a3b7b3e8ec9845278c63359a2eb881552da4a0e30e",
+							"signatures": [],
+							"asset": {}
+						},
+						{
+							"id": "3258995506575428122",
+							"amount": "9900000000",
+							"type": 0,
+							"timestamp": 102702700,
+							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
+							"senderId": "16313739661670634666L",
+							"recipientId": "2185933284430885504L",
+							"fee": "10000000",
+							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4723,15 +4723,15 @@
 							"asset": {}
 						},
 						{
-							"id": "3258995506575428122",
+							"id": "10488150576653287671",
 							"amount": "9900000000",
 							"type": 0,
 							"timestamp": 102702700,
 							"senderPublicKey": "c094ebee7ec0c50ebee32918655e089f6e1a604b83bcaa760293c61e0f18ab6f",
 							"senderId": "16313739661670634666L",
-							"recipientId": "2185933284430885504L",
+							"recipientId": "7806545753492919148L",
 							"fee": "10000000",
-							"signature": "13d8be91b1a00fe96dffeaf5b1d0bb8988cb0ec125edb6ca1f3acf23d78f804e345cf929b6e04b2f3fa4ed65a6b696030e6db66105154c0b9ecbaed7f213f20a",
+							"signature": "eec66000a042dbb85def2cd8cc029bdbca644d924bdd8ff848ac699609a81a470c755d4d094f9d8bcdf7d7524ff2e3db0c9547380e0252878248fda4e709a306",
 							"signatures": [],
 							"asset": {}
 						},
@@ -4892,8 +4892,8 @@
 							"asset": {}
 						}
 					],
-					"payloadHash": "4eb08d27f572b4e49b02556f2d7f2acbdc5e5cc8bdb45a6dc5c7590c3e636094",
-					"blockSignature": "4cb2e790e7c8e5f69f2f8e4a8f1feb24ddacd235a27a7d61cf11798743a85f8cb615cd55c7134f99dc59e3dec5dd6cab3e9c3cc89bf25401ae8b42b1503dd806",
+					"payloadHash": "70f0c3ee125d78c5a9eca70a3ca334be0ed8739aad1bab555f0adb381239cc5b",
+					"blockSignature": "123e74ede8c143578a4c37a9c8dc41c08385369261163d16638e3068ab25223debc9ba073af47f9f5875f726ba0acc962e7ade23b381c8d2e9f30de5d4cd350f",
 					"height": 5
 				},
 				{

--- a/protocol-specs/generators/block_processing_votes/index.js
+++ b/protocol-specs/generators/block_processing_votes/index.js
@@ -284,8 +284,17 @@ const generateTestCasesInvalidBlockVoteNoDelegateTx = () => {
 
 	// Forge the block so as to have all delegates in the store
 	chainStateBuilder.forge();
-
-	const notAdelegate = ChainStateBuilder.createAccount();
+	// this is ok to not be in the input for the spec as is just a random/invalid account
+	const notAdelegate = {
+		passphrase:
+			'finish key enact banner crouch rice legal scan palm noise gain claw',
+		privateKey:
+			'223a1d5dafe7bb019855929b010ddebc3326ffbf0ddb4dc32779d0b41e47f9f1b2b98de6f89d708a11af0bf5866db860f0889161e27af5b6bd7bbc9ad2cd797b',
+		publicKey:
+			'b2b98de6f89d708a11af0bf5866db860f0889161e27af5b6bd7bbc9ad2cd797b',
+		address: '4786496342079411836L',
+		balance: '0',
+	};
 	// Vote for an account is not a delegate
 	chainStateBuilder
 		.castVotesFrom('2222471382442610527L')


### PR DESCRIPTION
# What was the problem?

- votes  protocol spec generator was not generating constant output
- updated output of  protocol spec votes generator was not committed 

### How did I solve it?

- By fixing the generator
- By adding the updated generator outputs 

### How to manually test it?

run `node generators/block_processing_votes/index.js` and there should not be diff against the git files

### Review checklist

- [ ] The PR resolves #4686
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
