### PR TITLE
Add transaction pool missing functions - Closes #4968

### DIFF
--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -85,11 +85,7 @@ export class TransactionPool {
 			DEFAULT_REORGANIZE_TIME,
 		);
 		// FIXME: This is log to supress ts build error
-		console.log(
-			this._transactionExpiryTime,
-			this._maxTransactionsPerAccount,
-			this._minReplacementFeeDifference,
-		);
+		console.log(this._transactionExpiryTime);
 	}
 
 	public async start(): Promise<void> {
@@ -105,13 +101,11 @@ export class TransactionPool {
 	}
 
 	public get(id: string): Transaction | undefined {
-		console.log(id, this._transactionList);
-		return undefined;
+		return this._allTransactions[id];
 	}
 
 	public contains(id: string): boolean {
-		console.log(id);
-		return false;
+		return this._allTransactions[id] !== undefined;
 	}
 
 	public async addTransaction(incomingTx: Transaction): Promise<boolean> {
@@ -154,6 +148,10 @@ export class TransactionPool {
 		if (!this._transactionList[incomingTxAddress]) {
 			this._transactionList[incomingTxAddress] = new TransactionList(
 				incomingTxAddress,
+				{
+					maxSize: this._maxTransactionsPerAccount,
+					minReplacementFeeDifference: this._minReplacementFeeDifference,
+				},
 			);
 		}
 
@@ -199,7 +197,14 @@ export class TransactionPool {
 	public getProcessableTransactions(): {
 		readonly [address: string]: ReadonlyArray<Transaction>;
 	} {
-		return {};
+		const processableTransactions: {
+			[address: string]: ReadonlyArray<Transaction>;
+		} = {};
+		for (const address of Object.keys(this._transactionList)) {
+			const transactions = this._transactionList[address].getProcessable();
+			processableTransactions[address] = [...transactions];
+		}
+		return processableTransactions;
 	}
 
 	private async _reorganize(): Promise<void> {}

--- a/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
@@ -179,7 +179,7 @@ describe('TransactionList class', () => {
 			].promote([txs[3]]);
 		});
 
-		it('should return copy of the transaciton list', async () => {
+		it('should return copy of processable transactions list', async () => {
 			const processableTransactions = transactionPool.getProcessableTransactions();
 			const transactionFromSender0 =
 				processableTransactions[getAddressFromPublicKey(senderPublicKeys[0])];

--- a/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
@@ -78,6 +78,139 @@ describe('TransactionList class', () => {
 		});
 	});
 
+	describe('get', () => {
+		let txGetBytesStub: jest.Mock;
+		let tx: Transaction;
+
+		beforeEach(async () => {
+			tx = {
+				id: '1',
+				nonce: BigInt(1),
+				minFee: BigInt(10),
+				fee: BigInt(1000),
+				senderPublicKey: generateRandomPublicKeys()[0],
+			} as Transaction;
+
+			txGetBytesStub = jest.fn();
+			tx.getBytes = txGetBytesStub.mockReturnValue(Buffer.from(new Array(10)));
+			await transactionPool.addTransaction(tx);
+		});
+
+		it('should return transaction if exist', async () => {
+			expect(transactionPool.get('1')).toEqual(tx);
+		});
+
+		it('should return undefined if it does not exist', async () => {
+			expect(transactionPool.get('2')).toBeUndefined();
+		});
+	});
+
+	describe('contains', () => {
+		let txGetBytesStub: jest.Mock;
+		let tx: Transaction;
+
+		beforeEach(async () => {
+			tx = {
+				id: '1',
+				nonce: BigInt(1),
+				minFee: BigInt(10),
+				fee: BigInt(1000),
+				senderPublicKey: generateRandomPublicKeys()[0],
+			} as Transaction;
+
+			txGetBytesStub = jest.fn();
+			tx.getBytes = txGetBytesStub.mockReturnValue(Buffer.from(new Array(10)));
+			await transactionPool.addTransaction(tx);
+		});
+
+		it('should return transaction if exist', async () => {
+			expect(transactionPool.contains('1')).toBe(true);
+		});
+
+		it('should return undefined if it does not exist', async () => {
+			expect(transactionPool.contains('2')).toBe(false);
+		});
+	});
+
+	describe('getProcessableTransactions', () => {
+		let senderPublicKeys: string[];
+		beforeEach(async () => {
+			senderPublicKeys = generateRandomPublicKeys(2);
+			const txs = [
+				{
+					id: '1',
+					nonce: BigInt(1),
+					minFee: BigInt(10),
+					fee: BigInt(1000),
+					senderPublicKey: senderPublicKeys[0],
+				},
+				{
+					id: '2',
+					nonce: BigInt(2),
+					minFee: BigInt(10),
+					fee: BigInt(1000),
+					senderPublicKey: senderPublicKeys[0],
+				},
+				{
+					id: '9',
+					nonce: BigInt(9),
+					minFee: BigInt(10),
+					fee: BigInt(1000),
+					senderPublicKey: senderPublicKeys[0],
+				},
+				{
+					id: '3',
+					nonce: BigInt(1),
+					minFee: BigInt(10),
+					fee: BigInt(1000),
+					senderPublicKey: senderPublicKeys[1],
+				},
+			] as Transaction[];
+
+			for (const tx of txs) {
+				tx.getBytes = jest.fn().mockReturnValue(Buffer.from(new Array(10)));
+				await transactionPool.addTransaction(tx);
+			}
+			(transactionPool as any)._transactionList[
+				getAddressFromPublicKey(senderPublicKeys[0])
+			].promote([txs[0]]);
+			(transactionPool as any)._transactionList[
+				getAddressFromPublicKey(senderPublicKeys[1])
+			].promote([txs[3]]);
+		});
+
+		it('should return copy of the transaciton list', async () => {
+			const processableTransactions = transactionPool.getProcessableTransactions();
+			const transactionFromSender0 =
+				processableTransactions[getAddressFromPublicKey(senderPublicKeys[0])];
+			const transactionFromSender1 =
+				processableTransactions[getAddressFromPublicKey(senderPublicKeys[1])];
+
+			expect(transactionFromSender0).toHaveLength(1);
+			expect(transactionFromSender0[0].nonce.toString()).toEqual('1');
+			expect(transactionFromSender1).toHaveLength(1);
+			expect(transactionFromSender1[0].nonce.toString()).toEqual('1');
+			// Check if it is a copy
+			delete (processableTransactions as any)[
+				getAddressFromPublicKey(senderPublicKeys[0])
+			];
+			(processableTransactions as any)[
+				getAddressFromPublicKey(senderPublicKeys[1])
+			][0] = 'random thing';
+
+			expect(
+				(transactionPool as any)._transactionList[
+					getAddressFromPublicKey(senderPublicKeys[0])
+				],
+			).not.toBeUndefined();
+			expect(
+				transactionPool.getProcessableTransactions()[
+					getAddressFromPublicKey(senderPublicKeys[1])
+				],
+			).toHaveLength(1);
+		});
+	});
+
 	describe('addTransaction', () => {
 		let txGetBytesStub: any;
 		const tx = {


### PR DESCRIPTION
### What was the problem?

This PR resolves #4968 

### How was it solved?

- Added missing implementation for `get`, `contains` and `getProcessableTransactions`

### How was it tested?

- Added unit tests
