### PR TITLE
Add tests for transaction minFee - Closes #5045

### DIFF
--- a/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
+++ b/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
@@ -89,6 +89,18 @@ describe('Delegate registration transaction class', () => {
 		});
 	});
 
+	describe('#minFee', () => {
+		it('should set the minFee to nameFee plus minFeePerByte times bytelength', () => {
+			const byteLength = BigInt(validTestTransaction.getBytes().length);
+			const nameFee = 1000000000;
+			const minFeePerByte = 1000;
+
+			expect(validTestTransaction.minFee).toEqual(
+				BigInt(nameFee) + byteLength * BigInt(minFeePerByte),
+			);
+		});
+	});
+
 	describe('#assetToBytes', () => {
 		it('should return valid buffer', async () => {
 			const assetBytes = (validTestTransaction as any).assetToBytes();

--- a/elements/lisk-transactions/test/base_transaction.spec.ts
+++ b/elements/lisk-transactions/test/base_transaction.spec.ts
@@ -157,6 +157,33 @@ describe('Base transaction class', () => {
 					),
 			).not.toThrowError();
 		});
+
+		it('should set fee to zero if not provided in raw transaction', async () => {
+			const noFeeTransaction = new TestTransaction({
+				...defaultTransaction,
+				fee: 0,
+			});
+			expect(noFeeTransaction.fee).toEqual(BigInt('0'));
+		});
+
+		it('should set fee to zero if provided fee is invalid format', async () => {
+			const noFeeTransaction = new TestTransaction({
+				...defaultTransaction,
+				fee: 'abc',
+			});
+			expect(noFeeTransaction.fee).toEqual(BigInt('0'));
+		});
+	});
+
+	describe('#minFee', () => {
+		it('should set the minFee to minFeePerByte times bytelength for non delegate registration', () => {
+			const byteLength = BigInt(validTestTransaction.getBytes().length);
+			const minFeePerByte = 1000;
+
+			expect(validTestTransaction.minFee).toEqual(
+				byteLength * BigInt(minFeePerByte),
+			);
+		});
 	});
 
 	describe('#assetToJSON', () => {


### PR DESCRIPTION
### What was the problem?

Adding additional unit tests for transaction min fee.

This PR resolves #5045

### How was it solved?

Added additional unit tests.

### How was it tested?

Added additional tests in `lisk-transaction`
