### PR TITLE
Remove `git add` from lint-staged task - Closes #4965

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-	"*.js": ["prettier --write", "eslint", "git add"],
-	"*.ts": ["prettier --write", "tslint --format verbose", "git add"],
-	"*.{json,md}": ["prettier --write", "git add"]
+	"*.js": ["prettier --write", "eslint"],
+	"*.ts": ["prettier --write", "tslint --format verbose"],
+	"*.{json,md}": ["prettier --write"]
 }


### PR DESCRIPTION
### What was the problem?
Refer #4965 

### How was it solved?

- Removed `git add` from lint staged

### How was it tested?

- Do git add and commit, you should not receive any warnings.