### PR TITLE
Update transaction pool to emit remove event and log - Closes #5034

### DIFF
--- a/elements/lisk-transaction-pool/src/transaction_list.ts
+++ b/elements/lisk-transaction-pool/src/transaction_list.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { EventEmitter } from 'events';
 
 import { MinHeap } from './min_heap';
 import { Transaction } from './types';
@@ -25,12 +24,8 @@ export interface TransactionListOptions {
 const DEFAULT_MAX_SIZE = 64;
 const DEFAULT_REPLACEMENT_FEE_DIFF = BigInt(0);
 
-export const EVENT_TRANSACTION_ADDED = 'EVENT_TRANSACTION_ADDED';
-export const EVENT_TRANSACTION_REMOVED = 'EVENT_TRANSACTION_REMOVED';
-
 export class TransactionList {
 	public readonly address: string;
-	public readonly events: EventEmitter;
 
 	private _processable: Array<bigint>;
 	private readonly _transactions: { [nonce: string]: Transaction };
@@ -41,7 +36,6 @@ export class TransactionList {
 
 	public constructor(address: string, options?: TransactionListOptions) {
 		this.address = address;
-		this.events = new EventEmitter();
 		this._transactions = {};
 		this._nonceHeap = new MinHeap<undefined, bigint>();
 		this._processable = [];
@@ -68,10 +62,6 @@ export class TransactionList {
 			// Mark this and all subsequent nonce unprocessable
 			this._demoteAfter(incomingTx.nonce);
 			this._transactions[incomingTx.nonce.toString()] = incomingTx;
-			this.events.emit(EVENT_TRANSACTION_REMOVED, {
-				address: this.address,
-				id: existingTx.id,
-			});
 
 			return { added: true, removedID: existingTx.id };
 		}
@@ -114,11 +104,6 @@ export class TransactionList {
 			}
 		}
 		this._demoteAfter(nonce);
-
-		this.events.emit(EVENT_TRANSACTION_REMOVED, {
-			address: this.address,
-			id: removingTx.id,
-		});
 
 		return removingTx.id;
 	}

--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -238,12 +238,12 @@ export class TransactionPool {
 
 		if (removedID) {
 			debug('Removing from transaction pool with id', removedID);
-			const removingTx = this._allTransactions[removedID];
+			const removedTx = this._allTransactions[removedID];
 			delete this._allTransactions[removedID];
 			this.events.emit(events.EVENT_TRANSACTION_REMOVED, {
-				id: removingTx.id,
-				nonce: removingTx.nonce.toString(),
-				senderPublicKey: removingTx.senderPublicKey,
+				id: removedTx.id,
+				nonce: removedTx.nonce.toString(),
+				senderPublicKey: removedTx.senderPublicKey,
 				reason: 'Transaction List executed remove',
 			});
 		}

--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -60,6 +60,9 @@ export const DEFAULT_EXPIRE_INTERVAL = 60 * 60 * 1000; // 1 hour in ms
 // tslint:disable-next-line no-magic-numbers
 export const DEFAULT_MINIMUM_REPLACEMENT_FEE_DIFFERENCE = BigInt(10);
 export const DEFAULT_REORGANIZE_TIME = 500;
+export const events = {
+	EVENT_TRANSACTION_REMOVED: 'EVENT_TRANSACTION_REMOVED',
+};
 
 // FIXME: Remove this once implemented
 // tslint:disable
@@ -235,7 +238,14 @@ export class TransactionPool {
 
 		if (removedID) {
 			debug('Removing from transaction pool with id', removedID);
+			const removingTx = this._allTransactions[removedID];
 			delete this._allTransactions[removedID];
+			this.events.emit(events.EVENT_TRANSACTION_REMOVED, {
+				id: removingTx.id,
+				nonce: removingTx.nonce.toString(),
+				senderPublicKey: removingTx.senderPublicKey,
+				reason: 'Transaction List executed remove',
+			});
 		}
 
 		// Add received time to the incoming tx object
@@ -346,6 +356,12 @@ export class TransactionPool {
 			return false;
 		}
 
+		this.events.emit(events.EVENT_TRANSACTION_REMOVED, {
+			id: evictedTransaction.value.id,
+			nonce: evictedTransaction.value.nonce.toString(),
+			senderPublicKey: evictedTransaction.value.senderPublicKey,
+			reason: 'Pool exceeded the size limit',
+		});
 		return this.remove(evictedTransaction.value);
 	}
 
@@ -375,6 +391,12 @@ export class TransactionPool {
 			return false;
 		}
 
+		this.events.emit(events.EVENT_TRANSACTION_REMOVED, {
+			id: evictedTransaction.value.id,
+			nonce: evictedTransaction.value.nonce.toString(),
+			senderPublicKey: evictedTransaction.value.senderPublicKey,
+			reason: 'Pool exceeded the size limit',
+		});
 		return this.remove(evictedTransaction.value);
 	}
 
@@ -422,6 +444,12 @@ export class TransactionPool {
 			if (invalidTransaction) {
 				for (const tx of allTransactions) {
 					if (tx.nonce >= invalidTransaction.nonce) {
+						this.events.emit(events.EVENT_TRANSACTION_REMOVED, {
+							id: tx.id,
+							nonce: tx.nonce.toString(),
+							senderPublicKey: tx.senderPublicKey,
+							reason: `Invalid transaction ${invalidTransaction.id}`,
+						});
 						this.remove(tx);
 					}
 				}
@@ -437,6 +465,12 @@ export class TransactionPool {
 				),
 			);
 			if (timeDifference > this._transactionExpiryTime) {
+				this.events.emit(events.EVENT_TRANSACTION_REMOVED, {
+					id: transaction.id,
+					nonce: transaction.nonce.toString(),
+					senderPublicKey: transaction.senderPublicKey,
+					reason: 'Transaction exceeded the expiry time',
+				});
 				this.remove(transaction);
 			}
 		}

--- a/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
@@ -12,10 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import {
-	TransactionList,
-	EVENT_TRANSACTION_REMOVED,
-} from '../../src/transaction_list';
+import { TransactionList } from '../../src/transaction_list';
 import { Transaction } from '../../src/types';
 
 const insertNTransactions = (
@@ -339,7 +336,6 @@ describe('TransactionList class', () => {
 						fee: addedTxs[0].fee + BigInt(500000000),
 						nonce: BigInt(0),
 					} as Transaction;
-					jest.spyOn(transactionList.events, 'emit');
 					// Act
 					const { added, removedID } = transactionList.add(adding);
 					// Assert
@@ -347,13 +343,6 @@ describe('TransactionList class', () => {
 					expect(removedID).toEqual('10');
 					expect(transactionList.size).toEqual(10);
 					expect(transactionList.get(BigInt(0))?.id).toEqual('new-id');
-					expect(transactionList.events.emit).toHaveBeenCalledWith(
-						EVENT_TRANSACTION_REMOVED,
-						{
-							address: defaultAddress,
-							id: '10',
-						},
-					);
 				});
 			});
 		});

--- a/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
@@ -29,6 +29,7 @@ describe('TransactionPool class', () => {
 				.mockResolvedValue([{ status: Status.OK, errors: [] }]),
 			transactionReorganizationInterval: 1,
 		});
+		jest.spyOn(transactionPool.events, 'emit');
 	});
 
 	describe('constructor', () => {
@@ -517,6 +518,7 @@ describe('TransactionPool class', () => {
 				transactionReorganizationInterval: 1,
 				maxTransactions: 2,
 			});
+			jest.spyOn(transactionPool.events, 'emit');
 			await transactionPool.add(transactions[0]);
 			await transactionPool.add(transactions[1]);
 		});
@@ -533,6 +535,7 @@ describe('TransactionPool class', () => {
 			expect((transactionPool as any)._allTransactions).not.toContain(
 				transactions[0],
 			);
+			expect(transactionPool.events.emit).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -571,6 +574,7 @@ describe('TransactionPool class', () => {
 				transactionReorganizationInterval: 1,
 				maxTransactions: 2,
 			});
+			jest.spyOn(transactionPool.events, 'emit');
 			await transactionPool.add(transactions[0]);
 			await transactionPool.add(transactions[1]);
 		});
@@ -587,6 +591,7 @@ describe('TransactionPool class', () => {
 			expect((transactionPool as any)._allTransactions).not.toContain(
 				transactions[0],
 			);
+			expect(transactionPool.events.emit).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -720,6 +725,7 @@ describe('TransactionPool class', () => {
 			expect((transactionPool as any).remove).toHaveBeenCalledWith(
 				transactions[2],
 			);
+			expect(transactionPool.events.emit).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/framework/src/application/node/node.js
+++ b/framework/src/application/node/node.js
@@ -24,7 +24,10 @@ const {
 } = require('@liskhq/lisk-dpos');
 const { EVENT_BFT_BLOCK_FINALIZED, BFT } = require('@liskhq/lisk-bft');
 const { getNetworkIdentifier } = require('@liskhq/lisk-cryptography');
-const { TransactionPool } = require('@liskhq/lisk-transaction-pool');
+const {
+	TransactionPool,
+	events: { EVENT_TRANSACTION_REMOVED },
+} = require('@liskhq/lisk-transaction-pool');
 const { convertErrorsToString } = require('./utils/error_handlers');
 const { Sequence } = require('./utils/sequence');
 const jobQueue = require('./utils/jobs_queue');
@@ -589,6 +592,10 @@ module.exports = class Node {
 				});
 			},
 		);
+
+		this.transactionPool.events.on(EVENT_TRANSACTION_REMOVED, event => {
+			this.logger.debug(event, 'Transaction was removed from the pool.');
+		});
 
 		this.bft.on(EVENT_BFT_BLOCK_FINALIZED, ({ height }) => {
 			this.dpos.onBlockFinalized({ height });

--- a/framework/src/application/node/processor/processor.js
+++ b/framework/src/application/node/processor/processor.js
@@ -187,10 +187,10 @@ class Processor {
 	}
 
 	async create(values) {
-		const { previousBlock, ...restOFValues } = values;
+		const { previousBlock } = values;
 		this.logger.trace('Creating block', {
-			restOFValues,
 			previousBlockId: previousBlock.id,
+			previousBlockHeight: previousBlock.height,
 		});
 		const highestVersion = Math.max.apply(null, Object.keys(this.processors));
 		const processor = this.processors[highestVersion];

--- a/framework/src/application/node/transport/transport.js
+++ b/framework/src/application/node/transport/transport.js
@@ -406,7 +406,14 @@ class Transport {
 		const { errors } = await this.transactionPoolModule.add(transaction);
 
 		if (!errors.length) {
-			this.logger.info({ transaction }, 'Added transaction to pool');
+			this.logger.info(
+				{
+					id: transaction.id,
+					nonce: transaction.nonce.toString(),
+					senderPublicKey: transaction.senderPublicKey,
+				},
+				'Added transaction to pool',
+			);
 			return transaction.id;
 		}
 

--- a/framework/src/components/logger/logger.js
+++ b/framework/src/components/logger/logger.js
@@ -54,20 +54,36 @@ class ConsoleLog {
 	// eslint-disable-next-line
 	write(rec) {
 		try {
+			const {
+				time,
+				level,
+				name,
+				msg,
+				module,
+				err,
+				hostname,
+				pid,
+				src,
+				v,
+				...others
+			} = rec;
 			let log = util.format(
 				'%s %s %s: %s (module=%s)\n',
-				new Date(rec.time).toLocaleTimeString('en-US', { hour12: false }),
-				levelToName[rec.level],
-				rec.name,
-				rec.msg,
-				rec.module || 'unknown',
+				new Date(time).toLocaleTimeString('en-US', { hour12: false }),
+				levelToName[level],
+				name,
+				msg,
+				module || 'unknown',
 			);
-			if (rec.err) {
+			if (err) {
 				log += util.format(
 					'Message: %s \n Trace: %s \n',
-					rec.err.message,
-					rec.err.stack,
+					err.message,
+					err.stack,
 				);
+			}
+			if (Object.keys(others).length > 0) {
+				log += util.format('%s \n', JSON.stringify(others, undefined, ' '));
 			}
 			process.stdout.write(log);
 		} catch (err) {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5034

### How was it solved?

- Update to emit event on asynchronous removal of transaction from pool
- Add logging for the remove transaction
- #5023 is fixed, too

### How was it tested?

- Added test
- Observe addition and removal logs
