### PR TITLE
Fix commander to allow -t flag for multisig - Closes #4999

### DIFF
--- a/commander/src/commands/transaction/create.ts
+++ b/commander/src/commands/transaction/create.ts
@@ -19,6 +19,7 @@ import BaseCommand from '../../base';
 import { flags as commonFlags } from '../../utils/flags';
 
 import DelegateCommand from './create/delegate';
+import MultisignatureCommand from './create/multisignature';
 import TransferCommand from './create/transfer';
 import VoteCommand from './create/vote';
 
@@ -52,6 +53,7 @@ const typeClassMap: TypeClassMap = {
 	transfer: TransferCommand,
 	vote: VoteCommand,
 	delegate: DelegateCommand,
+	multisignature: MultisignatureCommand,
 };
 
 const resolveFlags = (

--- a/commander/test/commands/transaction/create.test.ts
+++ b/commander/test/commands/transaction/create.test.ts
@@ -18,6 +18,7 @@ import { expect, test } from '@oclif/test';
 import * as config from '../../../src/utils/config';
 import * as printUtils from '../../../src/utils/print';
 import TransferCommand from '../../../src/commands/transaction/create/transfer';
+import MultisignatureCommand from '../../../src/commands/transaction/create/multisignature';
 import DelegateCommand from '../../../src/commands/transaction/create/delegate';
 import VoteCommand from '../../../src/commands/transaction/create/vote';
 
@@ -33,7 +34,8 @@ describe('transaction:create', () => {
 			)
 			.stub(TransferCommand, 'run', sandbox.stub())
 			.stub(DelegateCommand, 'run', sandbox.stub())
-			.stub(VoteCommand, 'run', sandbox.stub());
+			.stub(VoteCommand, 'run', sandbox.stub())
+			.stub(MultisignatureCommand, 'run', sandbox.stub());
 
 	describe('transaction:create', () => {
 		setupTest()
@@ -98,6 +100,34 @@ describe('transaction:create', () => {
 				return expect(VoteCommand.run).to.be.calledWithExactly([
 					'--votes',
 					'xxx,xxx',
+				]);
+			});
+
+		setupTest()
+			.command([
+				'transaction:create',
+				'--type=12',
+				'--mandatory-key=xxx',
+				'--optional-key=yyy',
+			])
+			.it('should call type 12 command with flag type=12', () => {
+				return expect(MultisignatureCommand.run).to.be.calledWithExactly([
+					'--mandatory-key=xxx',
+					'--optional-key=yyy',
+				]);
+			});
+
+		setupTest()
+			.command([
+				'transaction:create',
+				'-t=multisignature',
+				'--mandatory-key=xxx',
+				'--optional-key=yyy',
+			])
+			.it('should call type 12 command with flag type=multisignature', () => {
+				return expect(MultisignatureCommand.run).to.be.calledWithExactly([
+					'--mandatory-key=xxx',
+					'--optional-key=yyy',
 				]);
 			});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #4999 

### How was it solved?

Add routing for the multi-signature

### How was it tested?
- Added test
- `./bin/run transaction:create -t 12`
