### PR TITLE
Fix not to expose serialize format outside of chain library - Closes #4867

### DIFF
--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -15,7 +15,6 @@ import { BaseTransaction, TransactionJSON } from '@liskhq/lisk-transactions';
 
 import { Account } from '../account';
 import {
-	AccountJSON,
 	BlockHeader,
 	BlockHeaderJSON,
 	BlockInstance,
@@ -306,12 +305,12 @@ export class DataAccess {
 	/** Begin: Accounts */
 	public async getAccountsByPublicKey(
 		arrayOfPublicKeys: ReadonlyArray<string>,
-	): Promise<AccountJSON[]> {
+	): Promise<Account[]> {
 		const accounts = await this._storage.getAccountsByPublicKey(
 			arrayOfPublicKeys,
 		);
 
-		return accounts;
+		return accounts.map(account => new Account(account));
 	}
 
 	public async getAccountByAddress(address: string): Promise<Account> {
@@ -328,10 +327,10 @@ export class DataAccess {
 		return accounts.map(account => new Account(account));
 	}
 
-	public async getDelegateAccounts(limit: number): Promise<AccountJSON[]> {
+	public async getDelegateAccounts(limit: number): Promise<Account[]> {
 		const accounts = await this._storage.getDelegateAccounts(limit);
 
-		return accounts;
+		return accounts.map(account => new Account(account));
 	}
 
 	public async resetAccountMemTables(): Promise<void> {
@@ -342,12 +341,14 @@ export class DataAccess {
 	/** Begin: Transactions */
 	public async getTransactionsByIDs(
 		arrayOfTransactionIds: ReadonlyArray<string>,
-	): Promise<TransactionJSON[]> {
+	): Promise<BaseTransaction[]> {
 		const transactions = await this._storage.getTransactionsByIDs(
 			arrayOfTransactionIds,
 		);
 
-		return transactions;
+		return transactions.map(transaction =>
+			this.deserializeTransaction(transaction),
+		);
 	}
 
 	public async isTransactionPersisted(transactionId: string): Promise<boolean> {

--- a/elements/lisk-chain/src/transactions/transactions_handlers.ts
+++ b/elements/lisk-chain/src/transactions/transactions_handlers.ts
@@ -16,7 +16,6 @@ import {
 	BaseTransaction,
 	Status as TransactionStatus,
 	TransactionError,
-	TransactionJSON,
 	TransactionResponse,
 } from '@liskhq/lisk-transactions';
 
@@ -127,7 +126,7 @@ export const checkPersistedTransactions = (dataAccess: DataAccess) => async (
 	);
 
 	const persistedTransactionIds = confirmedTransactions.map(
-		(transaction: TransactionJSON) => transaction.id,
+		(transaction: BaseTransaction) => transaction.id,
 	);
 	const persistedTransactions = transactions.filter(transaction =>
 		persistedTransactionIds.includes(transaction.id),

--- a/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
+++ b/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
@@ -37,12 +37,14 @@ describe('data_access.storage', () => {
 					truncate: jest.fn(),
 				},
 				Account: {
-					get: jest.fn(),
+					get: jest.fn().mockResolvedValue([{ balance: '0', address: '123L' }]),
 					getOne: jest.fn(),
 					resetMemTables: jest.fn(),
 				},
 				Transaction: {
-					get: jest.fn(),
+					get: jest
+						.fn()
+						.mockResolvedValue([{ nonce: '2', type: 8, fee: '100' }]),
 					isPersisted: jest.fn(),
 				},
 			},
@@ -306,10 +308,11 @@ describe('data_access.storage', () => {
 	describe('#getAccountsByPublicKey', () => {
 		it('should call storage.getAccountsByPublicKey', async () => {
 			// Act
-			await dataAccess.getAccountsByPublicKey(['1L']);
+			const [result] = await dataAccess.getAccountsByPublicKey(['1L']);
 
 			// Assert
 			expect(storageMock.entities.Account.get).toHaveBeenCalled();
+			expect(typeof result.nonce).toBe('bigint');
 		});
 	});
 
@@ -347,23 +350,25 @@ describe('data_access.storage', () => {
 
 		it('should call storage.getDelegateAccounts', async () => {
 			// Act
-			await dataAccess.getDelegateAccounts(DEFAULT_LIMIT);
+			const [result] = await dataAccess.getDelegateAccounts(DEFAULT_LIMIT);
 
 			// Assert
 			expect(storageMock.entities.Account.get).toHaveBeenCalledWith(
 				{ isDelegate: true },
 				{ limit: DEFAULT_LIMIT, sort: ['voteWeight:desc', 'publicKey:asc'] },
 			);
+			expect(typeof result.nonce).toBe('bigint');
 		});
 	});
 
 	describe('#getTransactionsByIDs', () => {
 		it('should call storage.getTransactionsByIDs', async () => {
 			// Act
-			await dataAccess.getTransactionsByIDs(['1']);
+			const [result] = await dataAccess.getTransactionsByIDs(['1']);
 
 			// Assert
 			expect(storageMock.entities.Transaction.get).toHaveBeenCalled();
+			expect(typeof result.fee).toBe('bigint');
 		});
 	});
 

--- a/elements/lisk-chain/test/unit/process.spec.ts
+++ b/elements/lisk-chain/test/unit/process.spec.ts
@@ -497,17 +497,18 @@ describe('blocks/header', () => {
 				storageStub.entities.Account.get.mockResolvedValue([
 					{ address: genesisAccount.address, balance: '100000000000000' },
 				]);
+				const validTxJSON = transfer({
+					fee: '10000000',
+					nonce: '0',
+					passphrase: genesisAccount.passphrase,
+					recipientId: '123L',
+					amount: '100',
+					networkIdentifier,
+				});
 				const validTx = chainInstance.deserializeTransaction(
-					transfer({
-						fee: '10000000',
-						nonce: '0',
-						passphrase: genesisAccount.passphrase,
-						recipientId: '123L',
-						amount: '100',
-						networkIdentifier,
-					}) as TransactionJSON,
+					validTxJSON as TransactionJSON,
 				);
-				storageStub.entities.Transaction.get.mockResolvedValue([validTx]);
+				storageStub.entities.Transaction.get.mockResolvedValue([validTxJSON]);
 				block = newBlock({ transactions: [validTx] });
 			});
 

--- a/elements/lisk-chain/test/unit/transactions.spec.ts
+++ b/elements/lisk-chain/test/unit/transactions.spec.ts
@@ -163,7 +163,7 @@ describe('blocks/transactions', () => {
 				// Arrange
 				storageStub.entities.Account.get
 					.mockResolvedValueOnce([
-						{ address: genesisAccount.address, balance: '210000000'},
+						{ address: genesisAccount.address, balance: '210000000' },
 					])
 					.mockResolvedValue([]);
 				const validTx = chainInstance.deserializeTransaction(
@@ -495,7 +495,9 @@ describe('blocks/transactions', () => {
 						networkIdentifier,
 					}) as TransactionJSON,
 				);
-				storageStub.entities.Transaction.get.mockResolvedValue([validTx2]);
+				storageStub.entities.Transaction.get.mockResolvedValue([
+					validTx2.toJSON(),
+				]);
 				// Act
 				const transactionsResponses = await chainInstance.applyTransactions([
 					validTx,


### PR DESCRIPTION
### What was the problem?

This PR resolves #4867 

### How was it solved?

- Deserialize before exposing to the outside

### How was it tested?

- Added tests to check if it's serialized
