### PR TITLE
Remove transaction id validation - Closes #5009

### DIFF
--- a/elements/lisk-transactions/src/schema.ts
+++ b/elements/lisk-transactions/src/schema.ts
@@ -64,10 +64,6 @@ export const baseTransaction = {
 	type: 'object',
 	required: ['type', 'senderPublicKey', 'fee', 'nonce', 'asset', 'signatures'],
 	properties: {
-		id: {
-			type: 'string',
-			format: 'id',
-		},
 		blockId: {
 			type: 'string',
 			format: 'id',

--- a/framework/src/application/node/transport/transport.js
+++ b/framework/src/application/node/transport/transport.js
@@ -394,8 +394,8 @@ class Transport {
 			throw err;
 		}
 
-		if (this.transactionPoolModule.contains(transactionJSON.id)) {
-			return transactionJSON.id;
+		if (this.transactionPoolModule.contains(transaction.id)) {
+			return transaction.id;
 		}
 
 		// Broadcast transaction to network if not present in pool

--- a/framework/src/application/node/transport/transport.js
+++ b/framework/src/application/node/transport/transport.js
@@ -364,10 +364,6 @@ class Transport {
 	}
 
 	async _receiveTransaction(transactionJSON) {
-		if (this.transactionPoolModule.contains(transactionJSON.id)) {
-			return transactionJSON.id;
-		}
-
 		let transaction;
 		try {
 			transaction = this.chainModule.deserializeTransaction(transactionJSON);
@@ -396,6 +392,10 @@ class Transport {
 			);
 
 			throw err;
+		}
+
+		if (this.transactionPoolModule.contains(transactionJSON.id)) {
+			return transactionJSON.id;
 		}
 
 		// Broadcast transaction to network if not present in pool

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -1069,7 +1069,6 @@ definitions:
   TransactionRequest:
     type: object
     required:
-      - id
       - type
       - senderPublicKey
       - nonce
@@ -1077,15 +1076,6 @@ definitions:
       - asset
       - signatures
     properties:
-      id:
-        type: string
-        format: id
-        example: '222675625422353767'
-        minLength: 1
-        maxLength: 20
-        description: |
-          Unique identifier of the transaction.
-          Derived from the transaction signature.
       type:
         type: integer
         minimum: 0

--- a/framework/test/jest/unit/specs/application/transport/transport.spec.js
+++ b/framework/test/jest/unit/specs/application/transport/transport.spec.js
@@ -362,6 +362,25 @@ describe('transport', () => {
 				});
 			});
 
+			describe('when transaction has no id', () => {
+				let invalidTransaction;
+
+				beforeEach(async () => {
+					invalidTransaction = {
+						...transaction,
+						id: undefined,
+					};
+				});
+
+				it('should resolve with result = transaction.id', async () => {
+					const res = await transportModule._receiveTransaction(
+						invalidTransaction,
+					);
+
+					expect(res).toEqual(transaction.id);
+				});
+			});
+
 			describe('when modules.transactions.add fails', () => {
 				let addError;
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5009

### How was it solved?

Remove transactionId validation in schema check

### How was it tested?

npm run test
