### PR TITLE
Handle block data to log properly and fix event log - Closes #4998

### DIFF
--- a/framework/src/application/node/processor/processor.js
+++ b/framework/src/application/node/processor/processor.js
@@ -187,7 +187,11 @@ class Processor {
 	}
 
 	async create(values) {
-		this.logger.trace({ data: values }, 'Creating block');
+		const { previousBlock, ...restOFValues } = values;
+		this.logger.trace('Creating block', {
+			restOFValues,
+			previousBlockId: previousBlock.id,
+		});
 		const highestVersion = Math.max.apply(null, Object.keys(this.processors));
 		const processor = this.processors[highestVersion];
 		return processor.create.run(values);

--- a/framework/src/controller/controller.js
+++ b/framework/src/controller/controller.js
@@ -111,14 +111,7 @@ class Controller {
 		// If log level is greater than info
 		if (this.logger.level && this.logger.level() < 30) {
 			this.bus.onAny(event => {
-				this.logger.trace(
-					{
-						module: event.module,
-						name: event.name,
-						data: event.data,
-					},
-					'Monitor Bus Channel',
-				);
+				this.logger.trace(`eventName: ${event},`, 'Monitor Bus Channel');
 			});
 		}
 	}

--- a/framework/test/jest/unit/specs/application/node/processor/processor.spec.js
+++ b/framework/test/jest/unit/specs/application/node/processor/processor.spec.js
@@ -654,7 +654,7 @@ describe('processor', () => {
 				publicKey: Buffer.from('publicKey', 'utf8'),
 				privateKey: Buffer.from('privateKey', 'utf8'),
 			},
-			lastBlock: defaultLastBlock,
+			previousBlock: defaultLastBlock,
 		};
 
 		const createResult = {


### PR DESCRIPTION
### What was the problem?

This PR resolves #4998 

### How was it solved?

- [x] Logging only `previousBlockId` instead of all the `previousBlock` data
- [x] Event is a string so logging it as a string Monitor Bus Channel logging


### How was it tested?

`LISK_CONSOLE_LOG_LEVEL=trace node test/test_app` and check the logs
