### PR TITLE
Update sorting logic to feePriorty than fee in forger strategy - Closes #5053

### DIFF
--- a/framework/src/application/node/forger/strategies.js
+++ b/framework/src/application/node/forger/strategies.js
@@ -50,7 +50,7 @@ class HighFeeForgingStrategy {
 		const feePriorityHeap = new MaxHeap();
 		for (const senderId of Object.keys(transactionsBySender)) {
 			const lowestNonceTrx = transactionsBySender[senderId][0];
-			feePriorityHeap.push(lowestNonceTrx.fee, lowestNonceTrx);
+			feePriorityHeap.push(lowestNonceTrx.feePriority, lowestNonceTrx);
 		}
 
 		// Loop till we have last account exhausted to pick transactions
@@ -111,7 +111,7 @@ class HighFeeForgingStrategy {
 			const nextLowestNonceTransaction =
 				transactionsBySender[lowestNonceHighestFeeTrx.senderId][0];
 			feePriorityHeap.push(
-				nextLowestNonceTransaction.fee,
+				nextLowestNonceTransaction.feePriority,
 				nextLowestNonceTransaction,
 			);
 		}

--- a/framework/test/jest/unit/specs/application/node/forger/forging_fixtures.js
+++ b/framework/test/jest/unit/specs/application/node/forger/forging_fixtures.js
@@ -18,19 +18,19 @@ const allValidCase = {
 	input: {
 		maxPayloadLength: 1000,
 		transactions: [
-			{ id: 1, senderId: 'A', fee: 1, nonce: 1 },
-			{ id: 2, senderId: 'A', fee: 2, nonce: 2 },
-			{ id: 3, senderId: 'B', fee: 1, nonce: 1 },
-			{ id: 4, senderId: 'B', fee: 2, nonce: 2 },
-			{ id: 5, senderId: 'C', fee: 3, nonce: 1 },
+			{ id: 1, senderId: 'A', fee: 1, nonce: 1, feePriority: 1 },
+			{ id: 2, senderId: 'A', fee: 2, nonce: 2, feePriority: 2 },
+			{ id: 3, senderId: 'B', fee: 1, nonce: 1, feePriority: 1 },
+			{ id: 4, senderId: 'B', fee: 2, nonce: 2, feePriority: 2 },
+			{ id: 5, senderId: 'C', fee: 3, nonce: 1, feePriority: 3 },
 		],
 	},
 	output: [
-		{ id: 5, senderId: 'C', fee: 3, nonce: 1 },
-		{ id: 3, senderId: 'B', fee: 1, nonce: 1 },
-		{ id: 4, senderId: 'B', fee: 2, nonce: 2 },
-		{ id: 1, senderId: 'A', fee: 1, nonce: 1 },
-		{ id: 2, senderId: 'A', fee: 2, nonce: 2 },
+		{ id: 5, senderId: 'C', fee: 3, nonce: 1, feePriority: 3 },
+		{ id: 3, senderId: 'B', fee: 1, nonce: 1, feePriority: 1 },
+		{ id: 4, senderId: 'B', fee: 2, nonce: 2, feePriority: 2 },
+		{ id: 1, senderId: 'A', fee: 1, nonce: 1, feePriority: 1 },
+		{ id: 2, senderId: 'A', fee: 2, nonce: 2, feePriority: 2 },
 	],
 };
 
@@ -38,18 +38,18 @@ const maxPayloadLengthCase = {
 	input: {
 		maxPayloadLength: 1000,
 		transactions: [
-			{ id: 1, senderId: 'A', fee: 1, nonce: 1, bytes: 300 },
-			{ id: 2, senderId: 'A', fee: 2, nonce: 2, bytes: 200 },
-			{ id: 3, senderId: 'B', fee: 1, nonce: 1, bytes: 200 },
-			{ id: 4, senderId: 'B', fee: 2, nonce: 2, bytes: 100 },
-			{ id: 5, senderId: 'C', fee: 3, nonce: 1, bytes: 300 },
+			{ id: 1, senderId: 'A', fee: 1, nonce: 1, bytes: 300, feePriority: 1 },
+			{ id: 2, senderId: 'A', fee: 2, nonce: 2, bytes: 200, feePriority: 2 },
+			{ id: 3, senderId: 'B', fee: 1, nonce: 1, bytes: 200, feePriority: 1 },
+			{ id: 4, senderId: 'B', fee: 2, nonce: 2, bytes: 100, feePriority: 2 },
+			{ id: 5, senderId: 'C', fee: 3, nonce: 1, bytes: 300, feePriority: 3 },
 		],
 	},
 	output: [
-		{ id: 5, senderId: 'C', fee: 3, nonce: 1, bytes: 300 },
-		{ id: 3, senderId: 'B', fee: 1, nonce: 1, bytes: 200 },
-		{ id: 4, senderId: 'B', fee: 2, nonce: 2, bytes: 100 },
-		{ id: 1, senderId: 'A', fee: 1, nonce: 1, bytes: 300 },
+		{ id: 5, senderId: 'C', fee: 3, nonce: 1, bytes: 300, feePriority: 3 },
+		{ id: 3, senderId: 'B', fee: 1, nonce: 1, bytes: 200, feePriority: 1 },
+		{ id: 4, senderId: 'B', fee: 2, nonce: 2, bytes: 100, feePriority: 2 },
+		{ id: 1, senderId: 'A', fee: 1, nonce: 1, bytes: 300, feePriority: 1 },
 	],
 };
 
@@ -57,17 +57,17 @@ const invalidTxCase = {
 	input: {
 		maxPayloadLength: 1000,
 		transactions: [
-			{ id: 1, senderId: 'A', fee: 1, nonce: 1 },
-			{ id: 2, senderId: 'A', fee: 2, nonce: 2, valid: false },
-			{ id: 3, senderId: 'A', fee: 1, nonce: 3 },
-			{ id: 4, senderId: 'B', fee: 2, nonce: 2 },
-			{ id: 5, senderId: 'C', fee: 3, nonce: 1 },
+			{ id: 1, senderId: 'A', fee: 1, nonce: 1, feePriority: 1 },
+			{ id: 2, senderId: 'A', fee: 2, nonce: 2, valid: false, feePriority: 2 },
+			{ id: 3, senderId: 'A', fee: 1, nonce: 3, feePriority: 1 },
+			{ id: 4, senderId: 'B', fee: 2, nonce: 2, feePriority: 2 },
+			{ id: 5, senderId: 'C', fee: 3, nonce: 1, feePriority: 3 },
 		],
 	},
 	output: [
-		{ id: 5, senderId: 'C', fee: 3, nonce: 1 },
-		{ id: 4, senderId: 'B', fee: 2, nonce: 2 },
-		{ id: 1, senderId: 'A', fee: 1, nonce: 1 },
+		{ id: 5, senderId: 'C', fee: 3, nonce: 1, feePriority: 3 },
+		{ id: 4, senderId: 'B', fee: 2, nonce: 2, feePriority: 2 },
+		{ id: 1, senderId: 'A', fee: 1, nonce: 1, feePriority: 1 },
 	],
 };
 
@@ -75,11 +75,11 @@ const allInvalidCase = {
 	input: {
 		maxPayloadLength: 1000,
 		transactions: [
-			{ id: 1, senderId: 'A', fee: 1, nonce: 1, valid: false },
-			{ id: 2, senderId: 'A', fee: 2, nonce: 2, valid: false },
-			{ id: 3, senderId: 'A', fee: 1, nonce: 3, valid: false },
-			{ id: 4, senderId: 'B', fee: 2, nonce: 2, valid: false },
-			{ id: 5, senderId: 'C', fee: 3, nonce: 1, valid: false },
+			{ id: 1, senderId: 'A', fee: 1, nonce: 1, valid: false, feePriority: 1 },
+			{ id: 2, senderId: 'A', fee: 2, nonce: 2, valid: false, feePriority: 2 },
+			{ id: 3, senderId: 'A', fee: 1, nonce: 3, valid: false, feePriority: 1 },
+			{ id: 4, senderId: 'B', fee: 2, nonce: 2, valid: false, feePriority: 2 },
+			{ id: 5, senderId: 'C', fee: 3, nonce: 1, valid: false, feePriority: 3 },
 		],
 	},
 	output: [],

--- a/framework/test/jest/unit/specs/application/node/forger/strategies.spec.js
+++ b/framework/test/jest/unit/specs/application/node/forger/strategies.spec.js
@@ -27,7 +27,16 @@ const {
 } = require('./forging_fixtures');
 
 const getTxMock = (
-	{ id, senderId, nonce, fee, bytes = 0, basicBytes = 0, valid = true } = {},
+	{
+		id,
+		senderId,
+		nonce,
+		fee,
+		feePriority,
+		bytes = 0,
+		basicBytes = 0,
+		valid = true,
+	} = {},
 	chainMock,
 ) => {
 	const tx = {
@@ -35,6 +44,7 @@ const getTxMock = (
 		senderId,
 		nonce,
 		fee,
+		feePriority,
 		getBytes: jest.fn().mockReturnValue(Array(bytes)),
 		getBasicBytes: jest.fn().mockReturnValue(Array(basicBytes)),
 	};
@@ -110,7 +120,7 @@ describe('strategies', () => {
 				// Assert
 				expect(mockTxPool.getProcessableTransactions).toBeCalledTimes(1);
 			});
-			it('should return transactions in order by highest fee and lowest nonce', async () => {
+			it('should return transactions in order by highest feePriority and lowest nonce', async () => {
 				// Arrange
 				mockTxPool.getProcessableTransactions.mockReturnValue(
 					buildProcessableTxMock(


### PR DESCRIPTION
### What was the problem?

This PR resolves #5053

### How was it solved?

Updated the sort property to `feePriority` than `fee`

### How was it tested?

Run unit tests for forging strategy. 
