### PR TITLE
Fix usage of await in account endpoint - Closes #4983

### DIFF
--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -84,7 +84,8 @@ AccountsController.getAccounts = async (context, next) => {
 
 	try {
 		const lastBlock = await channel.invoke('app:getLastBlock');
-		const data = await storage.entities.Account.get(filters, options).map(
+		const accounts = await storage.entities.Account.get(filters, options);
+		const data = accounts.map(
 			accountFormatter.bind(
 				null,
 				lastBlock.height


### PR DESCRIPTION
### What was the problem?

This PR resolves #4983

### How was it solved?

`await` was chained, but it should not be chained

### How was it tested?

Call http://localhost:4000/api/accounts?address=11237980039345381032L
