### PR TITLE
Locale should be specified when using toLocaleString - Closes #4747

### DIFF
--- a/elements/lisk-transactions/src/utils/format.ts
+++ b/elements/lisk-transactions/src/utils/format.ts
@@ -35,7 +35,7 @@ export const convertBeddowsToLSK = (beddowsAmount?: string): string => {
 	const floating =
 		Number(beddowsAmountBigInt % BigInt(FIXED_POINT)) / FIXED_POINT;
 	const floatingPointsSplit = floating
-		.toLocaleString(undefined, {
+		.toLocaleString('en-US', {
 			maximumFractionDigits: LISK_MAX_DECIMAL_POINTS,
 		})
 		.split('.')[1];


### PR DESCRIPTION
### What was the problem?
This PR resolves #4747

### How was it solved?
By specifying the locale `en-US`

### How was it tested?
By running tests
