### PR TITLE
Use consistent naming format for key in key-value table - Closes #5064

### DIFF
--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -24,7 +24,7 @@ import * as forkChoiceRule from './fork_choice_rule';
 import { BlockHeader, Chain, DPoS, ForkStatus, StateStore } from './types';
 import { validateBlockHeader } from './utils';
 
-export const CONSENSUS_STATE_FINALIZED_HEIGHT_KEY = 'BFT.finalizedHeight';
+export const CONSENSUS_STATE_FINALIZED_HEIGHT_KEY = 'bft:finalizedHeight';
 export const EVENT_BFT_BLOCK_FINALIZED = 'EVENT_BFT_BLOCK_FINALIZED';
 
 /**

--- a/elements/lisk-chain/src/block_reward.ts
+++ b/elements/lisk-chain/src/block_reward.ts
@@ -14,7 +14,7 @@
 
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 
-import { CHAIN_STATE_KEY_BURNT_FEE } from './constants';
+import { CHAIN_STATE_BURNT_FEE } from './constants';
 import { StateStore } from './state_store';
 import { BlockInstance, BlockRewardOptions } from './types';
 
@@ -163,16 +163,14 @@ export const applyFeeAndRewards = async (
 	// This is necessary only for genesis block case, where total fee is 0, which is invalid
 	// Also, genesis block channot be reverted
 	generator.balance += givenFee > 0 ? givenFee : BigInt(0);
-	const totalFeeBurntStr = await stateStore.chain.get(
-		CHAIN_STATE_KEY_BURNT_FEE,
-	);
+	const totalFeeBurntStr = await stateStore.chain.get(CHAIN_STATE_BURNT_FEE);
 	// tslint:disable-next-line no-let
 	let totalFeeBurnt = BigInt(totalFeeBurntStr || 0);
 	totalFeeBurnt += givenFee > 0 ? totalMinFee : BigInt(0);
 
 	// Update state store
 	stateStore.account.set(generatorAddress, generator);
-	stateStore.chain.set(CHAIN_STATE_KEY_BURNT_FEE, totalFeeBurnt.toString());
+	stateStore.chain.set(CHAIN_STATE_BURNT_FEE, totalFeeBurnt.toString());
 };
 
 export const undoFeeAndRewards = async (
@@ -194,14 +192,12 @@ export const undoFeeAndRewards = async (
 	const { totalFee, totalMinFee } = getTotalFees(blockInstance);
 
 	generator.balance -= totalFee - totalMinFee;
-	const totalFeeBurntStr = await stateStore.chain.get(
-		CHAIN_STATE_KEY_BURNT_FEE,
-	);
+	const totalFeeBurntStr = await stateStore.chain.get(CHAIN_STATE_BURNT_FEE);
 	// tslint:disable-next-line no-let
 	let totalFeeBurnt = BigInt(totalFeeBurntStr || 0);
 	totalFeeBurnt -= totalMinFee;
 
 	// Update state store
 	stateStore.account.set(generatorAddress, generator);
-	stateStore.chain.set(CHAIN_STATE_KEY_BURNT_FEE, totalFeeBurnt.toString());
+	stateStore.chain.set(CHAIN_STATE_BURNT_FEE, totalFeeBurnt.toString());
 };

--- a/elements/lisk-chain/src/constants.ts
+++ b/elements/lisk-chain/src/constants.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export const CHAIN_STATE_BURNT_FEE = 'Chain:burntFee';
+export const CHAIN_STATE_BURNT_FEE = 'chain:burntFee';
 
 export const DEFAULT_MIN_BLOCK_HEADER_CACHE = 309;
 export const DEFAULT_MAX_BLOCK_HEADER_CACHE = 515;

--- a/elements/lisk-chain/src/constants.ts
+++ b/elements/lisk-chain/src/constants.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export const CHAIN_STATE_KEY_BURNT_FEE = 'CHAIN_STATE_KEY_BURNT_FEE';
+export const CHAIN_STATE_BURNT_FEE = 'Chain:burntFee';
 
 export const DEFAULT_MIN_BLOCK_HEADER_CACHE = 309;
 export const DEFAULT_MAX_BLOCK_HEADER_CACHE = 515;

--- a/elements/lisk-chain/test/unit/process.spec.ts
+++ b/elements/lisk-chain/test/unit/process.spec.ts
@@ -30,7 +30,7 @@ import { genesisAccount } from '../fixtures/default_account';
 import { registeredTransactions } from '../utils/registered_transactions';
 import { Slots } from '../../src/slots';
 import { BlockInstance, ExceptionOptions } from '../../src/types';
-import { CHAIN_STATE_KEY_BURNT_FEE } from '../../src/constants';
+import { CHAIN_STATE_BURNT_FEE } from '../../src/constants';
 
 jest.mock('events');
 
@@ -806,7 +806,7 @@ describe('blocks/header', () => {
 			});
 
 			it('should update burntFee in the chain state', async () => {
-				const burntFee = await stateStore.chain.get(CHAIN_STATE_KEY_BURNT_FEE);
+				const burntFee = await stateStore.chain.get(CHAIN_STATE_BURNT_FEE);
 				let expected = BigInt(0);
 				for (const tx of block.transactions) {
 					expected += tx.minFee;
@@ -890,7 +890,7 @@ describe('blocks/header', () => {
 
 			it('should not update burnt fee on chain state', async () => {
 				const genesisAccountFromStore = await stateStore.chain.get(
-					CHAIN_STATE_KEY_BURNT_FEE,
+					CHAIN_STATE_BURNT_FEE,
 				);
 				expect(genesisAccountFromStore).toBe('0');
 			});
@@ -1105,7 +1105,7 @@ describe('blocks/header', () => {
 			});
 
 			it('should debit burntFee in the chain state', async () => {
-				const burntFee = await stateStore.chain.get(CHAIN_STATE_KEY_BURNT_FEE);
+				const burntFee = await stateStore.chain.get(CHAIN_STATE_BURNT_FEE);
 				let expected = BigInt(0);
 				for (const tx of block.transactions) {
 					expected += tx.minFee;

--- a/elements/lisk-dpos/src/constants.ts
+++ b/elements/lisk-dpos/src/constants.ts
@@ -13,8 +13,8 @@
  */
 
 export const EVENT_ROUND_CHANGED = 'EVENT_ROUND_CHANGED';
-export const CONSENSUS_STATE_FORGERS_LIST_KEY = 'DPoS.forgersList';
-export const CONSENSUS_STATE_VOTE_WEIGHTS_KEY = 'DPoS.voteWeights';
+export const CONSENSUS_STATE_FORGERS_LIST_KEY = 'dpos:forgersList';
+export const CONSENSUS_STATE_VOTE_WEIGHTS_KEY = 'dpos:voteWeights';
 
 export const DEFAULT_ACTIVE_DELEGATE = 101;
 export const DEFAULT_STANDBY_DELEGATE = 2;

--- a/framework/src/application/network/network.js
+++ b/framework/src/application/network/network.js
@@ -40,8 +40,8 @@ const { lookupPeersIPs } = require('./utils');
 
 const hasNamespaceReg = /:/;
 
-const NETWORK_INFO_KEY_NODE_SECRET = 'node_secret';
-const NETWORK_INFO_KEY_TRIED_PEERS = 'tried_peers_list';
+const NETWORK_INFO_KEY_NODE_SECRET = 'Network:nodeSecret';
+const NETWORK_INFO_KEY_TRIED_PEERS = 'Network:triedPeersList';
 const DEFAULT_PEER_SAVE_INTERVAL = 10 * 60 * 1000; // 10min in ms
 
 module.exports = class Network {

--- a/framework/src/application/network/network.js
+++ b/framework/src/application/network/network.js
@@ -40,8 +40,8 @@ const { lookupPeersIPs } = require('./utils');
 
 const hasNamespaceReg = /:/;
 
-const NETWORK_INFO_KEY_NODE_SECRET = 'Network:nodeSecret';
-const NETWORK_INFO_KEY_TRIED_PEERS = 'Network:triedPeersList';
+const NETWORK_INFO_KEY_NODE_SECRET = 'network:nodeSecret';
+const NETWORK_INFO_KEY_TRIED_PEERS = 'network:triedPeersList';
 const DEFAULT_PEER_SAVE_INTERVAL = 10 * 60 * 1000; // 10min in ms
 
 module.exports = class Network {

--- a/framework/src/application/node/block_processor_v2.js
+++ b/framework/src/application/node/block_processor_v2.js
@@ -26,7 +26,7 @@ const {
 } = require('@liskhq/lisk-cryptography');
 const { BaseBlockProcessor } = require('./processor');
 
-const FORGER_INFO_KEY_PREVIOUSLY_FORGED = 'Forger:previouslyForged';
+const FORGER_INFO_KEY_PREVIOUSLY_FORGED = 'forger:previouslyForged';
 
 const SIZE_INT32 = 4;
 const SIZE_INT64 = 8;

--- a/framework/src/application/node/block_processor_v2.js
+++ b/framework/src/application/node/block_processor_v2.js
@@ -26,7 +26,7 @@ const {
 } = require('@liskhq/lisk-cryptography');
 const { BaseBlockProcessor } = require('./processor');
 
-const FORGER_INFO_KEY_PREVIOUSLY_FORGED = 'previouslyForged';
+const FORGER_INFO_KEY_PREVIOUSLY_FORGED = 'Forger:previouslyForged';
 
 const SIZE_INT32 = 4;
 const SIZE_INT64 = 8;

--- a/framework/src/application/node/forger/constant.js
+++ b/framework/src/application/node/forger/constant.js
@@ -14,8 +14,9 @@
 
 'use strict';
 
-const FORGER_INFO_KEY_USED_HASH_ONION = 'usedHashOnion';
-const FORGER_INFO_KEY_REGISTERED_HASH_ONION_SEEDS = 'registeredHashOnion';
+const FORGER_INFO_KEY_USED_HASH_ONION = 'Forger:usedHashOnion';
+const FORGER_INFO_KEY_REGISTERED_HASH_ONION_SEEDS =
+	'Forger:registeredHashOnion';
 
 module.exports = {
 	FORGER_INFO_KEY_USED_HASH_ONION,

--- a/framework/src/application/node/forger/constant.js
+++ b/framework/src/application/node/forger/constant.js
@@ -14,9 +14,9 @@
 
 'use strict';
 
-const FORGER_INFO_KEY_USED_HASH_ONION = 'Forger:usedHashOnion';
+const FORGER_INFO_KEY_USED_HASH_ONION = 'forger:usedHashOnion';
 const FORGER_INFO_KEY_REGISTERED_HASH_ONION_SEEDS =
-	'Forger:registeredHashOnion';
+	'forger:registeredHashOnion';
 
 module.exports = {
 	FORGER_INFO_KEY_USED_HASH_ONION,

--- a/framework/test/jest/integration/specs/application/node/components/storage/entities/chain_state.spec.js
+++ b/framework/test/jest/integration/specs/application/node/components/storage/entities/chain_state.spec.js
@@ -132,8 +132,8 @@ describe('ChainState', () => {
 	});
 
 	describe('getOne', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Chain:myKey1', value: 'myValue' };
+		const data2 = { key: 'Chain:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ChainStateEntity.setKey(data1.key, data1.value);
@@ -158,8 +158,8 @@ describe('ChainState', () => {
 	});
 
 	describe('getKey', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Chain:myKey1', value: 'myValue' };
+		const data2 = { key: 'Chain:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ChainStateEntity.setKey(data1.key, data1.value);
@@ -189,13 +189,13 @@ describe('ChainState', () => {
 		});
 
 		it('should resolve with error when invoked without value', async () => {
-			await expect(ChainStateEntity.setKey('myKey')).rejects.toThrow(
+			await expect(ChainStateEntity.setKey('Chain:myKey')).rejects.toThrow(
 				'Must provide the value to set',
 			);
 		});
 
 		it('should create key value pair if not exists', async () => {
-			const key = 'myKey';
+			const key = 'Chain:myKey';
 			const value = 'myValue';
 			await ChainStateEntity.setKey(key, value);
 
@@ -205,7 +205,7 @@ describe('ChainState', () => {
 		});
 
 		it('should update the value if key already exists', async () => {
-			const key = 'myKey';
+			const key = 'Chain:myKey';
 			const value = 'myValue';
 			const updatedValue = 'myUpdatedValue';
 
@@ -218,8 +218,8 @@ describe('ChainState', () => {
 	});
 
 	describe('delete', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Chain:myKey1', value: 'myValue' };
+		const data2 = { key: 'Chain:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ChainStateEntity.setKey(data1.key, data1.value);
@@ -239,7 +239,7 @@ describe('ChainState', () => {
 		});
 
 		it('should not throw error if no matching record found', async () => {
-			const nonExistingKey = 'nonExistingKey';
+			const nonExistingKey = 'Chain:nonExistingKey';
 
 			await expect(
 				ChainStateEntity.delete({ key: nonExistingKey }),

--- a/framework/test/jest/integration/specs/application/node/components/storage/entities/chain_state.spec.js
+++ b/framework/test/jest/integration/specs/application/node/components/storage/entities/chain_state.spec.js
@@ -132,8 +132,8 @@ describe('ChainState', () => {
 	});
 
 	describe('getOne', () => {
-		const data1 = { key: 'Chain:myKey1', value: 'myValue' };
-		const data2 = { key: 'Chain:myKey2', value: 'myValue' };
+		const data1 = { key: 'chain:myKey1', value: 'myValue' };
+		const data2 = { key: 'chain:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ChainStateEntity.setKey(data1.key, data1.value);
@@ -152,14 +152,14 @@ describe('ChainState', () => {
 
 		it('should reject with error if provided filter does not match', async () => {
 			await expect(
-				ChainStateEntity.getOne({ key: 'custom-key' }),
+				ChainStateEntity.getOne({ key: 'chain:customKey' }),
 			).rejects.toThrow('No data returned from the query.');
 		});
 	});
 
 	describe('getKey', () => {
-		const data1 = { key: 'Chain:myKey1', value: 'myValue' };
-		const data2 = { key: 'Chain:myKey2', value: 'myValue' };
+		const data1 = { key: 'chain:myKey1', value: 'myValue' };
+		const data2 = { key: 'chain:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ChainStateEntity.setKey(data1.key, data1.value);
@@ -189,13 +189,13 @@ describe('ChainState', () => {
 		});
 
 		it('should resolve with error when invoked without value', async () => {
-			await expect(ChainStateEntity.setKey('Chain:myKey')).rejects.toThrow(
+			await expect(ChainStateEntity.setKey('chain:myKey')).rejects.toThrow(
 				'Must provide the value to set',
 			);
 		});
 
 		it('should create key value pair if not exists', async () => {
-			const key = 'Chain:myKey';
+			const key = 'chain:myKey';
 			const value = 'myValue';
 			await ChainStateEntity.setKey(key, value);
 
@@ -205,7 +205,7 @@ describe('ChainState', () => {
 		});
 
 		it('should update the value if key already exists', async () => {
-			const key = 'Chain:myKey';
+			const key = 'chain:myKey';
 			const value = 'myValue';
 			const updatedValue = 'myUpdatedValue';
 
@@ -218,8 +218,8 @@ describe('ChainState', () => {
 	});
 
 	describe('delete', () => {
-		const data1 = { key: 'Chain:myKey1', value: 'myValue' };
-		const data2 = { key: 'Chain:myKey2', value: 'myValue' };
+		const data1 = { key: 'chain:myKey1', value: 'myValue' };
+		const data2 = { key: 'chain:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ChainStateEntity.setKey(data1.key, data1.value);
@@ -239,7 +239,7 @@ describe('ChainState', () => {
 		});
 
 		it('should not throw error if no matching record found', async () => {
-			const nonExistingKey = 'Chain:nonExistingKey';
+			const nonExistingKey = 'chain:nonExistingKey';
 
 			await expect(
 				ChainStateEntity.delete({ key: nonExistingKey }),

--- a/framework/test/jest/integration/specs/application/node/components/storage/entities/consensus_state.spec.js
+++ b/framework/test/jest/integration/specs/application/node/components/storage/entities/consensus_state.spec.js
@@ -109,8 +109,8 @@ describe('ConsensusState', () => {
 	});
 
 	describe('get', () => {
-		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
-		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
+		const data1 = { key: 'dpos:myKey1', value: 'myValue' };
+		const data2 = { key: 'dpos:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -134,8 +134,8 @@ describe('ConsensusState', () => {
 	});
 
 	describe('getOne', () => {
-		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
-		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
+		const data1 = { key: 'dpos:myKey1', value: 'myValue' };
+		const data2 = { key: 'dpos:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -156,14 +156,14 @@ describe('ConsensusState', () => {
 
 		it('should reject with error if provided filter does not match', async () => {
 			await expect(
-				ConsensusStateEntity.getOne({ key: 'DPoS:customKey' }),
+				ConsensusStateEntity.getOne({ key: 'dpos:customKey' }),
 			).rejects.toThrow('No data returned from the query.');
 		});
 	});
 
 	describe('getKey', () => {
-		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
-		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
+		const data1 = { key: 'dpos:myKey1', value: 'myValue' };
+		const data2 = { key: 'dpos:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -193,13 +193,13 @@ describe('ConsensusState', () => {
 		});
 
 		it('should resolve with error when invoked without value', async () => {
-			await expect(ConsensusStateEntity.setKey('DPoS:myKey')).rejects.toThrow(
+			await expect(ConsensusStateEntity.setKey('dpos:myKey')).rejects.toThrow(
 				'Must provide the value to set',
 			);
 		});
 
 		it('should create key value pair if not exists', async () => {
-			const key = 'DPoS:myKey';
+			const key = 'dpos:myKey';
 			const value = 'myValue';
 			await ConsensusStateEntity.setKey(key, value);
 
@@ -209,7 +209,7 @@ describe('ConsensusState', () => {
 		});
 
 		it('should update the value if key already exists', async () => {
-			const key = 'DPoS:myKey';
+			const key = 'dpos:myKey';
 			const value = 'myValue';
 			const updatedValue = 'myUpdatedValue';
 
@@ -222,8 +222,8 @@ describe('ConsensusState', () => {
 	});
 
 	describe('delete', () => {
-		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
-		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
+		const data1 = { key: 'dpos:myKey1', value: 'myValue' };
+		const data2 = { key: 'dpos:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -243,7 +243,7 @@ describe('ConsensusState', () => {
 		});
 
 		it('should not throw error if no matching record found', async () => {
-			const nonExistingKey = 'DPoS:nonExistingKey';
+			const nonExistingKey = 'dpos:nonExistingKey';
 
 			await expect(
 				ConsensusStateEntity.delete({ key: nonExistingKey }),

--- a/framework/test/jest/integration/specs/application/node/components/storage/entities/consensus_state.spec.js
+++ b/framework/test/jest/integration/specs/application/node/components/storage/entities/consensus_state.spec.js
@@ -109,8 +109,8 @@ describe('ConsensusState', () => {
 	});
 
 	describe('get', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
+		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -134,8 +134,8 @@ describe('ConsensusState', () => {
 	});
 
 	describe('getOne', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
+		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -156,14 +156,14 @@ describe('ConsensusState', () => {
 
 		it('should reject with error if provided filter does not match', async () => {
 			await expect(
-				ConsensusStateEntity.getOne({ key: 'custom-key' }),
+				ConsensusStateEntity.getOne({ key: 'DPoS:customKey' }),
 			).rejects.toThrow('No data returned from the query.');
 		});
 	});
 
 	describe('getKey', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
+		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -193,13 +193,13 @@ describe('ConsensusState', () => {
 		});
 
 		it('should resolve with error when invoked without value', async () => {
-			await expect(ConsensusStateEntity.setKey('myKey')).rejects.toThrow(
+			await expect(ConsensusStateEntity.setKey('DPoS:myKey')).rejects.toThrow(
 				'Must provide the value to set',
 			);
 		});
 
 		it('should create key value pair if not exists', async () => {
-			const key = 'myKey';
+			const key = 'DPoS:myKey';
 			const value = 'myValue';
 			await ConsensusStateEntity.setKey(key, value);
 
@@ -209,7 +209,7 @@ describe('ConsensusState', () => {
 		});
 
 		it('should update the value if key already exists', async () => {
-			const key = 'myKey';
+			const key = 'DPoS:myKey';
 			const value = 'myValue';
 			const updatedValue = 'myUpdatedValue';
 
@@ -222,8 +222,8 @@ describe('ConsensusState', () => {
 	});
 
 	describe('delete', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'DPoS:myKey1', value: 'myValue' };
+		const data2 = { key: 'DPoS:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ConsensusStateEntity.setKey(data1.key, data1.value);
@@ -243,7 +243,7 @@ describe('ConsensusState', () => {
 		});
 
 		it('should not throw error if no matching record found', async () => {
-			const nonExistingKey = 'nonExistingKey';
+			const nonExistingKey = 'DPoS:nonExistingKey';
 
 			await expect(
 				ConsensusStateEntity.delete({ key: nonExistingKey }),

--- a/framework/test/jest/integration/specs/application/node/components/storage/entities/forger_info.spec.js
+++ b/framework/test/jest/integration/specs/application/node/components/storage/entities/forger_info.spec.js
@@ -109,8 +109,8 @@ describe('ForgerInfo', () => {
 	});
 
 	describe('get', () => {
-		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
-		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
+		const data1 = { key: 'forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -127,15 +127,15 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should return empty array if no matching result found', async () => {
-			expect(await ForgerInfoEntity.get({ key: 'Forger:customKey' })).toEqual(
+			expect(await ForgerInfoEntity.get({ key: 'forger:customKey' })).toEqual(
 				[],
 			);
 		});
 	});
 
 	describe('getOne', () => {
-		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
-		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
+		const data1 = { key: 'forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -154,14 +154,14 @@ describe('ForgerInfo', () => {
 
 		it('should reject with error if provided filter does not match', async () => {
 			await expect(
-				ForgerInfoEntity.getOne({ key: 'Forger:customKey' }),
+				ForgerInfoEntity.getOne({ key: 'forger:customKey' }),
 			).rejects.toThrow('No data returned from the query.');
 		});
 	});
 
 	describe('getKey', () => {
-		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
-		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
+		const data1 = { key: 'forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -191,13 +191,13 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should resolve with error when invoked without value', async () => {
-			await expect(ForgerInfoEntity.setKey('Forger:mykey')).rejects.toThrow(
+			await expect(ForgerInfoEntity.setKey('forger:mykey')).rejects.toThrow(
 				'Must provide the value to set',
 			);
 		});
 
 		it('should create key value pair if not exists', async () => {
-			const key = 'Forger:myKey';
+			const key = 'forger:myKey';
 			const value = 'myValue';
 			await ForgerInfoEntity.setKey(key, value);
 
@@ -207,7 +207,7 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should update the value if key already exists', async () => {
-			const key = 'Forger:myKey';
+			const key = 'forger:myKey';
 			const value = 'myValue';
 			const updatedValue = 'myUpdatedValue';
 
@@ -220,8 +220,8 @@ describe('ForgerInfo', () => {
 	});
 
 	describe('delete', () => {
-		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
-		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
+		const data1 = { key: 'forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -241,7 +241,7 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should not throw error if no matching record found', async () => {
-			const nonExistingKey = 'Forger:nonExistingKey';
+			const nonExistingKey = 'forger:nonExistingKey';
 
 			await expect(
 				ForgerInfoEntity.delete({ key: nonExistingKey }),

--- a/framework/test/jest/integration/specs/application/node/components/storage/entities/forger_info.spec.js
+++ b/framework/test/jest/integration/specs/application/node/components/storage/entities/forger_info.spec.js
@@ -109,8 +109,8 @@ describe('ForgerInfo', () => {
 	});
 
 	describe('get', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -127,13 +127,15 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should return empty array if no matching result found', async () => {
-			expect(await ForgerInfoEntity.get({ key: 'custom-key' })).toEqual([]);
+			expect(await ForgerInfoEntity.get({ key: 'Forger:customKey' })).toEqual(
+				[],
+			);
 		});
 	});
 
 	describe('getOne', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -152,14 +154,14 @@ describe('ForgerInfo', () => {
 
 		it('should reject with error if provided filter does not match', async () => {
 			await expect(
-				ForgerInfoEntity.getOne({ key: 'custom-key' }),
+				ForgerInfoEntity.getOne({ key: 'Forger:customKey' }),
 			).rejects.toThrow('No data returned from the query.');
 		});
 	});
 
 	describe('getKey', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -189,13 +191,13 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should resolve with error when invoked without value', async () => {
-			await expect(ForgerInfoEntity.setKey('mykey')).rejects.toThrow(
+			await expect(ForgerInfoEntity.setKey('Forger:mykey')).rejects.toThrow(
 				'Must provide the value to set',
 			);
 		});
 
 		it('should create key value pair if not exists', async () => {
-			const key = 'myKey';
+			const key = 'Forger:myKey';
 			const value = 'myValue';
 			await ForgerInfoEntity.setKey(key, value);
 
@@ -205,7 +207,7 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should update the value if key already exists', async () => {
-			const key = 'myKey';
+			const key = 'Forger:myKey';
 			const value = 'myValue';
 			const updatedValue = 'myUpdatedValue';
 
@@ -218,8 +220,8 @@ describe('ForgerInfo', () => {
 	});
 
 	describe('delete', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Forger:myKey1', value: 'myValue' };
+		const data2 = { key: 'Forger:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await ForgerInfoEntity.setKey(data1.key, data1.value);
@@ -239,7 +241,7 @@ describe('ForgerInfo', () => {
 		});
 
 		it('should not throw error if no matching record found', async () => {
-			const nonExistingKey = 'nonExistingKey';
+			const nonExistingKey = 'Forger:nonExistingKey';
 
 			await expect(
 				ForgerInfoEntity.delete({ key: nonExistingKey }),

--- a/framework/test/jest/integration/specs/modules/network/components/storage/entities/network_info.spec.js
+++ b/framework/test/jest/integration/specs/modules/network/components/storage/entities/network_info.spec.js
@@ -109,8 +109,8 @@ describe('NetworkInfo', () => {
 	});
 
 	describe('get', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Network:myKey1', value: 'myValue' };
+		const data2 = { key: 'Network:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await NetworkInfoEntity.setKey(data1.key, data1.value);
@@ -127,13 +127,15 @@ describe('NetworkInfo', () => {
 		});
 
 		it('should return empty array if no matching result found', async () => {
-			expect(await NetworkInfoEntity.get({ key: 'custom-key' })).toEqual([]);
+			expect(await NetworkInfoEntity.get({ key: 'Network:customKey' })).toEqual(
+				[],
+			);
 		});
 	});
 
 	describe('getOne', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Network:myKey1', value: 'myValue' };
+		const data2 = { key: 'Network:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await NetworkInfoEntity.setKey(data1.key, data1.value);
@@ -152,14 +154,14 @@ describe('NetworkInfo', () => {
 
 		it('should reject with error if provided filter does not match', async () => {
 			await expect(
-				NetworkInfoEntity.getOne({ key: 'custom-key' }),
+				NetworkInfoEntity.getOne({ key: 'Network:customKey' }),
 			).rejects.toThrow('No data returned from the query.');
 		});
 	});
 
 	describe('getKey', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Network:myKey1', value: 'myValue' };
+		const data2 = { key: 'Network:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await NetworkInfoEntity.setKey(data1.key, data1.value);
@@ -177,7 +179,7 @@ describe('NetworkInfo', () => {
 		});
 
 		it('should resolve with null if provided filter does not match', async () => {
-			expect(await NetworkInfoEntity.getKey('custom-key')).toBeNull();
+			expect(await NetworkInfoEntity.getKey('Network:customKey')).toBeNull();
 		});
 	});
 
@@ -189,13 +191,13 @@ describe('NetworkInfo', () => {
 		});
 
 		it('should resolve with error when invoked without value', async () => {
-			await expect(NetworkInfoEntity.setKey('myKey')).rejects.toThrow(
+			await expect(NetworkInfoEntity.setKey('Network:myKey')).rejects.toThrow(
 				'Must provide the value to set',
 			);
 		});
 
 		it('should create key value pair if not exists', async () => {
-			const key = 'myKey';
+			const key = 'Network:myKey';
 			const value = 'myValue';
 			await NetworkInfoEntity.setKey(key, value);
 
@@ -205,7 +207,7 @@ describe('NetworkInfo', () => {
 		});
 
 		it('should update the value if key already exists', async () => {
-			const key = 'myKey';
+			const key = 'Network:myKey';
 			const value = 'myValue';
 			const updatedValue = 'myUpdatedValue';
 
@@ -218,8 +220,8 @@ describe('NetworkInfo', () => {
 	});
 
 	describe('delete', () => {
-		const data1 = { key: 'myKey1', value: 'myValue' };
-		const data2 = { key: 'myKey2', value: 'myValue' };
+		const data1 = { key: 'Network:myKey1', value: 'myValue' };
+		const data2 = { key: 'Network:myKey2', value: 'myValue' };
 
 		beforeEach(async () => {
 			await NetworkInfoEntity.setKey(data1.key, data1.value);
@@ -239,7 +241,7 @@ describe('NetworkInfo', () => {
 		});
 
 		it('should not throw error if no matching record found', async () => {
-			const nonExistingKey = 'nonExistingKey';
+			const nonExistingKey = 'Network:nonExistingKey';
 
 			await expect(
 				NetworkInfoEntity.delete({ key: nonExistingKey }),

--- a/framework/test/jest/unit/specs/application/node/block_processor_v2.spec.js
+++ b/framework/test/jest/unit/specs/application/node/block_processor_v2.spec.js
@@ -137,7 +137,7 @@ describe('block processor v2', () => {
 			});
 			// Assert
 			expect(storageStub.entities.ForgerInfo.getKey).toHaveBeenCalledWith(
-				'previouslyForged',
+				'Forger:previouslyForged',
 			);
 			// previousBlock.height + 1
 			expect(block.maxHeightPreviouslyForged).toBe(0);
@@ -162,7 +162,7 @@ describe('block processor v2', () => {
 			});
 			// Assert
 			expect(storageStub.entities.ForgerInfo.getKey).toHaveBeenCalledWith(
-				'previouslyForged',
+				'Forger:previouslyForged',
 			);
 			expect(block.maxHeightPreviouslyForged).toBe(previouslyForgedHeight);
 		});
@@ -198,7 +198,7 @@ describe('block processor v2', () => {
 				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
-				'previouslyForged',
+				'Forger:previouslyForged',
 				maxHeightResult,
 			);
 		});
@@ -222,7 +222,7 @@ describe('block processor v2', () => {
 				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
-				'previouslyForged',
+				'Forger:previouslyForged',
 				maxHeightResult,
 			);
 		});

--- a/framework/test/jest/unit/specs/application/node/block_processor_v2.spec.js
+++ b/framework/test/jest/unit/specs/application/node/block_processor_v2.spec.js
@@ -137,7 +137,7 @@ describe('block processor v2', () => {
 			});
 			// Assert
 			expect(storageStub.entities.ForgerInfo.getKey).toHaveBeenCalledWith(
-				'Forger:previouslyForged',
+				'forger:previouslyForged',
 			);
 			// previousBlock.height + 1
 			expect(block.maxHeightPreviouslyForged).toBe(0);
@@ -162,7 +162,7 @@ describe('block processor v2', () => {
 			});
 			// Assert
 			expect(storageStub.entities.ForgerInfo.getKey).toHaveBeenCalledWith(
-				'Forger:previouslyForged',
+				'forger:previouslyForged',
 			);
 			expect(block.maxHeightPreviouslyForged).toBe(previouslyForgedHeight);
 		});
@@ -198,7 +198,7 @@ describe('block processor v2', () => {
 				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
-				'Forger:previouslyForged',
+				'forger:previouslyForged',
 				maxHeightResult,
 			);
 		});
@@ -222,7 +222,7 @@ describe('block processor v2', () => {
 				},
 			});
 			expect(storageStub.entities.ForgerInfo.setKey).toHaveBeenCalledWith(
-				'Forger:previouslyForged',
+				'forger:previouslyForged',
 				maxHeightResult,
 			);
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5064 

### How was it solved?

- Updated key value to format `modulename:keyName`

### How was it tested?

- Update tests 
- Run application and check database with key
