### PR TITLE
Remove restart from FCS - Closes #4761

### DIFF
--- a/framework/src/modules/chain/synchronizer/fast_chain_switching_mechanism.js
+++ b/framework/src/modules/chain/synchronizer/fast_chain_switching_mechanism.js
@@ -22,7 +22,6 @@ const {
 } = require('./utils');
 const {
 	ApplyPenaltyAndAbortError,
-	ApplyPenaltyAndRestartError,
 	AbortError,
 	BlockProcessingError,
 	RestartError,
@@ -66,14 +65,6 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 			await this._validateBlocks(blocks, highestCommonBlock, peerId);
 			await this._switchChain(highestCommonBlock, blocks, peerId);
 		} catch (err) {
-			if (err instanceof ApplyPenaltyAndRestartError) {
-				return this._applyPenaltyAndRestartSync(
-					err.peerId,
-					receivedBlock,
-					err.reason,
-				);
-			}
-
 			if (err instanceof ApplyPenaltyAndAbortError) {
 				this.logger.info(
 					{ err, peerId, reason: err.reason },
@@ -110,7 +101,11 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		return true;
 	}
 
-	async isValidFor(receivedBlock) {
+	async isValidFor(receivedBlock, peerId) {
+		if (!peerId) {
+			// If peerId is not specified, fast chain switching cannot be done
+			return false;
+		}
 		const { lastBlock } = this.blocks;
 
 		// 3. Step: Check whether B justifies fast chain switching mechanism
@@ -162,14 +157,14 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 
 	async _queryBlocks(receivedBlock, highestCommonBlock, peerId) {
 		if (!highestCommonBlock) {
-			throw new ApplyPenaltyAndRestartError(
+			throw new ApplyPenaltyAndAbortError(
 				peerId,
 				"Peer didn't return a common block",
 			);
 		}
 
 		if (highestCommonBlock.height < this.bft.finalizedHeight) {
-			throw new ApplyPenaltyAndRestartError(
+			throw new ApplyPenaltyAndAbortError(
 				peerId,
 				`Common block height ${highestCommonBlock.height} is lower than the finalized height of the chain ${this.bft.finalizedHeight}`,
 			);
@@ -203,7 +198,7 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		);
 
 		if (!blocks || !blocks.length) {
-			throw new ApplyPenaltyAndRestartError(
+			throw new ApplyPenaltyAndAbortError(
 				peerId,
 				`Peer didn't return any requested block within IDs ${highestCommonBlock.id} and ${receivedBlock.id}`,
 			);
@@ -279,7 +274,7 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		);
 		this.logger.debug('Restoring blocks from temporary table');
 		await restoreBlocks(this.blocks, this.processor);
-		throw new ApplyPenaltyAndRestartError(
+		throw new ApplyPenaltyAndAbortError(
 			peerId,
 			'Detected invalid block while processing list of requested blocks',
 		);

--- a/framework/src/modules/chain/synchronizer/synchronizer.js
+++ b/framework/src/modules/chain/synchronizer/synchronizer.js
@@ -81,11 +81,6 @@ class Synchronizer {
 				receivedBlock,
 				'A block must be provided to the Synchronizer in order to run',
 			);
-			assert(
-				peerId,
-				'A peer ID from the peer sending the block must be provided to the Synchronizer in order to run',
-			);
-
 			this.logger.info(
 				{ blockId: receivedBlock.id, height: receivedBlock.height },
 				'Starting synchronizer',
@@ -101,6 +96,7 @@ class Synchronizer {
 			// Choose the right mechanism to sync
 			const validMechanism = await this._determineSyncMechanism(
 				receivedBlockInstance,
+				peerId,
 			);
 
 			if (!validMechanism) {
@@ -132,9 +128,9 @@ class Synchronizer {
 	}
 
 	// eslint-disable-next-line class-methods-use-this, no-unused-vars
-	async _determineSyncMechanism(receivedBlock) {
+	async _determineSyncMechanism(receivedBlock, peerId) {
 		for (const mechanism of this.mechanisms) {
-			if (await mechanism.isValidFor(receivedBlock)) {
+			if (await mechanism.isValidFor(receivedBlock, peerId)) {
 				return mechanism;
 			}
 		}

--- a/framework/test/jest/unit/specs/modules/chain/synchronizer/synchronizer.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/synchronizer/synchronizer.spec.js
@@ -462,13 +462,6 @@ describe('Synchronizer', () => {
 			expect(synchronizer.active).toBeFalsy();
 		});
 
-		it('should reject with error if required properties are missing (peerId)', async () => {
-			await expect(synchronizer.run({ height: 1 })).rejects.toThrow(
-				'A peer ID from the peer sending the block must be provided to the Synchronizer in order to run',
-			);
-			expect(synchronizer.active).toBeFalsy();
-		});
-
 		it('should validate the block before sync', async () => {
 			jest.spyOn(processorModule, 'validateDetached');
 


### PR DESCRIPTION
### What was the problem?
Fast chain switching was in some cases, banning a peer and restarting.
However, fast chain switching cannot be restarted if the peer is banned.

### How did I solve it?
In stead of restarting, it bans the peer, but it waits for the next block to decide.

### How to manually test it?
Make FCS fail manually, and see if it doesn't fail

### Review checklist

- [ ] The PR resolves #4761 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
