### PR TITLE
Fix sorting for bigint - Closes #4984

### DIFF
--- a/elements/lisk-transaction-pool/src/transaction_list.ts
+++ b/elements/lisk-transaction-pool/src/transaction_list.ts
@@ -133,7 +133,8 @@ export class TransactionList {
 		}
 		this._processable = Array.from(
 			new Set([...this._processable, ...promotingNonces]),
-		).sort();
+		);
+		this._sortProcessable();
 
 		return true;
 	}
@@ -223,6 +224,7 @@ export class TransactionList {
 		this._processable = this._processable.filter(
 			processableNonce => processableNonce < nonce,
 		);
+		this._sortProcessable();
 	}
 
 	private _highestNonce(): bigint {
@@ -240,5 +242,18 @@ export class TransactionList {
 
 			return prev;
 		}, highestNonce);
+	}
+
+	private _sortProcessable(): void {
+		this._processable.sort((a, b) => {
+			if (a - b > BigInt(0)) {
+				return 1;
+			}
+			if (a - b < BigInt(0)) {
+				return -1;
+			}
+
+			return 0;
+		});
 	}
 }

--- a/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
@@ -419,13 +419,27 @@ describe('TransactionList class', () => {
 		});
 
 		describe('when promoting transaction matches id', () => {
-			it('should mark all the transactions as promotable', async () => {
+			it('should mark all the transactions as processable', async () => {
 				// Arrange
 				const addedTrx = insertNTransactions(transactionList, 10);
 				// Act
 				transactionList.promote(addedTrx.slice(0, 3));
 				// Assert
 				expect(transactionList.getProcessable()).toHaveLength(3);
+			});
+
+			it('should maintain processable in order ', async () => {
+				// Arrange
+				const addedTrx = insertNTransactions(transactionList, 60);
+				// Act
+				transactionList.promote(addedTrx.slice(9, 10));
+				transactionList.promote(addedTrx.slice(10, 22));
+				// Assert
+				const processable = transactionList.getProcessable();
+				expect(processable[0].nonce.toString()).toEqual('9');
+				expect(processable[processable.length - 1].nonce.toString()).toEqual(
+					'21',
+				);
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #4984

### How was it solved?

Add sorting function where the array is sorted.
Behavior of bigint sorting is unstable. In particular cases tested, it doesn't work, but in other cases it seems to work fine with `sort`

### How was it tested?
- Added test
