### PR TITLE
One usage of BigNum is still present  - Closes #4725

### DIFF
--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -193,7 +193,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 					block.height,
 				);
 				if (!this.bftModule.isBFTProtocolCompliant(block)) {
-					expectedReward *= 0.25;
+					expectedReward /= BigInt(4);
 				}
 				this.blocksModule.validateBlockHeader(
 					block,
@@ -360,7 +360,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 
 		// Reduce reward based on BFT rules
 		if (!this.bftModule.isBFTProtocolCompliant(block)) {
-			block.reward = block.reward.times(0.25);
+			block.reward /= BigInt(4);
 		}
 
 		return {


### PR DESCRIPTION
# What was the problem?

A calculation in block processor v2 was trying to use a method from BigNum that was replaced by BigInt

### How did I solve it?

By replacing the method call and operation with a BigInt operation

### How to manually test it?

- Build should be green

### Review checklist

- [ ] The PR resolves #4725
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
