### PR TITLE
Signatures property in transation not checked for empty signature - Closes #5021

### DIFF
--- a/elements/lisk-transactions/src/12_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/12_multisignature_transaction.ts
@@ -349,6 +349,15 @@ export class MultisignatureTransaction extends BaseTransaction {
 			]);
 		}
 
+		// Check if empty signatures are present
+		if (this.signatures.includes('')) {
+			return createResponse(this.id, [
+				new TransactionError(
+					'A signature is required for each registered key.',
+				),
+			]);
+		}
+
 		// Verify first signature is from senderPublicKey
 		const { valid, error } = validateSignature(
 			this.senderPublicKey,

--- a/elements/lisk-transactions/src/utils/verify.ts
+++ b/elements/lisk-transactions/src/utils/verify.ts
@@ -104,7 +104,7 @@ export const validateKeysSignatures = (
 		if (signatures[i].length === 0) {
 			errors.push(
 				new TransactionError(
-					'All mandatory keys have to sign the transaction.',
+					'Invalid signatures format. signatures should not include empty string.',
 					undefined,
 					'.signatures',
 					signatures.join(','),

--- a/elements/lisk-transactions/src/utils/verify.ts
+++ b/elements/lisk-transactions/src/utils/verify.ts
@@ -98,8 +98,20 @@ export const validateKeysSignatures = (
 	transactionBytes: Buffer,
 ) => {
 	const errors = [];
+
 	// tslint:disable-next-line: prefer-for-of no-let
 	for (let i = 0; i < keys.length; i += 1) {
+		if (signatures[i].length === 0) {
+			errors.push(
+				new TransactionError(
+					'All mandatory keys have to sign the transaction.',
+					undefined,
+					'.signatures',
+					signatures.join(','),
+				),
+			);
+			break;
+		}
 		const { error } = validateSignature(
 			keys[i],
 			signatures[i],

--- a/elements/lisk-transactions/test/12_multisignature_transaction.spec.ts
+++ b/elements/lisk-transactions/test/12_multisignature_transaction.spec.ts
@@ -22,6 +22,7 @@ import * as multisigOnlyMandatory from '../fixtures/transaction_multisignature_r
 import * as multisigOptionalOnly from '../fixtures/transaction_multisignature_registration/multisignature_transaction_only_optional_members.json';
 import * as senderIsMember from '../fixtures/transaction_multisignature_registration/multisignature_transaction_sender_is_mandatory_member.json';
 import { validTransaction } from '../fixtures';
+import cloneDeep = require('lodash.clonedeep');
 
 describe('Multisignature transaction class', () => {
 	const validMultisignatureRegistrationTransaction =
@@ -840,6 +841,18 @@ describe('Multisignature transaction class', () => {
 			const result = await invalid.verifySignatures(store);
 			expect(result.status).toBe(0);
 			expect(result.errors[0].message).toBe('There are missing signatures');
+		});
+
+		it('should fail if any of the signatures is empty string', async () => {
+			const invalidRegistration = cloneDeep(validTestTransaction);
+			invalidRegistration.signatures[0] = '';
+
+			const result = await invalidRegistration.verifySignatures(store);
+
+			expect(result.status).toBe(0);
+			expect(result.errors[0].message).toBe(
+				`A signature is required for each registered key.`,
+			);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5021

### How was it solved?

By adding a check for empty string in the `signatures` array for multi signature registration/

### How was it tested?

Unit test added
