### PR TITLE
Fix to allow to sign with only mandatory or optional - Closes #5000

### DIFF
--- a/commander/src/commands/transaction/sign.ts
+++ b/commander/src/commands/transaction/sign.ts
@@ -128,8 +128,8 @@ export default class SignCommand extends BaseCommand {
 		});
 
 		const keys = {
-			mandatoryKeys,
-			optionalKeys,
+			mandatoryKeys: mandatoryKeys ?? [],
+			optionalKeys: optionalKeys ?? [],
 		};
 
 		if (mandatoryKeys?.length || optionalKeys?.length) {

--- a/commander/test/commands/transaction/sign.test.ts
+++ b/commander/test/commands/transaction/sign.test.ts
@@ -212,10 +212,10 @@ describe('transaction:sign', () => {
 				`--passphrase=${anotherUserPassphrase}`,
 				`--mandatory-key=${KeyOne}`,
 			])
-			.catch(error => {
-				return expect(error.message).to.contain('Cannot read property');
-			})
-			.it('should throw error when optionalKey flag is missing');
+			.it('should output the signed transaction', () => {
+				const transaction = printMethodStub.getCall(0).lastArg;
+				return expect(transaction.signatures).to.have.lengthOf(1);
+			});
 	});
 
 	describe('transaction:sign transaction --passphrase=xxx --optional-key=aaa', () => {
@@ -226,10 +226,10 @@ describe('transaction:sign', () => {
 				`--passphrase=${anotherUserPassphrase}`,
 				`--optional-key=${KeyOne}`,
 			])
-			.catch(error => {
-				return expect(error.message).to.contain('Cannot read property');
-			})
-			.it('should throw error when mandatoryKey flag is missing');
+			.it('should output the signed transaction', () => {
+				const transaction = printMethodStub.getCall(0).lastArg;
+				return expect(transaction.signatures).to.have.lengthOf(1);
+			});
 	});
 
 	describe('transaction:sign transaction --passphrase=yyy --mandatory-key=aaa --optional-key=bbb', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5000 

### How was it solved?

- Allow to have only mandatory key or optional key

### How was it tested?

- Updated test
- `./bin/run transaction:sign txObject --optional-key=xxx --optional-key=xxx`
