### PR TITLE
Create account class - Closes #4746

### DIFF
--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -30,9 +30,11 @@ export const accountDefaultValues = {
 	nameExist: false,
 	multiMin: 0,
 	multiLifetime: 0,
-	votedDelegatesPublicKeys: [],
+	// tslint:disable-next-line:no-null-keyword
+	votedDelegatesPublicKeys: null,
 	asset: {},
-	membersPublicKeys: [],
+	// tslint:disable-next-line:no-null-keyword
+	membersPublicKeys: null,
 };
 
 export class Account {
@@ -79,11 +81,12 @@ export class Account {
 		this.multiLifetime = accountInfo.multiLifetime;
 		this.asset = accountInfo.asset;
 		this.votedDelegatesPublicKeys =
+			!accountInfo.votedDelegatesPublicKeys ||
 			accountInfo.votedDelegatesPublicKeys === null
 				? []
 				: accountInfo.votedDelegatesPublicKeys;
 		this.membersPublicKeys =
-			accountInfo.membersPublicKeys === null
+			!accountInfo.membersPublicKeys || accountInfo.membersPublicKeys === null
 				? []
 				: accountInfo.membersPublicKeys;
 	}
@@ -114,14 +117,14 @@ export class Account {
 			multiMin: this.multiMin,
 			multiLifetime: this.multiLifetime,
 			votedDelegatesPublicKeys:
-				this.votedDelegatesPublicKeys.length > 0
-					? this.votedDelegatesPublicKeys
-					: // tslint:disable-next-line:no-null-keyword
-					  null,
+				this.votedDelegatesPublicKeys.length < 1
+					? // tslint:disable-next-line:no-null-keyword
+					  null
+					: this.votedDelegatesPublicKeys,
 			asset: this.asset,
 			membersPublicKeys:
 				// tslint:disable-next-line:no-null-keyword
-				this.membersPublicKeys.length > 0 ? this.membersPublicKeys : null,
+				this.membersPublicKeys.length < 1 ? null : this.membersPublicKeys,
 		};
 	}
 }

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -56,8 +56,14 @@ export class Account {
 		this.multiMin = accountInfo.multiMin;
 		this.multiLifetime = accountInfo.multiLifetime;
 		this.asset = accountInfo.asset;
-		this.votedDelegatesPublicKeys = accountInfo.votedDelegatesPublicKeys;
-		this.membersPublicKeys = accountInfo.membersPublicKeys;
+		this.votedDelegatesPublicKeys =
+			accountInfo.votedDelegatesPublicKeys === null
+				? []
+				: accountInfo.votedDelegatesPublicKeys;
+		this.membersPublicKeys =
+			accountInfo.membersPublicKeys === null
+				? []
+				: accountInfo.membersPublicKeys;
 	}
 
 	public static getDefaultAccount = (address: string): Account =>
@@ -83,6 +89,37 @@ export class Account {
 			asset: {},
 			membersPublicKeys: [],
 		});
+
+	public getAccountJSON(): AccountJSON {
+		return {
+			address: this.address,
+			publicKey: this.publicKey,
+			// tslint:disable-next-line:no-null-keyword
+			secondPublicKey: this.secondPublicKey,
+			secondSignature: this.secondSignature,
+			// tslint:disable-next-line:no-null-keyword
+			username: this.username,
+			isDelegate: this.isDelegate,
+			balance: this.balance.toString(),
+			missedBlocks: this.missedBlocks,
+			producedBlocks: this.producedBlocks,
+			fees: this.fees.toString(),
+			rewards: this.rewards.toString(),
+			voteWeight: this.voteWeight.toString(),
+			nameExist: this.nameExist,
+			multiMin: this.multiMin,
+			multiLifetime: this.multiLifetime,
+			votedDelegatesPublicKeys:
+				this.votedDelegatesPublicKeys.length > 0
+					? this.votedDelegatesPublicKeys
+					: // tslint:disable-next-line:no-null-keyword
+					  null,
+			asset: this.asset,
+			membersPublicKeys:
+				// tslint:disable-next-line:no-null-keyword
+				this.membersPublicKeys.length > 0 ? this.membersPublicKeys : null,
+		};
+	}
 
 	public addBalance(balance: string | BigInt): void {
 		this.balance = this.balance + BigInt(balance);

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -21,12 +21,12 @@ export const accountDefaultValues = {
 	// tslint:disable-next-line:no-null-keyword
 	username: null,
 	isDelegate: 0,
-	balance: BigInt(0),
+	balance: '0',
 	missedBlocks: 0,
 	producedBlocks: 0,
-	fees: BigInt(0),
-	rewards: BigInt(0),
-	voteWeight: BigInt(0),
+	fees: '0',
+	rewards: '0',
+	voteWeight: '0',
 	nameExist: false,
 	multiMin: 0,
 	multiLifetime: 0,
@@ -34,6 +34,7 @@ export const accountDefaultValues = {
 	asset: {},
 	membersPublicKeys: [],
 };
+
 export class Account {
 	public address: string;
 	public balance: bigint;

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -123,8 +123,4 @@ export class Account {
 				this.membersPublicKeys.length > 0 ? this.membersPublicKeys : null,
 		};
 	}
-
-	public addBalance(balance: string | BigInt): void {
-		this.balance = this.balance + BigInt(balance);
-	}
 }

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { AccountJSON } from './types';
-export type AccountInfoWithoutAddress = Omit<AccountJSON, 'address'>;
 
 export class Account {
 	public address: string;
@@ -61,25 +60,27 @@ export class Account {
 		this.membersPublicKeys = accountInfo.membersPublicKeys;
 	}
 
-	public static defaultAccount: AccountInfoWithoutAddress = {
-		publicKey: undefined,
-		secondPublicKey: undefined,
-		secondSignature: false,
-		username: undefined,
-		isDelegate: 0,
-		balance: BigInt(0),
-		missedBlocks: 0,
-		producedBlocks: 0,
-		fees: BigInt(0),
-		rewards: BigInt(0),
-		voteWeight: BigInt(0),
-		nameExist: false,
-		multiMin: 0,
-		multiLifetime: 0,
-		votedDelegatesPublicKeys: undefined,
-		asset: {},
-		membersPublicKeys: [],
-	};
+	public static getDefaultAccount = (address: string): Account =>
+		new Account({
+			address,
+			publicKey: undefined,
+			secondPublicKey: undefined,
+			secondSignature: false,
+			username: undefined,
+			isDelegate: 0,
+			balance: BigInt(0),
+			missedBlocks: 0,
+			producedBlocks: 0,
+			fees: BigInt(0),
+			rewards: BigInt(0),
+			voteWeight: BigInt(0),
+			nameExist: false,
+			multiMin: 0,
+			multiLifetime: 0,
+			votedDelegatesPublicKeys: undefined,
+			asset: {},
+			membersPublicKeys: [],
+		});
 
 	public addBalance(balance: string | BigInt): void {
 		this.balance = this.balance + BigInt(balance);

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -16,22 +16,22 @@ import { AccountJSON } from './types';
 export class Account {
 	public address: string;
 	public balance: bigint;
-	public fees?: bigint;
-	public rewards?: bigint;
-	public voteWeight?: bigint;
-	public missedBlocks?: number;
-	public producedBlocks?: number;
-	public publicKey?: string;
-	public secondPublicKey?: string;
-	public secondSignature?: boolean;
-	public username?: string;
-	public isDelegate?: number;
-	public nameExist?: false;
-	public multiMin?: number;
-	public multiLifetime?: number;
-	public asset?: object;
-	public membersPublicKeys?: ReadonlyArray<string>;
-	public votedDelegatesPublicKeys?: string[];
+	public fees: bigint;
+	public rewards: bigint;
+	public voteWeight: bigint;
+	public missedBlocks: number;
+	public producedBlocks: number;
+	public publicKey: string | undefined;
+	public secondPublicKey: string | null;
+	public secondSignature: number;
+	public username: string | null;
+	public isDelegate: number;
+	public nameExist: boolean;
+	public multiMin: number;
+	public multiLifetime: number;
+	public asset: object;
+	public membersPublicKeys: string[];
+	public votedDelegatesPublicKeys: string[];
 
 	public constructor(accountInfo: AccountJSON) {
 		this.address = accountInfo.address;
@@ -64,9 +64,11 @@ export class Account {
 		new Account({
 			address,
 			publicKey: undefined,
-			secondPublicKey: undefined,
-			secondSignature: false,
-			username: undefined,
+			// tslint:disable-next-line:no-null-keyword
+			secondPublicKey: null,
+			secondSignature: 0,
+			// tslint:disable-next-line:no-null-keyword
+			username: null,
 			isDelegate: 0,
 			balance: BigInt(0),
 			missedBlocks: 0,
@@ -77,7 +79,7 @@ export class Account {
 			nameExist: false,
 			multiMin: 0,
 			multiLifetime: 0,
-			votedDelegatesPublicKeys: undefined,
+			votedDelegatesPublicKeys: [],
 			asset: {},
 			membersPublicKeys: [],
 		});

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -13,6 +13,27 @@
  */
 import { AccountJSON } from './types';
 
+export const accountDefaultValues = {
+	publicKey: undefined,
+	// tslint:disable-next-line:no-null-keyword
+	secondPublicKey: null,
+	secondSignature: 0,
+	// tslint:disable-next-line:no-null-keyword
+	username: null,
+	isDelegate: 0,
+	balance: BigInt(0),
+	missedBlocks: 0,
+	producedBlocks: 0,
+	fees: BigInt(0),
+	rewards: BigInt(0),
+	voteWeight: BigInt(0),
+	nameExist: false,
+	multiMin: 0,
+	multiLifetime: 0,
+	votedDelegatesPublicKeys: [],
+	asset: {},
+	membersPublicKeys: [],
+};
 export class Account {
 	public address: string;
 	public balance: bigint;
@@ -69,25 +90,7 @@ export class Account {
 	public static getDefaultAccount = (address: string): Account =>
 		new Account({
 			address,
-			publicKey: undefined,
-			// tslint:disable-next-line:no-null-keyword
-			secondPublicKey: null,
-			secondSignature: 0,
-			// tslint:disable-next-line:no-null-keyword
-			username: null,
-			isDelegate: 0,
-			balance: BigInt(0),
-			missedBlocks: 0,
-			producedBlocks: 0,
-			fees: BigInt(0),
-			rewards: BigInt(0),
-			voteWeight: BigInt(0),
-			nameExist: false,
-			multiMin: 0,
-			multiLifetime: 0,
-			votedDelegatesPublicKeys: [],
-			asset: {},
-			membersPublicKeys: [],
+			...accountDefaultValues,
 		});
 
 	public getAccountJSON(): AccountJSON {

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { AccountJSON } from './types';
+export type AccountInfoWithoutAddress = Omit<AccountJSON, 'address'>;
+
+export class Account {
+	public address: string;
+	public balance: bigint;
+	public fees?: bigint;
+	public rewards?: bigint;
+	public voteWeight?: bigint;
+	public missedBlocks?: number;
+	public producedBlocks?: number;
+	public publicKey?: string;
+	public secondPublicKey?: string;
+	public secondSignature?: boolean;
+	public username?: string;
+	public isDelegate?: number;
+	public nameExist?: false;
+	public multiMin?: number;
+	public multiLifetime?: number;
+	public asset?: object;
+	public membersPublicKeys?: ReadonlyArray<string>;
+	public votedDelegatesPublicKeys?: string[];
+
+	public constructor(accountInfo: AccountJSON) {
+		this.address = accountInfo.address;
+		this.balance = accountInfo.balance
+			? BigInt(accountInfo.balance)
+			: BigInt(0);
+		this.missedBlocks = accountInfo.missedBlocks;
+		this.producedBlocks = accountInfo.producedBlocks;
+		this.isDelegate = accountInfo.isDelegate;
+		this.publicKey = accountInfo.publicKey;
+		this.secondPublicKey = accountInfo.secondPublicKey;
+		this.secondSignature = accountInfo.secondSignature;
+		this.username = accountInfo.username;
+		this.fees = accountInfo.fees ? BigInt(accountInfo.fees) : BigInt(0);
+		this.rewards = accountInfo.rewards
+			? BigInt(accountInfo.rewards)
+			: BigInt(0);
+		this.voteWeight = accountInfo.voteWeight
+			? BigInt(accountInfo.voteWeight)
+			: BigInt(0);
+		this.nameExist = accountInfo.nameExist;
+		this.multiMin = accountInfo.multiMin;
+		this.multiLifetime = accountInfo.multiLifetime;
+		this.asset = accountInfo.asset;
+		this.votedDelegatesPublicKeys = accountInfo.votedDelegatesPublicKeys;
+		this.membersPublicKeys = accountInfo.membersPublicKeys;
+	}
+
+	public static defaultAccount: AccountInfoWithoutAddress = {
+		publicKey: undefined,
+		secondPublicKey: undefined,
+		secondSignature: false,
+		username: undefined,
+		isDelegate: 0,
+		balance: BigInt(0),
+		missedBlocks: 0,
+		producedBlocks: 0,
+		fees: BigInt(0),
+		rewards: BigInt(0),
+		voteWeight: BigInt(0),
+		nameExist: false,
+		multiMin: 0,
+		multiLifetime: 0,
+		votedDelegatesPublicKeys: undefined,
+		asset: {},
+		membersPublicKeys: [],
+	};
+
+	public addBalance(balance: string | BigInt): void {
+		this.balance = this.balance + BigInt(balance);
+	}
+}

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -31,10 +31,10 @@ export const accountDefaultValues = {
 	multiMin: 0,
 	multiLifetime: 0,
 	// tslint:disable-next-line:no-null-keyword
-	votedDelegatesPublicKeys: null,
+	votedDelegatesPublicKeys: [],
 	asset: {},
 	// tslint:disable-next-line:no-null-keyword
-	membersPublicKeys: null,
+	membersPublicKeys: [],
 };
 
 export class Account {
@@ -81,12 +81,13 @@ export class Account {
 		this.multiLifetime = accountInfo.multiLifetime;
 		this.asset = accountInfo.asset;
 		this.votedDelegatesPublicKeys =
-			!accountInfo.votedDelegatesPublicKeys ||
+			accountInfo.votedDelegatesPublicKeys === undefined ||
 			accountInfo.votedDelegatesPublicKeys === null
 				? []
 				: accountInfo.votedDelegatesPublicKeys;
 		this.membersPublicKeys =
-			!accountInfo.membersPublicKeys || accountInfo.membersPublicKeys === null
+			accountInfo.membersPublicKeys === undefined ||
+			accountInfo.membersPublicKeys === null
 				? []
 				: accountInfo.membersPublicKeys;
 	}

--- a/elements/lisk-blocks/src/account.ts
+++ b/elements/lisk-blocks/src/account.ts
@@ -93,7 +93,7 @@ export class Account {
 			...accountDefaultValues,
 		});
 
-	public getAccountJSON(): AccountJSON {
+	public toJSON(): AccountJSON {
 		return {
 			address: this.address,
 			publicKey: this.publicKey,

--- a/elements/lisk-blocks/src/data_access/data_access.ts
+++ b/elements/lisk-blocks/src/data_access/data_access.ts
@@ -282,7 +282,7 @@ export class DataAccess {
 	/** Begin: Accounts */
 	public async getAccountsByPublicKey(
 		arrayOfPublicKeys: ReadonlyArray<string>,
-	): Promise<Account[]> {
+	): Promise<AccountJSON[]> {
 		const accounts = await this._storage.getAccountsByPublicKey(
 			arrayOfPublicKeys,
 		);
@@ -292,13 +292,13 @@ export class DataAccess {
 
 	public async getAccountsByAddress(
 		arrayOfAddresses: ReadonlyArray<string>,
-	): Promise<Account[]> {
+	): Promise<AccountJSON[]> {
 		const accounts = await this._storage.getAccountsByAddress(arrayOfAddresses);
 
 		return accounts;
 	}
 
-	public async getDelegateAccounts(limit: number): Promise<Account[]> {
+	public async getDelegateAccounts(limit: number): Promise<AccountJSON[]> {
 		const accounts = await this._storage.getDelegateAccounts(limit);
 
 		return accounts;

--- a/elements/lisk-blocks/src/data_access/data_access.ts
+++ b/elements/lisk-blocks/src/data_access/data_access.ts
@@ -14,7 +14,7 @@
 import { BaseTransaction, TransactionJSON } from '@liskhq/lisk-transactions';
 
 import {
-	Account,
+	AccountJSON,
 	BlockHeader,
 	BlockHeaderJSON,
 	BlockInstance,

--- a/elements/lisk-blocks/src/data_access/storage.ts
+++ b/elements/lisk-blocks/src/data_access/storage.ts
@@ -225,7 +225,7 @@ export class Storage {
 	*/
 	public async getAccountsByPublicKey(
 		arrayOfPublicKeys: ReadonlyArray<string>,
-	): Promise<Account[]> {
+	): Promise<AccountJSON[]> {
 		const accounts = await this._storage.entities.Account.get(
 			{ publicKey_in: arrayOfPublicKeys },
 			{ limit: arrayOfPublicKeys.length },
@@ -236,7 +236,7 @@ export class Storage {
 
 	public async getAccountsByAddress(
 		arrayOfAddresses: ReadonlyArray<string>,
-	): Promise<Account[]> {
+	): Promise<AccountJSON[]> {
 		const accounts = await this._storage.entities.Account.get(
 			{ address_in: arrayOfAddresses },
 			{ limit: arrayOfAddresses.length },
@@ -245,7 +245,7 @@ export class Storage {
 		return accounts;
 	}
 
-	public async getDelegateAccounts(limit: number): Promise<Account[]> {
+	public async getDelegateAccounts(limit: number): Promise<AccountJSON[]> {
 		const accounts = await this._storage.entities.Account.get(
 			{ isDelegate: true },
 			{ limit, sort: ['voteWeight:desc', 'publicKey:asc'] },

--- a/elements/lisk-blocks/src/data_access/storage.ts
+++ b/elements/lisk-blocks/src/data_access/storage.ts
@@ -15,7 +15,7 @@
 import { TransactionJSON } from '@liskhq/lisk-transactions';
 
 import {
-	Account,
+	AccountJSON,
 	BlockJSON,
 	BlockRound,
 	Storage as DBStorage,

--- a/elements/lisk-blocks/src/index.ts
+++ b/elements/lisk-blocks/src/index.ts
@@ -11,7 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-
+export { Account } from './account';
 export * from './block_reward';
 export { Blocks } from './blocks';
 export { baseBlockSchema } from './schema';

--- a/elements/lisk-blocks/src/state_store/account_store.ts
+++ b/elements/lisk-blocks/src/state_store/account_store.ts
@@ -36,10 +36,10 @@ export const sanitizeAccountForStorage = (
 
 	return {
 		...restOfAccount,
-		balance: balance?.toString(),
-		voteWeight: voteWeight?.toString(),
-		fees: fees?.toString(),
-		rewards: rewards?.toString(),
+		balance: balance ? balance.toString() : '0',
+		voteWeight: voteWeight ? voteWeight.toString() : '0',
+		fees: fees ? fees.toString() : '0',
+		rewards: rewards ? rewards.toString() : '0',
 	};
 };
 

--- a/elements/lisk-blocks/src/state_store/account_store.ts
+++ b/elements/lisk-blocks/src/state_store/account_store.ts
@@ -75,7 +75,7 @@ export class AccountStore {
 		);
 
 		if (element) {
-			return cloneDeep(element);
+			return new Account(element.toJSON());
 		}
 
 		// Account was not cached previously so we try to fetch it from db
@@ -89,7 +89,7 @@ export class AccountStore {
 		if (elementFromDB) {
 			this._data.push(new Account(elementFromDB));
 
-			return cloneDeep(new Account(elementFromDB));
+			return new Account(elementFromDB);
 		}
 
 		// Account does not exist we can not continue
@@ -104,7 +104,7 @@ export class AccountStore {
 			item => item[this._primaryKey] === primaryValue,
 		);
 		if (element) {
-			return element;
+			return new Account(element.toJSON());
 		}
 
 		// Account was not cached previously so we try to fetch it from db (example delegate account is voted)
@@ -118,7 +118,7 @@ export class AccountStore {
 		if (elementFromDB) {
 			this._data.push(new Account(elementFromDB));
 
-			return cloneDeep(new Account(elementFromDB));
+			return new Account(elementFromDB);
 		}
 
 		const defaultElement: Account = Account.getDefaultAccount(primaryValue);
@@ -126,7 +126,7 @@ export class AccountStore {
 		const newElementIndex = this._data.push(defaultElement) - 1;
 		this._updatedKeys[newElementIndex] = Object.keys(defaultElement);
 
-		return defaultElement;
+		return new Account(defaultElement.toJSON());
 	}
 
 	public getUpdated(): ReadonlyArray<Account> {

--- a/elements/lisk-blocks/src/state_store/account_store.ts
+++ b/elements/lisk-blocks/src/state_store/account_store.ts
@@ -179,7 +179,7 @@ export class AccountStore {
 	public async finalize(tx: StorageTransaction): Promise<void> {
 		const affectedAccounts = Object.entries(this._updatedKeys).map(
 			([index, updatedKeys]) => ({
-				updatedItem: this._data[parseInt(index, 10)].getAccountJSON(),
+				updatedItem: this._data[parseInt(index, 10)].toJSON(),
 				updatedKeys,
 			}),
 		);

--- a/elements/lisk-blocks/src/state_store/account_store.ts
+++ b/elements/lisk-blocks/src/state_store/account_store.ts
@@ -145,7 +145,10 @@ export class AccountStore {
 	}
 
 	public set(primaryValue: string, updatedElement: Account): void {
-		const updatedElementObj = new Account(updatedElement);
+		const updatedElementObj =
+			updatedElement instanceof Account
+				? updatedElement
+				: new Account(updatedElement);
 
 		const elementIndex = this._data.findIndex(
 			item => item[this._primaryKey] === primaryValue,

--- a/elements/lisk-blocks/src/state_store/account_store.ts
+++ b/elements/lisk-blocks/src/state_store/account_store.ts
@@ -141,7 +141,7 @@ export class AccountStore {
 			return undefined;
 		}
 
-		return foundAccount;
+		return new Account(foundAccount.toJSON());
 	}
 
 	public set(primaryValue: string, updatedElement: Account): void {

--- a/elements/lisk-blocks/src/state_store/account_store.ts
+++ b/elements/lisk-blocks/src/state_store/account_store.ts
@@ -52,7 +52,7 @@ export class AccountStore {
 	private readonly _primaryKey = 'address';
 	private readonly _name = 'Account';
 
-	public constructor(accountEntity: StorageEntity<Account>) {
+	public constructor(accountEntity: StorageEntity<AccountJSON>) {
 		this._account = accountEntity;
 		this._data = [];
 		this._updatedKeys = {};

--- a/elements/lisk-blocks/src/state_store/account_store.ts
+++ b/elements/lisk-blocks/src/state_store/account_store.ts
@@ -145,11 +145,6 @@ export class AccountStore {
 	}
 
 	public set(primaryValue: string, updatedElement: Account): void {
-		const updatedElementObj =
-			updatedElement instanceof Account
-				? updatedElement
-				: new Account(updatedElement);
-
 		const elementIndex = this._data.findIndex(
 			item => item[this._primaryKey] === primaryValue,
 		);
@@ -160,7 +155,7 @@ export class AccountStore {
 			);
 		}
 
-		const updatedKeys = Object.entries(updatedElementObj).reduce(
+		const updatedKeys = Object.entries(updatedElement).reduce(
 			(existingUpdatedKeys, [key, value]) => {
 				const account = this._data[elementIndex];
 				// tslint:disable-next-line:no-any
@@ -173,7 +168,7 @@ export class AccountStore {
 			[] as string[],
 		);
 
-		this._data[elementIndex] = updatedElementObj;
+		this._data[elementIndex] = updatedElement;
 		this._updatedKeys[elementIndex] = this._updatedKeys[elementIndex]
 			? uniq([...this._updatedKeys[elementIndex], ...updatedKeys])
 			: updatedKeys;

--- a/elements/lisk-blocks/src/transactions/transactions_handlers.ts
+++ b/elements/lisk-blocks/src/transactions/transactions_handlers.ts
@@ -92,7 +92,7 @@ export const verifyTotalSpending = async (
 
 		// Grab the sender balance
 		const account = await stateStore.account.get(senderId);
-		const senderBalance = BigInt(account.balance);
+		const senderBalance = account.balance;
 
 		// Initialize the sender spending with zero
 		senderSpending[senderId] = BigInt(0);

--- a/elements/lisk-blocks/src/transactions/votes_weight.ts
+++ b/elements/lisk-blocks/src/transactions/votes_weight.ts
@@ -221,7 +221,7 @@ const updateDelegateVotes = async (
 		const delegatePublicKey = vote.slice(1);
 
 		const senderAccount = await stateStore.account.get(transaction.senderId);
-		const amount = senderAccount.balance.toString();
+		const amount = senderAccount.balance;
 
 		await updateDelegateVote(stateStore, {
 			delegatePublicKey,

--- a/elements/lisk-blocks/src/transactions/votes_weight.ts
+++ b/elements/lisk-blocks/src/transactions/votes_weight.ts
@@ -67,7 +67,7 @@ const updateDelegateVote = async (
 		: voteBigInt - BigInt(amount);
 
 	const updatedDelegatedAccount = new Account(delegateAccount);
-	updatedDelegatedAccount.voteWeight = BigInt(voteWeight.toString());
+	updatedDelegatedAccount.voteWeight = voteWeight;
 	stateStore.account.set(delegateAddress, updatedDelegatedAccount);
 };
 

--- a/elements/lisk-blocks/src/transactions/votes_weight.ts
+++ b/elements/lisk-blocks/src/transactions/votes_weight.ts
@@ -15,6 +15,7 @@
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import { BaseTransaction } from '@liskhq/lisk-transactions';
 
+import { Account } from '../account';
 import { StateStore } from '../state_store';
 import { ExceptionOptions } from '../types';
 
@@ -64,8 +65,10 @@ const updateDelegateVote = async (
 	const voteWeight = add
 		? voteBigInt + BigInt(amount)
 		: voteBigInt - BigInt(amount);
-	delegateAccount.voteWeight = voteWeight.toString();
-	stateStore.account.set(delegateAddress, delegateAccount);
+
+	const updatedDelegatedAccount = new Account(delegateAccount);
+	updatedDelegatedAccount.voteWeight = BigInt(voteWeight.toString());
+	stateStore.account.set(delegateAddress, updatedDelegatedAccount);
 };
 
 const getRecipientAddress = (
@@ -220,7 +223,7 @@ const updateDelegateVotes = async (
 		const delegatePublicKey = vote.slice(1);
 
 		const senderAccount = await stateStore.account.get(transaction.senderId);
-		const amount = BigInt(senderAccount.balance).toString();
+		const amount = senderAccount.balance.toString();
 
 		await updateDelegateVote(stateStore, {
 			delegatePublicKey,

--- a/elements/lisk-blocks/src/transactions/votes_weight.ts
+++ b/elements/lisk-blocks/src/transactions/votes_weight.ts
@@ -15,7 +15,6 @@
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import { BaseTransaction } from '@liskhq/lisk-transactions';
 
-import { Account } from '../account';
 import { StateStore } from '../state_store';
 import { ExceptionOptions } from '../types';
 
@@ -61,14 +60,13 @@ const updateDelegateVote = async (
 ) => {
 	const delegateAddress = getAddressFromPublicKey(delegatePublicKey);
 	const delegateAccount = await stateStore.account.get(delegateAddress);
-	const voteBigInt = BigInt(delegateAccount.voteWeight || '0');
+	const voteBigInt = delegateAccount.voteWeight || BigInt('0');
 	const voteWeight = add
 		? voteBigInt + BigInt(amount)
 		: voteBigInt - BigInt(amount);
 
-	const updatedDelegatedAccount = new Account(delegateAccount);
-	updatedDelegatedAccount.voteWeight = voteWeight;
-	stateStore.account.set(delegateAddress, updatedDelegatedAccount);
+	delegateAccount.voteWeight = voteWeight;
+	stateStore.account.set(delegateAddress, delegateAccount);
 };
 
 const getRecipientAddress = (

--- a/elements/lisk-blocks/src/types.ts
+++ b/elements/lisk-blocks/src/types.ts
@@ -19,24 +19,26 @@ import {
 
 export interface AccountJSON {
 	readonly address: string;
-	readonly balance: string;
-	readonly missedBlocks: number;
-	readonly producedBlocks: number;
+	readonly balance: string | bigint;
+	readonly missedBlocks?: number;
+	readonly producedBlocks?: number;
 	readonly publicKey?: string;
 	readonly secondPublicKey?: string;
-	readonly secondSignature?: number;
+	readonly secondSignature?: boolean;
 	readonly username?: string;
 	readonly isDelegate?: number;
-	readonly fees: string;
-	readonly rewards: string;
+	readonly fees?: string | bigint;
+	readonly rewards?: string | bigint;
 	// tslint:disable-next-line readonly-keyword
-	voteWeight: string;
-	readonly nameExist: false;
-	readonly multiMin: number;
-	readonly multiLifetime: number;
-	readonly asset: object;
+	voteWeight?: string | bigint;
+	readonly nameExist?: false;
+	readonly multiMin?: number;
+	readonly multiLifetime?: number;
+	readonly asset?: object;
 	// tslint:disable-next-line readonly-keyword
 	votedDelegatesPublicKeys?: string[];
+	// tslint:disable-next-line readonly-keyword
+	membersPublicKeys?: ReadonlyArray<string>;
 }
 
 export interface Context {
@@ -203,7 +205,7 @@ export interface StorageEntity<T> {
 	) => Promise<void>;
 }
 
-export interface AccountStorageEntity extends StorageEntity<Account> {
+export interface AccountStorageEntity extends StorageEntity<AccountJSON> {
 	readonly resetMemTables: () => Promise<void>;
 }
 

--- a/elements/lisk-blocks/src/types.ts
+++ b/elements/lisk-blocks/src/types.ts
@@ -17,7 +17,7 @@ import {
 	TransactionResponse,
 } from '@liskhq/lisk-transactions';
 
-export interface Account {
+export interface AccountJSON {
 	readonly address: string;
 	readonly balance: string;
 	readonly missedBlocks: number;

--- a/elements/lisk-blocks/src/types.ts
+++ b/elements/lisk-blocks/src/types.ts
@@ -36,9 +36,9 @@ export interface AccountJSON {
 	readonly multiLifetime: number;
 	readonly asset: object;
 	// tslint:disable-next-line readonly-keyword
-	votedDelegatesPublicKeys: string[];
+	votedDelegatesPublicKeys: string[] | null;
 	// tslint:disable-next-line readonly-keyword
-	membersPublicKeys: string[];
+	membersPublicKeys: string[] | null;
 }
 
 export interface Context {

--- a/elements/lisk-blocks/src/types.ts
+++ b/elements/lisk-blocks/src/types.ts
@@ -19,7 +19,7 @@ import {
 
 export interface AccountJSON {
 	readonly address: string;
-	readonly balance: string | bigint;
+	readonly balance: string;
 	readonly missedBlocks: number;
 	readonly producedBlocks: number;
 	readonly publicKey: string | undefined;
@@ -27,18 +27,18 @@ export interface AccountJSON {
 	readonly secondSignature: number;
 	readonly username: string | null;
 	readonly isDelegate: number;
-	readonly fees: string | bigint;
-	readonly rewards: string | bigint;
+	readonly fees: string;
+	readonly rewards: string;
 	// tslint:disable-next-line readonly-keyword
-	voteWeight: string | bigint;
+	readonly voteWeight: string;
 	readonly nameExist: boolean;
 	readonly multiMin: number;
 	readonly multiLifetime: number;
 	readonly asset: object;
 	// tslint:disable-next-line readonly-keyword
-	votedDelegatesPublicKeys: string[] | null;
+	readonly votedDelegatesPublicKeys: string[] | null;
 	// tslint:disable-next-line readonly-keyword
-	membersPublicKeys: string[] | null;
+	readonly membersPublicKeys: string[] | null;
 }
 
 export interface Context {

--- a/elements/lisk-blocks/src/types.ts
+++ b/elements/lisk-blocks/src/types.ts
@@ -20,25 +20,25 @@ import {
 export interface AccountJSON {
 	readonly address: string;
 	readonly balance: string | bigint;
-	readonly missedBlocks?: number;
-	readonly producedBlocks?: number;
-	readonly publicKey?: string;
-	readonly secondPublicKey?: string;
-	readonly secondSignature?: boolean;
-	readonly username?: string;
-	readonly isDelegate?: number;
-	readonly fees?: string | bigint;
-	readonly rewards?: string | bigint;
+	readonly missedBlocks: number;
+	readonly producedBlocks: number;
+	readonly publicKey: string | undefined;
+	readonly secondPublicKey: string | null;
+	readonly secondSignature: number;
+	readonly username: string | null;
+	readonly isDelegate: number;
+	readonly fees: string | bigint;
+	readonly rewards: string | bigint;
 	// tslint:disable-next-line readonly-keyword
-	voteWeight?: string | bigint;
-	readonly nameExist?: false;
-	readonly multiMin?: number;
-	readonly multiLifetime?: number;
-	readonly asset?: object;
+	voteWeight: string | bigint;
+	readonly nameExist: boolean;
+	readonly multiMin: number;
+	readonly multiLifetime: number;
+	readonly asset: object;
 	// tslint:disable-next-line readonly-keyword
-	votedDelegatesPublicKeys?: string[];
+	votedDelegatesPublicKeys: string[];
 	// tslint:disable-next-line readonly-keyword
-	membersPublicKeys?: ReadonlyArray<string>;
+	membersPublicKeys: string[];
 }
 
 export interface Context {

--- a/elements/lisk-blocks/test/unit/account.spec.ts
+++ b/elements/lisk-blocks/test/unit/account.spec.ts
@@ -112,15 +112,4 @@ describe('account', () => {
 			expect(accountJSON.asset).toEqual({});
 		});
 	});
-
-	describe('addBalance', () => {
-		it('should update the balance by taking string or bigint', () => {
-			const balance1 = '8';
-			const balance2 = BigInt('8');
-			defaultAccount.addBalance(balance1);
-			expect(defaultAccount.balance).toEqual(BigInt(balance1));
-			defaultAccount.addBalance(balance2);
-			expect(defaultAccount.balance).toEqual(BigInt(balance1) + balance2);
-		});
-	});
 });

--- a/elements/lisk-blocks/test/unit/account.spec.ts
+++ b/elements/lisk-blocks/test/unit/account.spec.ts
@@ -68,9 +68,9 @@ describe('account', () => {
 		});
 	});
 
-	describe('getAccountJSON', () => {
+	describe('toJSON', () => {
 		defaultAccount = Account.getDefaultAccount(accountAddress1);
-		const accountJSON = defaultAccount.getAccountJSON();
+		const accountJSON = defaultAccount.toJSON();
 		it('should return default account JSON object with relevant types', () => {
 			expect(accountJSON.address).toEqual(accountAddress1);
 			expect(accountJSON.balance).toBeString;

--- a/elements/lisk-blocks/test/unit/account.spec.ts
+++ b/elements/lisk-blocks/test/unit/account.spec.ts
@@ -31,12 +31,16 @@ describe('account', () => {
 			expect(defaultAccount).toHaveProperty('fees');
 			expect(defaultAccount).toHaveProperty('voteWeight');
 			expect(defaultAccount).toHaveProperty('rewards');
-			expect(defaultAccount.balance).toEqual(accountDefaultValues.balance);
-			expect(defaultAccount.fees).toEqual(accountDefaultValues.fees);
-			expect(defaultAccount.voteWeight).toEqual(
-				accountDefaultValues.voteWeight,
+			expect(defaultAccount.balance).toEqual(
+				BigInt(accountDefaultValues.balance),
 			);
-			expect(defaultAccount.rewards).toEqual(accountDefaultValues.rewards);
+			expect(defaultAccount.fees).toEqual(BigInt(accountDefaultValues.fees));
+			expect(defaultAccount.voteWeight).toEqual(
+				BigInt(accountDefaultValues.voteWeight),
+			);
+			expect(defaultAccount.rewards).toEqual(
+				BigInt(accountDefaultValues.rewards),
+			);
 		});
 	});
 

--- a/elements/lisk-blocks/test/unit/account.spec.ts
+++ b/elements/lisk-blocks/test/unit/account.spec.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import * as randomUtils from '../utils/random';
+import { Account } from '../../src';
+import { accountDefaultValues } from '../../src/account';
+
+describe('account', () => {
+	const accountAddress1 = randomUtils.account().address;
+	let defaultAccount: Account;
+
+	beforeEach(() => {
+		defaultAccount = Account.getDefaultAccount(accountAddress1);
+	});
+
+	describe('constructor', () => {
+		it('should create an Account object with default values', () => {
+			expect(defaultAccount).toBeInstanceOf(Account);
+			expect(defaultAccount).toHaveProperty('balance');
+			expect(defaultAccount).toHaveProperty('fees');
+			expect(defaultAccount).toHaveProperty('voteWeight');
+			expect(defaultAccount).toHaveProperty('rewards');
+			expect(defaultAccount.balance).toEqual(accountDefaultValues.balance);
+			expect(defaultAccount.fees).toEqual(accountDefaultValues.fees);
+			expect(defaultAccount.voteWeight).toEqual(
+				accountDefaultValues.voteWeight,
+			);
+			expect(defaultAccount.rewards).toEqual(accountDefaultValues.rewards);
+		});
+	});
+
+	describe('getDefaultAccount', () => {
+		const accountAddress = randomUtils.account().address;
+		let accountObj: Account;
+		it('should return an instance of Account class with default values for a given address', () => {
+			accountObj = Account.getDefaultAccount(accountAddress);
+			expect(accountObj).toBeObject;
+			expect(accountObj).toHaveProperty('address');
+			expect(accountObj.address).toEqual(accountAddress);
+			expect(accountObj.balance).toEqual(BigInt('0'));
+			expect(accountObj.fees).toEqual(BigInt('0'));
+			expect(accountObj.voteWeight).toEqual(BigInt('0'));
+			expect(accountObj.rewards).toEqual(BigInt('0'));
+			expect(accountObj.votedDelegatesPublicKeys).toEqual([]);
+			expect(accountObj.membersPublicKeys).toEqual([]);
+			expect(accountObj.username).toBeNull;
+			expect(accountObj.secondPublicKey).toBeNull;
+			expect(accountObj.secondSignature).toEqual(0);
+			expect(accountObj.publicKey).toEqual(undefined);
+			expect(accountObj.isDelegate).toEqual(0);
+			expect(accountObj.missedBlocks).toEqual(0);
+			expect(accountObj.producedBlocks).toEqual(0);
+			expect(accountObj.nameExist).toEqual(false);
+			expect(accountObj.multiMin).toEqual(0);
+			expect(accountObj.multiLifetime).toEqual(0);
+			expect(accountObj.asset).toEqual({});
+		});
+	});
+
+	describe('getAccountJSON', () => {
+		defaultAccount = Account.getDefaultAccount(accountAddress1);
+		const accountJSON = defaultAccount.getAccountJSON();
+		it('should return default account JSON object with relevant types', () => {
+			expect(accountJSON.address).toEqual(accountAddress1);
+			expect(accountJSON.balance).toBeString;
+			expect(accountJSON.fees).toBeString;
+			expect(accountJSON.voteWeight).toBeString;
+			expect(accountJSON.rewards).toBeString;
+			expect(accountJSON.votedDelegatesPublicKeys).toBeNull;
+			expect(accountJSON.membersPublicKeys).toBeNull;
+			expect(accountJSON.username).toBeNull;
+			expect(accountJSON.secondPublicKey).toBeNull;
+			expect(accountJSON.secondSignature).toBeNumber;
+			expect(accountJSON.publicKey).toBeUndefined;
+			expect(accountJSON.isDelegate).toBeNumber;
+			expect(accountJSON.missedBlocks).toBeNumber;
+			expect(accountJSON.producedBlocks).toBeNumber;
+			expect(accountJSON.nameExist).toBeBoolean;
+			expect(accountJSON.multiMin).toBeNumber;
+			expect(accountJSON.multiLifetime).toBeNumber;
+			expect(accountJSON.asset).toBeObject;
+		});
+		it('should return account JSON object with relevant values', () => {
+			expect(accountJSON.address).toEqual(accountAddress1);
+			expect(accountJSON.balance).toEqual('0');
+			expect(accountJSON.fees).toEqual('0');
+			expect(accountJSON.voteWeight).toEqual('0');
+			expect(accountJSON.rewards).toEqual('0');
+			expect(accountJSON.votedDelegatesPublicKeys).toEqual(null);
+			expect(accountJSON.membersPublicKeys).toEqual(null);
+			expect(accountJSON.username).toBeNull;
+			expect(accountJSON.secondPublicKey).toBeNull;
+			expect(accountJSON.secondSignature).toEqual(0);
+			expect(accountJSON.publicKey).toEqual(undefined);
+			expect(accountJSON.isDelegate).toEqual(0);
+			expect(accountJSON.missedBlocks).toEqual(0);
+			expect(accountJSON.producedBlocks).toEqual(0);
+			expect(accountJSON.nameExist).toEqual(false);
+			expect(accountJSON.multiMin).toEqual(0);
+			expect(accountJSON.multiLifetime).toEqual(0);
+			expect(accountJSON.asset).toEqual({});
+		});
+	});
+
+	describe('addBalance', () => {
+		it('should update the balance by taking string or bigint', () => {
+			const balance1 = '8';
+			const balance2 = BigInt('8');
+			defaultAccount.addBalance(balance1);
+			expect(defaultAccount.balance).toEqual(BigInt(balance1));
+			defaultAccount.addBalance(balance2);
+			expect(defaultAccount.balance).toEqual(BigInt(balance1) + balance2);
+		});
+	});
+});

--- a/elements/lisk-blocks/test/unit/process.spec.ts
+++ b/elements/lisk-blocks/test/unit/process.spec.ts
@@ -753,8 +753,8 @@ describe('blocks/header', () => {
 			it('should update vote weight on voted delegate', async () => {
 				const delegateOne = await stateStore.account.get(delegate1.address);
 				const deletateTwo = await stateStore.account.get(delegate2.address);
-				expect(delegateOne.voteWeight).toBe('9889999900');
-				expect(deletateTwo.voteWeight).toBe('9889999900');
+				expect(delegateOne.voteWeight?.toString()).toBe('9889999900');
+				expect(deletateTwo.voteWeight?.toString()).toBe('9889999900');
 			});
 
 			it('should update vote weight on sender and recipient', async () => {
@@ -775,8 +775,8 @@ describe('blocks/header', () => {
 				// it should decrease by fee
 				const delegateOne = await stateStore.account.get(delegate1.address);
 				const deletateTwo = await stateStore.account.get(delegate2.address);
-				expect(delegateOne.voteWeight).toBe('9879999900');
-				expect(deletateTwo.voteWeight).toBe('9879999900');
+				expect(delegateOne.voteWeight?.toString()).toBe('9879999900');
+				expect(deletateTwo.voteWeight?.toString()).toBe('9879999900');
 			});
 		});
 	});
@@ -800,7 +800,9 @@ describe('blocks/header', () => {
 				const genesisAccountFromStore = await stateStore.account.get(
 					genesisAccount.address,
 				);
-				expect(genesisAccountFromStore.balance).toBe('10000000000000000');
+				expect(genesisAccountFromStore.balance.toString()).toBe(
+					'10000000000000000',
+				);
 			});
 
 			it('should not call account update', async () => {
@@ -935,8 +937,8 @@ describe('blocks/header', () => {
 			it('should update vote weight on voted delegate', async () => {
 				const delegateOne = await stateStore.account.get(delegate1.address);
 				const deletateTwo = await stateStore.account.get(delegate2.address);
-				expect(delegateOne.voteWeight).toBe('0');
-				expect(deletateTwo.voteWeight).toBe('0');
+				expect(delegateOne.voteWeight?.toString()).toBe('0');
+				expect(deletateTwo.voteWeight?.toString()).toBe('0');
 			});
 		});
 	});

--- a/elements/lisk-blocks/test/unit/process.spec.ts
+++ b/elements/lisk-blocks/test/unit/process.spec.ts
@@ -753,8 +753,8 @@ describe('blocks/header', () => {
 			it('should update vote weight on voted delegate', async () => {
 				const delegateOne = await stateStore.account.get(delegate1.address);
 				const deletateTwo = await stateStore.account.get(delegate2.address);
-				expect(delegateOne.voteWeight?.toString()).toBe('9889999900');
-				expect(deletateTwo.voteWeight?.toString()).toBe('9889999900');
+				expect(delegateOne.voteWeight).toBe(BigInt('9889999900'));
+				expect(deletateTwo.voteWeight).toBe(BigInt('9889999900'));
 			});
 
 			it('should update vote weight on sender and recipient', async () => {
@@ -774,9 +774,7 @@ describe('blocks/header', () => {
 				// expect
 				// it should decrease by fee
 				const delegateOne = await stateStore.account.get(delegate1.address);
-				const deletateTwo = await stateStore.account.get(delegate2.address);
-				expect(delegateOne.voteWeight?.toString()).toBe('9879999900');
-				expect(deletateTwo.voteWeight?.toString()).toBe('9879999900');
+				expect(delegateOne.voteWeight).toBe(BigInt('9879999900'));
 			});
 		});
 	});
@@ -800,8 +798,8 @@ describe('blocks/header', () => {
 				const genesisAccountFromStore = await stateStore.account.get(
 					genesisAccount.address,
 				);
-				expect(genesisAccountFromStore.balance.toString()).toBe(
-					'10000000000000000',
+				expect(genesisAccountFromStore.balance).toBe(
+					BigInt('10000000000000000'),
 				);
 			});
 
@@ -937,8 +935,8 @@ describe('blocks/header', () => {
 			it('should update vote weight on voted delegate', async () => {
 				const delegateOne = await stateStore.account.get(delegate1.address);
 				const deletateTwo = await stateStore.account.get(delegate2.address);
-				expect(delegateOne.voteWeight?.toString()).toBe('0');
-				expect(deletateTwo.voteWeight?.toString()).toBe('0');
+				expect(delegateOne.voteWeight).toBe(BigInt('0'));
+				expect(deletateTwo.voteWeight).toBe(BigInt('0'));
 			});
 		});
 	});

--- a/elements/lisk-blocks/test/unit/state_store_account.spec.ts
+++ b/elements/lisk-blocks/test/unit/state_store_account.spec.ts
@@ -256,11 +256,21 @@ describe('state store / account', () => {
 		let updatedAccount;
 		let secondPublicKey: string;
 		let secondSignature: number;
+		let accountUpsertObj: object;
 
 		beforeEach(async () => {
 			secondPublicKey =
 				'edf5786bef965f1836b8009e2c566463d62b6edd94e9cced49c1f098c972b92b';
 			secondSignature = 1;
+
+			accountUpsertObj = {
+				secondPublicKey,
+				secondSignature,
+				balance: '0',
+				fees: '0',
+				rewards: '0',
+				voteWeight: '0',
+			};
 
 			storageStub.entities.Account.get.mockResolvedValue(defaultAccounts);
 
@@ -287,7 +297,7 @@ describe('state store / account', () => {
 
 			expect(storageStub.entities.Account.upsert).toHaveBeenCalledWith(
 				{ address: defaultAccounts[0].address },
-				{ secondPublicKey, secondSignature },
+				accountUpsertObj,
 				null,
 				txStub,
 			);

--- a/elements/lisk-blocks/test/unit/state_store_account.spec.ts
+++ b/elements/lisk-blocks/test/unit/state_store_account.spec.ts
@@ -23,18 +23,18 @@ describe('state store / account', () => {
 		secondSignature: 0,
 		username: null,
 		isDelegate: 0,
-		balance: BigInt(0),
+		balance: '0',
 		nameExist: false,
 		missedBlocks: 0,
 		producedBlocks: 0,
-		fees: BigInt(0),
-		rewards: BigInt(0),
-		voteWeight: BigInt(0),
+		fees: '0',
+		rewards: '0',
+		voteWeight: '0',
 		multiMin: 0,
 		multiLifetime: 0,
-		votedDelegatesPublicKeys: [],
+		votedDelegatesPublicKeys: null,
 		asset: {},
-		membersPublicKeys: [],
+		membersPublicKeys: null,
 	};
 
 	const defaultAccounts = [
@@ -54,12 +54,12 @@ describe('state store / account', () => {
 		new Account({
 			...defaultAccount,
 			address: '1276152240083265771L',
-			balance: BigInt(100),
+			balance: '100',
 		}),
 		new Account({
 			...defaultAccount,
 			address: '11237980039345381032L',
-			balance: BigInt(555),
+			balance: '555',
 		}),
 	];
 
@@ -189,7 +189,9 @@ describe('state store / account', () => {
 			// Act
 			const account = await stateStore.account.getOrDefault('123L');
 			// Assert
-			expect(account).toEqual({ ...defaultAccount, address: '123L' });
+			expect(account).toEqual(
+				new Account({ ...defaultAccount, address: '123L' }),
+			);
 			expect(account.balance).toBe(BigInt(0));
 		});
 	});
@@ -234,7 +236,7 @@ describe('state store / account', () => {
 				defaultAccounts[0].address,
 			);
 			const updatedAccount = new Account({
-				...existingAccount,
+				...existingAccount.toJSON(),
 				secondPublicKey,
 				secondSignature,
 			});
@@ -280,7 +282,7 @@ describe('state store / account', () => {
 				defaultAccounts[0].address,
 			);
 			updatedAccount = new Account({
-				...existingAccount,
+				...existingAccount.toJSON(),
 				secondPublicKey,
 				secondSignature,
 			});

--- a/elements/lisk-blocks/test/unit/state_store_account.spec.ts
+++ b/elements/lisk-blocks/test/unit/state_store_account.spec.ts
@@ -17,32 +17,6 @@ import { StorageTransaction } from '../../src/types';
 import { Account } from '../../src';
 
 describe('state store / account', () => {
-	const defaultAccounts = [
-		{
-			...Account.defaultAccount,
-			address: '1276152240083265771L',
-			balance: '100',
-		},
-		{
-			...Account.defaultAccount,
-			address: '11237980039345381032L',
-			balance: '555',
-		},
-	];
-
-	const stateStoreAccounts = [
-		new Account({
-			...Account.defaultAccount,
-			address: '1276152240083265771L',
-			balance: BigInt(100),
-		}),
-		new Account({
-			...Account.defaultAccount,
-			address: '11237980039345381032L',
-			balance: BigInt(555),
-		}),
-	];
-
 	const defaultAccount = {
 		publicKey: undefined,
 		secondPublicKey: undefined,
@@ -55,13 +29,38 @@ describe('state store / account', () => {
 		fees: BigInt(0),
 		rewards: BigInt(0),
 		voteWeight: BigInt(0),
-		nameExist: false,
 		multiMin: 0,
 		multiLifetime: 0,
 		votedDelegatesPublicKeys: undefined,
 		asset: {},
 		membersPublicKeys: [],
 	};
+
+	const defaultAccounts = [
+		{
+			...defaultAccount,
+			address: '1276152240083265771L',
+			balance: '100',
+		},
+		{
+			...defaultAccount,
+			address: '11237980039345381032L',
+			balance: '555',
+		},
+	];
+
+	const stateStoreAccounts = [
+		new Account({
+			...defaultAccount,
+			address: '1276152240083265771L',
+			balance: BigInt(100),
+		}),
+		new Account({
+			...defaultAccount,
+			address: '11237980039345381032L',
+			balance: BigInt(555),
+		}),
+	];
 
 	let stateStore: StateStore;
 	let storageStub: any;

--- a/elements/lisk-blocks/test/unit/state_store_account.spec.ts
+++ b/elements/lisk-blocks/test/unit/state_store_account.spec.ts
@@ -19,11 +19,12 @@ import { Account } from '../../src';
 describe('state store / account', () => {
 	const defaultAccount = {
 		publicKey: undefined,
-		secondPublicKey: undefined,
-		secondSignature: false,
-		username: undefined,
+		secondPublicKey: null,
+		secondSignature: 0,
+		username: null,
 		isDelegate: 0,
 		balance: BigInt(0),
+		nameExist: false,
 		missedBlocks: 0,
 		producedBlocks: 0,
 		fees: BigInt(0),
@@ -31,7 +32,7 @@ describe('state store / account', () => {
 		voteWeight: BigInt(0),
 		multiMin: 0,
 		multiLifetime: 0,
-		votedDelegatesPublicKeys: undefined,
+		votedDelegatesPublicKeys: [],
 		asset: {},
 		membersPublicKeys: [],
 	};
@@ -195,13 +196,13 @@ describe('state store / account', () => {
 
 	describe('set', () => {
 		let secondPublicKey: string;
-		let secondSignature: boolean;
+		let secondSignature: number;
 
 		beforeEach(async () => {
 			// Arrange
 			secondPublicKey =
 				'edf5786bef965f1836b8009e2c566463d62b6edd94e9cced49c1f098c972b92b';
-			secondSignature = true;
+			secondSignature = 1;
 			storageStub.entities.Account.get.mockResolvedValue(defaultAccounts);
 			const filter = [
 				{ address: defaultAccounts[0].address },
@@ -254,12 +255,12 @@ describe('state store / account', () => {
 		let existingAccount;
 		let updatedAccount;
 		let secondPublicKey: string;
-		let secondSignature: boolean;
+		let secondSignature: number;
 
 		beforeEach(async () => {
 			secondPublicKey =
 				'edf5786bef965f1836b8009e2c566463d62b6edd94e9cced49c1f098c972b92b';
-			secondSignature = true;
+			secondSignature = 1;
 
 			storageStub.entities.Account.get.mockResolvedValue(defaultAccounts);
 

--- a/elements/lisk-blocks/test/unit/state_store_account.spec.ts
+++ b/elements/lisk-blocks/test/unit/state_store_account.spec.ts
@@ -266,10 +266,6 @@ describe('state store / account', () => {
 			accountUpsertObj = {
 				secondPublicKey,
 				secondSignature,
-				balance: '0',
-				fees: '0',
-				rewards: '0',
-				voteWeight: '0',
 			};
 
 			storageStub.entities.Account.get.mockResolvedValue(defaultAccounts);

--- a/elements/lisk-blocks/test/unit/transactions.spec.ts
+++ b/elements/lisk-blocks/test/unit/transactions.spec.ts
@@ -118,7 +118,7 @@ describe('blocks/transactions', () => {
 		};
 	});
 
-	describe.skip('#filterReadyTransactions', () => {
+	describe('#filterReadyTransactions', () => {
 		describe('when transactions include not allowed transaction based on the context', () => {
 			it('should return transaction which are allowed', async () => {
 				// Arrange
@@ -785,7 +785,13 @@ describe('blocks/transactions', () => {
 			it('should return invalid transaction response', async () => {
 				// Arrange
 				storageStub.entities.Account.get.mockResolvedValue([
-					{ address: genesisAccount.address, balance: '10000100' },
+					{
+						address: genesisAccount.address,
+						balance: '10000100',
+						membersPublicKeys: [
+							'2104c3882088fa512df4c64033a03cac911eec7e71dc03352cc2244dfc10a74c',
+						],
+					},
 				]);
 				const validTx = blocksInstance.deserializeTransaction(
 					transfer({

--- a/elements/lisk-dpos/src/delegates_info.ts
+++ b/elements/lisk-dpos/src/delegates_info.ts
@@ -98,16 +98,10 @@ const _updateBalanceRewardsAndFees = async (
 
 		const factor = undo ? BigInt(-1) : BigInt(1);
 		const amount = fee + reward;
-		const balance = BigInt(account.balance) + amount * factor;
-		const fees = BigInt(account.fees) + fee * factor;
-		const rewards = BigInt(account.rewards) + reward * factor;
-		const updatedAccount = {
-			...account,
-			balance: balance.toString(),
-			fees: fees.toString(),
-			rewards: rewards.toString(),
-		};
-		stateStore.account.set(account.address, updatedAccount);
+		account.balance += amount * factor;
+		account.fees += fee * factor;
+		account.rewards += reward * factor;
+		stateStore.account.set(account.address, account);
 	}
 };
 
@@ -131,11 +125,8 @@ const _updateVotedDelegatesVoteWeight = async (
 			);
 			const amount = fee + reward;
 			const factor = undo ? BigInt(-1) : BigInt(1);
-			const updatedAccount: Account = {
-				...account,
-				voteWeight: (BigInt(account.voteWeight) + amount * factor).toString(),
-			};
-			stateStore.account.set(account.address, updatedAccount);
+			account.voteWeight += amount * factor;
+			stateStore.account.set(account.address, account);
 		}
 	}
 };

--- a/elements/lisk-dpos/src/types.ts
+++ b/elements/lisk-dpos/src/types.ts
@@ -37,29 +37,19 @@ export interface BlockHeader extends Earnings {
 	readonly timestamp: number;
 }
 
+// tslint:disable readonly-keyword
 export interface Account {
 	readonly address: string;
-	readonly balance: string;
-	// tslint:disable-next-line readonly-keyword
+	balance: bigint;
 	producedBlocks: number;
-	// tslint:disable-next-line readonly-keyword
 	missedBlocks: number;
-	readonly fees: string;
-	readonly rewards: string;
+	fees: bigint;
+	rewards: bigint;
 	readonly publicKey: string;
-	readonly voteWeight: string;
+	voteWeight: bigint;
 	readonly votedDelegatesPublicKeys: ReadonlyArray<string>;
 }
-
-export interface ParsedAccount
-	extends Omit<Account, 'balance' | 'fees' | 'rewards'> {
-	// tslint:disable-next-line readonly-keyword
-	balance: bigint;
-	// tslint:disable-next-line readonly-keyword
-	fees: bigint;
-	// tslint:disable-next-line readonly-keyword
-	rewards: bigint;
-}
+// tslint:enable readonly-keyword
 
 export interface DPoSProcessingOptions {
 	readonly delegateListRoundOffset: number;

--- a/elements/lisk-dpos/test/unit/apply.spec.ts
+++ b/elements/lisk-dpos/test/unit/apply.spec.ts
@@ -318,8 +318,8 @@ describe('dpos.apply()', () => {
 				const { rewards, fees } = await stateStore.account.get(
 					delegate.address,
 				);
-				expect(rewards).toEqual((BigInt(delegate.rewards) + reward).toString());
-				expect(fees).toEqual((BigInt(delegate.fees) + fee).toString());
+				expect(rewards).toEqual(BigInt(delegate.rewards) + reward);
+				expect(fees).toEqual(BigInt(delegate.fees) + fee);
 			}
 
 			// Assert Group 2/2
@@ -344,8 +344,8 @@ describe('dpos.apply()', () => {
 				);
 				const { reward, fee } = getTotalEarningsOfDelegate(delegate);
 
-				expect(rewards).toEqual((BigInt(delegate.rewards) + reward).toString());
-				expect(fees).toEqual((BigInt(delegate.fees) + fee).toString());
+				expect(rewards).toEqual(BigInt(delegate.rewards) + reward);
+				expect(fees).toEqual(BigInt(delegate.fees) + fee);
 			}
 		});
 
@@ -359,9 +359,9 @@ describe('dpos.apply()', () => {
 				const { fee, reward } = getTotalEarningsOfDelegate(delegate);
 				const amount = fee + reward;
 				const data = {
-					balance: (BigInt(delegate.balance) + amount).toString(),
-					fees: (BigInt(delegate.fees) + fee).toString(),
-					rewards: (BigInt(delegate.rewards) + reward).toString(),
+					balance: BigInt(delegate.balance) + amount,
+					fees: BigInt(delegate.fees) + fee,
+					rewards: BigInt(delegate.rewards) + reward,
 				};
 				const account = await stateStore.account.get(delegate.address);
 
@@ -402,11 +402,9 @@ describe('dpos.apply()', () => {
 				delegateWhoForgedLast.address,
 			);
 			expect(lastDelegate.fees).toEqual(
-				(
-					BigInt(delegateWhoForgedLast.fees) +
+				BigInt(delegateWhoForgedLast.fees) +
 					feePerDelegate * BigInt(3) +
-					BigInt(remainingFee)
-				).toString(),
+					BigInt(remainingFee),
 			);
 
 			for (const delegate of uniqueDelegatesWhoForged) {
@@ -418,10 +416,7 @@ describe('dpos.apply()', () => {
 					d => d.publicKey === account.publicKey,
 				).length;
 				expect(account.fees).toEqual(
-					(
-						BigInt(delegate.fees) +
-						feePerDelegate * BigInt(blockCount)
-					).toString(),
+					BigInt(delegate.fees) + feePerDelegate * BigInt(blockCount),
 				);
 			}
 		});
@@ -446,7 +441,7 @@ describe('dpos.apply()', () => {
 			);
 
 			for (const publicKey of Object.keys(publicKeysToUpdate)) {
-				const amount = publicKeysToUpdate[publicKey].toString();
+				const amount = publicKeysToUpdate[publicKey];
 				const account = await stateStore.account.get(
 					getAddressFromPublicKey(publicKey),
 				);
@@ -644,7 +639,7 @@ describe('dpos.apply()', () => {
 				// Assert
 				expect.assertions(publicKeysToUpdate.length);
 				for (const publicKey of Object.keys(publicKeysToUpdate)) {
-					const amount = publicKeysToUpdate[publicKey].toString();
+					const amount = publicKeysToUpdate[publicKey];
 					const account = await stateStore.account.get(
 						getAddressFromPublicKey(publicKey),
 					);
@@ -691,9 +686,7 @@ describe('dpos.apply()', () => {
 					const { reward } = getTotalEarningsOfDelegate(delegate);
 					const exceptionReward =
 						reward * BigInt(exceptionFactors.rewards_factor);
-					const expectedReward = (
-						BigInt(delegate.rewards) + exceptionReward
-					).toString();
+					const expectedReward = BigInt(delegate.rewards) + exceptionReward;
 					const account = await stateStore.account.get(delegate.address);
 					expect(account.rewards).toEqual(expectedReward);
 				}
@@ -714,7 +707,7 @@ describe('dpos.apply()', () => {
 
 					const earnedFee =
 						(exceptionTotalFee / BigInt(ACTIVE_DELEGATES)) * BigInt(blockCount);
-					const expectedFee = (BigInt(delegate.fees) + earnedFee).toString();
+					const expectedFee = BigInt(delegate.fees) + earnedFee;
 					const account = await stateStore.account.get(delegate.address);
 
 					expect(account.fees).toEqual(expectedFee);

--- a/elements/lisk-dpos/test/unit/undo.spec.ts
+++ b/elements/lisk-dpos/test/unit/undo.spec.ts
@@ -263,10 +263,8 @@ describe('dpos.undo()', () => {
 			for (const delegate of uniqueDelegatesWhoForged) {
 				const account = await stateStore.account.get(delegate.address);
 				const { reward, fee } = getTotalEarningsOfDelegate(account);
-				expect(account.rewards).toEqual(
-					(BigInt(delegate.rewards) - reward).toString(),
-				);
-				expect(account.fees).toEqual((BigInt(delegate.fees) - fee).toString());
+				expect(account.rewards).toEqual(BigInt(delegate.rewards) - reward);
+				expect(account.fees).toEqual(BigInt(delegate.fees) - fee);
 			}
 			for (const delegate of delegatesWhoForgedNone) {
 				const account = await stateStore.account.get(delegate.address);
@@ -286,10 +284,8 @@ describe('dpos.undo()', () => {
 				const account = await stateStore.account.get(delegate.address);
 				const { reward, fee } = getTotalEarningsOfDelegate(account);
 				// Assert
-				expect(account.rewards).toEqual(
-					(BigInt(delegate.rewards) - reward).toString(),
-				);
-				expect(account.fees).toEqual((BigInt(delegate.fees) - fee).toString());
+				expect(account.rewards).toEqual(BigInt(delegate.rewards) - reward);
+				expect(account.fees).toEqual(BigInt(delegate.fees) - fee);
 			}
 		});
 
@@ -304,9 +300,9 @@ describe('dpos.undo()', () => {
 				const { reward, fee } = getTotalEarningsOfDelegate(account);
 				const amount = fee + reward;
 				const data = {
-					balance: (BigInt(delegate.balance) - amount).toString(),
-					fees: (BigInt(delegate.fees) - fee).toString(),
-					rewards: (BigInt(delegate.rewards) - reward).toString(),
+					balance: BigInt(delegate.balance) - amount,
+					fees: BigInt(delegate.fees) - fee,
+					rewards: BigInt(delegate.rewards) - reward,
 				};
 				expect(account.rewards).toEqual(data.rewards);
 				expect(account.fees).toEqual(data.fees);
@@ -344,10 +340,8 @@ describe('dpos.undo()', () => {
 				delegateWhoForgedLast.address,
 			);
 			expect(lastDelegate.fees).toEqual(
-				(
-					BigInt(delegateWhoForgedLast.fees) -
-					(feePerDelegate * BigInt(3) + BigInt(remainingFee))
-				).toString(),
+				BigInt(delegateWhoForgedLast.fees) -
+					(feePerDelegate * BigInt(3) + BigInt(remainingFee)),
 			);
 			for (const delegate of uniqueDelegatesWhoForged) {
 				if (delegate.address === delegateWhoForgedLast.address) {
@@ -358,10 +352,7 @@ describe('dpos.undo()', () => {
 				).length;
 				const account = await stateStore.account.get(delegate.address);
 				expect(account.fees).toEqual(
-					(
-						BigInt(delegate.fees) -
-						feePerDelegate * BigInt(blockCount)
-					).toString(),
+					BigInt(delegate.fees) - feePerDelegate * BigInt(blockCount),
 				);
 			}
 		});
@@ -388,12 +379,12 @@ describe('dpos.undo()', () => {
 			// Assert
 			expect.assertions(publicKeysToUpdate.length);
 			for (const publicKey of Object.keys(publicKeysToUpdate)) {
-				const amount = publicKeysToUpdate[publicKey].toString();
+				const amount = publicKeysToUpdate[publicKey];
 				const account = await stateStore.account.get(
 					getAddressFromPublicKey(publicKey),
 				);
 				// Assuming that the initial value was 0
-				expect(account.voteWeight).toEqual(`-${amount}`);
+				expect(account.voteWeight).toEqual(BigInt(`-${amount}`));
 			}
 		});
 
@@ -496,9 +487,7 @@ describe('dpos.undo()', () => {
 					// Undo will use -1 as we're undoing
 					const exceptionReward =
 						reward * BigInt(-1 * exceptionFactors.rewards_factor);
-					const rewards = (
-						BigInt(delegate.rewards) + exceptionReward
-					).toString();
+					const rewards = BigInt(delegate.rewards) + exceptionReward;
 					const account = await stateStore.account.get(delegate.address);
 					expect(account.rewards).toEqual(rewards);
 				}
@@ -520,7 +509,7 @@ describe('dpos.undo()', () => {
 					const earnedFee =
 						(exceptionTotalFee / BigInt(ACTIVE_DELEGATES)) * BigInt(blockCount);
 
-					const fees = (BigInt(delegate.fees) - earnedFee).toString();
+					const fees = BigInt(delegate.fees) - earnedFee;
 					const account = await stateStore.account.get(delegate.address);
 					expect(account.fees).toEqual(fees);
 				}

--- a/elements/lisk-dpos/test/utils/round_delegates.ts
+++ b/elements/lisk-dpos/test/utils/round_delegates.ts
@@ -36,10 +36,10 @@ for (
 		publicKey,
 		producedBlocks: 0,
 		missedBlocks: 0,
-		balance,
-		fees: '0',
-		rewards: '0',
-		voteWeight: '0',
+		balance: BigInt(balance),
+		fees: BigInt('0'),
+		rewards: BigInt('0'),
+		voteWeight: BigInt('0'),
 		votedDelegatesPublicKeys: [],
 	});
 }
@@ -57,12 +57,12 @@ export const delegateAccounts = delegatePublicKeys.map(
 		];
 		return {
 			address: getAddressFromPublicKey(pk),
-			balance,
+			balance: BigInt(balance),
 			producedBlocks: 0,
 			missedBlocks: 0,
-			rewards,
-			voteWeight,
-			fees: (BigInt(balance) - BigInt(rewards)).toString(),
+			rewards: BigInt(rewards),
+			voteWeight: BigInt(voteWeight),
+			fees: BigInt(balance) - BigInt(rewards),
 			publicKey: pk,
 			votedDelegatesPublicKeys,
 		};

--- a/elements/lisk-p2p/test/functional/broadcast.ts
+++ b/elements/lisk-p2p/test/functional/broadcast.ts
@@ -14,11 +14,7 @@
  */
 import { P2P, events } from '../../src/index';
 import { wait } from '../utils/helpers';
-import {
-	createNetwork,
-	destroyNetwork,
-	NETWORK_PEER_COUNT,
-} from '../utils/network_setup';
+import { createNetwork, destroyNetwork } from '../utils/network_setup';
 
 describe('P2P.broadcast', () => {
 	let p2pNodeList: ReadonlyArray<P2P> = [];
@@ -57,7 +53,9 @@ describe('P2P.broadcast', () => {
 		await wait(100);
 
 		// Assert
-		expect(Object.keys(collectedMessages)).toHaveLength(NETWORK_PEER_COUNT - 1);
+		expect(Object.keys(collectedMessages)).toHaveLength(
+			firstP2PNode.getConnectedPeers().length,
+		);
 		for (let receivedMessageData of collectedMessages) {
 			if (!nodePortToMessagesMap[receivedMessageData.nodePort]) {
 				nodePortToMessagesMap[receivedMessageData.nodePort] = [];
@@ -68,7 +66,7 @@ describe('P2P.broadcast', () => {
 		}
 
 		expect(Object.keys(nodePortToMessagesMap)).toHaveLength(
-			NETWORK_PEER_COUNT - 1,
+			firstP2PNode.getConnectedPeers().length,
 		);
 		for (let receivedMessages of Object.values(nodePortToMessagesMap) as any) {
 			expect(receivedMessages).toEqual(expect.any(Array));
@@ -86,7 +84,9 @@ describe('P2P.broadcast', () => {
 
 		// Assert
 		expect(collectedMessages).toEqual(expect.any(Array));
-		expect(collectedMessages).toHaveLength(NETWORK_PEER_COUNT - 1);
+		expect(collectedMessages).toHaveLength(
+			firstP2PNode.getConnectedPeers().length,
+		);
 
 		expect(collectedMessages[0]).toMatchObject({
 			message: {

--- a/elements/lisk-p2p/test/functional/broadcast.ts
+++ b/elements/lisk-p2p/test/functional/broadcast.ts
@@ -50,12 +50,14 @@ describe('P2P.broadcast', () => {
 
 		// Act
 		firstP2PNode.broadcast({ event: BROADCAST_EVENT, data: BROADCAST_DATA });
-		await wait(100);
+		const numOfConnectedPeers = firstP2PNode.getConnectedPeers().length;
+		await wait(200);
 
 		// Assert
-		expect(Object.keys(collectedMessages)).toHaveLength(
-			firstP2PNode.getConnectedPeers().length,
+		expect(Object.keys(collectedMessages).length).toBeGreaterThanOrEqual(
+			numOfConnectedPeers - 1,
 		);
+
 		for (let receivedMessageData of collectedMessages) {
 			if (!nodePortToMessagesMap[receivedMessageData.nodePort]) {
 				nodePortToMessagesMap[receivedMessageData.nodePort] = [];
@@ -65,8 +67,8 @@ describe('P2P.broadcast', () => {
 			);
 		}
 
-		expect(Object.keys(nodePortToMessagesMap)).toHaveLength(
-			firstP2PNode.getConnectedPeers().length,
+		expect(Object.keys(nodePortToMessagesMap).length).toBeGreaterThanOrEqual(
+			numOfConnectedPeers - 1,
 		);
 		for (let receivedMessages of Object.values(nodePortToMessagesMap) as any) {
 			expect(receivedMessages).toEqual(expect.any(Array));
@@ -80,12 +82,13 @@ describe('P2P.broadcast', () => {
 
 		// Act
 		firstP2PNode.broadcast({ event: BROADCAST_EVENT, data: BROADCAST_DATA });
-		await wait(100);
+		const numOfConnectedPeers = firstP2PNode.getConnectedPeers().length;
+		await wait(200);
 
 		// Assert
 		expect(collectedMessages).toEqual(expect.any(Array));
-		expect(collectedMessages).toHaveLength(
-			firstP2PNode.getConnectedPeers().length,
+		expect(collectedMessages.length).toBeGreaterThanOrEqual(
+			numOfConnectedPeers,
 		);
 
 		expect(collectedMessages[0]).toMatchObject({

--- a/elements/lisk-transactions/src/10_delegate_transaction.ts
+++ b/elements/lisk-transactions/src/10_delegate_transaction.ts
@@ -131,13 +131,10 @@ export class DelegateTransaction extends BaseTransaction {
 				),
 			);
 		}
-		const updatedSender = {
-			...sender,
-			username: this.asset.username,
-			vote: 0,
-			isDelegate: 1,
-		};
-		store.account.set(updatedSender.address, updatedSender);
+		sender.username = this.asset.username;
+		sender.isDelegate = 1;
+		sender.voteWeight = BigInt(0);
+		store.account.set(sender.address, sender);
 
 		return errors;
 	}
@@ -147,14 +144,11 @@ export class DelegateTransaction extends BaseTransaction {
 	): Promise<ReadonlyArray<TransactionError>> {
 		const sender = await store.account.get(this.senderId);
 		const { username, ...strippedSender } = sender;
-		const resetSender = {
-			...sender,
-			// tslint:disable-next-line no-null-keyword - Exception for compatibility with Core 1.4
-			username: null,
-			vote: 0,
-			isDelegate: 0,
-		};
-		store.account.set(strippedSender.address, resetSender);
+		// tslint:disable-next-line:no-null-keyword
+		sender.username = null;
+		sender.isDelegate = 0;
+		sender.voteWeight = BigInt(0);
+		store.account.set(strippedSender.address, sender);
 
 		return [];
 	}

--- a/elements/lisk-transactions/src/10_delegate_transaction.ts
+++ b/elements/lisk-transactions/src/10_delegate_transaction.ts
@@ -143,12 +143,11 @@ export class DelegateTransaction extends BaseTransaction {
 		store: StateStore,
 	): Promise<ReadonlyArray<TransactionError>> {
 		const sender = await store.account.get(this.senderId);
-		const { username, ...strippedSender } = sender;
 		// tslint:disable-next-line:no-null-keyword
 		sender.username = null;
 		sender.isDelegate = 0;
 		sender.voteWeight = BigInt(0);
-		store.account.set(strippedSender.address, sender);
+		store.account.set(sender.address, sender);
 
 		return [];
 	}

--- a/elements/lisk-transactions/src/11_vote_transaction.ts
+++ b/elements/lisk-transactions/src/11_vote_transaction.ts
@@ -232,7 +232,7 @@ export class VoteTransaction extends BaseTransaction {
 		}
 		const updatedSender = {
 			...sender,
-			votedDelegatesPublicKeys,
+			votedDelegatesPublicKeys: votedDelegatesPublicKeys as string[],
 		};
 		store.account.set(updatedSender.address, updatedSender);
 
@@ -270,7 +270,7 @@ export class VoteTransaction extends BaseTransaction {
 
 		const updatedSender = {
 			...sender,
-			votedDelegatesPublicKeys,
+			votedDelegatesPublicKeys: votedDelegatesPublicKeys as string[],
 		};
 		store.account.set(updatedSender.address, updatedSender);
 

--- a/elements/lisk-transactions/src/11_vote_transaction.ts
+++ b/elements/lisk-transactions/src/11_vote_transaction.ts
@@ -230,11 +230,8 @@ export class VoteTransaction extends BaseTransaction {
 				),
 			);
 		}
-		const updatedSender = {
-			...sender,
-			votedDelegatesPublicKeys: votedDelegatesPublicKeys as string[],
-		};
-		store.account.set(updatedSender.address, updatedSender);
+		sender.votedDelegatesPublicKeys = votedDelegatesPublicKeys as string[];
+		store.account.set(sender.address, sender);
 
 		return errors;
 	}
@@ -268,11 +265,8 @@ export class VoteTransaction extends BaseTransaction {
 			);
 		}
 
-		const updatedSender = {
-			...sender,
-			votedDelegatesPublicKeys: votedDelegatesPublicKeys as string[],
-		};
-		store.account.set(updatedSender.address, updatedSender);
+		sender.votedDelegatesPublicKeys = votedDelegatesPublicKeys as string[];
+		store.account.set(sender.address, sender);
 
 		return errors;
 	}

--- a/elements/lisk-transactions/src/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/8_transfer_transaction.ts
@@ -182,12 +182,8 @@ export class TransferTransaction extends BaseTransaction {
 		}
 
 		const updatedSenderBalance = sender.balance - this.asset.amount;
-
-		const updatedSender = {
-			...sender,
-			balance: updatedSenderBalance,
-		};
-		store.account.set(updatedSender.address, updatedSender);
+		sender.balance = updatedSenderBalance;
+		store.account.set(sender.address, sender);
 		const recipient = await store.account.getOrDefault(this.asset.recipientId);
 
 		const updatedRecipientBalance = recipient.balance + this.asset.amount;
@@ -202,12 +198,8 @@ export class TransferTransaction extends BaseTransaction {
 				),
 			);
 		}
-
-		const updatedRecipient = {
-			...recipient,
-			balance: updatedRecipientBalance,
-		};
-		store.account.set(updatedRecipient.address, updatedRecipient);
+		recipient.balance = updatedRecipientBalance;
+		store.account.set(recipient.address, recipient);
 
 		return errors;
 	}
@@ -230,11 +222,8 @@ export class TransferTransaction extends BaseTransaction {
 			);
 		}
 
-		const updatedSender = {
-			...sender,
-			balance: updatedSenderBalance,
-		};
-		store.account.set(updatedSender.address, updatedSender);
+		sender.balance = updatedSenderBalance;
+		store.account.set(sender.address, sender);
 		const recipient = await store.account.getOrDefault(this.asset.recipientId);
 
 		const balanceError = verifyBalance(this.id, recipient, this.asset.amount);
@@ -244,13 +233,9 @@ export class TransferTransaction extends BaseTransaction {
 		}
 
 		const updatedRecipientBalance = recipient.balance - this.asset.amount;
+		recipient.balance = updatedRecipientBalance;
 
-		const updatedRecipient = {
-			...recipient,
-			balance: updatedRecipientBalance,
-		};
-
-		store.account.set(updatedRecipient.address, updatedRecipient);
+		store.account.set(recipient.address, recipient);
 
 		return errors;
 	}

--- a/elements/lisk-transactions/src/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/8_transfer_transaction.ts
@@ -192,7 +192,7 @@ export class TransferTransaction extends BaseTransaction {
 
 		const updatedRecipientBalance = recipient.balance + this.asset.amount;
 
-		if (BigInt(updatedRecipientBalance) > BigInt(MAX_TRANSACTION_AMOUNT)) {
+		if (updatedRecipientBalance > BigInt(MAX_TRANSACTION_AMOUNT)) {
 			errors.push(
 				new TransactionError(
 					'Invalid amount',
@@ -219,7 +219,7 @@ export class TransferTransaction extends BaseTransaction {
 		const sender = await store.account.get(this.senderId);
 		const updatedSenderBalance = sender.balance + this.asset.amount;
 
-		if (BigInt(updatedSenderBalance) > BigInt(MAX_TRANSACTION_AMOUNT)) {
+		if (updatedSenderBalance > BigInt(MAX_TRANSACTION_AMOUNT)) {
 			errors.push(
 				new TransactionError(
 					'Invalid amount',

--- a/elements/lisk-transactions/src/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/8_transfer_transaction.ts
@@ -181,18 +181,17 @@ export class TransferTransaction extends BaseTransaction {
 			errors.push(balanceError);
 		}
 
-		const updatedSenderBalance =
-			BigInt(sender.balance) - BigInt(this.asset.amount);
+		const updatedSenderBalance = sender.balance - BigInt(this.asset.amount);
 
 		const updatedSender = {
 			...sender,
-			balance: updatedSenderBalance.toString(),
+			balance: updatedSenderBalance,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 		const recipient = await store.account.getOrDefault(this.asset.recipientId);
 
 		const updatedRecipientBalance =
-			BigInt(recipient.balance) + BigInt(this.asset.amount);
+			recipient.balance + BigInt(this.asset.amount);
 
 		if (updatedRecipientBalance > BigInt(MAX_TRANSACTION_AMOUNT)) {
 			errors.push(
@@ -207,7 +206,7 @@ export class TransferTransaction extends BaseTransaction {
 
 		const updatedRecipient = {
 			...recipient,
-			balance: updatedRecipientBalance.toString(),
+			balance: updatedRecipientBalance,
 		};
 		store.account.set(updatedRecipient.address, updatedRecipient);
 
@@ -219,8 +218,7 @@ export class TransferTransaction extends BaseTransaction {
 	): Promise<ReadonlyArray<TransactionError>> {
 		const errors: TransactionError[] = [];
 		const sender = await store.account.get(this.senderId);
-		const updatedSenderBalance =
-			BigInt(sender.balance) + BigInt(this.asset.amount);
+		const updatedSenderBalance = sender.balance + BigInt(this.asset.amount);
 
 		if (updatedSenderBalance > BigInt(MAX_TRANSACTION_AMOUNT)) {
 			errors.push(
@@ -235,7 +233,7 @@ export class TransferTransaction extends BaseTransaction {
 
 		const updatedSender = {
 			...sender,
-			balance: updatedSenderBalance.toString(),
+			balance: updatedSenderBalance,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 		const recipient = await store.account.getOrDefault(this.asset.recipientId);
@@ -247,11 +245,11 @@ export class TransferTransaction extends BaseTransaction {
 		}
 
 		const updatedRecipientBalance =
-			BigInt(recipient.balance) - BigInt(this.asset.amount);
+			recipient.balance - BigInt(this.asset.amount);
 
 		const updatedRecipient = {
 			...recipient,
-			balance: updatedRecipientBalance.toString(),
+			balance: updatedRecipientBalance,
 		};
 
 		store.account.set(updatedRecipient.address, updatedRecipient);

--- a/elements/lisk-transactions/src/8_transfer_transaction.ts
+++ b/elements/lisk-transactions/src/8_transfer_transaction.ts
@@ -181,7 +181,7 @@ export class TransferTransaction extends BaseTransaction {
 			errors.push(balanceError);
 		}
 
-		const updatedSenderBalance = sender.balance - BigInt(this.asset.amount);
+		const updatedSenderBalance = sender.balance - this.asset.amount;
 
 		const updatedSender = {
 			...sender,
@@ -190,10 +190,9 @@ export class TransferTransaction extends BaseTransaction {
 		store.account.set(updatedSender.address, updatedSender);
 		const recipient = await store.account.getOrDefault(this.asset.recipientId);
 
-		const updatedRecipientBalance =
-			recipient.balance + BigInt(this.asset.amount);
+		const updatedRecipientBalance = recipient.balance + this.asset.amount;
 
-		if (updatedRecipientBalance > BigInt(MAX_TRANSACTION_AMOUNT)) {
+		if (BigInt(updatedRecipientBalance) > BigInt(MAX_TRANSACTION_AMOUNT)) {
 			errors.push(
 				new TransactionError(
 					'Invalid amount',
@@ -218,9 +217,9 @@ export class TransferTransaction extends BaseTransaction {
 	): Promise<ReadonlyArray<TransactionError>> {
 		const errors: TransactionError[] = [];
 		const sender = await store.account.get(this.senderId);
-		const updatedSenderBalance = sender.balance + BigInt(this.asset.amount);
+		const updatedSenderBalance = sender.balance + this.asset.amount;
 
-		if (updatedSenderBalance > BigInt(MAX_TRANSACTION_AMOUNT)) {
+		if (BigInt(updatedSenderBalance) > BigInt(MAX_TRANSACTION_AMOUNT)) {
 			errors.push(
 				new TransactionError(
 					'Invalid amount',
@@ -244,8 +243,7 @@ export class TransferTransaction extends BaseTransaction {
 			errors.push(balanceError);
 		}
 
-		const updatedRecipientBalance =
-			recipient.balance - BigInt(this.asset.amount);
+		const updatedRecipientBalance = recipient.balance - this.asset.amount;
 
 		const updatedRecipient = {
 			...recipient,

--- a/elements/lisk-transactions/src/9_second_signature_transaction.ts
+++ b/elements/lisk-transactions/src/9_second_signature_transaction.ts
@@ -114,12 +114,10 @@ export class SecondSignatureTransaction extends BaseTransaction {
 				),
 			);
 		}
-		const updatedSender = {
-			...sender,
-			secondPublicKey: this.asset.publicKey,
-			secondSignature: 1,
-		};
-		store.account.set(updatedSender.address, updatedSender);
+
+		sender.secondPublicKey = this.asset.publicKey;
+		sender.secondSignature = 1;
+		store.account.set(sender.address, sender);
 
 		return errors;
 	}
@@ -128,14 +126,11 @@ export class SecondSignatureTransaction extends BaseTransaction {
 		store: StateStore,
 	): Promise<ReadonlyArray<TransactionError>> {
 		const sender = await store.account.get(this.senderId);
-		const resetSender = {
-			...sender,
-			// tslint:disable-next-line no-null-keyword - Exception for compatibility with Core 1.4
-			secondPublicKey: null,
-			secondSignature: 0,
-		};
+		// tslint:disable-next-line:no-null-keyword
+		sender.secondPublicKey = null;
+		sender.secondSignature = 0;
 
-		store.account.set(resetSender.address, resetSender);
+		store.account.set(sender.address, sender);
 
 		return [];
 	}

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -346,7 +346,7 @@ export abstract class BaseTransaction {
 			publicKey: sender.publicKey || this.senderPublicKey,
 		};
 		const errors =
-			BigInt(updatedBalance) <= BigInt(MAX_TRANSACTION_AMOUNT)
+			updatedBalance <= BigInt(MAX_TRANSACTION_AMOUNT)
 				? []
 				: [
 						new TransactionError(

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -311,10 +311,10 @@ export abstract class BaseTransaction {
 			errors.push(...multiSigError);
 		}
 
-		const updatedBalance = BigInt(sender.balance) - BigInt(this.fee);
+		const updatedBalance = sender.balance - this.fee;
 		const updatedSender = {
 			...sender,
-			balance: updatedBalance.toString(),
+			balance: updatedBalance,
 			publicKey: sender.publicKey || this.senderPublicKey,
 		};
 		store.account.set(updatedSender.address, updatedSender);
@@ -339,14 +339,14 @@ export abstract class BaseTransaction {
 
 	public async undo(store: StateStore): Promise<TransactionResponse> {
 		const sender = await store.account.getOrDefault(this.senderId);
-		const updatedBalance = BigInt(sender.balance) + this.fee;
+		const updatedBalance = sender.balance + this.fee;
 		const updatedAccount = {
 			...sender,
-			balance: updatedBalance.toString(),
+			balance: updatedBalance,
 			publicKey: sender.publicKey || this.senderPublicKey,
 		};
 		const errors =
-			updatedBalance <= BigInt(MAX_TRANSACTION_AMOUNT)
+			BigInt(updatedBalance) <= BigInt(MAX_TRANSACTION_AMOUNT)
 				? []
 				: [
 						new TransactionError(

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -312,12 +312,9 @@ export abstract class BaseTransaction {
 		}
 
 		const updatedBalance = sender.balance - this.fee;
-		const updatedSender = {
-			...sender,
-			balance: updatedBalance,
-			publicKey: sender.publicKey || this.senderPublicKey,
-		};
-		store.account.set(updatedSender.address, updatedSender);
+		sender.balance = updatedBalance;
+		sender.publicKey = sender.publicKey || this.senderPublicKey;
+		store.account.set(sender.address, sender);
 		const assetErrors = await this.applyAsset(store);
 
 		errors.push(...assetErrors);
@@ -340,11 +337,8 @@ export abstract class BaseTransaction {
 	public async undo(store: StateStore): Promise<TransactionResponse> {
 		const sender = await store.account.getOrDefault(this.senderId);
 		const updatedBalance = sender.balance + this.fee;
-		const updatedAccount = {
-			...sender,
-			balance: updatedBalance,
-			publicKey: sender.publicKey || this.senderPublicKey,
-		};
+		sender.balance = updatedBalance;
+		sender.publicKey = sender.publicKey || this.senderPublicKey;
 		const errors =
 			updatedBalance <= BigInt(MAX_TRANSACTION_AMOUNT)
 				? []
@@ -357,7 +351,7 @@ export abstract class BaseTransaction {
 							updatedBalance.toString(),
 						),
 				  ];
-		store.account.set(updatedAccount.address, updatedAccount);
+		store.account.set(sender.address, sender);
 		const assetErrors = await this.undoAsset(store);
 		errors.push(...assetErrors);
 

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -353,7 +353,7 @@ export abstract class BaseTransaction {
 							'Invalid balance amount',
 							this.id,
 							'.balance',
-							sender.balance,
+							sender.balance.toString(),
 							updatedBalance.toString(),
 						),
 				  ];

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -19,7 +19,7 @@ export interface Account {
 	readonly balance: bigint;
 	readonly missedBlocks: number;
 	readonly producedBlocks: number;
-	readonly publicKey: string;
+	readonly publicKey: string | undefined;
 	readonly secondPublicKey: string | null;
 	readonly secondSignature: number;
 	readonly username: string | null;
@@ -28,14 +28,14 @@ export interface Account {
 	readonly rewards: bigint;
 	// tslint:disable-next-line readonly-keyword
 	voteWeight: bigint;
-	readonly nameExist: false;
+	readonly nameExist: boolean;
 	readonly multiMin: number;
 	readonly multiLifetime: number;
 	readonly asset: object;
 	// tslint:disable-next-line readonly-keyword
 	votedDelegatesPublicKeys: string[];
 	// tslint:disable-next-line readonly-keyword
-	membersPublicKeys: ReadonlyArray<string>;
+	membersPublicKeys: string[];
 	// tslint:disable-next-line:no-mixed-interface
 	readonly addBalance: (fees: bigint) => void;
 }

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -16,7 +16,7 @@ import { TransactionError } from './errors';
 
 export interface Account {
 	readonly address: string;
-	readonly balance: string | bigint;
+	readonly balance: bigint;
 	readonly missedBlocks?: number;
 	readonly producedBlocks?: number;
 	readonly publicKey?: string;
@@ -24,10 +24,10 @@ export interface Account {
 	readonly secondSignature?: boolean | number;
 	readonly username?: string | null;
 	readonly isDelegate?: number;
-	readonly fees?: string | bigint;
-	readonly rewards?: string | bigint;
+	readonly fees?: bigint;
+	readonly rewards?: bigint;
 	// tslint:disable-next-line readonly-keyword
-	voteWeight?: string | bigint;
+	voteWeight?: bigint;
 	readonly nameExist?: false;
 	readonly multiMin?: number;
 	readonly multiLifetime?: number;

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -17,27 +17,27 @@ import { TransactionError } from './errors';
 export interface Account {
 	readonly address: string;
 	readonly balance: bigint;
-	readonly missedBlocks?: number;
-	readonly producedBlocks?: number;
-	readonly publicKey?: string;
-	readonly secondPublicKey?: string | null;
-	readonly secondSignature?: boolean | number;
-	readonly username?: string | null;
-	readonly isDelegate?: number;
-	readonly fees?: bigint;
-	readonly rewards?: bigint;
+	readonly missedBlocks: number;
+	readonly producedBlocks: number;
+	readonly publicKey: string;
+	readonly secondPublicKey: string | null;
+	readonly secondSignature: number;
+	readonly username: string | null;
+	readonly isDelegate: number;
+	readonly fees: bigint;
+	readonly rewards: bigint;
 	// tslint:disable-next-line readonly-keyword
-	voteWeight?: bigint;
-	readonly nameExist?: false;
-	readonly multiMin?: number;
-	readonly multiLifetime?: number;
-	readonly asset?: object;
+	voteWeight: bigint;
+	readonly nameExist: false;
+	readonly multiMin: number;
+	readonly multiLifetime: number;
+	readonly asset: object;
 	// tslint:disable-next-line readonly-keyword
-	votedDelegatesPublicKeys?: string[];
+	votedDelegatesPublicKeys: string[];
 	// tslint:disable-next-line readonly-keyword
-	membersPublicKeys?: ReadonlyArray<string>;
+	membersPublicKeys: ReadonlyArray<string>;
 	// tslint:disable-next-line:no-mixed-interface
-	readonly addBalance?: (fees: bigint) => void;
+	readonly addBalance: (fees: bigint) => void;
 }
 
 export interface Delegate {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -37,7 +37,7 @@ export interface Account {
 	// tslint:disable-next-line readonly-keyword
 	membersPublicKeys?: ReadonlyArray<string>;
 	// tslint:disable-next-line:no-mixed-interface
-	readonly addBalance: (fees: bigint) => void;
+	readonly addBalance?: (fees: bigint) => void;
 }
 
 export interface Delegate {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -36,6 +36,8 @@ export interface Account {
 	votedDelegatesPublicKeys?: string[];
 	// tslint:disable-next-line readonly-keyword
 	membersPublicKeys?: ReadonlyArray<string>;
+	// tslint:disable-next-line:no-mixed-interface
+	readonly addBalance: (fees: bigint) => void;
 }
 
 export interface Delegate {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -36,8 +36,6 @@ export interface Account {
 	votedDelegatesPublicKeys: string[];
 	// tslint:disable-next-line readonly-keyword
 	membersPublicKeys: string[];
-	// tslint:disable-next-line:no-mixed-interface
-	readonly addBalance: (fees: bigint) => void;
 }
 
 export interface Delegate {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -16,18 +16,26 @@ import { TransactionError } from './errors';
 
 export interface Account {
 	readonly address: string;
-	readonly balance: string;
-	readonly delegate?: Delegate;
+	readonly balance: string | bigint;
+	readonly missedBlocks?: number;
+	readonly producedBlocks?: number;
 	readonly publicKey?: string;
 	readonly secondPublicKey?: string | null;
-	readonly secondSignature?: number;
-	readonly membersPublicKeys?: ReadonlyArray<string>;
+	readonly secondSignature?: boolean | number;
+	readonly username?: string | null;
+	readonly isDelegate?: number;
+	readonly fees?: string | bigint;
+	readonly rewards?: string | bigint;
+	// tslint:disable-next-line readonly-keyword
+	voteWeight?: string | bigint;
+	readonly nameExist?: false;
 	readonly multiMin?: number;
 	readonly multiLifetime?: number;
-	readonly username?: string | null;
-	readonly votedDelegatesPublicKeys?: ReadonlyArray<string>;
-	readonly isDelegate?: number;
-	readonly vote?: number;
+	readonly asset?: object;
+	// tslint:disable-next-line readonly-keyword
+	votedDelegatesPublicKeys?: string[];
+	// tslint:disable-next-line readonly-keyword
+	membersPublicKeys?: ReadonlyArray<string>;
 }
 
 export interface Delegate {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -36,6 +36,8 @@ export interface Account {
 	votedDelegatesPublicKeys: string[];
 	// tslint:disable-next-line readonly-keyword
 	membersPublicKeys: string[];
+	// tslint:disable-next-line:no-mixed-interface
+	readonly toJSON: () => object;
 }
 
 export interface Delegate {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -13,33 +13,30 @@
  *
  */
 import { TransactionError } from './errors';
-
+// tslint:disable readonly-keyword
 export interface Account {
 	readonly address: string;
-	readonly balance: bigint;
-	readonly missedBlocks: number;
-	readonly producedBlocks: number;
-	readonly publicKey: string | undefined;
-	readonly secondPublicKey: string | null;
-	readonly secondSignature: number;
-	readonly username: string | null;
-	readonly isDelegate: number;
-	readonly fees: bigint;
-	readonly rewards: bigint;
-	// tslint:disable-next-line readonly-keyword
+	balance: bigint;
+	missedBlocks: number;
+	producedBlocks: number;
+	publicKey: string | undefined;
+	secondPublicKey: string | null;
+	secondSignature: number;
+	username: string | null;
+	isDelegate: number;
+	fees: bigint;
+	rewards: bigint;
 	voteWeight: bigint;
-	readonly nameExist: boolean;
-	readonly multiMin: number;
-	readonly multiLifetime: number;
-	readonly asset: object;
-	// tslint:disable-next-line readonly-keyword
+	nameExist: boolean;
+	multiMin: number;
+	multiLifetime: number;
+	asset: object;
 	votedDelegatesPublicKeys: string[];
-	// tslint:disable-next-line readonly-keyword
 	membersPublicKeys: string[];
 	// tslint:disable-next-line:no-mixed-interface
 	readonly toJSON: () => object;
 }
-
+// tslint:enable readonly-keyword
 export interface Delegate {
 	readonly username: string;
 }

--- a/elements/lisk-transactions/src/utils/verify.ts
+++ b/elements/lisk-transactions/src/utils/verify.ts
@@ -145,7 +145,7 @@ export const verifyMultiSignatures = (
 	const { valid, errors } = validateMultisignatures(
 		sender.membersPublicKeys as ReadonlyArray<string>,
 		signatures,
-		sender.multiMin as number,
+		sender.multiMin,
 		transactionBytes,
 		id,
 	);

--- a/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
+++ b/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
@@ -29,11 +29,15 @@ describe('Delegate registration transaction class', () => {
 	} = protocolSpecTransferFixture.testCases[0].input;
 
 	let validTestTransaction: DelegateTransaction;
-	let sender: Account;
+	let sender: Partial<Account>;
 	let storeAccountCacheStub: jest.SpyInstance;
 	let storeAccountGetStub: jest.SpyInstance;
 	let storeAccountSetStub: jest.SpyInstance;
 	let storeAccountFindStub: jest.SpyInstance;
+	const validDelegateAccountObj = {
+		...validDelegateAccount,
+		balance: BigInt(validDelegateAccount.balance),
+	};
 
 	beforeEach(async () => {
 		validTestTransaction = new DelegateTransaction({
@@ -44,7 +48,7 @@ describe('Delegate registration transaction class', () => {
 			protocolSpecDelegateFixture.testCases[0].input.account.passphrase,
 		);
 
-		sender = validDelegateAccount;
+		sender = validDelegateAccountObj;
 		storeAccountCacheStub = jest.spyOn(store.account, 'cache');
 		storeAccountGetStub = jest
 			.spyOn(store.account, 'get')
@@ -184,7 +188,7 @@ describe('Delegate registration transaction class', () => {
 			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, {
 				...sender,
 				isDelegate: 1,
-				vote: 0,
+				voteWeight: BigInt(0),
 				username: validTestTransaction.asset.username,
 			});
 		});
@@ -221,7 +225,7 @@ describe('Delegate registration transaction class', () => {
 			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, {
 				...sender,
 				isDelegate: 0,
-				vote: 0,
+				voteWeight: BigInt(0),
 				username: null,
 			});
 		});

--- a/elements/lisk-transactions/test/11_vote_transaction.spec.ts
+++ b/elements/lisk-transactions/test/11_vote_transaction.spec.ts
@@ -401,13 +401,7 @@ describe('Vote transaction class', () => {
 			expect(storeAccountFindStub).toHaveBeenCalledTimes(1);
 			expect(storeAccountSetStub).toHaveBeenCalledWith(
 				defaultValidSender.address,
-				{
-					...defaultValidSender,
-					votedDelegatesPublicKeys: [
-						...defaultValidSender.votedDelegatesPublicKeys,
-						'473c354cdf627b82e9113e02a337486dd3afc5615eb71ffd311c5a0beda37b8c',
-					],
-				},
+				defaultValidSender,
 			);
 		});
 

--- a/elements/lisk-transactions/test/11_vote_transaction.spec.ts
+++ b/elements/lisk-transactions/test/11_vote_transaction.spec.ts
@@ -15,7 +15,7 @@
 import { MockStateStore as store } from './helpers';
 import { VoteTransaction } from '../src/11_vote_transaction';
 import { validVoteTransactions } from '../fixtures';
-import { TransactionJSON } from '../src/transaction_types';
+import { TransactionJSON, Account } from '../src/transaction_types';
 import { Status } from '../src/response';
 import { generateRandomPublicKeys } from './helpers/cryptography';
 
@@ -26,19 +26,11 @@ describe('Vote transaction class', () => {
 	let storeAccountSetStub: jest.SpyInstance;
 	let storeAccountFindStub: jest.SpyInstance;
 
-	const defaultValidSender = {
-		address: '8004805717140184627L',
-		balance: '100000000',
-		publicKey:
-			'30c07dbb72b41e3fda9f29e1a4fc0fce893bb00788515a5e6f50b80312e2f483',
-		votedDelegatesPublicKeys: [
-			'5a82f58bf35ef4bdfac9a371a64e91914519af31a5cf64a5b8b03ca7d32c15dc',
-		],
-	};
+	let defaultValidSender: Partial<Account>;
 
 	const defaultValidDependentAccounts = [
 		{
-			balance: '0',
+			balance: BigInt('0'),
 			address: '123L',
 			publicKey:
 				'473c354cdf627b82e9113e02a337486dd3afc5615eb71ffd311c5a0beda37b8c',
@@ -167,6 +159,15 @@ describe('Vote transaction class', () => {
 		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 
 	beforeEach(async () => {
+		defaultValidSender = {
+			address: '8004805717140184627L',
+			balance: BigInt('100000000'),
+			publicKey:
+				'30c07dbb72b41e3fda9f29e1a4fc0fce893bb00788515a5e6f50b80312e2f483',
+			votedDelegatesPublicKeys: [
+				'5a82f58bf35ef4bdfac9a371a64e91914519af31a5cf64a5b8b03ca7d32c15dc',
+			],
+		};
 		validTestTransaction = new VoteTransaction({
 			...validVoteTransactions[2],
 			networkIdentifier,
@@ -408,7 +409,7 @@ describe('Vote transaction class', () => {
 		it('should return error when voted account is not a delegate', async () => {
 			const nonDelegateAccount = [
 				{
-					balance: '0',
+					balance: BigInt('0'),
 					address: '123L',
 					publicKey:
 						'473c354cdf627b82e9113e02a337486dd3afc5615eb71ffd311c5a0beda37b8c',

--- a/elements/lisk-transactions/test/12_multisignature_transaction.spec.ts
+++ b/elements/lisk-transactions/test/12_multisignature_transaction.spec.ts
@@ -34,7 +34,7 @@ describe('Multisignature transaction class', () => {
 		membersPublicKeys: multisignatureFixture.testCases[0].input.coSigners.map(
 			account => account.publicKey,
 		),
-		balance: '94378900000',
+		balance: BigInt('94378900000'),
 		multiMin: 2,
 		multiLifetime: 22,
 	};
@@ -47,8 +47,8 @@ describe('Multisignature transaction class', () => {
 	const networkIdentifier =
 		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
 	let validTestTransaction: MultisignatureTransaction;
-	let nonMultisignatureSender: Account;
-	let multisignatureSender: Account;
+	let nonMultisignatureSender: Partial<Account>;
+	let multisignatureSender: Partial<Account>;
 	let storeAccountCacheStub: jest.SpyInstance;
 	let storeAccountGetStub: jest.SpyInstance;
 	let storeAccountSetStub: jest.SpyInstance;

--- a/elements/lisk-transactions/test/8_transfer_transaction.spec.ts
+++ b/elements/lisk-transactions/test/8_transfer_transaction.spec.ts
@@ -24,8 +24,8 @@ describe('Transfer transaction class', () => {
 	const validTransferTransaction = fixture.testCases[0].output;
 	const validTransferAccount = fixture.testCases[0].input.account;
 	let validTransferTestTransaction: TransferTransaction;
-	let sender: Account;
-	let recipient: Account;
+	let sender: Partial<Account>;
+	let recipient: Partial<Account>;
 	let storeAccountCacheStub: jest.SpyInstance;
 	let storeAccountGetStub: jest.SpyInstance;
 	let storeAccountGetOrDefaultStub: jest.SpyInstance;
@@ -35,8 +35,8 @@ describe('Transfer transaction class', () => {
 		validTransferTestTransaction = new TransferTransaction(
 			validTransferTransaction,
 		);
-		sender = { ...validTransferAccount, balance: '10000000000' };
-		recipient = { ...validTransferAccount, balance: '10000000000' };
+		sender = { ...validTransferAccount, balance: BigInt('10000000000') };
+		recipient = { ...validTransferAccount, balance: BigInt('10000000000') };
 		storeAccountCacheStub = jest.spyOn(store.account, 'cache');
 		storeAccountGetStub = jest
 			.spyOn(store.account, 'get')
@@ -247,20 +247,18 @@ describe('Transfer transaction class', () => {
 			);
 			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, {
 				...sender,
-				balance: (
+				balance:
 					BigInt(sender.balance) -
-					BigInt(validTransferTestTransaction.asset.amount)
-				).toString(),
+					BigInt(validTransferTestTransaction.asset.amount),
 			});
 			expect(storeAccountGetOrDefaultStub).toHaveBeenCalledWith(
 				validTransferTestTransaction.asset.recipientId,
 			);
 			expect(storeAccountSetStub).toHaveBeenCalledWith(recipient.address, {
 				...recipient,
-				balance: (
+				balance:
 					BigInt(recipient.balance) -
-					BigInt(validTransferTestTransaction.asset.amount)
-				).toString(),
+					BigInt(validTransferTestTransaction.asset.amount),
 			});
 		});
 
@@ -298,20 +296,18 @@ describe('Transfer transaction class', () => {
 			);
 			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, {
 				...sender,
-				balance: (
+				balance:
 					BigInt(sender.balance) +
-					BigInt(validTransferTestTransaction.asset.amount)
-				).toString(),
+					BigInt(validTransferTestTransaction.asset.amount),
 			});
 			expect(storeAccountGetOrDefaultStub).toHaveBeenCalledWith(
 				validTransferTestTransaction.asset.recipientId,
 			);
 			expect(storeAccountSetStub).toHaveBeenCalledWith(recipient.address, {
 				...recipient,
-				balance: (
+				balance:
 					BigInt(recipient.balance) -
-					BigInt(validTransferTestTransaction.asset.amount)
-				).toString(),
+					BigInt(validTransferTestTransaction.asset.amount),
 			});
 		});
 

--- a/elements/lisk-transactions/test/8_transfer_transaction.spec.ts
+++ b/elements/lisk-transactions/test/8_transfer_transaction.spec.ts
@@ -245,21 +245,14 @@ describe('Transfer transaction class', () => {
 			expect(storeAccountGetStub).toHaveBeenCalledWith(
 				validTransferTestTransaction.senderId,
 			);
-			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, {
-				...sender,
-				balance:
-					BigInt(sender.balance) -
-					BigInt(validTransferTestTransaction.asset.amount),
-			});
+			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, sender);
 			expect(storeAccountGetOrDefaultStub).toHaveBeenCalledWith(
 				validTransferTestTransaction.asset.recipientId,
 			);
-			expect(storeAccountSetStub).toHaveBeenCalledWith(recipient.address, {
-				...recipient,
-				balance:
-					BigInt(recipient.balance) -
-					BigInt(validTransferTestTransaction.asset.amount),
-			});
+			expect(storeAccountSetStub).toHaveBeenCalledWith(
+				recipient.address,
+				recipient,
+			);
 		});
 
 		it('should return error when sender balance is insufficient', async () => {
@@ -294,21 +287,15 @@ describe('Transfer transaction class', () => {
 			expect(storeAccountGetStub).toHaveBeenCalledWith(
 				validTransferTestTransaction.senderId,
 			);
-			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, {
-				...sender,
-				balance:
-					BigInt(sender.balance) +
-					BigInt(validTransferTestTransaction.asset.amount),
-			});
+
+			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, sender);
 			expect(storeAccountGetOrDefaultStub).toHaveBeenCalledWith(
 				validTransferTestTransaction.asset.recipientId,
 			);
-			expect(storeAccountSetStub).toHaveBeenCalledWith(recipient.address, {
-				...recipient,
-				balance:
-					BigInt(recipient.balance) -
-					BigInt(validTransferTestTransaction.asset.amount),
-			});
+			expect(storeAccountSetStub).toHaveBeenCalledWith(
+				recipient.address,
+				recipient,
+			);
 		});
 
 		it('should return error when recipient balance is insufficient', async () => {

--- a/elements/lisk-transactions/test/9_second_passphrase_transaction.spec.ts
+++ b/elements/lisk-transactions/test/9_second_passphrase_transaction.spec.ts
@@ -177,11 +177,7 @@ describe('Second signature registration transaction class', () => {
 			expect(storeAccountGetStub).toHaveBeenCalledWith(
 				validTestTransaction.senderId,
 			);
-			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, {
-				...sender,
-				secondPublicKey: validTestTransaction.asset.publicKey,
-				secondSignature: 1,
-			});
+			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, sender);
 		});
 
 		it('should return no errors', async () => {

--- a/elements/lisk-transactions/test/9_second_passphrase_transaction.spec.ts
+++ b/elements/lisk-transactions/test/9_second_passphrase_transaction.spec.ts
@@ -16,8 +16,7 @@ import { MockStateStore as store } from './helpers';
 import { SecondSignatureTransaction } from '../src/9_second_signature_transaction';
 import * as protocolSpecSecondSignatureFixture from '../fixtures/transaction_network_id_and_change_order/second_signature_transaction_validate.json';
 import * as protocolSpecTransferFixture from '../fixtures/transaction_network_id_and_change_order/transfer_transaction_validate.json';
-
-import { TransactionJSON } from '../src/transaction_types';
+import { TransactionJSON, Account } from '../src/transaction_types';
 import { Status } from '../src/response';
 import { hexToBuffer } from '@liskhq/lisk-cryptography';
 
@@ -39,16 +38,7 @@ describe('Second signature registration transaction class', () => {
 	let storeAccountCacheStub: jest.SpyInstance;
 	let storeAccountGetStub: jest.SpyInstance;
 	let storeAccountSetStub: jest.SpyInstance;
-
-	const sender = {
-		address: '10020978176543317477L',
-		balance: '32981247530771',
-		publicKey:
-			'8aceda0f39b35d778f55593227f97152f0b5a78b80b5c4ae88979909095d6204',
-		secondPublicKey: null,
-		secondSignature: 0,
-	};
-
+	let sender: Partial<Account>;
 	beforeEach(async () => {
 		validTestTransaction = new SecondSignatureTransaction({
 			...validRegisterSecondSignatureTransaction,
@@ -57,7 +47,14 @@ describe('Second signature registration transaction class', () => {
 		validTestTransaction.sign(
 			protocolSpecSecondSignatureFixture.testCases[0].input.account.passphrase,
 		);
-
+		sender = {
+			address: '10020978176543317477L',
+			balance: BigInt('32981247530771'),
+			publicKey:
+				'8aceda0f39b35d778f55593227f97152f0b5a78b80b5c4ae88979909095d6204',
+			secondPublicKey: null,
+			secondSignature: 0,
+		};
 		storeAccountCacheStub = jest.spyOn(store.account, 'cache');
 		storeAccountGetStub = jest
 			.spyOn(store.account, 'get')
@@ -177,7 +174,13 @@ describe('Second signature registration transaction class', () => {
 			expect(storeAccountGetStub).toHaveBeenCalledWith(
 				validTestTransaction.senderId,
 			);
-			expect(storeAccountSetStub).toHaveBeenCalledWith(sender.address, sender);
+			expect(storeAccountSetStub).toHaveBeenCalledWith(
+				sender.address,
+				expect.objectContaining({
+					secondSignature: 1,
+					secondPublicKey: validTestTransaction.asset.publicKey,
+				}),
+			);
 		});
 
 		it('should return no errors', async () => {

--- a/elements/lisk-transactions/test/base_transaction.spec.ts
+++ b/elements/lisk-transactions/test/base_transaction.spec.ts
@@ -38,7 +38,7 @@ describe('Base transaction class', () => {
 	);
 	const defaultSenderAccount = {
 		...transferFixture.testCases[0].input.account,
-		balance: '1000000000000',
+		balance: BigInt('1000000000000'),
 	};
 	const defaultSecondSignatureTransaction = addTransactionFields(
 		validSecondSignatureTransaction,
@@ -51,7 +51,7 @@ describe('Base transaction class', () => {
 		membersPublicKeys: multisignatureFixture.testCases[0].input.coSigners.map(
 			account => account.publicKey,
 		),
-		balance: '94378900000',
+		balance: BigInt('94378900000'),
 		multiMin: 2,
 		multiLifetime: 1,
 	};
@@ -773,7 +773,7 @@ describe('Base transaction class', () => {
 		it('should return a failed transaction response with insufficient account balance', async () => {
 			storeAccountGetOrDefaultStub.mockReturnValue({
 				...defaultSenderAccount,
-				balance: '0',
+				balance: BigInt('0'),
 			});
 			const { id, status, errors } = await validTestTransaction.apply(store);
 
@@ -799,7 +799,7 @@ describe('Base transaction class', () => {
 		it('should return a failed transaction response with account balance exceeding max amount', async () => {
 			storeAccountGetOrDefaultStub.mockReturnValue({
 				...defaultSenderAccount,
-				balance: MAX_TRANSACTION_AMOUNT.toString(),
+				balance: BigInt(MAX_TRANSACTION_AMOUNT),
 			});
 			const { id, status, errors } = await validTestTransaction.undo(store);
 			expect(id).toEqual(validTestTransaction.id);

--- a/elements/lisk-transactions/test/utils/sign_and_validate.spec.ts
+++ b/elements/lisk-transactions/test/utils/sign_and_validate.spec.ts
@@ -18,7 +18,6 @@ import { validateMultisignatures, validateSignature } from '../../src/utils';
 import { TransactionError, TransactionPendingError } from '../../src/errors';
 // The list of valid transactions was created with lisk-js v0.5.1
 // using the below mentioned passphrases.
-import { Account } from '../../src/transaction_types';
 import {
 	validMultisignatureAccount as defaultMultisignatureAccount,
 	validMultisignatureTransaction,
@@ -142,7 +141,7 @@ describe('signAndVerify module', () => {
 
 		const {
 			membersPublicKeys: memberPublicKeys,
-		} = defaultMultisignatureAccount as Account;
+		} = defaultMultisignatureAccount;
 
 		it('should return a valid response with valid signatures', async () => {
 			const { valid } = validateMultisignatures(

--- a/framework/test/mocha/integration/blocks/chain/delete_last_block_accounts.js
+++ b/framework/test/mocha/integration/blocks/chain/delete_last_block_accounts.js
@@ -346,7 +346,7 @@ describe('integration test (blocks) - chain/deleteLastBlock', () => {
 					);
 					testAccountData = account;
 					expect(account.publicKey).to.be.null;
-					expect(account.votedDelegatesPublicKeys).to.be.null;
+					expect(account.votedDelegatesPublicKeys).eql([]);
 				});
 
 				it('should forge a block', done => {
@@ -422,7 +422,7 @@ describe('integration test (blocks) - chain/deleteLastBlock', () => {
 					expect(account.publicKey).to.be.null;
 					expect(account.multiLifetime).to.equal(0);
 					expect(account.multiMin).to.equal(0);
-					expect(account.membersPublicKeys).to.be.null;
+					expect(account.membersPublicKeys).eql([]);
 				});
 
 				it('should forge a block', done => {

--- a/framework/test/mocha/integration/blocks/chain/delete_last_block_accounts.js
+++ b/framework/test/mocha/integration/blocks/chain/delete_last_block_accounts.js
@@ -346,7 +346,7 @@ describe('integration test (blocks) - chain/deleteLastBlock', () => {
 					);
 					testAccountData = account;
 					expect(account.publicKey).to.be.null;
-					expect(account.votedDelegatesPublicKeys).eql([]);
+					expect(account.votedDelegatesPublicKeys).eql(null);
 				});
 
 				it('should forge a block', done => {
@@ -386,7 +386,7 @@ describe('integration test (blocks) - chain/deleteLastBlock', () => {
 						{ extended: true },
 					);
 					expect(account.balance).to.equal(testAccountData.balance);
-					expect(account.votedDelegatesPublicKeys).to.eql([]);
+					expect(account.votedDelegatesPublicKeys).to.eql(null);
 				});
 
 				it('should forge a block with transaction pool', done => {
@@ -422,7 +422,7 @@ describe('integration test (blocks) - chain/deleteLastBlock', () => {
 					expect(account.publicKey).to.be.null;
 					expect(account.multiLifetime).to.equal(0);
 					expect(account.multiMin).to.equal(0);
-					expect(account.membersPublicKeys).eql([]);
+					expect(account.membersPublicKeys).eql(null);
 				});
 
 				it('should forge a block', done => {
@@ -480,7 +480,7 @@ describe('integration test (blocks) - chain/deleteLastBlock', () => {
 					expect(account.balance).to.equal(testAccountData.balance);
 					expect(account.multiLifetime).to.equal(0);
 					expect(account.multiMin).to.equal(0);
-					expect(account.membersPublicKeys).to.eql([]);
+					expect(account.membersPublicKeys).to.eql(null);
 				});
 
 				it('should forge a block with transaction pool', done => {

--- a/framework/test/mocha/integration/transactions/4_multisignature/4_multisignature_account.js
+++ b/framework/test/mocha/integration/transactions/4_multisignature/4_multisignature_account.js
@@ -158,7 +158,7 @@ describe('integration test (type 4) - effect of multisignature registration on m
 				});
 
 				it('should have no data in mem_account.membersPublicKeys', async () => {
-					return expect(accountRow.membersPublicKeys).to.eql([]);
+					return expect(accountRow.membersPublicKeys).to.eql(null);
 				});
 
 				it('should have multimin field set to 0 on mem_accounts', async () => {
@@ -181,7 +181,7 @@ describe('integration test (type 4) - effect of multisignature registration on m
 				});
 
 				it('should set multisignatures field to empty array on account', async () => {
-					return expect(account.membersPublicKeys).to.eql([]);
+					return expect(account.membersPublicKeys).to.eql(null);
 				});
 
 				it('should set multimin field to 0 on account', async () => {


### PR DESCRIPTION
### Description

Following changes required to fulfill #4746  

- Rename interface `Account` to `AccountJSON`
- Create `Account` class with all the properties as `AccountJSON`
- Create `addbalance` function in `Account` class
- Use `AccountJSON` only when reading or writing from the database
- Update `lisk-transactions` library interface Account to match with `Account` class in `lisk-blocks`
- Remove the usage of `BigInt` everywhere when reading a value from `Account` class object.
- Use `addBalance`  to update the balance
- Fix all the relevant tests


### Review checklist

- [x] The PR resolves #4746 
- [x] All new code is covered with unit tests
- [x] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
