### PR TITLE
Update crypto not to call fast if slow is specified - Closes #4759

### DIFF
--- a/elements/lisk-cryptography/src/nacl/index.ts
+++ b/elements/lisk-cryptography/src/nacl/index.ts
@@ -14,20 +14,16 @@
  */
 import { NaclInterface } from './nacl_types';
 
-// tslint:disable-next-line no-let
-let lib: NaclInterface;
+// tslint:disable-next-line no-let no-require-imports no-var-requires
+let lib: NaclInterface = require('./slow');
 
 try {
-	if (process.env.NACL_FAST === 'disable') {
-		throw new Error('Use tweetnacl');
+	if (process.env.NACL_FAST !== 'disable') {
+		// tslint:disable-next-line no-var-requires no-require-imports
+		lib = require('./fast');
 	}
-	// Require used for conditional importing
-	// tslint:disable-next-line no-var-requires no-require-imports
-	lib = require('./fast');
 } catch (err) {
 	process.env.NACL_FAST = 'disable';
-	// tslint:disable-next-line no-var-requires no-require-imports
-	lib = require('./slow');
 }
 
 export const NACL_SIGN_PUBLICKEY_LENGTH = 32;


### PR DESCRIPTION
### What was the problem?
Webpack build process did not allow to catch error

### How did I solve it?
If the `process.env.NACL_FAST === disable`, then it doesn't read the `fast` module

### How to manually test it?
Try to build with webpack with this change

### Review checklist

- [ ] The PR resolves #4759 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
