### PR TITLE
Add multisignature information to account endpoint - Closes #5005

### DIFF
--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -33,6 +33,7 @@ function accountFormatter(totalSupply, account) {
 		'balance',
 		'nonce',
 		'asset',
+		'keys',
 	]);
 
 	if (account.isDelegate) {
@@ -50,6 +51,10 @@ function accountFormatter(totalSupply, account) {
 			formattedAccount.delegate.voteWeight,
 			totalSupply,
 		);
+	}
+
+	if (formattedAccount.keys.numberOfSignatures === 0) {
+		delete formattedAccount.keys;
 	}
 
 	formattedAccount.publicKey = formattedAccount.publicKey || '';

--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -53,6 +53,7 @@ function accountFormatter(totalSupply, account) {
 		);
 	}
 
+	// If an account is not multi signature, then do not include keys for response
 	if (formattedAccount.keys.numberOfSignatures === 0) {
 		delete formattedAccount.keys;
 	}


### PR DESCRIPTION
### What was the problem?

This PR resolves #5005 

### How was it solved?

- Added mandatory-keys, optional-keys and number of signatures
 
### How was it tested?

- Create a multi-sig account and query `api/accounts`