### PR TITLE
BFT fails, forging stops when restarting a node - Closes #4727

### DIFF
--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -273,7 +273,8 @@ export class BFT extends EventEmitter {
 
 		const rows = await this.blockEntity.get(
 			{ height_gte: fromHeight, height_lte: tillHeight },
-			{ limit: undefined, sort: sortOrder },
+			// tslint:disable-next-line no-null-keyword
+			{ limit: null, sort: sortOrder },
 		);
 
 		const BLOCK_VERSION2 = 2;

--- a/elements/lisk-bft/test/unit/bft.spec.ts
+++ b/elements/lisk-bft/test/unit/bft.spec.ts
@@ -470,7 +470,7 @@ describe('bft', () => {
 				expect(storageMock.entities.Block.get).toHaveBeenCalledTimes(1);
 				expect(storageMock.entities.Block.get).toHaveBeenLastCalledWith(
 					{ height_lte: 400, height_gte: 450 - activeDelegates * 2 },
-					{ limit: undefined, sort: 'height:desc' },
+					{ limit: null, sort: 'height:desc' },
 				);
 			});
 

--- a/framework/test/jest/unit/specs/modules/chain/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.js
@@ -195,7 +195,7 @@ describe('block_synchronization_mechanism', () => {
 					height_gte: genesisBlockDevnet.height,
 					height_lte: lastBlock.height,
 				},
-				{ limit: undefined, sort: 'height:asc' },
+				{ limit: null, sort: 'height:asc' },
 			)
 			.mockResolvedValue([genesisBlockDevnet, lastBlock]);
 
@@ -652,7 +652,7 @@ describe('block_synchronization_mechanism', () => {
 								height_gte: expect.any(Number),
 								height_lte: expect.any(Number),
 							}),
-							{ limit: undefined, sort: 'height:asc' },
+							{ limit: null, sort: 'height:asc' },
 						)
 						.mockResolvedValue([lastBlock]);
 

--- a/framework/test/jest/unit/specs/modules/chain/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.js
@@ -223,7 +223,7 @@ describe('fast_chain_switching_mechanism', () => {
 						height_gte: genesisBlockDevnet.height,
 						height_lte: lastBlock.height,
 					},
-					{ limit: undefined, sort: 'height:asc' },
+					{ limit: null, sort: 'height:asc' },
 				)
 				.mockResolvedValue([genesisBlockDevnet, lastBlock]);
 
@@ -438,7 +438,7 @@ describe('fast_chain_switching_mechanism', () => {
 							height_gte: expect.any(Number),
 							height_lte: expect.any(Number),
 						}),
-						{ limit: undefined, sort: 'height:asc' },
+						{ limit: null, sort: 'height:asc' },
 					)
 					.mockResolvedValue([lastBlock]);
 


### PR DESCRIPTION
### What was the problem?

There was a behavioural difference of using `null` and `undefined` with `loadash.defaults` function. 

```
> const _ = require('lodash')
> _.defaults({}, {limit: null}, {limit: 10})
{ limit: null }
> _.defaults({}, {limit: undefined}, {limit: 10})
{ limit: 10 }
``` 

There was a TSLint Rule to prefer not use `null`, so why it was changed to `undefined`. But since this behaviour is integral to the storage, so we should keep using `null` and disabling tslint rule. 

### How did I solve it?

Added tslint disable line and reverted change of `undefined` to `null`. 

### How to manually test it?

Run all tests. 

### Review checklist

- [ ] The PR resolves #4727
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
