### PR TITLE
Fix genesis block being calculated for burnt fee - Closes #4976

### DIFF
--- a/elements/lisk-chain/src/block_reward.ts
+++ b/elements/lisk-chain/src/block_reward.ts
@@ -168,7 +168,7 @@ export const applyFeeAndRewards = async (
 	);
 	// tslint:disable-next-line no-let
 	let totalFeeBurnt = BigInt(totalFeeBurntStr || 0);
-	totalFeeBurnt += totalMinFee;
+	totalFeeBurnt += givenFee > 0 ? totalMinFee : BigInt(0);
 
 	// Update state store
 	stateStore.account.set(generatorAddress, generator);

--- a/elements/lisk-chain/test/unit/process.spec.ts
+++ b/elements/lisk-chain/test/unit/process.spec.ts
@@ -863,6 +863,13 @@ describe('blocks/header', () => {
 			it('should not call account update', async () => {
 				expect(storageStub.entities.Account.upsert).not.toHaveBeenCalled();
 			});
+
+			it('should not update burnt fee on chain state', async () => {
+				const genesisAccountFromStore = await stateStore.chainState.get(
+					CHAIN_STATE_KEY_BURNT_FEE,
+				);
+				expect(genesisAccountFromStore).toBe('0');
+			});
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4976 

### How was it solved?

- Not update burnt fee if given fee is less than 0

### How was it tested?

- Updated test
- After starting the application fresh, check chain_state table
