### PR TITLE
Serialize block data when sending over the network - Closes #5007

### DIFF
--- a/framework/src/application/node/transport/transport.js
+++ b/framework/src/application/node/transport/transport.js
@@ -155,7 +155,7 @@ class Transport {
 
 		const commonBlock = await this.chainModule.getHighestCommonBlock(data.ids);
 
-		return commonBlock;
+		return this.chainModule.serialize(commonBlock);
 	}
 
 	async handleEventPostBlock(data, peerId) {

--- a/framework/test/jest/unit/specs/application/node/transport/transport.spec.js
+++ b/framework/test/jest/unit/specs/application/node/transport/transport.spec.js
@@ -66,6 +66,7 @@ describe('Transport', () => {
 			dataAccess: {
 				getTransactionsByIDs: jest.fn(),
 			},
+			serialize: jest.fn(),
 		};
 		processorStub = {};
 		transport = new Transport({
@@ -283,6 +284,7 @@ describe('Transport', () => {
 		describe('when commonBlock has not been found', () => {
 			beforeEach(async () => {
 				chainStub.getHighestCommonBlock.mockResolvedValue(null);
+				chainStub.serialize.mockResolvedValue(null);
 			});
 
 			it('should return null', async () => {
@@ -308,6 +310,7 @@ describe('Transport', () => {
 
 			beforeEach(async () => {
 				chainStub.getHighestCommonBlock.mockResolvedValue(validBlock);
+				chainStub.serialize.mockResolvedValue(validBlock);
 			});
 
 			it('should return the result', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5007 

### How was it solved?

Serialize the data before sending to the network 
These actions in `node` were responding with deserialized data and the application was failing.

`getHighestCommonBlock`
`getHighestCommonBlock`

### How was it tested?

`node test/test_app` and connect with multiple nodes
