### PR TITLE
Fix wrong min precommit height and overwrite of finality - Closes #4808

### DIFF
--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -213,6 +213,14 @@ class FinalityManager extends EventEmitter {
 		return true;
 	}
 
+	/**
+	 * Get the min height from which a delegate can make pre-commits
+	 *
+	 * The flow is as following:
+	 * - We search backward from top block to bottom block in the chain
+	 * - We can search down to current block height - processingThreshold(302)
+	 * -
+	 */
 	_getMinValidHeightToPreCommit(header) {
 		// We search backward from top block to bottom block in the chain
 
@@ -253,12 +261,13 @@ class FinalityManager extends EventEmitter {
 					return needleHeight + 1;
 				}
 				// Move the needle to previous block and consider it current for next iteration
-				// needleHeight = previousBlockHeader.maxHeightPreviouslyForged;
+				needleHeight = previousBlockHeader.maxHeightPreviouslyForged;
 				currentBlockHeader = previousBlockHeader;
+			} else {
+				needleHeight -= 1;
 			}
-			needleHeight -= 1;
 		}
-		return needleHeight + 1;
+		return Math.max(needleHeight + 1, searchTillHeight);
 	}
 
 	recompute() {

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -128,18 +128,15 @@ class FinalityManager extends EventEmitter {
 			maxPreCommitHeight: 0,
 		};
 
-		const validMinHeightToVoteAndCommit = this._getValidMinHeightToCommit(
-			header,
-		);
+		const heightNotPrevoted = this._getHeightNotPrevoted(header);
 
 		// If delegate is new then first block of the round will be considered
 		// if it forged before then we probably have the last commit height
 		// delegate can't pre-commit a block before the above mentioned conditions
 		const minPreCommitHeight = Math.max(
 			header.delegateMinHeightActive,
-			validMinHeightToVoteAndCommit + 1,
+			heightNotPrevoted + 1,
 			delegateState.maxPreCommitHeight + 1,
-			header.height - this.processingThreshold,
 		);
 
 		// Delegate can't pre-commit the blocks on tip of the chain
@@ -214,7 +211,7 @@ class FinalityManager extends EventEmitter {
 		return true;
 	}
 
-	_getValidMinHeightToCommit(header) {
+	_getHeightNotPrevoted(header) {
 		// We search backward from top block to bottom block in the chain
 
 		// We should search down to the height we have in our headers list

--- a/framework/src/modules/chain/bft/finality_manager.js
+++ b/framework/src/modules/chain/bft/finality_manager.js
@@ -238,11 +238,9 @@ class FinalityManager extends EventEmitter {
 			// We need to ensure that the delegate forging header did not forge on any other chain, i.e.,
 			// maxHeightPreviouslyForged always refers to a height with a block forged by the same delegate.
 			if (needleHeight === currentBlockHeader.maxHeightPreviouslyForged) {
-				let previousBlockHeader;
-				try {
-					previousBlockHeader = this.headers.get(needleHeight);
-				} catch (err) {
-					debug('Fail to get cached block header', err);
+				const previousBlockHeader = this.headers.get(needleHeight);
+				if (!previousBlockHeader) {
+					debug('Fail to get cached block header');
 					return -1;
 				}
 
@@ -255,9 +253,7 @@ class FinalityManager extends EventEmitter {
 				) {
 					return needleHeight;
 				}
-
 				// Move the needle to previous block and consider it current for next iteration
-				needleHeight = previousBlockHeader.maxHeightPreviouslyForged;
 				currentBlockHeader = previousBlockHeader;
 			}
 			needleHeight -= 1;

--- a/framework/src/modules/chain/bft/headers_list.js
+++ b/framework/src/modules/chain/bft/headers_list.js
@@ -126,6 +126,12 @@ class HeadersList {
 	}
 
 	get(height) {
+		if (
+			this.length === 0 ||
+			this._items[height - this.first.height] === undefined
+		) {
+			throw new Error(`Cannot get cache with height ${height}`);
+		}
 		return this._items[height - this.first.height];
 	}
 }

--- a/framework/src/modules/chain/bft/headers_list.js
+++ b/framework/src/modules/chain/bft/headers_list.js
@@ -126,10 +126,7 @@ class HeadersList {
 	}
 
 	get(height) {
-		if (
-			this.length === 0 ||
-			this._items[height - this.first.height] === undefined
-		) {
+		if (this.length === 0) {
 			return undefined;
 		}
 		return this._items[height - this.first.height];

--- a/framework/src/modules/chain/bft/headers_list.js
+++ b/framework/src/modules/chain/bft/headers_list.js
@@ -130,7 +130,7 @@ class HeadersList {
 			this.length === 0 ||
 			this._items[height - this.first.height] === undefined
 		) {
-			throw new Error(`Cannot get cache with height ${height}`);
+			return undefined;
 		}
 		return this._items[height - this.first.height];
 	}

--- a/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
+++ b/framework/test/jest/unit/specs/modules/chain/bft/bft.spec.js
@@ -659,7 +659,7 @@ describe('bft', () => {
 		});
 
 		describe('#reset', () => {
-			it('should reset headers and related stats to initial state', async () => {
+			it('should reset headers and related stats to initial state except finality', async () => {
 				// Arrange
 				storageMock.entities.Block.get.mockReturnValue([]);
 				storageMock.entities.ChainState.get.mockResolvedValue([
@@ -692,7 +692,11 @@ describe('bft', () => {
 
 				// Assert
 				expect(beforeResetInfo).not.toEqual(initialInfo);
-				expect(afterResetInfo).toEqual(initialInfo);
+				// Finalized height should not change
+				expect(afterResetInfo).toEqual({
+					...initialInfo,
+					finalizedHeight: beforeResetInfo.finalizedHeight,
+				});
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4808 

### How was it solved?
- Remove resetting the finality when recomputing
- Fix not to throw error when cache doesn't exist
- Fix the logic to for height count down

### How was it tested?
- it should not affect the property calculation on the success scenario
- Removed the cache manually (not initialize enough in the code, and observe it doesn't throw)
