### PR TITLE
Fix unique constraints - Closes #4668

### DIFF
--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -223,11 +223,13 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 			({ block, lastBlock }) => this.bftModule.forkChoice(block, lastBlock), // validate common block header
 		]);
 
-		this.verify.pipe([({ block }) => this.bftModule.verifyNewBlock(block)]);
-
-		this.apply.pipe([
+		this.verify.pipe([
+			({ block }) => this.bftModule.verifyNewBlock(block),
 			({ block, stateStore, skipExistingCheck }) =>
 				this.blocksModule.verify(block, stateStore, { skipExistingCheck }),
+		]);
+
+		this.apply.pipe([
 			({ block, stateStore }) => this.blocksModule.apply(block, stateStore),
 			({ block, tx }) => this.dposModule.apply(block, { tx }),
 			async ({ block, tx, stateStore }) => {

--- a/framework/src/modules/chain/processor/processor.js
+++ b/framework/src/modules/chain/processor/processor.js
@@ -304,6 +304,11 @@ class Processor {
 				});
 			}
 
+			if (!skipSave) {
+				// TODO: After moving everything to state store, save should get the state store and finalize the state store
+				await this.blocksModule.save(blockJSON, tx);
+			}
+
 			// Apply should always be executed after save as it performs database calculations
 			// i.e. Dpos.apply expects to have this processing block in the database
 			await processor.apply.run({
@@ -313,11 +318,6 @@ class Processor {
 				stateStore,
 				tx,
 			});
-
-			if (!skipSave) {
-				// TODO: After moving everything to state store, save should get the state store and finalize the state store
-				await this.blocksModule.save(blockJSON, tx);
-			}
 
 			if (removeFromTempTable) {
 				await this.blocksModule.removeBlockFromTempTable(block.id, tx);

--- a/framework/test/jest/unit/specs/modules/chain/dpos/apply.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/dpos/apply.spec.js
@@ -307,7 +307,6 @@ describe('dpos.apply()', () => {
 				reward: rewardPerDelegate,
 				height: 809 + i,
 			}));
-
 			forgedBlocks.splice(forgedBlocks.length - 1);
 
 			lastBlockOfTheRoundNine = {

--- a/framework/test/jest/unit/specs/modules/chain/processor/processor.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/processor/processor.spec.js
@@ -487,17 +487,15 @@ describe('processor', () => {
 			});
 
 			it('should emit newBlock event for the block', async () => {
-				expect(channelStub.publish).toHaveBeenCalledWith(
-					'chain:processor:newBlock',
-					{ block: blockV0 },
-				);
+				expect(
+					channelStub.publish,
+				).toHaveBeenCalledWith('chain:processor:newBlock', { block: blockV0 });
 			});
 
 			it('should emit broadcast event for the block', async () => {
-				expect(channelStub.publish).toHaveBeenCalledWith(
-					'chain:processor:broadcast',
-					{ block: blockV0 },
-				);
+				expect(
+					channelStub.publish,
+				).toHaveBeenCalledWith('chain:processor:broadcast', { block: blockV0 });
 			});
 		});
 
@@ -710,17 +708,15 @@ describe('processor', () => {
 			});
 
 			it('should broadcast with the block', async () => {
-				expect(channelStub.publish).toHaveBeenCalledWith(
-					'chain:processor:broadcast',
-					{ block: blockV0 },
-				);
+				expect(
+					channelStub.publish,
+				).toHaveBeenCalledWith('chain:processor:broadcast', { block: blockV0 });
 			});
 
 			it('should emit newBlock event with the block', async () => {
-				expect(channelStub.publish).toHaveBeenCalledWith(
-					'chain:processor:newBlock',
-					{ block: blockV0 },
-				);
+				expect(
+					channelStub.publish,
+				).toHaveBeenCalledWith('chain:processor:newBlock', { block: blockV0 });
 			});
 		});
 	});
@@ -990,7 +986,7 @@ describe('processor', () => {
 
 			it('should apply the block', async () => {
 				applySteps.forEach(step => {
-					expect(step).toHaveBeenCalled();
+					expect(step).not.toHaveBeenCalled();
 				});
 			});
 


### PR DESCRIPTION
### What was the problem?
Existence check was done after the `save` execution which results in DB error if the block contains duplicate transactions.
The original fix was to change the order of the execution, but that will result in the invalid account state due to inconsistent use of the state store if delegate who receives reward in the end of the block also gets mutated by the transaction in the block.

### How did I solve it?
Put the execution order to the original steps, but move the existence check to the verify pipeline where it should be. It is executed before the saving step.

### How to manually test it?
- Send the block with conflicting transactions

### Review checklist

- [ ] The PR resolves #4668 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
