### PR TITLE
Remove logger and use debug in lisk libraries - Closes #4774

### DIFF
--- a/elements/lisk-blocks/src/blocks.ts
+++ b/elements/lisk-blocks/src/blocks.ts
@@ -466,11 +466,9 @@ export class Blocks extends EventEmitter {
 			const highestCommonBlock = sortedBlocks.shift();
 
 			return highestCommonBlock;
-		} catch (e) {
-			const errMessage = 'Failed to fetch the highest common block';
-			debug(errMessage);
-			debug(e);
-			throw new Error(errMessage);
+		} catch (err) {
+			debug('Failed to fetch the highest common block', err);
+			throw new Error(err);
 		}
 	}
 

--- a/elements/lisk-blocks/src/blocks.ts
+++ b/elements/lisk-blocks/src/blocks.ts
@@ -468,8 +468,8 @@ export class Blocks extends EventEmitter {
 			return highestCommonBlock;
 		} catch (e) {
 			const errMessage = 'Failed to fetch the highest common block';
-			Debug(errMessage);
-			Debug(e);
+			debug(errMessage);
+			debug(e);
 			throw new Error(errMessage);
 		}
 	}

--- a/elements/lisk-blocks/src/blocks.ts
+++ b/elements/lisk-blocks/src/blocks.ts
@@ -458,18 +458,13 @@ export class Blocks extends EventEmitter {
 	public async getHighestCommonBlock(
 		ids: string[],
 	): Promise<BlockHeader | undefined> {
-		try {
-			const blocks = await this.dataAccess.getBlockHeadersByIDs(ids);
-			const sortedBlocks = [...blocks].sort(
-				(a: BlockHeader, b: BlockHeader) => b.height - a.height,
-			);
-			const highestCommonBlock = sortedBlocks.shift();
+		const blocks = await this.dataAccess.getBlockHeadersByIDs(ids);
+		const sortedBlocks = [...blocks].sort(
+			(a: BlockHeader, b: BlockHeader) => b.height - a.height,
+		);
+		const highestCommonBlock = sortedBlocks.shift();
 
-			return highestCommonBlock;
-		} catch (err) {
-			debug('Failed to fetch the highest common block', err);
-			throw new Error(err);
-		}
+		return highestCommonBlock;
 	}
 
 	public async filterReadyTransactions(

--- a/elements/lisk-blocks/src/blocks.ts
+++ b/elements/lisk-blocks/src/blocks.ts
@@ -468,6 +468,8 @@ export class Blocks extends EventEmitter {
 			return highestCommonBlock;
 		} catch (e) {
 			const errMessage = 'Failed to fetch the highest common block';
+			Debug(errMessage);
+			Debug(e);
 			throw new Error(errMessage);
 		}
 	}

--- a/elements/lisk-blocks/src/blocks.ts
+++ b/elements/lisk-blocks/src/blocks.ts
@@ -53,7 +53,6 @@ import {
 	BlockRewardOptions,
 	Contexter,
 	ExceptionOptions,
-	Logger,
 	MatcherTransaction,
 	SignatureObject,
 	Storage,
@@ -77,7 +76,6 @@ const DEFAULT_MAX_BLOCK_HEADER_CACHE = 500;
 
 interface BlocksConfig {
 	// Components
-	readonly logger: Logger;
 	readonly storage: Storage;
 	// Unique requirements
 	readonly genesisBlock: BlockJSON;
@@ -109,7 +107,6 @@ const debug = Debug('lisk:blocks');
 export class Blocks extends EventEmitter {
 	private _lastBlock: BlockInstance;
 	private readonly blocksVerify: BlocksVerify;
-	private readonly logger: Logger;
 	private readonly storage: Storage;
 	public readonly dataAccess: DataAccess;
 	public readonly slots: Slots;
@@ -133,7 +130,6 @@ export class Blocks extends EventEmitter {
 
 	public constructor({
 		// Components
-		logger,
 		storage,
 		// Unique requirements
 		genesisBlock,
@@ -158,7 +154,6 @@ export class Blocks extends EventEmitter {
 	}: BlocksConfig) {
 		super();
 
-		this.logger = logger;
 		this.storage = storage;
 		this.dataAccess = new DataAccess({
 			dbStorage: storage,
@@ -473,7 +468,6 @@ export class Blocks extends EventEmitter {
 			return highestCommonBlock;
 		} catch (e) {
 			const errMessage = 'Failed to fetch the highest common block';
-			this.logger.error({ err: e }, errMessage);
 			throw new Error(errMessage);
 		}
 	}

--- a/elements/lisk-blocks/src/types.ts
+++ b/elements/lisk-blocks/src/types.ts
@@ -253,13 +253,6 @@ export type WriteableTransactionResponse = {
 	-readonly [P in keyof TransactionResponse]: TransactionResponse[P];
 };
 
-export interface Logger {
-	// tslint:disable-next-line no-any
-	readonly info: (...input: any[]) => void;
-	// tslint:disable-next-line no-any
-	readonly error: (...input: any[]) => void;
-}
-
 export interface SignatureObject {
 	readonly signature: string;
 	readonly transactionId: string;

--- a/elements/lisk-blocks/test/unit/blocks.spec.ts
+++ b/elements/lisk-blocks/test/unit/blocks.spec.ts
@@ -721,7 +721,7 @@ describe('blocks', () => {
 			// Arrange
 			const ids = ['1', '2'];
 			stubs.dependencies.storage.entities.Block.get.mockRejectedValue(
-				new Error('anError'),
+				new Error('Failed to fetch the highest common block'),
 			);
 
 			// Act && Assert

--- a/elements/lisk-blocks/test/unit/blocks.spec.ts
+++ b/elements/lisk-blocks/test/unit/blocks.spec.ts
@@ -83,11 +83,6 @@ describe('blocks', () => {
 					},
 				},
 			},
-			logger: {
-				debug: jest.fn(),
-				log: jest.fn(),
-				error: jest.fn(),
-			},
 		};
 
 		slots = new Slots({

--- a/elements/lisk-blocks/test/unit/process.spec.ts
+++ b/elements/lisk-blocks/test/unit/process.spec.ts
@@ -26,7 +26,7 @@ import * as genesisBlock from '../fixtures/genesis_block.json';
 import { genesisAccount } from '../fixtures/default_account';
 import { registeredTransactions } from '../utils/registered_transactions';
 import { Slots } from '../../src/slots';
-import { BlockInstance, ExceptionOptions, Logger } from '../../src/types';
+import { BlockInstance, ExceptionOptions } from '../../src/types';
 
 jest.mock('events');
 
@@ -60,7 +60,6 @@ describe('blocks/header', () => {
 	let exceptions: ExceptionOptions = {};
 	let blocksInstance: Blocks;
 	let storageStub: any;
-	let loggerStub: Logger;
 	let slots: Slots;
 	let block: BlockInstance;
 	let blockBytes: Buffer;
@@ -93,10 +92,7 @@ describe('blocks/header', () => {
 				},
 			},
 		};
-		loggerStub = {
-			info: jest.fn(),
-			error: jest.fn(),
-		};
+
 		slots = new Slots({
 			epochTime: constants.epochTime,
 			interval: constants.blockTime,
@@ -105,7 +101,6 @@ describe('blocks/header', () => {
 
 		blocksInstance = new Blocks({
 			storage: storageStub,
-			logger: loggerStub,
 			genesisBlock,
 			networkIdentifier,
 			registeredTransactions,

--- a/elements/lisk-blocks/test/unit/transactions.spec.ts
+++ b/elements/lisk-blocks/test/unit/transactions.spec.ts
@@ -26,7 +26,6 @@ import * as genesisBlock from '../fixtures/genesis_block.json';
 import { genesisAccount } from '../fixtures/default_account';
 import { registeredTransactions } from '../utils/registered_transactions';
 import { Slots } from '../../src/slots';
-import { Logger } from '../../src/types';
 
 jest.mock('events');
 
@@ -59,7 +58,6 @@ describe('blocks/transactions', () => {
 	let exceptions = {};
 	let blocksInstance: Blocks;
 	let storageStub: any;
-	let loggerStub: Logger;
 	let slots: Slots;
 
 	beforeEach(async () => {
@@ -90,10 +88,7 @@ describe('blocks/transactions', () => {
 				},
 			},
 		};
-		loggerStub = {
-			info: jest.fn(),
-			error: jest.fn(),
-		};
+
 		slots = new Slots({
 			epochTime: constants.epochTime,
 			interval: constants.blockTime,
@@ -104,7 +99,6 @@ describe('blocks/transactions', () => {
 
 		blocksInstance = new Blocks({
 			storage: storageStub,
-			logger: loggerStub,
 			genesisBlock,
 			networkIdentifier,
 			registeredTransactions,


### PR DESCRIPTION
### What was the problem?
Elements library was using `logger`
### How did I solve it?
- Removed the usage of logger
### How to manually test it?
```
DEBUG=lisk-blocks LISK_CONSOLE_LOG_LEVEL=debug node framework/test/test_app | npx bunyan -o short -l info
```
### Review checklist

- [ ] The PR resolves #4774 
- [ ] All new code is covered with unit tests
- [ ] Relevant integration / functional tests are added
- [ ] Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
- [ ] Documentation has been added/updated
