### PR TITLE
Add test scenarios txpool - Closes #5046

### DIFF
--- a/elements/lisk-transaction-pool/src/transaction_list.ts
+++ b/elements/lisk-transaction-pool/src/transaction_list.ts
@@ -22,7 +22,8 @@ export interface TransactionListOptions {
 }
 
 const DEFAULT_MAX_SIZE = 64;
-const DEFAULT_REPLACEMENT_FEE_DIFF = BigInt(0);
+// tslint:disable-next-line no-magic-numbers
+export const DEFAULT_MINIMUM_REPLACEMENT_FEE_DIFFERENCE = BigInt(10);
 
 export class TransactionList {
 	public readonly address: string;
@@ -41,7 +42,7 @@ export class TransactionList {
 		this._processable = [];
 		this._maxSize = options?.maxSize ?? DEFAULT_MAX_SIZE;
 		this._minReplacementFeeDifference =
-			options?.minReplacementFeeDifference ?? DEFAULT_REPLACEMENT_FEE_DIFF;
+			options?.minReplacementFeeDifference ?? DEFAULT_MINIMUM_REPLACEMENT_FEE_DIFFERENCE;
 	}
 
 	public get(nonce: bigint): Transaction | undefined {

--- a/elements/lisk-transaction-pool/src/transaction_pool.ts
+++ b/elements/lisk-transaction-pool/src/transaction_pool.ts
@@ -199,7 +199,7 @@ export class TransactionPool {
 		const exceededTransactionsCount =
 			Object.keys(this._allTransactions).length - this._maxTransactions;
 
-		if (exceededTransactionsCount > 0) {
+		if (exceededTransactionsCount >= 0) {
 			const isEvicted = this._evictUnprocessable();
 
 			if (!isEvicted) {

--- a/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
@@ -134,7 +134,7 @@ describe('TransactionList class', () => {
 				});
 			});
 
-			describe('when the same nonce transaction with the lower than min replacement fee is added', () => {
+			describe('when the same nonce transaction with a lower fee than min replacement fee is added', () => {
 				it('should not replace and not add to the list', async () => {
 					// Arrange
 					const addedTxs = insertNTransactions(transactionList, 5);
@@ -290,7 +290,7 @@ describe('TransactionList class', () => {
 				});
 			});
 
-			describe('when the same nonce transaction with the lower than min replacement fee is added', () => {
+			describe('when the same nonce transaction with a lower fee than min replacement fee is added', () => {
 				it('should not replace and not add to the list', async () => {
 					// Arrange
 					const addedTxs = insertNTransactions(transactionList, 10);
@@ -398,7 +398,7 @@ describe('TransactionList class', () => {
 	});
 
 	describe('promote', () => {
-		describe('when promoting transaction does not exist id', () => {
+		describe('when promoting transaction id does not exist', () => {
 			it('should not mark any transactions as promotable', async () => {
 				// Arrange
 				insertNTransactions(transactionList, 10);
@@ -407,23 +407,6 @@ describe('TransactionList class', () => {
 					{
 						id: '11',
 						nonce: BigInt(11),
-						fee: BigInt(1000000),
-					} as Transaction,
-				]);
-				// Assert
-				expect(transactionList.getProcessable()).toHaveLength(0);
-			});
-		});
-
-		describe('when promoting transaction does not match id', () => {
-			it('should not mark any transactions as promotable', async () => {
-				// Arrange
-				insertNTransactions(transactionList, 10);
-				// Act
-				transactionList.promote([
-					{
-						id: 'new-id',
-						nonce: BigInt(0),
 						fee: BigInt(1000000),
 					} as Transaction,
 				]);
@@ -546,7 +529,7 @@ describe('TransactionList class', () => {
 			});
 		});
 
-		describe('when there are only unprocessable transactions and all nonce are not continuous', () => {
+		describe('when there are only unprocessable transactions and all nonces are not continuous', () => {
 			it('should return only the first unprocessable transaction', async () => {
 				// Arrange
 				const addedTxs = insertNTransactions(transactionList, 1);
@@ -561,7 +544,7 @@ describe('TransactionList class', () => {
 			});
 		});
 
-		describe('when there are only unprocessable transactions and all nonce are in sequence', () => {
+		describe('when there are only unprocessable transactions and all nonces are in sequence order', () => {
 			it('should return all the promotables in order of nonce', async () => {
 				// Arrange
 				insertNTransactions(transactionList, 10, 10);

--- a/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
@@ -210,7 +210,7 @@ describe('TransactionList class', () => {
 			});
 		});
 
-		describe('given list of trxs with continuous nonce', () => {
+		describe('when the transaction list is full', () => {
 			describe('when the same nonce transaction with higher fee is added', () => {
 				it('should replace with the new transaction', async () => {
 					// Arrange
@@ -330,7 +330,7 @@ describe('TransactionList class', () => {
 				});
 			});
 
-			describe('when new transaction is added with higher nonce than the existing highest nonce when transactionList.size >= maxSize', () => {
+			describe('when new transaction is added with higher nonce than the existing highest nonce', () => {
 				it('should not add to the list', async () => {
 					// Arrange
 					const addedTxs = insertNTransactions(transactionList, 10);
@@ -347,7 +347,7 @@ describe('TransactionList class', () => {
 				});
 			});
 
-			describe('when new transaction is added with lower nonce than the existing highest nonce when transactionList.size >= maxSize', () => {
+			describe('when new transaction is added with lower nonce than the existing highest nonce', () => {
 				it('should add the new transaction and remove the highest nonce transaction', async () => {
 					// Arrange
 					const addedTxs = insertNTransactions(transactionList, 10, 1);

--- a/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_list.spec.ts
@@ -249,7 +249,7 @@ describe('TransactionList class', () => {
 					expect(transactionList.get(addedTxs[0].nonce)?.id).toEqual('new-id');
 				});
 			});
-			// +& when the same nonce transaction with higher fee and equal or greater than the minReplacementFee
+
 			describe('when the same nonce transaction with higher fee and greater than minReplaceFeeDiff is added', () => {
 				it('should replace with the new transaction', async () => {
 					// Arrange
@@ -269,6 +269,7 @@ describe('TransactionList class', () => {
 					);
 				});
 			});
+
 			describe('when the same nonce transaction with higher fee but lower than minReplaceFeeDiff is added', () => {
 				it('should reject the new incoming replacing transaction', async () => {
 					// Arrange

--- a/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
+++ b/elements/lisk-transaction-pool/test/unit/transaction_pool.spec.ts
@@ -343,7 +343,7 @@ describe('TransactionPool class', () => {
 			expect(status).toEqual(Status.FAIL);
 		});
 
-		it('should evict lowest feePriotity among highest nonce trx from the pool when txPool is full and all the trxs are processable', async () => {
+		it('should evict lowest feePriority among highest nonce trx from the pool when txPool is full and all the trxs are processable', async () => {
 			const MAX_TRANSACTIONS = 10;
 			transactionPool = new TransactionPool({
 				applyTransactions: jest.fn(),
@@ -397,7 +397,7 @@ describe('TransactionPool class', () => {
 			expect(status).toEqual(Status.OK);
 		});
 
-		it('should evict unprocessable trx from the pool when txPool is full and not all trxs are processable', async () => {
+		it('should evict the unprocessable trx with the lowest feePriority from the pool when txPool is full and not all trxs are processable', async () => {
 			const MAX_TRANSACTIONS = 10;
 			transactionPool = new TransactionPool({
 				applyTransactions: jest.fn(),


### PR DESCRIPTION
### What was the problem?

This PR resolves #5046 & resolves  #5047 

### How was it solved?

- [x] DEFAULT_MINIMUM_REPLACEMENT_FEE_DIFFERENCE in TransactionList is equal to `10`
- [x] `exceededTransactionsCount >= 0` to trigger eviction when the TxPool size is equal maxSize
- [x]  **Test Scenario:** when the same nonce transaction with higher fee and greater than minReplaceFeeDiff is added
- [x] **Test Scenario:** should evict the trx from the pool when txPool is full when all the trxs are processable
- [x] **Test Scenario:** should evict the trx from the pool when txPool is full when not all of the trxs are processable
- [x] Use multiple addresses and their transactions for test cases

### How was it tested?

Run `npm t` under `/elements/lisk-transaction-pool`
