### PR TITLE
Update lisk-bft to use lisk-dpos to require as module - Closes #4701

### DIFF
--- a/elements/lisk-bft/test/bft_fork_choice_rules_protocol_specs.spec.js
+++ b/elements/lisk-bft/test/bft_fork_choice_rules_protocol_specs.spec.js
@@ -15,9 +15,14 @@
 'use strict';
 
 const forkChoiceSpecs = require('./bft_specs/bft_fork_choice_rules.json');
-const { Slots } = require('../../../../../../../src/modules/chain/dpos');
-const { BFT } = require('../../../../../../../src/modules/chain/bft');
-const { constants } = require('../../../../../../utils');
+const { Slots } = require('@liskhq/lisk-dpos');
+const { BFT } = require('../src/bft');
+
+const constants = {
+	ACTIVE_DELEGATES: 101,
+	EPOCH_TIME: '2016-05-24T17:00:00.000Z',
+	BLOCK_TIME: 10,
+};
 
 describe('bft', () => {
 	describe('forkChoice', () => {


### PR DESCRIPTION
### What was the problem?
The bft test was broken
### How did I solve it?
Updated the test to require properly
### How to manually test it?
`npm run test` inside bft element
### Review checklist

- [ ] The PR resolves #4701 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
