### PR TITLE
Fix to get last blocks with offset when deleting a block - Closes #5054

### DIFF
--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -358,12 +358,12 @@ export class Chain {
 		this.dataAccess.resetBlockHeaderCache();
 	}
 
-	public async newStateStore(heightOffset: number = 0): Promise<StateStore> {
+	public async newStateStore(skipLastHeights: number = 0): Promise<StateStore> {
 		const fromHeight = Math.max(
 			1,
-			this._lastBlock.height - this.constants.stateBlockSize - heightOffset,
+			this._lastBlock.height - this.constants.stateBlockSize - skipLastHeights,
 		);
-		const toHeight = Math.max(this._lastBlock.height - heightOffset, 1);
+		const toHeight = Math.max(this._lastBlock.height - skipLastHeights, 1);
 		const lastBlockHeaders = await this.dataAccess.getBlockHeadersByHeightBetween(
 			fromHeight,
 			toHeight,

--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -358,12 +358,12 @@ export class Chain {
 		this.dataAccess.resetBlockHeaderCache();
 	}
 
-	public async newStateStore(): Promise<StateStore> {
+	public async newStateStore(heightOffset: number = 0): Promise<StateStore> {
 		const fromHeight = Math.max(
 			1,
-			this._lastBlock.height - this.constants.stateBlockSize,
+			this._lastBlock.height - this.constants.stateBlockSize - heightOffset,
 		);
-		const toHeight = this._lastBlock.height;
+		const toHeight = Math.max(this._lastBlock.height - heightOffset, 1);
 		const lastBlockHeaders = await this.dataAccess.getBlockHeadersByHeightBetween(
 			fromHeight,
 			toHeight,

--- a/elements/lisk-chain/test/unit/chain.spec.ts
+++ b/elements/lisk-chain/test/unit/chain.spec.ts
@@ -294,7 +294,7 @@ describe('chain', () => {
 			);
 		});
 
-		it('should return with the chain state from last block to last block - 309', async () => {
+		it('should return with the chain state with lastBlock.height to lastBlock.height - 309', async () => {
 			await chainInstance.newStateStore();
 			await expect(
 				stubs.dependencies.storage.entities.Block.get,
@@ -307,7 +307,7 @@ describe('chain', () => {
 			);
 		});
 
-		it('should return with the chain state from last block - 1 to last block - 310', async () => {
+		it('should return with the chain state with lastBlock.height to lastBlock.height - 310', async () => {
 			await chainInstance.newStateStore(1);
 			await expect(
 				stubs.dependencies.storage.entities.Block.get,

--- a/elements/lisk-chain/test/unit/chain.spec.ts
+++ b/elements/lisk-chain/test/unit/chain.spec.ts
@@ -271,6 +271,56 @@ describe('chain', () => {
 		});
 	});
 
+	describe('newStateStore', () => {
+		beforeEach(async () => {
+			chainInstance['_lastBlock'] = newBlock({ height: 532 });
+			stubs.dependencies.storage.entities.Block.get.mockResolvedValue([
+				newBlock(),
+				genesisBlock,
+			]);
+		});
+
+		it('should populate the chain state with genesis block', async () => {
+			chainInstance['_lastBlock'] = newBlock({ height: 1 });
+			await chainInstance.newStateStore();
+			await expect(
+				stubs.dependencies.storage.entities.Block.get,
+			).toHaveBeenCalledWith(
+				{
+					height_gte: 1,
+					height_lte: 1,
+				},
+				{ limit: null, sort: 'height:desc' },
+			);
+		});
+
+		it('should return with the chain state from last block to last block - 309', async () => {
+			await chainInstance.newStateStore();
+			await expect(
+				stubs.dependencies.storage.entities.Block.get,
+			).toHaveBeenCalledWith(
+				{
+					height_gte: chainInstance.lastBlock.height - 309,
+					height_lte: chainInstance.lastBlock.height,
+				},
+				{ limit: null, sort: 'height:desc' },
+			);
+		});
+
+		it('should return with the chain state from last block - 1 to last block - 310', async () => {
+			await chainInstance.newStateStore(1);
+			await expect(
+				stubs.dependencies.storage.entities.Block.get,
+			).toHaveBeenCalledWith(
+				{
+					height_gte: chainInstance.lastBlock.height - 310,
+					height_lte: chainInstance.lastBlock.height - 1,
+				},
+				{ limit: null, sort: 'height:desc' },
+			);
+		});
+	});
+
 	describe('serialize', () => {
 		const transaction = new TransferTransaction(randomUtils.transaction());
 		const block = newBlock({ transactions: [transaction] });

--- a/framework/src/application/node/processor/processor.js
+++ b/framework/src/application/node/processor/processor.js
@@ -335,7 +335,8 @@ class Processor {
 	}
 
 	async _deleteBlock(block, processor, saveTempBlock = false) {
-		const stateStore = await this.chainModule.newStateStore();
+		// Offset must be set to 1, because lastBlock is still this deleting block
+		const stateStore = await this.chainModule.newStateStore(1);
 		await processor.undo.run({
 			block,
 			stateStore,


### PR DESCRIPTION
### What was the problem?

This PR resolves #5054

### How was it solved?

- Add offset while creating the state store
- Use offset 1 while deleting a block
 
### How was it tested?

Added unit test to show which range of the blocks is used
