### PR TITLE
Implement removeTransaction function in TxPool - Closes #4861

### DIFF
--- a/elements/lisk-transaction-pool/src/min_heap.ts
+++ b/elements/lisk-transaction-pool/src/min_heap.ts
@@ -75,10 +75,6 @@ export class MinHeap<T, K = bigint | number> {
 		return this._nodes.map(n => n.value);
 	}
 
-	public getAllNodes(): ReadonlyArray<Node<T, K>> {
-		return [...this._nodes];
-	}
-
 	private _insertAll(heap: MinHeap<T, K>): void {
 		if (!(heap instanceof MinHeap)) {
 			throw new Error('Only heap instance can be inserted');

--- a/elements/lisk-transaction-pool/src/min_heap.ts
+++ b/elements/lisk-transaction-pool/src/min_heap.ts
@@ -75,6 +75,10 @@ export class MinHeap<T, K = bigint | number> {
 		return this._nodes.map(n => n.value);
 	}
 
+	public getAllNodes(): ReadonlyArray<Node<T, K>> {
+		return [...this._nodes];
+	}
+
 	private _insertAll(heap: MinHeap<T, K>): void {
 		if (!(heap instanceof MinHeap)) {
 			throw new Error('Only heap instance can be inserted');

--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -186,10 +186,13 @@ export class TransactionPool {
 
 		// Remove from feePriorityQueue
 		this._feePriorityQueue.clear();
-		for (const node of this._feePriorityQueue.getAllNodes()) {
-			if (node.value !== foundTx.id) {
-				this._feePriorityQueue.push(node.key, node.value);
-			}
+		for (const txObject of this.getAllTransactions()) {
+			this._feePriorityQueue.push(
+				txObject.feePriority
+					? txObject.feePriority
+					: this._calculateFeePriority(txObject),
+				txObject.id,
+			);
 		}
 
 		return true;

--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -188,9 +188,7 @@ export class TransactionPool {
 		this._feePriorityQueue.clear();
 		for (const txObject of this.getAllTransactions()) {
 			this._feePriorityQueue.push(
-				txObject.feePriority
-					? txObject.feePriority
-					: this._calculateFeePriority(txObject),
+				txObject.feePriority ?? this._calculateFeePriority(txObject),
 				txObject.id,
 			);
 		}

--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -174,9 +174,25 @@ export class TransactionPool {
 	}
 
 	public removeTransaction(tx: Transaction): boolean {
-		// FIXME: this is log to supress ts build error
-		console.log(tx);
-		return false;
+		const foundTx = this._allTransactions[tx.id];
+		if (!foundTx) {
+			return false;
+		}
+
+		delete this._allTransactions[tx.id];
+		this._transactionList[
+			getAddressFromPublicKey(foundTx.senderPublicKey)
+		].remove(tx.nonce);
+
+		// Remove from feePriorityQueue
+		this._feePriorityQueue.clear();
+		for (const node of this._feePriorityQueue.getAllNodes()) {
+			if (node.value !== foundTx.id) {
+				this._feePriorityQueue.push(node.key, node.value);
+			}
+		}
+
+		return true;
 	}
 
 	public getProcessableTransactions(): {

--- a/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
@@ -251,10 +251,15 @@ describe('TransactionList class', () => {
 		txGetBytesStub = jest.fn();
 		tx.getBytes = txGetBytesStub.mockReturnValue(Buffer.from(new Array(10)));
 
+		beforeEach(async () => {
+			await transactionPool.addTransaction(tx);
+		});
+
+		afterEach(async () => {
+			await transactionPool.removeTransaction(tx);
+		});
+
 		it('should return false when a tx id does not exist', async () => {
-			const addStatus = await transactionPool.addTransaction(tx);
-			expect(addStatus).toEqual(true);
-			expect(transactionPool.getAllTransactions().length).toEqual(1);
 			expect(
 				transactionPool['_transactionList'][
 					getAddressFromPublicKey(tx.senderPublicKey)
@@ -275,9 +280,6 @@ describe('TransactionList class', () => {
 		});
 
 		it('should remove the transaction from _allTransactions, _transactionList and _feePriorityQueue', async () => {
-			const addStatus = await transactionPool.addTransaction(tx);
-			expect(addStatus).toEqual(true);
-			expect(transactionPool.getAllTransactions().length).toEqual(1);
 			expect(
 				transactionPool['_transactionList'][
 					getAddressFromPublicKey(tx.senderPublicKey)


### PR DESCRIPTION
### What was the problem?

This PR resolves #4861 

### How was it solved?

- [x] It should remove from the corresponding `TransactionList`
- [x] Remove transaction id from `all` transaction map
- [x] Test if transaction list do not contain the deleted transactions
- [x] Test if `all` transaction set does not contain transactions

### How was it tested?

`npm t`
