### PR TITLE
Fix commander coverage - Closes #4753

### DIFF
--- a/commander/.nycrc
+++ b/commander/.nycrc
@@ -1,0 +1,4 @@
+{
+	"exclude": ["test/**", "**/*.d.ts"],
+	"extension": [".ts"]
+}

--- a/commander/test/setup.ts
+++ b/commander/test/setup.ts
@@ -50,6 +50,6 @@ Assertion.addMethod('customError', function handleAssert(
 
 [sinonChai, chaiAsPromised].forEach(chai.use);
 
-global.sandbox = sinon.sandbox.create({
+global.sandbox = sinon.createSandbox({
 	useFakeTimers: true,
 });

--- a/commander/test/tsconfig.json
+++ b/commander/test/tsconfig.json
@@ -4,12 +4,11 @@
 		"baseUrl": ".",
 		"noEmit": true,
 		"typeRoots": [
-			"../../types",
 			"../types",
 			"../node_modules/@types",
 			"../../node_modules/@types"
 		]
 	},
 	"references": [{ "path": ".." }],
-	"include": ["./**/*", "../../types/**/*", "../types/**/*", "../src/**/*"]
+	"include": ["./**/*", "../types/**/*", "../src/**/*"]
 }

--- a/commander/test/utils/core/pm2.ts
+++ b/commander/test/utils/core/pm2.ts
@@ -47,7 +47,7 @@ describe('pm2 node utils', () => {
 			sandbox.stub(pm2, 'stop').yields(null, 'stopped');
 			sandbox
 				.stub(fsExtra, 'readJson')
-				.resolves({ apps: [{ script: 'src/index.js' }] });
+				.resolves({ apps: [{ script: 'src/index.js' }] } as any);
 		});
 
 		it('should register an application', async () => {

--- a/commander/test/utils/cryptography.ts
+++ b/commander/test/utils/cryptography.ts
@@ -31,7 +31,7 @@ describe('crypto utils', () => {
 		beforeEach(() => {
 			sandbox
 				.stub(cryptographyModule, 'encryptMessageWithPassphrase')
-				.returns(result);
+				.returns(result as any);
 			return Promise.resolve();
 		});
 
@@ -223,7 +223,7 @@ describe('crypto utils', () => {
 		beforeEach(() => {
 			return sandbox
 				.stub(cryptographyModule, 'signMessageWithPassphrase')
-				.returns(result);
+				.returns(result as any);
 		});
 
 		it('singed message should equal to the result of signMessageWithPassphrase', () => {

--- a/commander/test/utils/helpers.ts
+++ b/commander/test/utils/helpers.ts
@@ -123,7 +123,7 @@ describe('helpers utils', () => {
 
 		it('should throw a non-EPIPE error', () => {
 			const message = 'some error';
-			return expect(handleEPIPE.bind(null, new Error(message))).to.throw(
+			return expect(handleEPIPE.bind(null, new Error(message) as any)).to.throw(
 				message,
 			);
 		});

--- a/commander/test/utils/input/index.ts
+++ b/commander/test/utils/input/index.ts
@@ -50,7 +50,7 @@ describe('input utils', () => {
 				data: undefined,
 			});
 			sandbox.stub(inputUtils, 'getPassphrase');
-			sandbox.stub(console, 'warn').returns('');
+			sandbox.stub(console, 'warn');
 			return sandbox.stub(inputUtils, 'getData');
 		});
 

--- a/commander/test/utils/input/utils.ts
+++ b/commander/test/utils/input/utils.ts
@@ -49,7 +49,7 @@ describe('input/utils utils', () => {
 		beforeEach(() => {
 			createInterfaceStub = sandbox
 				.stub(readline, 'createInterface')
-				.returns(createFakeInterface(stdInContents));
+				.returns(createFakeInterface(stdInContents) as any);
 			return Promise.resolve();
 		});
 
@@ -299,7 +299,7 @@ describe('input/utils utils', () => {
 					(type: string, callback: Function) =>
 						type === 'error' && callback(error),
 				);
-				return sandbox.stub(fs, 'createReadStream').returns(streamStub);
+				return sandbox.stub(fs, 'createReadStream').returns(streamStub as any);
 			});
 
 			it('should throw an error', () => {
@@ -319,7 +319,7 @@ describe('input/utils utils', () => {
 					(type: string, callback: Function) =>
 						type === 'error' && callback(error),
 				);
-				return sandbox.stub(fs, 'createReadStream').returns(streamStub);
+				return sandbox.stub(fs, 'createReadStream').returns(streamStub as any);
 			});
 
 			it('should throw an error', () => {
@@ -339,7 +339,7 @@ describe('input/utils utils', () => {
 					(type: string, callback: Function) =>
 						type === 'error' && callback(error),
 				);
-				return sandbox.stub(fs, 'createReadStream').returns(streamStub);
+				return sandbox.stub(fs, 'createReadStream').returns(streamStub as any);
 			});
 
 			it('should throw an error when file does not exist', () => {
@@ -354,7 +354,7 @@ describe('input/utils utils', () => {
 			beforeEach(() => {
 				return sandbox
 					.stub(readline, 'createInterface')
-					.returns(createFakeInterface(fileContents));
+					.returns(createFakeInterface(fileContents) as any);
 			});
 
 			it('should resolve to the fileContents', () => {
@@ -386,7 +386,7 @@ describe('input/utils utils', () => {
 		beforeEach(() => {
 			return sandbox
 				.stub(readline, 'createInterface')
-				.returns(createFakeInterface(password));
+				.returns(createFakeInterface(password) as any);
 		});
 
 		it('should get from env', () => {

--- a/commander/test/utils/print.ts
+++ b/commander/test/utils/print.ts
@@ -41,7 +41,7 @@ describe('print utils', () => {
 	type Printer = (result: ReadonlyArray<StringMap> | StringMap) => void;
 
 	beforeEach(() => {
-		sandbox.stub(tablifyUtil, 'tablify').returns(tablifyResult);
+		sandbox.stub(tablifyUtil, 'tablify').returns(tablifyResult as any);
 		sandbox.stub(JSON, 'stringify').returns(stringifyResult);
 		return Promise.resolve();
 	});

--- a/commander/tsconfig.json
+++ b/commander/tsconfig.json
@@ -7,23 +7,10 @@
 		"importHelpers": true,
 		"rootDir": "src",
 		"outDir": "dist",
-		"types": [
-			"bip39",
-			"chai",
-			"chai-as-promised",
-			"expect",
-			"fs-extra",
-			"inquirer",
-			"jquery",
-			"listr",
-			"lockfile",
-			"mocha",
-			"node",
-			"semver",
-			"sinon",
-			"sinon-chai",
-			"strip-ansi",
-			"tar"
+		"typeRoots": [
+			"../types",
+			"../node_modules/@types",
+			"../../node_modules/@types"
 		]
 	},
 	"include": ["src/**/*", "types/**/*", "../types/**/*"],

--- a/commander/types/chai/index.d.ts
+++ b/commander/types/chai/index.d.ts
@@ -1,0 +1,24 @@
+/* tslint:disable:callable-types no-any no-method-signature readonly-keyword no-mixed-interface */
+declare module 'chai' {
+	global {
+		export namespace Chai {
+			interface ChaiStatic {
+				_obj: any;
+				Assertion: {
+					new (value: any): Assertion;
+					addProperty(name: string, handler: () => void): void;
+					addMethod(name: string, handler: (val: any) => void): void;
+				};
+			}
+			interface Assert {
+				(expression: any, message?: string, messageNegative?: string): void;
+			}
+			export interface TypeComparison {
+				hexString: Assertion;
+				integer: Assertion;
+				customError: (obj?: Error | typeof Error | string) => Assertion;
+				matchAny: Assertion;
+			}
+		}
+	}
+}

--- a/commander/types/globals/index.d.ts
+++ b/commander/types/globals/index.d.ts
@@ -1,0 +1,13 @@
+/* tslint:disable:readonly-keyword */
+/// <reference types="sinon" />
+
+declare global {
+	export namespace NodeJS {
+		export interface Global {
+			sandbox: sinon.SinonSandbox;
+		}
+	}
+	var sandbox: sinon.SinonSandbox;
+}
+
+export {};


### PR DESCRIPTION
### What was the problem?
Commander was not showing the coverage, which was caused by missing `.nycrc`

### How did I solve it?
- Add missing `.nycrc`
- Fix the type checks
- Use update interface for sinon

### How to manually test it?
Coverage should include commander

### Review checklist

- [ ] The PR resolves #4753 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
