### PR TITLE
Fix to always choose distinct voted delegate list - Closes #4907

### DIFF
--- a/elements/lisk-dpos/test/utils/round_delegates.ts
+++ b/elements/lisk-dpos/test/utils/round_delegates.ts
@@ -53,7 +53,7 @@ export const delegateAccounts = delegatePublicKeys.map(
 		const votedDelegatesPublicKeys = [
 			votedDelegates[index].publicKey,
 			votedDelegates[index + 1].publicKey,
-			votedDelegates[index % 10].publicKey,
+			votedDelegates[index + 2].publicKey,
 		];
 		return {
 			address: getAddressFromPublicKey(pk),


### PR DESCRIPTION
### What was the problem?

This PR resolves #4907 

### How was it solved?

Choose distinct voted delegate list for test.

### How was it tested?

Test should be stably passing
