### PR TITLE
Commander sign transaction should take care empty signature space - Closes #5004

### DIFF
--- a/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
+++ b/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
@@ -96,7 +96,7 @@ export const signMultiSignatureTransaction = (options: {
 		passphrase,
 	);
 
-	if (tx.signatures.indexOf(signature) !== -1) {
+	if (tx.signatures.includes(signature)) {
 		sanitizeSignaturesArray(tx, keys);
 
 		return tx;

--- a/elements/lisk-transactions/test/sign_multi_signature_transaction.spec.ts
+++ b/elements/lisk-transactions/test/sign_multi_signature_transaction.spec.ts
@@ -17,6 +17,7 @@ import { signMultiSignatureTransaction } from '../src/sign_multi_signature_trans
 import * as multisigFixture from '../fixtures/transaction_multisignature_registration/multisignature_registration_transaction.json';
 import { TransactionJSON } from '../src/transaction_types';
 import cloneDeep = require('lodash.clonedeep');
+import { TransferTransaction } from '../src';
 
 describe('#sign multi signature transaction', () => {
 	let registrationTx: Partial<TransactionJSON>;
@@ -148,6 +149,131 @@ describe('#sign multi signature transaction', () => {
 			expect(txSignedByMember.signatures[4]).toBe(
 				validMultisigRegistrationTx.signatures[4],
 			);
+		});
+
+		it('should return a transaction with third signature and empty string for the rest', async () => {
+			const validTransfer = new TransferTransaction({
+				id: 123,
+				senderPublicKey:
+					'0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+				asset: {
+					amount: '500000000',
+					recipientId: '13360160607553818129L',
+				},
+			});
+
+			const partiallySignedTransaction: any = validTransfer.toJSON();
+
+			const txSignedByMember = signMultiSignatureTransaction({
+				transaction: partiallySignedTransaction,
+				passphrase:
+					'sugar object slender confirm clock peanut auto spice carbon knife increase estate',
+				networkIdentifier:
+					'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255',
+				keys: {
+					mandatoryKeys: [
+						'4a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd39',
+						'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+					],
+					optionalKeys: [
+						'57df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4',
+						'fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b6',
+					],
+				},
+			});
+
+			expect(txSignedByMember.signatures).toStrictEqual([
+				'',
+				'',
+				'15161b9fcd6813f0ec42c8119ce63376093438b4fb9ade1e4e9873c15dbf8ec21a2cd534430d98cb24dc615e8d6e106fb80ac46251db2ec91ba75415fc4cbe07',
+				'',
+			]);
+		});
+
+		it('should return a transaction with third signature added and existing ones unmodified', async () => {
+			const validTransfer = new TransferTransaction({
+				id: 123,
+				senderPublicKey:
+					'0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+				asset: {
+					amount: '500000000',
+					recipientId: '13360160607553818129L',
+				},
+			});
+
+			// Add signature from 'sugar object slender confirm clock peanut auto spice carbon knife increase estate'
+			const partiallySignedTransaction: any = validTransfer.toJSON();
+			partiallySignedTransaction.signatures = [];
+			partiallySignedTransaction.signatures[2] =
+				'15161b9fcd6813f0ec42c8119ce63376093438b4fb9ade1e4e9873c15dbf8ec21a2cd534430d98cb24dc615e8d6e106fb80ac46251db2ec91ba75415fc4cbe07';
+
+			const txSignedByMember = signMultiSignatureTransaction({
+				transaction: partiallySignedTransaction,
+				passphrase:
+					'faculty inspire crouch quit sorry vague hard ski scrap jaguar garment limb',
+				networkIdentifier:
+					'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255',
+				keys: {
+					mandatoryKeys: [
+						'4a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd39',
+						'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+					],
+					optionalKeys: [
+						'57df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4',
+						'fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b6',
+					],
+				},
+			});
+
+			expect(txSignedByMember.signatures).toStrictEqual([
+				'',
+				'',
+				'15161b9fcd6813f0ec42c8119ce63376093438b4fb9ade1e4e9873c15dbf8ec21a2cd534430d98cb24dc615e8d6e106fb80ac46251db2ec91ba75415fc4cbe07',
+				'5fbfd1e0f35a230356f3544856b5b9ed288d40c9a7096af7f72e624562f3528ff4381956f7ed6ffe88b60df8d2b6baedfe176beae786a3889f98d4af2190c80b',
+			]);
+		});
+
+		it('should return a transaction with no modifications if signature already present', async () => {
+			const validTransfer = new TransferTransaction({
+				id: 123,
+				senderPublicKey:
+					'0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+				asset: {
+					amount: '500000000',
+					recipientId: '13360160607553818129L',
+				},
+			});
+
+			// Add signature from 'sugar object slender confirm clock peanut auto spice carbon knife increase estate'
+			const partiallySignedTransaction: any = validTransfer.toJSON();
+			partiallySignedTransaction.signatures = [];
+			partiallySignedTransaction.signatures[2] =
+				'15161b9fcd6813f0ec42c8119ce63376093438b4fb9ade1e4e9873c15dbf8ec21a2cd534430d98cb24dc615e8d6e106fb80ac46251db2ec91ba75415fc4cbe07';
+
+			const txSignedByMember = signMultiSignatureTransaction({
+				transaction: partiallySignedTransaction,
+				passphrase:
+					'sugar object slender confirm clock peanut auto spice carbon knife increase estate',
+				networkIdentifier:
+					'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255',
+				keys: {
+					mandatoryKeys: [
+						'4a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd39',
+						'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+					],
+					optionalKeys: [
+						'57df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4',
+						'fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b6',
+					],
+				},
+			});
+
+			expect(txSignedByMember.signatures).toStrictEqual([
+				'',
+				'',
+				'15161b9fcd6813f0ec42c8119ce63376093438b4fb9ade1e4e9873c15dbf8ec21a2cd534430d98cb24dc615e8d6e106fb80ac46251db2ec91ba75415fc4cbe07',
+				'',
+			]);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5004

### How was it solved?

- Added code to complete missing signatures with empty string `''` for missing signatures
- If signatures are provided and the signature for the passphrase is found the transaction is returned without pushing it again but the signatures array still goes to the previous step

### How was it tested?

Unit tests
