### PR TITLE
Fix BFT condition - Closes #4768

### DIFF
--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -307,19 +307,23 @@ class FinalityManager extends EventEmitter {
 		// Order the two block headers such that earlierBlock must be forged first
 		let earlierBlock = delegateLastBlock;
 		let laterBlock = blockHeader;
-		if (
+		const higherMaxHeightPreviouslyForgerd =
 			earlierBlock.maxHeightPreviouslyForged >
-				laterBlock.maxHeightPreviouslyForged ||
-			(earlierBlock.maxHeightPreviouslyForged ===
-				laterBlock.maxHeightPreviouslyForged &&
-				earlierBlock.maxHeightPrevoted > laterBlock.maxHeightPrevoted) ||
-			(earlierBlock.maxHeightPreviouslyForged ===
-				laterBlock.maxHeightPreviouslyForged &&
-				earlierBlock.maxHeightPrevoted === laterBlock.maxHeightPrevoted &&
-				earlierBlock.height > laterBlock.height)
+			laterBlock.maxHeightPreviouslyForged;
+		const sameMaxHeightPreviouslyForgerd =
+			earlierBlock.maxHeightPreviouslyForged ===
+			laterBlock.maxHeightPreviouslyForged;
+		const higherMaxHeightPrevoted =
+			earlierBlock.maxHeightPrevoted > laterBlock.maxHeightPrevoted;
+		const sameMaxHeightPrevoted =
+			earlierBlock.maxHeightPrevoted === laterBlock.maxHeightPrevoted;
+		const higherHeight = earlierBlock.height > laterBlock.height;
+		if (
+			higherMaxHeightPreviouslyForgerd ||
+			(sameMaxHeightPreviouslyForgerd && higherMaxHeightPrevoted) ||
+			(sameMaxHeightPreviouslyForgerd && sameMaxHeightPrevoted && higherHeight)
 		) {
-			earlierBlock = blockHeader;
-			laterBlock = delegateLastBlock;
+			[earlierBlock, laterBlock] = [laterBlock, earlierBlock];
 		}
 
 		if (

--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -286,7 +286,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 				const height = data.previousBlock.height + 1;
 				const previousBlockId = data.previousBlock.id;
 				const maxHeightPreviouslyForged =
-					previouslyForgedMap[delegatePublicKey] || height;
+					previouslyForgedMap[delegatePublicKey] || 0;
 				const block = this._create({
 					...data,
 					height,

--- a/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
@@ -130,16 +130,18 @@ describe('finality_manager', () => {
 			});
 
 			it('should throw error if same delegate forged block on different height', async () => {
-				const maxHeightPreviouslyForged = 10;
+				const maxHeightPrevoted = 10;
 				const delegateAccount = accountFixture();
 				const lastBlock = blockHeaderFixture({
 					delegatePublicKey: delegateAccount.publicKey,
-					maxHeightPreviouslyForged,
+					maxHeightPreviouslyForged: 5,
+					maxHeightPrevoted,
 					height: 10,
 				});
 				const currentBlock = blockHeaderFixture({
 					delegatePublicKey: delegateAccount.publicKey,
-					maxHeightPreviouslyForged,
+					maxHeightPrevoted,
+					maxHeightPreviouslyForged: 6,
 					height: 9,
 				});
 

--- a/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
@@ -92,7 +92,7 @@ describe('block processor v2', () => {
 	describe('create', () => {
 		let block;
 
-		it('should set maxPreviouslyForgedHeight to height when the delegate did not forge before', async () => {
+		it('should set maxPreviouslyForgedHeight to zero when the delegate did not forge before', async () => {
 			// Arrange
 			const maxHeightResult = JSON.stringify({});
 			storageStub.entities.ForgerInfo.getKey.mockResolvedValue(maxHeightResult);

--- a/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
@@ -110,7 +110,7 @@ describe('block processor v2', () => {
 				'maxHeightPreviouslyForged',
 			);
 			// previousBlock.height + 1
-			expect(block.maxHeightPreviouslyForged).toBe(11);
+			expect(block.maxHeightPreviouslyForged).toBe(0);
 		});
 
 		it('should save maxPreviouslyForgedHeight as the block height created', async () => {


### PR DESCRIPTION
### What was the problem?
Refer to #4768 

### How did I solve it?
Update the BFT condition

### How to manually test it?
- Start forging on local, and check if the initial forger_info doesn't contain `0`
- BFT condition depends on fork scenario

### Review checklist

- [ ] The PR resolves #4768 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
