### PR TITLE
Allow /delegates endpoint to accept voteWeight as sort parameter - Closes #4715, #4716

### DIFF
--- a/elements/lisk-api-client/src/resources/delegates.ts
+++ b/elements/lisk-api-client/src/resources/delegates.ts
@@ -31,7 +31,7 @@ export class DelegatesResource extends APIResource {
 
 		this.get = apiMethod({
 			defaultData: {
-				sort: 'username:asc',
+				sort: 'voteWeight:desc',
 			},
 			method: GET,
 		}).bind(this);
@@ -39,7 +39,7 @@ export class DelegatesResource extends APIResource {
 		this.getStandby = apiMethod({
 			defaultData: {
 				offset: 101,
-				sort: 'username:asc',
+				sort: 'voteWeight:desc',
 			},
 			method: GET,
 		}).bind(this);

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -585,7 +585,7 @@ paths:
             - producedBlocks:desc
             - voteWeight:asc
             - voteWeight:desc
-          default: username:asc
+          default: voteWeight:desc
       responses:
         200:
           description: Search results matching criteria

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -583,6 +583,8 @@ paths:
             - missedBlocks:desc
             - producedBlocks:asc
             - producedBlocks:desc
+            - voteWeight:asc
+            - voteWeight:desc
           default: username:asc
       responses:
         200:

--- a/framework/test/mocha/functional/http/get/delegates.js
+++ b/framework/test/mocha/functional/http/get/delegates.js
@@ -515,6 +515,28 @@ describe('GET /delegates', () => {
 					});
 			});
 
+			it('using sort="voteWeight:asc" should sort results in ascending order', async () => {
+				return delegatesEndpoint
+					.makeRequest({ sort: 'voteWeight:asc' }, 200)
+					.then(res => {
+						expect(_.map(res.data, 'voteWeight').sort()).to.eql(
+							_.map(res.data, 'voteWeight'),
+						);
+					});
+			});
+
+			it('using sort="voteWeight:desc" should sort results in descending order', async () => {
+				return delegatesEndpoint
+					.makeRequest({ sort: 'voteWeight:desc' }, 200)
+					.then(res => {
+						expect(
+							_.map(res.data, 'voteWeight')
+								.sort()
+								.reverse(),
+						).to.eql(_.map(res.data, 'voteWeight'));
+					});
+			});
+
 			it('using sort with any of sort fields should not place NULLs first', async () => {
 				const delegatesSortFields = [
 					'username',


### PR DESCRIPTION
### What was the problem?

The `voteWeight` sort parameter was not supported by `/api/delegates` endpoint. Also this default value support was added to the `lisk-api-client`

### How did I solve it?

Added the sort parameter support for `voteWeight` and updated the `lisk-api-client`

### How to manually test it?

Run functional tests for `http/get/delegates`

### Review checklist

- [ ] The PR resolves #4715, #4716
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
