### PR TITLE
Remove network identifier from the constructor of transaction - Closes #4961

### DIFF
--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -257,7 +257,6 @@ export class Chain {
 		this.storage = storage;
 		this.dataAccess = new DataAccess({
 			dbStorage: storage,
-			networkIdentifier,
 			registeredTransactions,
 			minBlockHeaderCache,
 			maxBlockHeaderCache,

--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -29,7 +29,6 @@ import { TransactionInterfaceAdapter } from './transaction_interface_adapter';
 
 interface DAConstructor {
 	readonly dbStorage: DBStorage;
-	readonly networkIdentifier: string;
 	readonly registeredTransactions: {
 		readonly [key: number]: typeof BaseTransaction;
 	};
@@ -44,7 +43,6 @@ export class DataAccess {
 
 	public constructor({
 		dbStorage,
-		networkIdentifier,
 		registeredTransactions,
 		minBlockHeaderCache,
 		maxBlockHeaderCache,
@@ -55,7 +53,6 @@ export class DataAccess {
 			maxBlockHeaderCache,
 		);
 		this._transactionAdapter = new TransactionInterfaceAdapter(
-			networkIdentifier,
 			registeredTransactions,
 		);
 	}

--- a/elements/lisk-chain/src/data_access/transaction_interface_adapter.ts
+++ b/elements/lisk-chain/src/data_access/transaction_interface_adapter.ts
@@ -18,15 +18,10 @@ export interface RegisteredTransactions {
 }
 
 export class TransactionInterfaceAdapter {
-	private readonly _networkIdentifier: string;
 	// tslint:disable-next-line no-any
 	private readonly _transactionClassMap: Map<number, any>;
 
-	public constructor(
-		networkIdentifier: string,
-		registeredTransactions: RegisteredTransactions = {},
-	) {
-		this._networkIdentifier = networkIdentifier;
+	public constructor(registeredTransactions: RegisteredTransactions = {}) {
 		this._transactionClassMap = new Map();
 		Object.keys(registeredTransactions).forEach(transactionType => {
 			this._transactionClassMap.set(
@@ -46,7 +41,6 @@ export class TransactionInterfaceAdapter {
 
 		return new TransactionClass({
 			...rawTx,
-			networkIdentifier: this._networkIdentifier,
 		});
 	}
 }

--- a/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
+++ b/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
@@ -52,7 +52,6 @@ describe('data_access.storage', () => {
 
 		dataAccess = new DataAccess({
 			dbStorage: storageMock,
-			networkIdentifier: 'TEST',
 			registeredTransactions: { '8': TransferTransaction },
 			minBlockHeaderCache: 3,
 			maxBlockHeaderCache: 5,

--- a/elements/lisk-chain/test/unit/process.spec.ts
+++ b/elements/lisk-chain/test/unit/process.spec.ts
@@ -23,7 +23,7 @@ import {
 	getNetworkIdentifier,
 	getAddressFromPublicKey,
 } from '@liskhq/lisk-cryptography';
-import { newBlock, getBytes } from '../utils/block';
+import { newBlock, getBytes, defaultNetworkIdentifier } from '../utils/block';
 import { Chain, StateStore } from '../../src';
 import * as genesisBlock from '../fixtures/genesis_block.json';
 import { genesisAccount } from '../fixtures/default_account';
@@ -346,7 +346,7 @@ describe('blocks/header', () => {
 				// Act
 				const stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				await chainInstance.verify(block, stateStore, {
 					skipExistingCheck: true,
@@ -410,7 +410,7 @@ describe('blocks/header', () => {
 				// Arrange
 				const stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 
 				// Act && Assert
@@ -452,7 +452,7 @@ describe('blocks/header', () => {
 				// Act
 				const stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				expect.assertions(1);
 				let err;
@@ -491,7 +491,7 @@ describe('blocks/header', () => {
 				// Arrange
 				const stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 
 				// Act && Assert
@@ -528,7 +528,7 @@ describe('blocks/header', () => {
 				// Arrange
 				const stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 
 				// Act && Assert
@@ -563,7 +563,7 @@ describe('blocks/header', () => {
 				storageStub.entities.ChainState.getKey.mockResolvedValue('100');
 				stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				await stateStore.account.cache({
 					address_in: [
@@ -619,7 +619,7 @@ describe('blocks/header', () => {
 				// Act
 				stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				await stateStore.account.cache({
 					address_in: [
@@ -662,7 +662,7 @@ describe('blocks/header', () => {
 				// Act
 				stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				await stateStore.account.cache({
 					address_in: [genesisAccount.address],
@@ -773,7 +773,7 @@ describe('blocks/header', () => {
 				// Act
 				stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				await chainInstance.apply(block, stateStore);
 			});
@@ -869,7 +869,7 @@ describe('blocks/header', () => {
 			// Act
 			stateStore = new StateStore(storageStub, {
 				lastBlockHeaders: [],
-				networkIdentifier: 'network-identifier-chain-1',
+				networkIdentifier: defaultNetworkIdentifier,
 			});
 			await chainInstance.applyGenesis(genesisInstance, stateStore);
 		});
@@ -906,7 +906,7 @@ describe('blocks/header', () => {
 			beforeEach(async () => {
 				stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				// Arrage
 				block = newBlock({ reward });
@@ -968,7 +968,7 @@ describe('blocks/header', () => {
 				// Act
 				stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				await chainInstance.undo(block, stateStore);
 			});
@@ -1070,7 +1070,7 @@ describe('blocks/header', () => {
 				// Act
 				stateStore = new StateStore(storageStub, {
 					lastBlockHeaders: [],
-					networkIdentifier: 'network-identifier-chain-1',
+					networkIdentifier: defaultNetworkIdentifier,
 				});
 				await chainInstance.undo(block, stateStore);
 			});

--- a/elements/lisk-chain/test/unit/transaction_interface_adapter.spec.ts
+++ b/elements/lisk-chain/test/unit/transaction_interface_adapter.spec.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { getNetworkIdentifier } from '@liskhq/lisk-cryptography';
 import {
 	TransferTransaction,
 	DelegateTransaction,
@@ -20,12 +19,6 @@ import {
 	MultisignatureTransaction,
 } from '@liskhq/lisk-transactions';
 import { TransactionInterfaceAdapter } from '../../src/data_access/transaction_interface_adapter';
-import * as genesisBlock from '../fixtures/genesis_block.json';
-
-const networkIdentifier = getNetworkIdentifier(
-	genesisBlock.payloadHash,
-	genesisBlock.communityIdentifier,
-);
 
 // TODO: re-implement for new transaction processing
 describe('transactions', () => {
@@ -41,10 +34,7 @@ describe('transactions', () => {
 
 		beforeEach(async () => {
 			// Act
-			transactions = new TransactionInterfaceAdapter(
-				networkIdentifier,
-				registeredTransactions,
-			);
+			transactions = new TransactionInterfaceAdapter(registeredTransactions);
 		});
 
 		describe('constructor', () => {

--- a/elements/lisk-chain/test/utils/block.ts
+++ b/elements/lisk-chain/test/utils/block.ts
@@ -29,7 +29,7 @@ import { BaseTransaction } from '@liskhq/lisk-transactions';
 const SIZE_INT32 = 4;
 const SIZE_INT64 = 8;
 
-const defaultNetworkIdentifier =
+export const defaultNetworkIdentifier =
 	'11a254dc30db5eb1ce4001acde35fd5a14d62584f886d30df161e4e883220eb7';
 
 export const getBytes = (block: BlockInstance): Buffer => {

--- a/elements/lisk-transactions/src/12_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/12_multisignature_transaction.ts
@@ -329,9 +329,12 @@ export class MultisignatureTransaction extends BaseTransaction {
 	}
 
 	// Verifies multisig signatures as per LIP-0017
-	public async verifySignatures(_: StateStore): Promise<TransactionResponse> {
+	public async verifySignatures(
+		store: StateStore,
+	): Promise<TransactionResponse> {
+		const { networkIdentifier } = store.chain;
 		const transactionBytes = this.getBasicBytes();
-		const networkIdentifierBytes = hexToBuffer(this._networkIdentifier);
+		const networkIdentifierBytes = hexToBuffer(networkIdentifier);
 		const transactionWithNetworkIdentifierBytes = Buffer.concat([
 			networkIdentifierBytes,
 			transactionBytes,
@@ -402,10 +405,6 @@ export class MultisignatureTransaction extends BaseTransaction {
 			readonly numberOfSignatures: number;
 		},
 	): void {
-		// Set network identifier if it was previously not set in the transaction
-		if (!this._networkIdentifier) {
-			this._networkIdentifier = networkIdentifier;
-		}
 		// Sort the keys in the transaction
 		sortKeysAscending(this.asset.mandatoryKeys);
 		sortKeysAscending(this.asset.optionalKeys);
@@ -423,7 +422,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 
 		this.senderPublicKey = publicKey;
 
-		const networkIdentifierBytes = hexToBuffer(this._networkIdentifier);
+		const networkIdentifierBytes = hexToBuffer(networkIdentifier);
 		const transactionWithNetworkIdentifierBytes = Buffer.concat([
 			networkIdentifierBytes,
 			this.getBasicBytes(),

--- a/elements/lisk-transactions/src/cast_votes.ts
+++ b/elements/lisk-transactions/src/cast_votes.ts
@@ -81,7 +81,6 @@ export const castVotes = (inputs: CastVoteInputs): Partial<TransactionJSON> => {
 		asset: {
 			...transaction.asset,
 		},
-		networkIdentifier,
 	};
 
 	const voteTransaction = new VoteTransaction(transactionWithSenderInfo);

--- a/elements/lisk-transactions/src/register_delegate.ts
+++ b/elements/lisk-transactions/src/register_delegate.ts
@@ -70,7 +70,6 @@ export const registerDelegate = (
 		// For txs from multisig senderPublicKey must be set before attempting signing
 		senderPublicKey,
 		asset: { username },
-		networkIdentifier,
 	};
 
 	if (!passphrase && !passphrases?.length) {

--- a/elements/lisk-transactions/src/register_multisignature_account.ts
+++ b/elements/lisk-transactions/src/register_multisignature_account.ts
@@ -152,7 +152,6 @@ export const registerMultisignature = (
 	const transaction = {
 		...createBaseTransaction(inputs),
 		type: 12,
-		networkIdentifier,
 		asset: {
 			mandatoryKeys,
 			optionalKeys,

--- a/elements/lisk-transactions/src/transfer.ts
+++ b/elements/lisk-transactions/src/transfer.ts
@@ -139,7 +139,6 @@ export const transfer = (inputs: TransferInputs): Partial<TransactionJSON> => {
 
 	const transactionWithSenderInfo = {
 		...transaction,
-		networkIdentifier,
 		senderPublicKey: transaction.senderPublicKey as string,
 		asset: {
 			...transaction.asset,

--- a/elements/lisk-transactions/src/unlock_token.ts
+++ b/elements/lisk-transactions/src/unlock_token.ts
@@ -83,7 +83,6 @@ export const unlockToken = (
 		asset: {
 			...transaction.asset,
 		},
-		networkIdentifier,
 	};
 
 	const unlockTransaction = new UnlockTransaction(transactionWithSenderInfo);

--- a/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
+++ b/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
@@ -12,7 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { defaultAccount, StateStoreMock } from './utils/state_store_mock';
+import {
+	defaultAccount,
+	StateStoreMock,
+	defaultNetworkIdentifier,
+} from './utils/state_store_mock';
 import { DelegateTransaction } from '../src/10_delegate_transaction';
 import { validDelegateAccount } from '../fixtures';
 import * as protocolSpecDelegateFixture from '../fixtures/transaction_network_id_and_change_order/delegate_transaction_validate.json';
@@ -47,6 +51,7 @@ describe('Delegate registration transaction class', () => {
 			networkIdentifier,
 		});
 		validTestTransaction.sign(
+			defaultNetworkIdentifier,
 			protocolSpecDelegateFixture.testCases[0].input.account.passphrase,
 		);
 

--- a/elements/lisk-transactions/test/base_transaction.spec.ts
+++ b/elements/lisk-transactions/test/base_transaction.spec.ts
@@ -70,13 +70,9 @@ describe('Base transaction class', () => {
 	beforeEach(async () => {
 		validTestTransaction = new TransferTransaction({
 			...defaultTransaction,
-			networkIdentifier,
 		});
-		transactionWithDefaultValues = new TransferTransaction({
-			networkIdentifier,
-		});
+		transactionWithDefaultValues = new TransferTransaction({});
 		transactionWithBasicImpl = new TestTransactionBasicImpl({
-			networkIdentifier,
 			nonce: '1',
 			fee: '1000000',
 		});
@@ -122,10 +118,6 @@ describe('Base transaction class', () => {
 
 		it('should have receivedAt Date', async () => {
 			expect(validTestTransaction.receivedAt).toBeInstanceOf(Date);
-		});
-
-		it('should have _networkIdentifier string', async () => {
-			expect((validTestTransaction as any)._networkIdentifier).toBeString();
 		});
 
 		it('should not throw with undefined input', async () => {
@@ -620,8 +612,6 @@ describe('Base transaction class', () => {
 					nonce: '0',
 					fee: '10000000',
 					senderPublicKey: collisionAccounts[0].publicKey,
-					networkIdentifier:
-						transferFixture.testCases[0].input.networkIdentifier,
 				});
 				validCollisionTransaction.sign(
 					networkIdentifier,
@@ -644,8 +634,6 @@ describe('Base transaction class', () => {
 					nonce: '0',
 					fee: '10000000',
 					senderPublicKey: collisionAccounts[1].publicKey,
-					networkIdentifier:
-						transferFixture.testCases[0].input.networkIdentifier,
 				});
 				invalidCollisionTransaction.sign(
 					networkIdentifier,

--- a/elements/lisk-transactions/test/utils/state_store_mock.ts
+++ b/elements/lisk-transactions/test/utils/state_store_mock.ts
@@ -56,6 +56,9 @@ export const defaultAccount = {
 	},
 };
 
+export const defaultNetworkIdentifier =
+	'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
+
 export interface AdditionalInfo {
 	readonly networkIdentifier?: string;
 	readonly lastBlockHeader?: BlockHeader;
@@ -116,7 +119,7 @@ export class StateStoreMock {
 
 		this.chain = {
 			networkIdentifier:
-				addtionalInfo?.networkIdentifier ?? 'network-identifier',
+				addtionalInfo?.networkIdentifier ?? defaultNetworkIdentifier,
 			lastBlockHeader: addtionalInfo?.lastBlockHeader ?? ({} as BlockHeader),
 		};
 	}

--- a/framework/test/jest/integration/specs/application/node/matcher.spec.js
+++ b/framework/test/jest/integration/specs/application/node/matcher.spec.js
@@ -89,7 +89,6 @@ const createRawCustomTransaction = ({
 	senderPublicKey,
 }) => {
 	const aCustomTransation = new CustomTransationClass({
-		networkIdentifier,
 		type: 7,
 		nonce,
 		senderPublicKey,
@@ -98,7 +97,7 @@ const createRawCustomTransaction = ({
 		},
 		fee: (10000000).toString(),
 	});
-	aCustomTransation.sign(passphrase);
+	aCustomTransation.sign(networkIdentifier, passphrase);
 
 	return aCustomTransation.toJSON();
 };
@@ -152,7 +151,6 @@ describe('Matcher', () => {
 					genesis.address,
 				);
 				const aCustomTransation = new CustomTransationClass({
-					networkIdentifier: node.networkIdentifier,
 					senderPublicKey: genesis.publicKey,
 					nonce: genesisAccount.nonce.toString(),
 					type: 7,


### PR DESCRIPTION
### What was the problem?

This PR resolves #4961

### How was it solved?

- Remove the network identifier while instantiating the transaction
- Use the network identifier in the chain state to validate signature
- Remove variable networkIdentifier in the base transaction

### How was it tested?

- Run unit tests for transactions module
- Instantiate transaction without passing `networkIdentifier` and it should work
- sign an instance of transaction without `networkIdentifier` and it should throw error