### PR TITLE
signMultiSignatureTransaction should not fail due to missing transaction id - Closes #5012

### DIFF
--- a/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
+++ b/elements/lisk-transactions/src/sign_multi_signature_transaction.ts
@@ -66,10 +66,6 @@ export const signMultiSignatureTransaction = (options: {
 		throw new Error('Invalid transaction type.');
 	}
 
-	if (!transaction.id) {
-		throw new Error('Transaction ID is required to create a signature object.');
-	}
-
 	// Sort keys
 	sortKeysAscending(keys.mandatoryKeys);
 	sortKeysAscending(keys.optionalKeys);

--- a/elements/lisk-transactions/test/sign_multi_signature_transaction.spec.ts
+++ b/elements/lisk-transactions/test/sign_multi_signature_transaction.spec.ts
@@ -235,7 +235,6 @@ describe('#sign multi signature transaction', () => {
 
 		it('should return a transaction with no modifications if signature already present', async () => {
 			const validTransfer = new TransferTransaction({
-				id: 123,
 				senderPublicKey:
 					'0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
 				asset: {
@@ -274,6 +273,42 @@ describe('#sign multi signature transaction', () => {
 				'15161b9fcd6813f0ec42c8119ce63376093438b4fb9ade1e4e9873c15dbf8ec21a2cd534430d98cb24dc615e8d6e106fb80ac46251db2ec91ba75415fc4cbe07',
 				'',
 			]);
+		});
+
+		it('should return signature in the correct position', async () => {
+			const validTransfer = new TransferTransaction({
+				senderPublicKey:
+					'0b211fce4b615083701cb8a8c99407e464b2f9aa4f367095322de1b77e5fcfbe',
+				asset: {
+					amount: '500000000',
+					recipientId: '13360160607553818129L',
+				},
+			});
+
+			// Add signature from 'sugar object slender confirm clock peanut auto spice carbon knife increase estate'
+			const partiallySignedTransaction: any = validTransfer.toJSON();
+
+			const txSignedByMember = signMultiSignatureTransaction({
+				transaction: partiallySignedTransaction,
+				passphrase:
+					'sugar object slender confirm clock peanut auto spice carbon knife increase estate',
+				networkIdentifier:
+					'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255',
+				keys: {
+					mandatoryKeys: [
+						'4a67646a446313db964c39370359845c52fce9225a3929770ef41448c258fd39',
+						'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
+					],
+					optionalKeys: [
+						'57df5c3811961939f8dcfa858c6eaefebfaa4de942f7e703bf88127e0ee9cca4',
+						'fa406b6952d377f0278920e3eb8da919e4cf5c68b02eeba5d8b3334fdc0369b6',
+					],
+				},
+			});
+
+			expect(txSignedByMember.signatures[2]).toBe(
+				'15161b9fcd6813f0ec42c8119ce63376093438b4fb9ade1e4e9873c15dbf8ec21a2cd534430d98cb24dc615e8d6e106fb80ac46251db2ec91ba75415fc4cbe07',
+			);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5012

### How was it solved?

- by removing check for presence of `id`
- also added test for correct position of signature based on key ordering

### How was it tested?

Unit test 
