### PR TITLE
Updating CONTRIBUTING_GUIDE

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Before creating bug reports, please check [this list](#before-submitting-a-bug-r
 
 #### How Do I Submit A (Good) Bug Report?
 
-Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](https://github.com/LiskHQ) your bug is related to, create an issue on that repository and provide the following information by filling in [the template](ISSUE_TEMPLATE.md).
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](https://github.com/LiskHQ) your bug is related to, create an issue on that repository and provide the following information by filling in [the template](../.github/ISSUE_TEMPLATE/bug-report.md).
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
@@ -88,7 +88,7 @@ Explain the problem and include additional details to help maintainers reproduce
 * **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
 * **Explain which behavior you expected to see instead and why.**
-* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/cgoodrich/byzanz) on Linux.
 * **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
@@ -101,7 +101,7 @@ Provide more context by answering these questions:
 
 This section guides you through submitting an enhancement suggestion for Lisk SDK, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
- When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](../.github/ISSUE_TEMPLATE/bug-report.md), including the steps that you imagine you would take if the feature you're requesting existed.
+ When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](../.github/ISSUE_TEMPLATE/feature-request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 
@@ -111,7 +111,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 * **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 * **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
-* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk SDK which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk SDK which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/cgoodrich/byzanz) on Linux.
 * **Explain why this enhancement would be useful** to most Lisk and Lisk SDK users.
 * **Specify which version of Lisk and Lisk SDK you're using.**
 * **Specify the name and version of the OS you're using.**

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,7 +67,7 @@ In case you've never submitted a pull request (PR) via GitHub before, please rea
 
 This section guides you through submitting a bug report for Lisk SDK. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
-Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](../.github/ISSUE_TEMPLATE/bug-report.md), the information it asks for helps us resolve issues faster.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -101,7 +101,7 @@ Provide more context by answering these questions:
 
 This section guides you through submitting an enhancement suggestion for Lisk SDK, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
- When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
+ When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](../.github/ISSUE_TEMPLATE/bug-report.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,8 +37,8 @@ Lisk is an open-source decentralized project, there are many ways and platforms 
 
 If you prefer to chat with LiskHQ and other developers directly:
 
-* [Join the LiskHQ Gitter](https://gitter.im/LiskHQ/lisk)
-* Even though Gitter is a chat service, sometimes it takes several hours for community members to respond &mdash; please be patient!
+* [Join the LiskHQ Discord](https://discordapp.com/invite/7EKWJ7b)
+* Even though Discord is a chat service, sometimes it takes several hours for community members to respond &mdash; please be patient!
 
 ## How Can I Contribute?
 


### PR DESCRIPTION
**What was the problem?**
Contributing guide is not up-to date

**How was it solved?**

- Gitter chat channel is replaced with Discord
- By fixing the broken URLs & images
- byzanz URL is replaced with new working URL