### PR TITLE
Fix variable and the condition for incoming payload - Closes #5028

### DIFF
--- a/elements/lisk-p2p/src/peer_server/peer_server.ts
+++ b/elements/lisk-p2p/src/peer_server/peer_server.ts
@@ -462,7 +462,7 @@ export class PeerServer extends EventEmitter {
 			const {
 				address: peerIpAddress,
 				port: wsPort,
-			} = ws._socket._peername.address;
+			} = ws._socket._peername;
 
 			const peerId = constructPeerId(peerIpAddress, wsPort);
 
@@ -480,7 +480,7 @@ export class PeerServer extends EventEmitter {
 				if (
 					(parsed.event && typeof parsed.event !== 'string') ||
 					invalidEvents.has(parsed.event) ||
-					parsed.event.length > MAX_EVENT_NAME_LENGTH
+					(parsed.event && parsed.event.length > MAX_EVENT_NAME_LENGTH)
 				) {
 					throw new InvalidPayloadError('Received invalid payload', parsed);
 				}


### PR DESCRIPTION
### What was the problem?

This PR resolves #5028 

### How was it solved?

1. Corrected deconstructor for peername variable
```typescript
const { address: peerIpAddress, port: wsPort } = ws._socket._peername;
```

2. Check if event exists or not before accessing its length
```typescript
(parsed.event && parsed.event.length > MAX_EVENT_NAME_LENGTH)
```
### How was it tested?

Run the application and check for error while connecting with other nodes.
