### PR TITLE
Fix the cache loading to be consistent - Closes #4776

### DIFF
--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -22,6 +22,7 @@ const {
 } = require('./finality_manager');
 const forkChoiceRule = require('./fork_choice_rule');
 const { validateBlockHeader } = require('./utils');
+const { BFT_ROUND_THRESHOLD } = require('./constant');
 
 const CHAIN_STATE_FINALIZED_HEIGHT = 'BFT.finalizedHeight';
 const EVENT_BFT_BLOCK_FINALIZED = 'EVENT_BFT_BLOCK_FINALIZED';
@@ -72,7 +73,7 @@ class BFT extends EventEmitter {
 
 		const loadFromHeight = Math.max(
 			finalizedHeight,
-			lastBlockHeight - this.constants.activeDelegates * 2,
+			lastBlockHeight - this.constants.activeDelegates * BFT_ROUND_THRESHOLD,
 			this.constants.startingHeight,
 		);
 
@@ -112,14 +113,15 @@ class BFT extends EventEmitter {
 			aboveHeight: removeFromHeight - 1,
 		});
 
-		// Make sure there are 2 rounds of block headers available
+		// Make sure there are BFT_ROUND_THRESHOLD rounds of block headers available
 		if (
 			this.finalityManager.maxHeight - this.finalityManager.minHeight <
-			this.constants.activeDelegates * 2
+			this.constants.activeDelegates * BFT_ROUND_THRESHOLD
 		) {
 			const tillHeight = this.finalityManager.minHeight - 1;
 			const fromHeight =
-				this.finalityManager.maxHeight - this.constants.activeDelegates * 2;
+				this.finalityManager.maxHeight -
+				this.constants.activeDelegates * BFT_ROUND_THRESHOLD;
 			await this._loadBlocksFromStorage({
 				fromHeight,
 				tillHeight,
@@ -197,7 +199,8 @@ class BFT extends EventEmitter {
 		// Check BFT migration height
 		// https://github.com/LiskHQ/lips/blob/master/proposals/lip-0014.md#backwards-compatibility
 		const bftMigrationHeight =
-			this.constants.startingHeight - this.constants.activeDelegates * 2;
+			this.constants.startingHeight -
+			this.constants.activeDelegates * BFT_ROUND_THRESHOLD;
 
 		// Choose max between stored finalized height or migration height
 		const finalizedHeight = Math.max(finalizedHeightStored, bftMigrationHeight);

--- a/framework/src/modules/chain/bft/constant.js
+++ b/framework/src/modules/chain/bft/constant.js
@@ -16,4 +16,5 @@
 
 module.exports = {
 	BFT_ROUND_THRESHOLD: 3,
+	BFT_MIGRATION_ROUND_OFFSET: 2,
 };

--- a/framework/src/modules/chain/bft/constant.js
+++ b/framework/src/modules/chain/bft/constant.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+'use strict';
+
+module.exports = {
+	BFT_ROUND_THRESHOLD: 3,
+};

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -17,6 +17,7 @@
 const assert = require('assert');
 const debug = require('debug')('lisk:bft:consensus_manager');
 const EventEmitter = require('events');
+const { BFT_ROUND_THRESHOLD } = require('./constant');
 const { HeadersList } = require('./headers_list');
 const { validateBlockHeader } = require('./utils');
 const {
@@ -45,7 +46,7 @@ class FinalityManager extends EventEmitter {
 		this.preCommitThreshold = Math.ceil((this.activeDelegates * 2) / 3);
 
 		// Limit for blocks to make perform verification or pre-vote/pre-commit (1 block less than 3 rounds)
-		this.processingThreshold = this.activeDelegates * 3 - 1;
+		this.processingThreshold = this.activeDelegates * BFT_ROUND_THRESHOLD - 1;
 
 		// Maximum headers to store (5 rounds)
 		this.maxHeaders = this.activeDelegates * 5;

--- a/framework/src/modules/chain/bft/headers_list.js
+++ b/framework/src/modules/chain/bft/headers_list.js
@@ -112,6 +112,10 @@ class HeadersList {
 	top(size) {
 		assert(size, 'Please provide the size');
 
+		if (this.length <= size) {
+			return [...this._items];
+		}
+
 		return this.items.slice(this.length - size, this.length + 1);
 	}
 

--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -167,9 +167,9 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 
 		this.init.pipe([
 			async ({ stateStore }) => {
-				// minActiveHeightsOfDelegates will be used to load 202 blocks from the storage
-				// That's why we need to get the delegates who were active in the last 2 rounds.
-				const numberOfRounds = 2;
+				// minActiveHeightsOfDelegates will be used to load 303 blocks from the storage
+				// That's why we need to get the delegates who were active in the last 3 rounds.
+				const numberOfRounds = 3;
 				const minActiveHeightsOfDelegates = await this.dposModule.getMinActiveHeightsOfDelegates(
 					numberOfRounds,
 				);

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -208,7 +208,7 @@ describe('bft', () => {
 
 				expect(bft._loadBlocksFromStorage).toHaveBeenCalledTimes(1);
 				expect(bft._loadBlocksFromStorage).toHaveBeenCalledWith({
-					fromHeight: lastBlockHeight - activeDelegates * 3,
+					fromHeight: lastBlockHeight - activeDelegates * 3 + 1,
 					tillHeight: lastBlockHeight,
 					minActiveHeightsOfDelegates,
 				});
@@ -412,7 +412,7 @@ describe('bft', () => {
 				);
 				expect(storageMock.entities.Block.get).toHaveBeenCalledTimes(1);
 				expect(storageMock.entities.Block.get).toHaveBeenLastCalledWith(
-					{ height_lte: 400, height_gte: 450 - activeDelegates * 3 },
+					{ height_lte: 400, height_gte: 450 - activeDelegates * 3 + 1 },
 					{ limit: null, sort: 'height:desc' },
 				);
 			});
@@ -712,7 +712,7 @@ describe('bft', () => {
 				expect(finalityManager).toBeInstanceOf(FinalityManager);
 				expect(finalityManager.activeDelegates).toEqual(activeDelegates);
 				expect(finalityManager.finalizedHeight).toEqual(
-					startingHeightHigher - activeDelegates * 3,
+					startingHeightHigher - activeDelegates * 2,
 				);
 			});
 		});

--- a/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
@@ -78,14 +78,14 @@ describe('block processor v2', () => {
 	});
 
 	describe('init', () => {
-		it('should get activeSince from dpos for 2 rounds', async () => {
+		it('should get activeSince from dpos for 3 rounds', async () => {
 			// Arrange & Act
 			const stateStore = new StateStore(storageStub);
 			await blockProcessor.init.run({ stateStore });
 			// Assert
 			expect(
 				dposModuleStub.getMinActiveHeightsOfDelegates,
-			).toHaveBeenCalledWith(2);
+			).toHaveBeenCalledWith(3);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
The PR resolves #4776 

### How did I solve it?
Update the parameter to be 3 rounds in stead of 2.
Fix the cache `top` mechanism to return value

### How to manually test it?
- Start double forging using 2 nodes, and on the second round, restart one of the nodes, and check the validation is correct
