### PR TITLE
Fix BFT delete blocks logic - Closes #4800

### DIFF
--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -118,15 +118,8 @@ class BFT extends EventEmitter {
 		this.finalityManager.removeBlockHeaders({
 			aboveHeight: removeFromHeight - 1,
 		});
-
 		// Make sure there are BFT_ROUND_THRESHOLD rounds of block headers available
-		if (
-			this.finalityManager.maxHeight - this.finalityManager.minHeight <
-			this.constants.activeDelegates * BFT_ROUND_THRESHOLD
-		) {
-			await this._fillCache(minActiveHeightsOfDelegates);
-			this.finalityManager.recompute();
-		}
+		await this._fillCache(minActiveHeightsOfDelegates);
 	}
 
 	addNewBlock(block, stateStore) {
@@ -334,6 +327,13 @@ class BFT extends EventEmitter {
 	}
 
 	async _fillCache(minActiveHeightsOfDelegates) {
+		if (
+			this.finalityManager.maxHeight - this.finalityManager.minHeight >=
+			this.constants.activeDelegates * BFT_ROUND_THRESHOLD
+		) {
+			return;
+		}
+
 		const tillHeight = this.finalityManager.minHeight - 1;
 		const fromHeight =
 			this.finalityManager.maxHeight -
@@ -382,6 +382,7 @@ class BFT extends EventEmitter {
 				extractBFTBlockHeaderFromBlock(blockHeader),
 			);
 		}
+		this.finalityManager.recompute();
 	}
 }
 

--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -325,7 +325,7 @@ class BFT extends EventEmitter {
 	}
 
 	get maxHeightPrevoted() {
-		return this.finalityManager.chainMaxHeightFinalized;
+		return this.finalityManager.chainMaxHeightPrevoted;
 	}
 
 	reset() {

--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -124,17 +124,8 @@ class BFT extends EventEmitter {
 			this.finalityManager.maxHeight - this.finalityManager.minHeight <
 			this.constants.activeDelegates * BFT_ROUND_THRESHOLD
 		) {
-			const tillHeight = this.finalityManager.minHeight - 1;
-			const fromHeight =
-				this.finalityManager.maxHeight -
-				// Search is inclusive, therefore, it should start from one above (ex: 288 - 500, which results total 303)
-				this.constants.activeDelegates * BFT_ROUND_THRESHOLD +
-				1;
-			await this._loadBlocksFromStorage({
-				fromHeight,
-				tillHeight,
-				minActiveHeightsOfDelegates,
-			});
+			await this._fillCache(minActiveHeightsOfDelegates);
+			this.finalityManager.recompute();
 		}
 	}
 
@@ -340,6 +331,57 @@ class BFT extends EventEmitter {
 	reset() {
 		this.finalityManager.headers.empty();
 		this.finalityManager.recompute();
+	}
+
+	async _fillCache(minActiveHeightsOfDelegates) {
+		const tillHeight = this.finalityManager.minHeight - 1;
+		const fromHeight =
+			this.finalityManager.maxHeight -
+			// Search is inclusive, therefore, it should start from one above (ex: 288 - 500, which results total 303)
+			this.constants.activeDelegates * BFT_ROUND_THRESHOLD +
+			1;
+		const blocksJSON = await this.blockEntity.get(
+			{ height_gte: fromHeight, height_lte: tillHeight },
+			{ limit: null, sort: 'height:desc' },
+		);
+		for (const blockJSON of blocksJSON) {
+			if (blockJSON.height === 1) {
+				this.finalityManager.headers.add(
+					extractBFTBlockHeaderFromBlock({
+						...blockJSON,
+						delegateMinHeightActive: 1,
+					}),
+				);
+				return;
+			}
+
+			const activeHeights =
+				minActiveHeightsOfDelegates[blockJSON.generatorPublicKey];
+			if (!activeHeights) {
+				throw new Error(
+					`Minimum active heights were not found for delegate "${blockJSON.generatorPublicKey}".`,
+				);
+			}
+
+			// If there is no minHeightActive until this point,
+			// we can set the value to 0
+			const minimumPossibleActiveHeight = this.slots.calcRoundStartHeight(
+				this.slots.calcRound(
+					Math.max(blockJSON.height - this.constants.activeDelegates * 3, 1),
+				),
+			);
+			const [delegateMinHeightActive] = activeHeights.filter(
+				height => height >= minimumPossibleActiveHeight,
+			);
+
+			const blockHeader = {
+				...blockJSON,
+				delegateMinHeightActive,
+			};
+			this.finalityManager.headers.add(
+				extractBFTBlockHeaderFromBlock(blockHeader),
+			);
+		}
 	}
 }
 

--- a/framework/src/modules/chain/bft/bft.js
+++ b/framework/src/modules/chain/bft/bft.js
@@ -334,7 +334,7 @@ class BFT extends EventEmitter {
 	}
 
 	get maxHeightPrevoted() {
-		return this.finalityManager.prevotedConfirmedHeight;
+		return this.finalityManager.chainMaxHeightFinalized;
 	}
 
 	reset() {

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -58,7 +58,7 @@ class FinalityManager extends EventEmitter {
 		this.finalizedHeight = finalizedHeight;
 
 		// Height up to which blocks have pre-voted
-		this.chainMaxHeightFinalized = 0;
+		this.chainMaxHeightPrevoted = 0;
 
 		this.state = {};
 		this.preVotes = {};
@@ -88,7 +88,7 @@ class FinalityManager extends EventEmitter {
 
 		debug('after adding block header', {
 			finalizedHeight: this.finalizedHeight,
-			chainMaxHeightFinalized: this.chainMaxHeightFinalized,
+			chainMaxHeightPrevoted: this.chainMaxHeightPrevoted,
 			minHeight: this.minHeight,
 			maxHeight: this.maxHeight,
 		});
@@ -191,9 +191,9 @@ class FinalityManager extends EventEmitter {
 			.reverse()
 			.find(key => this.preVotes[key] >= this.preVoteThreshold);
 
-		this.chainMaxHeightFinalized = highestHeightPreVoted
+		this.chainMaxHeightPrevoted = highestHeightPreVoted
 			? parseInt(highestHeightPreVoted, 10)
-			: this.chainMaxHeightFinalized;
+			: this.chainMaxHeightPrevoted;
 
 		const highestHeightPreCommitted = Object.keys(this.preCommits)
 			.reverse()
@@ -262,7 +262,7 @@ class FinalityManager extends EventEmitter {
 	recompute() {
 		this.state = {};
 		this.finalizedHeight = this._initialFinalizedHeight;
-		this.chainMaxHeightFinalized = 0;
+		this.chainMaxHeightPrevoted = 0;
 		this.preVotes = {};
 		this.preCommits = {};
 
@@ -291,10 +291,10 @@ class FinalityManager extends EventEmitter {
 		// if maxHeightPrevoted is correct
 		if (
 			this.headers.length >= this.processingThreshold &&
-			blockHeader.maxHeightPrevoted !== this.chainMaxHeightFinalized
+			blockHeader.maxHeightPrevoted !== this.chainMaxHeightPrevoted
 		) {
 			throw new BFTInvalidAttributeError(
-				`Wrong maxHeightPrevoted in blockHeader. maxHeightPrevoted: ${blockHeader.maxHeightPrevoted}, : ${this.chainMaxHeightFinalized}`,
+				`Wrong maxHeightPrevoted in blockHeader. maxHeightPrevoted: ${blockHeader.maxHeightPrevoted}, : ${this.chainMaxHeightPrevoted}`,
 			);
 		}
 

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -58,7 +58,7 @@ class FinalityManager extends EventEmitter {
 		this.finalizedHeight = finalizedHeight;
 
 		// Height up to which blocks have pre-voted
-		this.prevotedConfirmedHeight = 0;
+		this.chainMaxHeightFinalized = 0;
 
 		this.state = {};
 		this.preVotes = {};
@@ -88,7 +88,7 @@ class FinalityManager extends EventEmitter {
 
 		debug('after adding block header', {
 			finalizedHeight: this.finalizedHeight,
-			prevotedConfirmedHeight: this.prevotedConfirmedHeight,
+			chainMaxHeightFinalized: this.chainMaxHeightFinalized,
 			minHeight: this.minHeight,
 			maxHeight: this.maxHeight,
 		});
@@ -191,9 +191,9 @@ class FinalityManager extends EventEmitter {
 			.reverse()
 			.find(key => this.preVotes[key] >= this.preVoteThreshold);
 
-		this.prevotedConfirmedHeight = highestHeightPreVoted
+		this.chainMaxHeightFinalized = highestHeightPreVoted
 			? parseInt(highestHeightPreVoted, 10)
-			: this.prevotedConfirmedHeight;
+			: this.chainMaxHeightFinalized;
 
 		const highestHeightPreCommitted = Object.keys(this.preCommits)
 			.reverse()
@@ -262,7 +262,7 @@ class FinalityManager extends EventEmitter {
 	recompute() {
 		this.state = {};
 		this.finalizedHeight = this._initialFinalizedHeight;
-		this.prevotedConfirmedHeight = 0;
+		this.chainMaxHeightFinalized = 0;
 		this.preVotes = {};
 		this.preCommits = {};
 
@@ -291,10 +291,10 @@ class FinalityManager extends EventEmitter {
 		// if maxHeightPrevoted is correct
 		if (
 			this.headers.length >= this.processingThreshold &&
-			blockHeader.maxHeightPrevoted !== this.prevotedConfirmedHeight
+			blockHeader.maxHeightPrevoted !== this.chainMaxHeightFinalized
 		) {
 			throw new BFTInvalidAttributeError(
-				`Wrong maxHeightPrevoted in blockHeader. maxHeightPrevoted: ${blockHeader.maxHeightPrevoted}, prevotedConfirmedHeight: ${this.prevotedConfirmedHeight}`,
+				`Wrong maxHeightPrevoted in blockHeader. maxHeightPrevoted: ${blockHeader.maxHeightPrevoted}, : ${this.chainMaxHeightFinalized}`,
 			);
 		}
 

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -98,7 +98,7 @@ class FinalityManager extends EventEmitter {
 	removeBlockHeaders({ aboveHeight }) {
 		debug('removeBlockHeaders invoked');
 
-		const removeAboveHeight = aboveHeight || this.maxHeight - 1;
+		const removeAboveHeight = aboveHeight;
 
 		// Remove block header from the list
 		this.headers.remove({ aboveHeight: removeAboveHeight });

--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -27,7 +27,7 @@ const {
 const { baseBlockSchema } = require('./blocks');
 const { BaseBlockProcessor } = require('./processor');
 
-const FORGER_INFO_KEY_MAX_HEIGHT_PREVIOUSLY_FORGED = 'previouslyForged';
+const FORGER_INFO_KEY_PREVIOUSLY_FORGED = 'previouslyForged';
 
 const SIZE_INT32 = 4;
 const SIZE_INT64 = 8;
@@ -376,7 +376,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 
 	async _getPreviouslyForgedMap() {
 		const previouslyForgedStr = await this.storage.entities.ForgerInfo.getKey(
-			FORGER_INFO_KEY_MAX_HEIGHT_PREVIOUSLY_FORGED,
+			FORGER_INFO_KEY_PREVIOUSLY_FORGED,
 		);
 		return previouslyForgedStr ? JSON.parse(previouslyForgedStr) : {};
 	}
@@ -409,7 +409,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 		};
 		const previouslyForgedStr = JSON.stringify(updatedPreviouslyForged);
 		await this.storage.entities.ForgerInfo.setKey(
-			FORGER_INFO_KEY_MAX_HEIGHT_PREVIOUSLY_FORGED,
+			FORGER_INFO_KEY_PREVIOUSLY_FORGED,
 			previouslyForgedStr,
 		);
 	}

--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -269,7 +269,7 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 			async ({ block, tx }) => {
 				// minActiveHeightsOfDelegates will be used to load 202 blocks from the storage
 				// That's why we need to get the delegates who were active in the last 2 rounds.
-				const numberOfRounds = 2;
+				const numberOfRounds = 3;
 				const minActiveHeightsOfDelegates = await this.dposModule.getMinActiveHeightsOfDelegates(
 					numberOfRounds,
 					{ tx },

--- a/framework/src/modules/chain/block_processor_v2.js
+++ b/framework/src/modules/chain/block_processor_v2.js
@@ -27,8 +27,7 @@ const {
 const { baseBlockSchema } = require('./blocks');
 const { BaseBlockProcessor } = require('./processor');
 
-const FORGER_INFO_KEY_MAX_HEIGHT_PREVIOUSLY_FORGED =
-	'maxHeightPreviouslyForged';
+const FORGER_INFO_KEY_MAX_HEIGHT_PREVIOUSLY_FORGED = 'previouslyForged';
 
 const SIZE_INT32 = 4;
 const SIZE_INT64 = 8;

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -451,8 +451,8 @@ describe('bft', () => {
 
 				// Load last 400 blocks to bft (101 to 500)
 				for (const block of blocksInBft) {
-					// This value is mutated to pass the prevotedConfirmedHeight validation
-					block.maxHeightPrevoted = bft.finalityManager.prevotedConfirmedHeight;
+					// This value is mutated to pass the chainMaxHeightFinalized validation
+					block.maxHeightPrevoted = bft.finalityManager.chainMaxHeightFinalized;
 					await bft.addNewBlock(block, stateStore);
 				}
 
@@ -489,8 +489,8 @@ describe('bft', () => {
 
 				// Load last 300 blocks to bft (201 to 500)
 				for (const block of blocksInBft) {
-					// This value is mutated to pass the prevotedConfirmedHeight validation
-					block.maxHeightPrevoted = bft.finalityManager.prevotedConfirmedHeight;
+					// This value is mutated to pass the chainMaxHeightFinalized validation
+					block.maxHeightPrevoted = bft.finalityManager.chainMaxHeightFinalized;
 					await bft.addNewBlock(block, stateStore);
 				}
 
@@ -673,7 +673,7 @@ describe('bft', () => {
 					await bft.addNewBlock(
 						{
 							...block,
-							maxHeightPrevoted: bft.finalityManager.prevotedConfirmedHeight,
+							maxHeightPrevoted: bft.finalityManager.chainMaxHeightFinalized,
 						},
 						stateStore,
 					);

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -376,6 +376,7 @@ describe('bft', () => {
 
 			it('should load more blocks from storage if remaining in headers list is less than 3 rounds', async () => {
 				// Arrange
+				jest.spyOn(bft.finalityManager, 'recompute');
 				// Generate 500 blocks
 				const numberOfBlocks = 500;
 				const numberOfBlocksToDelete = 50;
@@ -415,6 +416,7 @@ describe('bft', () => {
 				await bft.deleteBlocks(blocksToDelete, minActiveHeightsOfDelegates);
 
 				// Assert
+				expect(bft.finalityManager.recompute).toHaveBeenCalledTimes(2);
 				expect(bft.finalityManager.maxHeight).toEqual(450);
 				expect(bft.finalityManager.minHeight).toEqual(
 					450 - activeDelegates * 2,
@@ -428,6 +430,7 @@ describe('bft', () => {
 
 			it('should not load more blocks from storage if remaining in headers list is more than 3 rounds', async () => {
 				// Arrange
+				jest.spyOn(bft.finalityManager, 'recompute');
 				// Generate 500 blocks
 				const numberOfBlocks = 500;
 				const numberOfBlocksToDelete = 50;
@@ -460,6 +463,7 @@ describe('bft', () => {
 				await bft.deleteBlocks(blocksToDelete, minActiveHeightsOfDelegates);
 
 				// Assert
+				expect(bft.finalityManager.recompute).toHaveBeenCalledTimes(1);
 				expect(bft.finalityManager.maxHeight).toEqual(450);
 				expect(bft.finalityManager.minHeight).toEqual(101);
 				expect(storageMock.entities.Block.get).toHaveBeenCalledTimes(0);
@@ -467,6 +471,7 @@ describe('bft', () => {
 
 			it('should not load more blocks from storage if remaining in headers list is exactly 3 rounds', async () => {
 				// Arrange
+				jest.spyOn(bft.finalityManager, 'recompute');
 				// Generate 500 blocks
 				const numberOfBlocks = 500;
 				const blocks = generateBlocks({
@@ -498,6 +503,7 @@ describe('bft', () => {
 				await bft.deleteBlocks(blocksToDelete, minActiveHeightsOfDelegates);
 
 				// Assert
+				expect(bft.finalityManager.recompute).toHaveBeenCalledTimes(1);
 				expect(bft.finalityManager.maxHeight).toEqual(403);
 				expect(bft.finalityManager.minHeight).toEqual(100);
 				expect(storageMock.entities.Block.get).toHaveBeenCalledTimes(0);

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -454,8 +454,8 @@ describe('bft', () => {
 
 				// Load last 400 blocks to bft (101 to 500)
 				for (const block of blocksInBft) {
-					// This value is mutated to pass the chainMaxHeightFinalized validation
-					block.maxHeightPrevoted = bft.finalityManager.chainMaxHeightFinalized;
+					// This value is mutated to pass the chainMaxHeightPrevoted validation
+					block.maxHeightPrevoted = bft.finalityManager.chainMaxHeightPrevoted;
 					await bft.addNewBlock(block, stateStore);
 				}
 
@@ -494,8 +494,8 @@ describe('bft', () => {
 
 				// Load last 300 blocks to bft (201 to 500)
 				for (const block of blocksInBft) {
-					// This value is mutated to pass the chainMaxHeightFinalized validation
-					block.maxHeightPrevoted = bft.finalityManager.chainMaxHeightFinalized;
+					// This value is mutated to pass the chainMaxHeightPrevoted validation
+					block.maxHeightPrevoted = bft.finalityManager.chainMaxHeightPrevoted;
 					await bft.addNewBlock(block, stateStore);
 				}
 
@@ -679,7 +679,7 @@ describe('bft', () => {
 					await bft.addNewBlock(
 						{
 							...block,
-							maxHeightPrevoted: bft.finalityManager.chainMaxHeightFinalized,
+							maxHeightPrevoted: bft.finalityManager.chainMaxHeightPrevoted,
 						},
 						stateStore,
 					);

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft_finality_manager_protocol_specs.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft_finality_manager_protocol_specs.spec.js
@@ -53,7 +53,7 @@ describe('FinalityManager', () => {
 							testCase.output.finalizedHeight,
 						);
 
-						expect(myBft.chainMaxHeightFinalized).toEqual(
+						expect(myBft.chainMaxHeightPrevoted).toEqual(
 							testCase.output.preVotedConfirmedHeight,
 						);
 					});
@@ -84,7 +84,7 @@ describe('FinalityManager', () => {
 					expect(myBft.finalizedHeight).toEqual(
 						lastTestCaseOutput.finalizedHeight,
 					);
-					expect(myBft.chainMaxHeightFinalized).toEqual(
+					expect(myBft.chainMaxHeightPrevoted).toEqual(
 						lastTestCaseOutput.preVotedConfirmedHeight,
 					);
 
@@ -95,7 +95,7 @@ describe('FinalityManager', () => {
 					expect(myBft.finalizedHeight).toEqual(
 						lastTestCaseOutput.finalizedHeight,
 					);
-					expect(myBft.chainMaxHeightFinalized).toEqual(
+					expect(myBft.chainMaxHeightPrevoted).toEqual(
 						lastTestCaseOutput.preVotedConfirmedHeight,
 					);
 
@@ -143,7 +143,7 @@ describe('FinalityManager', () => {
 
 					// Assert - Values should match with out of that step
 					expect(myBft.finalizedHeight).toEqual(testCaseOutput.finalizedHeight);
-					expect(myBft.chainMaxHeightFinalized).toEqual(
+					expect(myBft.chainMaxHeightPrevoted).toEqual(
 						testCaseOutput.preVotedConfirmedHeight,
 					);
 				});

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft_finality_manager_protocol_specs.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft_finality_manager_protocol_specs.spec.js
@@ -53,7 +53,7 @@ describe('FinalityManager', () => {
 							testCase.output.finalizedHeight,
 						);
 
-						expect(myBft.prevotedConfirmedHeight).toEqual(
+						expect(myBft.chainMaxHeightFinalized).toEqual(
 							testCase.output.preVotedConfirmedHeight,
 						);
 					});
@@ -84,7 +84,7 @@ describe('FinalityManager', () => {
 					expect(myBft.finalizedHeight).toEqual(
 						lastTestCaseOutput.finalizedHeight,
 					);
-					expect(myBft.prevotedConfirmedHeight).toEqual(
+					expect(myBft.chainMaxHeightFinalized).toEqual(
 						lastTestCaseOutput.preVotedConfirmedHeight,
 					);
 
@@ -95,7 +95,7 @@ describe('FinalityManager', () => {
 					expect(myBft.finalizedHeight).toEqual(
 						lastTestCaseOutput.finalizedHeight,
 					);
-					expect(myBft.prevotedConfirmedHeight).toEqual(
+					expect(myBft.chainMaxHeightFinalized).toEqual(
 						lastTestCaseOutput.preVotedConfirmedHeight,
 					);
 
@@ -143,7 +143,7 @@ describe('FinalityManager', () => {
 
 					// Assert - Values should match with out of that step
 					expect(myBft.finalizedHeight).toEqual(testCaseOutput.finalizedHeight);
-					expect(myBft.prevotedConfirmedHeight).toEqual(
+					expect(myBft.chainMaxHeightFinalized).toEqual(
 						testCaseOutput.preVotedConfirmedHeight,
 					);
 				});

--- a/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
@@ -105,7 +105,7 @@ describe('finality_manager', () => {
 
 				expect(() => finalityManager.verifyBlockHeaders(header)).toThrow(
 					BFTInvalidAttributeError,
-					'Wrong prevotedConfirmedHeight in blockHeader.',
+					'Wrong chainMaxHeightFinalized in blockHeader.',
 				);
 			});
 
@@ -117,7 +117,7 @@ describe('finality_manager', () => {
 					},
 				);
 				const header = blockHeaderFixture({ maxHeightPrevoted: 10 });
-				finalityManager.prevotedConfirmedHeight = 10;
+				finalityManager.chainMaxHeightFinalized = 10;
 
 				expect(() => finalityManager.verifyBlockHeaders(header)).not.toThrow();
 			});

--- a/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/finality_manager.spec.js
@@ -105,7 +105,7 @@ describe('finality_manager', () => {
 
 				expect(() => finalityManager.verifyBlockHeaders(header)).toThrow(
 					BFTInvalidAttributeError,
-					'Wrong chainMaxHeightFinalized in blockHeader.',
+					'Wrong chainMaxHeightPrevoted in blockHeader.',
 				);
 			});
 
@@ -117,7 +117,7 @@ describe('finality_manager', () => {
 					},
 				);
 				const header = blockHeaderFixture({ maxHeightPrevoted: 10 });
-				finalityManager.chainMaxHeightFinalized = 10;
+				finalityManager.chainMaxHeightPrevoted = 10;
 
 				expect(() => finalityManager.verifyBlockHeaders(header)).not.toThrow();
 			});

--- a/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
@@ -130,7 +130,7 @@ describe('block processor v2', () => {
 			});
 			// Assert
 			expect(storageStub.entities.ForgerInfo.getKey).toHaveBeenCalledWith(
-				'maxHeightPreviouslyForged',
+				'previouslyForged',
 			);
 			// previousBlock.height + 1
 			expect(block.maxHeightPreviouslyForged).toBe(0);
@@ -154,7 +154,7 @@ describe('block processor v2', () => {
 			});
 			// Assert
 			expect(storageStub.entities.ForgerInfo.getKey).toHaveBeenCalledWith(
-				'maxHeightPreviouslyForged',
+				'previouslyForged',
 			);
 			expect(block.maxHeightPreviouslyForged).toBe(previouslyForgedHeight);
 		});
@@ -189,7 +189,7 @@ describe('block processor v2', () => {
 				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
-				'maxHeightPreviouslyForged',
+				'previouslyForged',
 				maxHeightResult,
 			);
 		});
@@ -212,7 +212,7 @@ describe('block processor v2', () => {
 				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
-				'maxHeightPreviouslyForged',
+				'previouslyForged',
 				maxHeightResult,
 			);
 		});

--- a/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/block_processor_v2.spec.js
@@ -140,7 +140,7 @@ describe('block processor v2', () => {
 			const previouslyForgedHeight = 100;
 			// Arrange
 			const maxHeightResult = JSON.stringify({
-				[defaultKeyPair.publicKey.toString('hex')]: 100,
+				[defaultKeyPair.publicKey.toString('hex')]: { height: 100 },
 			});
 			storageStub.entities.ForgerInfo.getKey.mockResolvedValue(maxHeightResult);
 			// Act
@@ -162,11 +162,11 @@ describe('block processor v2', () => {
 		it('should update maxPreviouslyForgedHeight to the next higher one but not change for other delegates', async () => {
 			// Arrange
 			const list = {
-				[defaultKeyPair.publicKey.toString('hex')]: 5,
-				a: 4,
-				b: 6,
-				c: 7,
-				x: 8,
+				[defaultKeyPair.publicKey.toString('hex')]: { height: 5 },
+				a: { height: 4 },
+				b: { height: 6 },
+				c: { height: 7 },
+				x: { height: 8 },
 			};
 			storageStub.entities.ForgerInfo.getKey.mockResolvedValue(
 				JSON.stringify(list),
@@ -182,7 +182,11 @@ describe('block processor v2', () => {
 			});
 			const maxHeightResult = JSON.stringify({
 				...list,
-				[defaultKeyPair.publicKey.toString('hex')]: 11,
+				[defaultKeyPair.publicKey.toString('hex')]: {
+					height: 11,
+					maxHeightPrevoted: 0,
+					maxHeightPreviouslyForged: 5,
+				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
 				'maxHeightPreviouslyForged',
@@ -201,7 +205,11 @@ describe('block processor v2', () => {
 				},
 			});
 			const maxHeightResult = JSON.stringify({
-				[defaultKeyPair.publicKey.toString('hex')]: 11,
+				[defaultKeyPair.publicKey.toString('hex')]: {
+					height: 11,
+					maxHeightPrevoted: 0,
+					maxHeightPreviouslyForged: 0,
+				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
 				'maxHeightPreviouslyForged',
@@ -213,7 +221,7 @@ describe('block processor v2', () => {
 			// Arrange
 			storageStub.entities.ForgerInfo.getKey.mockResolvedValue(
 				JSON.stringify({
-					[defaultKeyPair.publicKey.toString('hex')]: 15,
+					[defaultKeyPair.publicKey.toString('hex')]: { height: 15 },
 				}),
 			);
 			// Act


### PR DESCRIPTION
### What was the problem?
This PR resolves #4800 

### How was it solved?
- Update the saved forger info to be consistent with LIP
- Update variable name to be consistent with LIP
- delete block, but only populate the cache first and recompute without validation

### How was it tested?
- Added test case to check the recompute
- Check database to contain correct forger info
