### PR TITLE
Commander transaction:sign does not produce signatures in correct order - Closes #5002

### DIFF
--- a/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
+++ b/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
@@ -20,6 +20,7 @@ import { MultisignatureTransaction } from './12_multisignature_transaction';
 import { TransferTransaction } from './8_transfer_transaction';
 import { BaseTransaction } from './base_transaction';
 import { TransactionJSON } from './transaction_types';
+import { sortKeysAscending } from './utils';
 
 // tslint:disable-next-line no-any
 const transactionMap: { readonly [key: number]: any } = {
@@ -49,6 +50,15 @@ export const signMultiSignatureTransaction = (options: {
 
 	if (!transaction.id) {
 		throw new Error('Transaction ID is required to create a signature object.');
+	}
+
+	// Sort keys
+	if (keys.mandatoryKeys) {
+		sortKeysAscending(keys.mandatoryKeys);
+	}
+
+	if (keys.optionalKeys) {
+		sortKeysAscending(keys.optionalKeys);
 	}
 
 	// tslint:disable-next-line variable-name

--- a/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
+++ b/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
@@ -53,13 +53,8 @@ export const signMultiSignatureTransaction = (options: {
 	}
 
 	// Sort keys
-	if (keys.mandatoryKeys) {
-		sortKeysAscending(keys.mandatoryKeys);
-	}
-
-	if (keys.optionalKeys) {
-		sortKeysAscending(keys.optionalKeys);
-	}
+	sortKeysAscending(keys.mandatoryKeys);
+	sortKeysAscending(keys.optionalKeys);
 
 	// tslint:disable-next-line variable-name
 	const TransactionClass = transactionMap[transaction.type];


### PR DESCRIPTION
### What was the problem?

This PR resolves #5002

### How was it solved?

By sorting keys in `elements/lisk-transactions/src/sign_multi_signature_transaction.ts`

### How was it tested?

Unit test
