### PR TITLE
StateStoreCache type safety

### DIFF
--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -29,6 +29,8 @@ import {
 	UNCONFIRMED_TRANSACTION_TIMEOUT,
 } from './constants';
 import { convertToTransactionError, TransactionError } from './errors';
+import { AccountFilter } from './filters.account';
+import { TransactionFilter } from './filters.transaction';
 import { createResponse, Status } from './response';
 import * as schemas from './schema';
 import { Account, TransactionJSON } from './transaction_types';
@@ -77,7 +79,7 @@ export interface StateStore {
 
 export interface StateStoreCache<T> {
 	cache(
-		filterArray: ReadonlyArray<{ readonly [key: string]: string }>,
+		filterArray: ReadonlyArray<AccountFilter | TransactionFilter>,
 	): Promise<ReadonlyArray<T>>;
 }
 

--- a/elements/lisk-transactions/src/filters.account.d.ts
+++ b/elements/lisk-transactions/src/filters.account.d.ts
@@ -1,0 +1,177 @@
+// STRING : '' | '_in' | '_eql' | '_ne' | '_like' |
+// NUMBER : '' |'_eql' | '_ne' | '_gt' | '_gte' | '_lt' | '_lte' | '_in' |
+// BOOLEAN : '' | '_eql' | '_ne' |
+
+export type AccountStateStoreFilterKeys =
+	// Default type filters
+
+	| 'address'
+	| 'address_in'
+	| 'address_eql'
+	| 'address_ne'
+	| 'address_like'
+	| 'username'
+	| 'username_in'
+	| 'username_eql'
+	| 'username_ne'
+	| 'username_like'
+	| 'isDelegate'
+	| 'isDelegate_eql'
+	| 'isDelegate_ne'
+	| 'nonce'
+	| 'nonce_eql'
+	| 'nonce_ne'
+	| 'nameExist'
+	| 'nameExist_eql'
+	| 'nameExist_ne'
+	| 'balance'
+	| 'balance_eql'
+	| 'balance_ne'
+	| 'balance_gt'
+	| 'balance_gte'
+	| 'balance_lt'
+	| 'balance_lte'
+	| 'balance_in'
+	| 'fees'
+	| 'fees_eql'
+	| 'fees_ne'
+	| 'fees_gt'
+	| 'fees_gte'
+	| 'fees_lt'
+	| 'fees_lte'
+	| 'fees_in'
+	| 'rewards'
+	| 'rewards_eql'
+	| 'rewards_ne'
+	| 'rewards_gt'
+	| 'rewards_gte'
+	| 'rewards_lt'
+	| 'rewards_lte'
+	| 'rewards_in'
+	| 'producedBlocks'
+	| 'producedBlocks_eql'
+	| 'producedBlocks_ne'
+	| 'producedBlocks_gt'
+	| 'producedBlocks_gte'
+	| 'producedBlocks_lt'
+	| 'producedBlocks_lte'
+	| 'producedBlocks_in'
+	| 'missedBlocks'
+	| 'missedBlocks_eql'
+	| 'missedBlocks_ne'
+	| 'missedBlocks_gt'
+	| 'missedBlocks_gte'
+	| 'missedBlocks_lt'
+	| 'missedBlocks_lte'
+	| 'missedBlocks_in'
+	| 'voteWeight'
+	| 'voteWeight_eql'
+	| 'voteWeight_ne'
+	| 'voteWeight_gt'
+	| 'voteWeight_gte'
+	| 'voteWeight_lt'
+	| 'voteWeight_lte'
+	| 'voteWeight_in'
+	| 'asset'
+	| 'asset_in'
+	| 'asset_eql'
+	| 'asset_ne'
+	| 'asset_like'
+	| 'votedDelegatesPublicKeys'
+	| 'votedDelegatesPublicKeys_in'
+	| 'votedDelegatesPublicKeys_eql'
+	| 'votedDelegatesPublicKeys_ne'
+	| 'votedDelegatesPublicKeys_like'
+	| 'keys'
+	| 'keys_in'
+	| 'keys_eql'
+	| 'keys_ne'
+	| 'keys_like'
+
+	// Custom
+	| 'asset_contains'
+	| 'asset_exists';
+
+type keyExpectBoolean =
+	| 'isDelegate'
+	| 'isDelegate_eql'
+	| 'isDelegate_ne'
+	| 'nonce'
+	| 'nonce_eql'
+	| 'nonce_ne'
+	| 'nameExist'
+	| 'nameExist_eql'
+	| 'nameExist_ne'
+	| 'asset_exists';
+
+type keyExpectNumber =
+	| 'balance'
+	| 'balance_eql'
+	| 'balance_ne'
+	| 'balance_gt'
+	| 'balance_gte'
+	| 'balance_lt'
+	| 'balance_lte'
+	| 'fees'
+	| 'fees_eql'
+	| 'fees_ne'
+	| 'fees_gt'
+	| 'fees_gte'
+	| 'fees_lt'
+	| 'fees_lte'
+	| 'rewards'
+	| 'rewards_eql'
+	| 'rewards_ne'
+	| 'rewards_gt'
+	| 'rewards_gte'
+	| 'rewards_lt'
+	| 'rewards_lte'
+	| 'producedBlocks'
+	| 'producedBlocks_eql'
+	| 'producedBlocks_ne'
+	| 'producedBlocks_gt'
+	| 'producedBlocks_gte'
+	| 'producedBlocks_lt'
+	| 'producedBlocks_lte'
+	| 'missedBlocks'
+	| 'missedBlocks_eql'
+	| 'missedBlocks_ne'
+	| 'missedBlocks_gt'
+	| 'missedBlocks_gte'
+	| 'missedBlocks_lt'
+	| 'missedBlocks_lte'
+	| 'voteWeight'
+	| 'voteWeight_eql'
+	| 'voteWeight_ne'
+	| 'voteWeight_gt'
+	| 'voteWeight_gte'
+	| 'voteWeight_lt'
+	| 'voteWeight_lte';
+
+type keyExpectNumberArray =
+	| 'balance_in'
+	| 'fees_in'
+	| 'rewards_in'
+	| 'producedBlocks_in'
+	| 'missedBlocks_in'
+	| 'voteWeight_in';
+
+type keyExpectStringArray = 'address_in' | 'username_in';
+
+export type AccountStateStoreFilterValues<
+	Filter
+> = Filter extends keyExpectBoolean
+	? boolean
+	: Filter extends keyExpectNumber
+	? number
+	: Filter extends keyExpectNumberArray
+	? number[]
+	: Filter extends keyExpectStringArray
+	? string[]
+	: string; // Default to string
+
+export type AccountFilter = Partial<
+	{
+		[key in AccountStateStoreFilterKeys]: AccountStateStoreFilterValues<key>;
+	}
+>;

--- a/elements/lisk-transactions/src/filters.transaction.d.ts
+++ b/elements/lisk-transactions/src/filters.transaction.d.ts
@@ -1,0 +1,155 @@
+// STRING : '' | '_eql' | '_ne' | '_like' | '_in' |
+// NUMBER : '' |'_eql' | '_ne' | '_gt' | '_gte' | '_lt' | '_lte' | '_in' |
+// BOOLEAN : '' | '_eql' | '_ne' |
+
+export type TransactionStateStoreFilterKeys =
+	// Default type filters
+
+	// String
+	| 'rowId'
+	| 'rowId_eql'
+	| 'rowId_ne'
+	| 'rowId_like'
+	| 'rowId_in'
+	| 'transferData'
+	| 'transferData_eql'
+	| 'transferData_ne'
+	| 'transferData_like'
+	| 'transferData_in'
+	| 'id'
+	| 'id_eql'
+	| 'id_ne'
+	| 'id_like'
+	| 'id_in'
+	| 'blockId'
+	| 'blockId_eql'
+	| 'blockId_ne'
+	| 'blockId_like'
+	| 'blockId_in'
+	| 'nonce'
+	| 'nonce_eql'
+	| 'nonce_ne'
+	| 'nonce_like'
+	| 'nonce_in'
+	| 'senderPublicKey'
+	| 'senderPublicKey_eql'
+	| 'senderPublicKey_ne'
+	| 'senderPublicKey_like'
+	| 'senderPublicKey_in'
+	| 'recipientId'
+	| 'recipientId_eql'
+	| 'recipientId_ne'
+	| 'recipientId_like'
+	| 'recipientId_in'
+	| 'signatures'
+	| 'signatures_eql'
+	| 'signatures_ne'
+	| 'signatures_like'
+	| 'signatures_in'
+	| 'asset'
+	| 'asset_eql'
+	| 'asset_ne'
+	| 'asset_like'
+	| 'asset_in'
+
+	// Number
+	| 'blockHeight'
+	| 'blockHeight_eql'
+	| 'blockHeight_ne'
+	| 'blockHeight_gt'
+	| 'blockHeight_gte'
+	| 'blockHeight_lt'
+	| 'blockHeight_lte'
+	| 'blockHeight_in'
+	| 'type'
+	| 'type_eql'
+	| 'type_ne'
+	| 'type_gt'
+	| 'type_gte'
+	| 'type_lt'
+	| 'type_lte'
+	| 'type_in'
+	| 'amount'
+	| 'amount_eql'
+	| 'amount_ne'
+	| 'amount_gt'
+	| 'amount_gte'
+	| 'amount_lt'
+	| 'amount_lte'
+	| 'amount_in'
+	| 'fee'
+	| 'fee_eql'
+	| 'fee_ne'
+	| 'fee_gt'
+	| 'fee_gte'
+	| 'fee_lt'
+	| 'fee_lte'
+	| 'fee_in'
+
+	// Custom
+	| 'data_like';
+
+type keyExpectNumber =
+	| 'blockHeight'
+	| 'blockHeight_eql'
+	| 'blockHeight_ne'
+	| 'blockHeight_gt'
+	| 'blockHeight_gte'
+	| 'blockHeight_lt'
+	| 'blockHeight_lte'
+	| 'type'
+	| 'type_eql'
+	| 'type_ne'
+	| 'type_gt'
+	| 'type_gte'
+	| 'type_lt'
+	| 'type_lte'
+	| 'amount'
+	| 'amount_eql'
+	| 'amount_ne'
+	| 'amount_gt'
+	| 'amount_gte'
+	| 'amount_lt'
+	| 'amount_lte'
+	| 'fee'
+	| 'fee_eql'
+	| 'fee_ne'
+	| 'fee_gt'
+	| 'fee_gte'
+	| 'fee_lt'
+	| 'fee_lte';
+
+type keyExpectNumberArray =
+	| 'blockHeight_in'
+	| 'type_in'
+	| 'amount_in'
+	| 'fee_in';
+
+type keyExpectStringArray =
+	| 'rowId_in'
+	| 'transferData_in'
+	| 'id_in'
+	| 'blockId_in'
+	| 'nonce_in'
+	| 'senderPublicKey_in'
+	| 'recipientId_in'
+	| 'signatures_in'
+	| 'asset_in';
+
+export type TransactionStateStoreFilterValues<
+	Filter
+> = Filter extends keyExpectNumber
+	? number
+	: Filter extends keyExpectNumberArray
+	? number[]
+	: Filter extends keyExpectStringArray
+	? string[]
+	: string; // Default to string
+
+export type TransactionFilter = Partial<
+	{
+		[key in TransactionStateStoreFilterKeys]: TransactionStateStoreFilterValues<
+			key
+		>;
+	}
+>;


### PR DESCRIPTION
Feature request presented in #4949 .

StateStoreCache currently doesn't have a precise type definition. It actually have wrong type definition since everything is a string.

See https://github.com/LiskHQ/lisk-sdk/blob/development/elements/lisk-transactions/src/base_transaction.ts#L80

I added an exhaustive list of filter keys and their expected type.