### PR TITLE
Config formatter breaks ip check

### DIFF
--- a/framework/src/controller/validator/keywords/formatters.js
+++ b/framework/src/controller/validator/keywords/formatters.js
@@ -15,6 +15,13 @@
 'use strict';
 
 module.exports = {
+	stringToIpList: value => {
+		if (typeof value === 'string') {
+			return value.split(',');
+		}
+		return [];
+	},
+
 	stringToIpPortSet: value => {
 		if (typeof value === 'string') {
 			return value.split(',').map(peer => {

--- a/framework/src/modules/http_api/defaults/config.js
+++ b/framework/src/modules/http_api/defaults/config.js
@@ -47,7 +47,7 @@ const defaultConfig = {
 					type: 'array',
 					env: {
 						variable: 'LISK_API_WHITELIST',
-						formatter: 'stringToIpPortSet',
+						formatter: 'stringToIpList',
 					},
 				},
 			},
@@ -144,7 +144,7 @@ const defaultConfig = {
 							type: 'array',
 							env: {
 								variable: 'LISK_FORGING_WHITELIST',
-								formatter: 'stringToIpPortSet',
+								formatter: 'stringToIpList',
 							},
 						},
 					},


### PR DESCRIPTION
The config formatter turns whitelists into the wrong format, preventing internal firewall to work properly when the whitelist is loaded from ENV variables.