### PR TITLE
Fix to start/stop transaction pool in application/node - Closes #4978

### DIFF
--- a/framework/src/application/node/node.js
+++ b/framework/src/application/node/node.js
@@ -173,6 +173,7 @@ module.exports = class Node {
 			});
 
 			this.channel.subscribe('app:ready', async () => {
+				await this.transactionPool.start();
 				await this._startForging();
 			});
 
@@ -330,6 +331,7 @@ module.exports = class Node {
 	}
 
 	async cleanup(error) {
+		await this.transactionPool.stop();
 		this._unsubscribeToEvents();
 		const { modules } = this;
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4978 

### How was it solved?

Call `transaction.start` and `transaction.stop` when bootstrapping or cleaning.

### How was it tested?

- Added test
- Add log and see reorganize job is running
