### PR TITLE
Fix getHighestCommonBlock and getBlockFromId handling - Closes #5026

### DIFF
--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -306,6 +306,10 @@ export class Chain {
 		return this.dataAccess.serialize(blockJSON);
 	}
 
+	public serializeBlockHeader(blockHeader: BlockHeader): BlockHeaderJSON {
+		return this.dataAccess.serializeBlockHeader(blockHeader);
+	}
+
 	public deserializeBlockHeader(blockJSON: BlockHeaderJSON): BlockHeader {
 		return this.dataAccess.deserializeBlockHeader(blockJSON);
 	}

--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -361,24 +361,24 @@ export class DataAccess {
 
 	// tslint:disable-next-line:prefer-function-over-method
 	public serialize(blockInstance: BlockInstance): BlockJSON {
-		const blockJSON = {
-			...blockInstance,
-			totalAmount: blockInstance.totalAmount.toString(),
-			totalFee: blockInstance.totalFee.toString(),
-			reward: blockInstance.reward.toString(),
-			transactions: blockInstance.transactions.map(tx => ({
-				...tx.toJSON(),
-				blockId: blockInstance.id,
-			})),
-		};
+		const { transactions, ...blockHeader } = blockInstance;
+		const blockHeaderJSON = this.serializeBlockHeader(blockHeader);
+		const transactionsJSON = transactions.map(tx => ({
+			...tx.toJSON(),
+			blockId: blockInstance.id,
+		}));
 
-		return blockJSON;
+		return {
+			...blockHeaderJSON,
+			transactions: transactionsJSON,
+		};
 	}
 
 	public deserialize(blockJSON: BlockJSON): BlockInstance {
-		const transactions = (blockJSON.transactions || []).map(transaction =>
-			this._transactionAdapter.fromJSON(transaction),
-		);
+		const transactions =
+			blockJSON.transactions?.map(transaction =>
+				this._transactionAdapter.fromJSON(transaction),
+			) ?? [];
 
 		return {
 			...blockJSON,
@@ -386,6 +386,16 @@ export class DataAccess {
 			totalFee: BigInt(blockJSON.totalFee || 0),
 			reward: BigInt(blockJSON.reward || 0),
 			transactions,
+		};
+	}
+
+	// tslint:disable-next-line:prefer-function-over-method
+	public serializeBlockHeader(blockHeader: BlockHeader): BlockHeaderJSON {
+		return {
+			...blockHeader,
+			totalAmount: blockHeader.totalAmount.toString(),
+			totalFee: blockHeader.totalFee.toString(),
+			reward: blockHeader.reward.toString(),
 		};
 	}
 

--- a/framework/src/application/node/node.js
+++ b/framework/src/application/node/node.js
@@ -137,6 +137,8 @@ module.exports = class Node {
 			this.logger.info('Modules ready and launched');
 			// After binding, it should immediately load blockchain
 			await this.processor.init(this.options.genesisBlock);
+			// Check if blocks are left in temp_blocks table
+			await this.synchronizer.init();
 
 			// Update Application State after processor is initialized
 			this.channel.invoke('app:updateApplicationState', {
@@ -203,9 +205,6 @@ module.exports = class Node {
 					},
 				);
 			}
-
-			// Check if blocks are left in temp_blocks table
-			await this.synchronizer.init();
 		} catch (error) {
 			this.logger.fatal(
 				{

--- a/framework/src/application/node/synchronizer/block_synchronization_mechanism.js
+++ b/framework/src/application/node/synchronizer/block_synchronization_mechanism.js
@@ -128,6 +128,8 @@ class BlockSynchronizationMechanism extends BaseSynchronizer {
 			); // Note that the block matching lastFetchedID is not returned but only higher blocks.
 
 			if (blocks && blocks.length) {
+				// Sort blocks with height in ascending order because blocks are returned in decending order
+				blocks.sort((a, b) => a.height - b.height);
 				[{ id: lastFetchedID }] = blocks.slice(-1);
 				const index = blocks.findIndex(block => block.id === toId);
 				if (index > -1) {
@@ -375,15 +377,13 @@ class BlockSynchronizationMechanism extends BaseSynchronizer {
 			try {
 				// Request the highest common block with the previously computed list
 				// to the given peer
-				data = (
-					await this.channel.invokeFromNetwork('requestFromPeer', {
-						procedure: 'getHighestCommonBlock',
-						peerId,
-						data: {
-							ids: blockHeaders.map(block => block.id),
-						},
-					})
-				).data;
+				({ data } = await this.channel.invokeFromNetwork('requestFromPeer', {
+					procedure: 'getHighestCommonBlock',
+					peerId,
+					data: {
+						ids: blockHeaders.map(block => block.id),
+					},
+				}));
 			} catch (e) {
 				numberOfRequests += 1;
 				// eslint-disable-next-line no-continue

--- a/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
+++ b/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
@@ -137,6 +137,8 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 			); // Note that the block matching lastFetchedID is not returned but only higher blocks.
 
 			if (chunkOfBlocks && chunkOfBlocks.length) {
+				// Sort blocks with height in ascending order because blocks are returned in decending order
+				chunkOfBlocks.sort((a, b) => a.height - b.height);
 				blocks.push(...chunkOfBlocks);
 				[{ id: lastFetchedID }] = chunkOfBlocks.slice(-1);
 				const index = blocks.findIndex(block => block.id === toId);

--- a/framework/src/application/node/synchronizer/utils.js
+++ b/framework/src/application/node/synchronizer/utils.js
@@ -17,12 +17,8 @@
 const { maxBy } = require('lodash');
 const { ForkStatus } = require('@liskhq/lisk-bft');
 
-const restoreBlocks = async (chainModule, processorModule, tx = null) => {
-	const tempBlocks = await chainModule.dataAccess.getTempBlocks(
-		{},
-		{ sort: 'height:asc', limit: null },
-		tx,
-	);
+const restoreBlocks = async (chainModule, processorModule) => {
+	const tempBlocks = await chainModule.dataAccess.getTempBlocks();
 
 	if (!tempBlocks || tempBlocks.length === 0) {
 		return false;

--- a/framework/src/application/node/transport/transport.js
+++ b/framework/src/application/node/transport/transport.js
@@ -154,8 +154,11 @@ class Transport {
 		}
 
 		const commonBlock = await this.chainModule.getHighestCommonBlock(data.ids);
+		if (!commonBlock) {
+			throw new Error('Common block did not exist');
+		}
 
-		return this.chainModule.serialize(commonBlock);
+		return this.chainModule.serializeBlockHeader(commonBlock);
 	}
 
 	async handleEventPostBlock(data, peerId) {

--- a/framework/src/application/node/transport/transport.js
+++ b/framework/src/application/node/transport/transport.js
@@ -154,11 +154,10 @@ class Transport {
 		}
 
 		const commonBlock = await this.chainModule.getHighestCommonBlock(data.ids);
-		if (!commonBlock) {
-			throw new Error('Common block did not exist');
-		}
 
-		return this.chainModule.serializeBlockHeader(commonBlock);
+		return commonBlock
+			? this.chainModule.serializeBlockHeader(commonBlock)
+			: null;
 	}
 
 	async handleEventPostBlock(data, peerId) {

--- a/framework/test/jest/unit/specs/application/node/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.js
+++ b/framework/test/jest/unit/specs/application/node/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.js
@@ -263,7 +263,7 @@ describe('block_synchronization_mechanism', () => {
 						blockId: highestCommonBlock.id,
 					},
 				})
-				.mockResolvedValue({ data: cloneDeep(requestedBlocks) });
+				.mockResolvedValue({ data: cloneDeep(requestedBlocks).reverse() });
 		}
 		when(chainModule.dataAccess.getBlockHeadersWithHeights)
 			.calledWith(blockHeightsList)
@@ -507,7 +507,7 @@ describe('block_synchronization_mechanism', () => {
 								blockId: highestCommonBlock.id,
 							},
 						})
-						.mockResolvedValue({ data: requestedBlocks });
+						.mockResolvedValue({ data: cloneDeep(requestedBlocks).reverse() });
 				}
 
 				await blockSynchronizationMechanism.run(receivedBlock);
@@ -604,7 +604,9 @@ describe('block_synchronization_mechanism', () => {
 									blockId: highestCommonBlock.id,
 								},
 							})
-							.mockResolvedValue({ data: requestedBlocks });
+							.mockResolvedValue({
+								data: cloneDeep(requestedBlocks).reverse(),
+							});
 					}
 
 					when(chainModule.dataAccess.getBlockHeadersWithHeights)
@@ -745,7 +747,8 @@ describe('block_synchronization_mechanism', () => {
 		describe('request and apply blocks to current chain', () => {
 			it('should request blocks and apply them', async () => {
 				requestedBlocks = [
-					...new Array(10)
+					// From height 2 (highestCommonBlock.height + 1) to 9 (aBlock.height - 1)
+					...new Array(8)
 						.fill(0)
 						.map((_, index) =>
 							newBlock({ height: highestCommonBlock.height + 1 + index }),
@@ -766,7 +769,8 @@ describe('block_synchronization_mechanism', () => {
 								blockId: highestCommonBlock.id,
 							},
 						})
-						.mockResolvedValue({ data: cloneDeep(requestedBlocks) });
+						// getBlocksFromId returns in height desc order
+						.mockResolvedValue({ data: cloneDeep(requestedBlocks).reverse() });
 				}
 
 				await blockSynchronizationMechanism.run(aBlock);
@@ -795,6 +799,9 @@ describe('block_synchronization_mechanism', () => {
 					requestedBlocks.findIndex(block => block.id === aBlock.id) + 1,
 				);
 
+				expect(processorModule.process).toHaveBeenCalledTimes(
+					blocksToApply.length,
+				);
 				for (const requestedBlock of blocksToApply) {
 					expect(processorModule.process).toHaveBeenCalledWith(
 						await processorModule.deserialize(requestedBlock),
@@ -1000,7 +1007,9 @@ describe('block_synchronization_mechanism', () => {
 									blockId: highestCommonBlock.id,
 								},
 							})
-							.mockResolvedValue({ data: requestedBlocks });
+							.mockResolvedValue({
+								data: cloneDeep(requestedBlocks).reverse(),
+							});
 					}
 
 					chainModule.dataAccess.getTempBlocks.mockResolvedValue([

--- a/framework/test/jest/unit/specs/application/node/synchronizer/synchronizer.spec.js
+++ b/framework/test/jest/unit/specs/application/node/synchronizer/synchronizer.spec.js
@@ -108,7 +108,7 @@ describe('Synchronizer', () => {
 			getAccountsByPublicKey: jest.fn(),
 			getBlockHeaderByHeight: jest.fn(),
 			deserialize: chainModule.dataAccess.deserialize,
-			serialize: chainModule.dataAccess.serialize,
+			serializeBlockHeader: chainModule.dataAccess.serializeBlockHeader,
 			deserializeTransaction: chainModule.dataAccess.deserializeTransaction,
 		};
 		chainModule.dataAccess = dataAccessMock;
@@ -464,7 +464,7 @@ describe('Synchronizer', () => {
 		let aReceivedBlock;
 
 		beforeEach(async () => {
-			aReceivedBlock = await processorModule.serialize(newBlock()); // newBlock() creates a block instance, and we want to simulate a block in JSON format that comes from the network
+			aReceivedBlock = await chainModule.serializeBlockHeader(newBlock()); // newBlock() creates a block instance, and we want to simulate a block in JSON format that comes from the network
 		});
 
 		it('should reject with error if there is already an active mechanism', async () => {

--- a/framework/test/jest/unit/specs/application/node/synchronizer/utils.spec.js
+++ b/framework/test/jest/unit/specs/application/node/synchronizer/utils.spec.js
@@ -25,7 +25,6 @@ describe('#synchronizer/utils', () => {
 	let processorMock;
 	let storageMock;
 	let loggerMock;
-	const stubs = {};
 
 	beforeEach(async () => {
 		chainMock = {
@@ -57,8 +56,6 @@ describe('#synchronizer/utils', () => {
 				},
 			},
 		};
-
-		stubs.tx = jest.fn();
 	});
 
 	describe('restoreBlocks()', () => {
@@ -68,7 +65,7 @@ describe('#synchronizer/utils', () => {
 			chainMock.dataAccess.getTempBlocks = jest.fn().mockReturnValue(blocks);
 
 			// Act
-			const result = await restoreBlocks(chainMock, processorMock, stubs.tx);
+			const result = await restoreBlocks(chainMock, processorMock);
 
 			// Assert
 			expect(result).toBeTruthy();
@@ -83,14 +80,10 @@ describe('#synchronizer/utils', () => {
 			chainMock.dataAccess.getTempBlocks = jest.fn().mockReturnValue(blocks);
 
 			// Act
-			await restoreBlocks(chainMock, processorMock, stubs.tx);
+			await restoreBlocks(chainMock, processorMock);
 
 			// Assert
-			expect(chainMock.dataAccess.getTempBlocks).toHaveBeenCalledWith(
-				{},
-				{ sort: 'height:asc', limit: null },
-				stubs.tx,
-			);
+			expect(chainMock.dataAccess.getTempBlocks).toHaveBeenCalled();
 			expect(processorMock.processValidated).toHaveBeenCalledTimes(2);
 			expect(processorMock.processValidated).toHaveBeenNthCalledWith(
 				1,
@@ -109,15 +102,11 @@ describe('#synchronizer/utils', () => {
 			chainMock.dataAccess.getTempBlocks = jest.fn().mockReturnValue([]);
 
 			// Act
-			const result = await restoreBlocks(chainMock, processorMock, stubs.tx);
+			const result = await restoreBlocks(chainMock, processorMock);
 
 			// Assert
 			expect(result).toBeFalsy();
-			expect(chainMock.dataAccess.getTempBlocks).toHaveBeenCalledWith(
-				{},
-				{ sort: 'height:asc', limit: null },
-				stubs.tx,
-			);
+			expect(chainMock.dataAccess.getTempBlocks).toHaveBeenCalled();
 			expect(processorMock.processValidated).not.toHaveBeenCalled();
 		});
 	});

--- a/framework/test/jest/unit/specs/application/node/transport/transport.spec.js
+++ b/framework/test/jest/unit/specs/application/node/transport/transport.spec.js
@@ -66,7 +66,7 @@ describe('Transport', () => {
 			dataAccess: {
 				getTransactionsByIDs: jest.fn(),
 			},
-			serialize: jest.fn(),
+			serializeBlockHeader: jest.fn(),
 		};
 		processorStub = {};
 		transport = new Transport({
@@ -284,7 +284,7 @@ describe('Transport', () => {
 		describe('when commonBlock has not been found', () => {
 			beforeEach(async () => {
 				chainStub.getHighestCommonBlock.mockResolvedValue(null);
-				chainStub.serialize.mockResolvedValue(null);
+				chainStub.serializeBlockHeader.mockResolvedValue(null);
 			});
 
 			it('should return null', async () => {
@@ -310,7 +310,7 @@ describe('Transport', () => {
 
 			beforeEach(async () => {
 				chainStub.getHighestCommonBlock.mockResolvedValue(validBlock);
-				chainStub.serialize.mockResolvedValue(validBlock);
+				chainStub.serializeBlockHeader.mockResolvedValue(validBlock);
 			});
 
 			it('should return the result', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5026

### How was it solved?

- Add serialize blockHeader for the synching
- Add sorting while syncing because the response now come with `desc` order
- Change position of synchronizer.init so that it doesnt start accepting blocks without initialized

### How was it tested?

- Updated test to represent the new response
- Run 2 nodes to see if it will be sync up
