### PR TITLE
pass an array of ip instead of an array of entry

### DIFF
--- a/framework/src/modules/http_api/controllers/node.js
+++ b/framework/src/modules/http_api/controllers/node.js
@@ -299,7 +299,10 @@ NodeController.getStatus = async (context, next) => {
  */
 NodeController.getForgingStatus = async (context, next) => {
 	if (
-		!checkIpInList(library.config.forging.access.whiteList, context.request.ip)
+		!checkIpInList(
+			library.config.forging.access.whiteList.map(e => e.ip),
+			context.request.ip,
+		)
 	) {
 		context.statusCode = apiCodes.FORBIDDEN;
 		return next(new Error('Access Denied'));
@@ -323,7 +326,10 @@ NodeController.getForgingStatus = async (context, next) => {
  */
 NodeController.updateForgingStatus = async (context, next) => {
 	if (
-		!checkIpInList(library.config.forging.access.whiteList, context.request.ip)
+		!checkIpInList(
+			library.config.forging.access.whiteList.map(e => e.ip),
+			context.request.ip,
+		)
 	) {
 		context.statusCode = apiCodes.FORBIDDEN;
 		return next(new Error('Access Denied'));

--- a/framework/src/modules/http_api/init_steps/bootstrap_swagger.js
+++ b/framework/src/modules/http_api/init_steps/bootstrap_swagger.js
@@ -130,7 +130,7 @@ const middleware = {
 
 		if (
 			!config.access.public &&
-			!checkIpInList(config.access.whiteList, req.ip)
+			!checkIpInList(config.access.whiteList.map(e => e.ip), req.ip)
 		) {
 			return res.status(apiCodes.FORBIDDEN).send({
 				message: 'API access denied',


### PR DESCRIPTION
Once the config.json is parsed it is transformed into an entry : 

```typescript
type WhiteListEntry = {
  ip: string;
  wsPort: number;
}
```

And then injected into the config tree.
When this config is used, it is passed as is. Unfortunately the function `CheckIpInList`expects an array of string, not an array of object, resulting into an exception and therefore blocking the legitimate requests.

This PR fixes the passed values.