### PR TITLE
Default min entrance fee priority for transaction pool should be zero - Closes #5025

### DIFF
--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -52,7 +52,7 @@ interface AddTransactionResponse {
 
 export const DEFAULT_MAX_TRANSACTIONS = 4096;
 export const DEFAULT_MAX_TRANSACTIONS_PER_ACCOUNT = 64;
-export const DEFAULT_MIN_ENTRANCE_FEE_PRIORITY = BigInt(1);
+export const DEFAULT_MIN_ENTRANCE_FEE_PRIORITY = BigInt(0);
 // tslint:disable-next-line no-magic-numbers
 export const DEFAULT_EXPIRY_TIME = 3 * 60 * 60 * 1000; // 3 hours in ms
 // tslint:disable-next-line no-magic-numbers

--- a/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
@@ -37,7 +37,7 @@ describe('TransactionPool class', () => {
 				expect((transactionPool as any)._maxTransactions).toEqual(4096);
 				expect((transactionPool as any)._maxTransactionsPerAccount).toEqual(64);
 				expect((transactionPool as any)._minEntranceFeePriority).toEqual(
-					BigInt(1),
+					BigInt(0),
 				);
 				expect((transactionPool as any)._minReplacementFeeDifference).toEqual(
 					BigInt(10),


### PR DESCRIPTION
### What was the problem?

This PR resolves #5025

### How was it solved?

Set the min entrance fee value to zero. 

### How was it tested?

<!--- Please describe how you tested your changes -->
