### PR TITLE
Fix handling of self-vote - Closes #5077

### DIFF
--- a/elements/lisk-transactions/src/13_vote_transaction.ts
+++ b/elements/lisk-transactions/src/13_vote_transaction.ts
@@ -404,7 +404,7 @@ export class VoteTransaction extends BaseTransaction {
 						'Invalid data. unlocking object should exist while undo',
 					);
 				}
-				sender.unlocking.slice(unlockingIndex, 1);
+				sender.unlocking.splice(unlockingIndex, 1);
 
 				// Sort votes in case of readding
 				sender.votes.sort((a, b) =>

--- a/elements/lisk-transactions/src/13_vote_transaction.ts
+++ b/elements/lisk-transactions/src/13_vote_transaction.ts
@@ -243,9 +243,9 @@ export class VoteTransaction extends BaseTransaction {
 
 		for (const vote of assetCopy) {
 			const sender = await store.account.get(this.senderId);
-			const delegate = await store.account.get(vote.delegateAddress);
+			const votedDelegate = await store.account.get(vote.delegateAddress);
 
-			if (!delegate.username) {
+			if (!votedDelegate.username) {
 				errors.push(
 					new TransactionError(
 						'Voted delegate is not registered',
@@ -346,9 +346,11 @@ export class VoteTransaction extends BaseTransaction {
 					);
 				}
 			}
+			store.account.set(sender.address, sender);
+			// In case of self-vote, sender needs to be set and re-fetched to reflect both account change
+			const delegate = await store.account.get(vote.delegateAddress);
 			delegate.totalVotesReceived += vote.amount;
 			store.account.set(delegate.address, delegate);
-			store.account.set(sender.address, sender);
 		}
 
 		return errors;
@@ -372,7 +374,6 @@ export class VoteTransaction extends BaseTransaction {
 		});
 		for (const vote of assetCopy) {
 			const sender = await store.account.get(this.senderId);
-			const delegate = await store.account.get(vote.delegateAddress);
 			if (vote.amount < BigInt(0)) {
 				const originalUpvoteIndex = sender.votes.findIndex(
 					senderVote => senderVote.delegateAddress === vote.delegateAddress,
@@ -411,7 +412,6 @@ export class VoteTransaction extends BaseTransaction {
 				);
 				// Sort account.unlocking
 				sortUnlocking(sender.unlocking);
-				delegate.totalVotesReceived += vote.amount * BigInt(-1);
 			} else {
 				const originalUpvoteIndex = sender.votes.findIndex(
 					senderVote => senderVote.delegateAddress === vote.delegateAddress,
@@ -424,14 +424,16 @@ export class VoteTransaction extends BaseTransaction {
 					sender.votes.splice(originalUpvoteIndex, 1);
 				}
 				sender.balance += vote.amount;
-				delegate.totalVotesReceived -= vote.amount;
 				// Sort account.votes
 				sender.votes.sort((a, b) =>
 					a.delegateAddress.localeCompare(b.delegateAddress, 'en'),
 				);
 			}
-			store.account.set(delegate.address, delegate);
 			store.account.set(sender.address, sender);
+			// In case of self-vote, sender needs to be set and re-fetched to reflect both account change
+			const delegate = await store.account.get(vote.delegateAddress);
+			delegate.totalVotesReceived += vote.amount * BigInt(-1);
+			store.account.set(delegate.address, delegate);
 		}
 
 		return [];

--- a/elements/lisk-transactions/test/13_vote_transaction.spec.ts
+++ b/elements/lisk-transactions/test/13_vote_transaction.spec.ts
@@ -948,6 +948,65 @@ describe('Vote transaction', () => {
 				});
 			});
 		});
+
+		describe.only('when asset.votes contains self-vote', () => {
+			const senderBalnce = BigInt('1230000000000');
+			const voteAmount = BigInt('1000000000000');
+
+			beforeEach(async () => {
+				tx = new VoteTransaction({
+					...validMixvoteTransactionScenario.testCases.output,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					asset: {
+						votes: [
+							{
+								delegateAddress:
+									validMixvoteTransactionScenario.testCases.input.account
+										.address,
+								amount: voteAmount.toString(),
+							},
+						],
+					},
+				});
+				tx.sign(
+					validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					validMixvoteTransactionScenario.testCases.input.account.passphrase,
+				);
+				const sender = {
+					...defaultAccount,
+					nonce: BigInt(validMixvoteTransactionScenario.testCases.output.nonce),
+					address:
+						validMixvoteTransactionScenario.testCases.input.account.address,
+					balance: senderBalnce,
+					username: 'delegate_0',
+					votes: [],
+					unlocking: [],
+				};
+				store = new StateStoreMock([sender], {
+					lastBlockHeader: { height: 10 } as any,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+				});
+			});
+
+			it('should update votes and totalVotesReceived properly', async () => {
+				// Act
+				await tx.apply(store);
+
+				// Assert
+				const updatedSender = await store.account.get(
+					validMixvoteTransactionScenario.testCases.input.account.address,
+				);
+				expect(updatedSender.totalVotesReceived.toString()).toEqual(
+					voteAmount.toString(),
+				);
+				expect(updatedSender.votes).toHaveLength(1);
+				expect(updatedSender.balance.toString()).toEqual(
+					(senderBalnce - tx.fee - voteAmount).toString(),
+				);
+			});
+		});
 	});
 
 	describe('undoAsset', () => {
@@ -1317,6 +1376,70 @@ describe('Vote transaction', () => {
 					const updatedDelegate = await store.account.get(delegate.address);
 					expect(updatedDelegate).toStrictEqual(delegate);
 				}
+			});
+		});
+
+		describe('when asset.votes contains self-vote', () => {
+			const senderBalnce = BigInt('1230000000000');
+			const voteAmount = BigInt('1000000000000');
+
+			beforeEach(async () => {
+				tx = new VoteTransaction({
+					...validMixvoteTransactionScenario.testCases.output,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					asset: {
+						votes: [
+							{
+								delegateAddress:
+									validMixvoteTransactionScenario.testCases.input.account
+										.address,
+								amount: voteAmount.toString(),
+							},
+						],
+					},
+				});
+				tx.sign(
+					validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					validMixvoteTransactionScenario.testCases.input.account.passphrase,
+				);
+				const sender = {
+					...defaultAccount,
+					nonce: BigInt(validMixvoteTransactionScenario.testCases.output.nonce),
+					address:
+						validMixvoteTransactionScenario.testCases.input.account.address,
+					balance: senderBalnce - tx.fee - voteAmount,
+					totalVotesReceived: voteAmount,
+					votes: [
+						{
+							delegateAddress:
+								validMixvoteTransactionScenario.testCases.input.account.address,
+							amount: voteAmount,
+						},
+					],
+					username: 'delegate_0',
+					unlocking: [],
+				};
+				store = new StateStoreMock([sender], {
+					lastBlockHeader: { height: 10 } as any,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+				});
+			});
+
+			it('should update votes and totalVotesReceived properly', async () => {
+				// Act
+				await tx.undo(store);
+
+				// Assert
+				const updatedSender = await store.account.get(
+					validMixvoteTransactionScenario.testCases.input.account.address,
+				);
+				expect(updatedSender.totalVotesReceived.toString()).toEqual('0');
+				expect(updatedSender.votes).toHaveLength(0);
+				expect(updatedSender.balance.toString()).toEqual(
+					senderBalnce.toString(),
+				);
 			});
 		});
 	});

--- a/elements/lisk-transactions/test/13_vote_transaction.spec.ts
+++ b/elements/lisk-transactions/test/13_vote_transaction.spec.ts
@@ -949,7 +949,7 @@ describe('Vote transaction', () => {
 			});
 		});
 
-		describe.only('when asset.votes contains self-vote', () => {
+		describe('when asset.votes contains self-vote', () => {
 			const senderBalnce = BigInt('1230000000000');
 			const voteAmount = BigInt('1000000000000');
 
@@ -990,7 +990,7 @@ describe('Vote transaction', () => {
 				});
 			});
 
-			it('should update votes and totalVotesReceived properly', async () => {
+			it('should update votes and totalVotesReceived', async () => {
 				// Act
 				await tx.apply(store);
 
@@ -1004,6 +1004,75 @@ describe('Vote transaction', () => {
 				expect(updatedSender.votes).toHaveLength(1);
 				expect(updatedSender.balance.toString()).toEqual(
 					(senderBalnce - tx.fee - voteAmount).toString(),
+				);
+			});
+		});
+
+		describe('when asset.votes contains self-downvote', () => {
+			const senderBalnce = BigInt('1230000000000');
+			const voteAmount = BigInt('-1000000000000');
+
+			beforeEach(async () => {
+				tx = new VoteTransaction({
+					...validMixvoteTransactionScenario.testCases.output,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					asset: {
+						votes: [
+							{
+								delegateAddress:
+									validMixvoteTransactionScenario.testCases.input.account
+										.address,
+								amount: voteAmount.toString(),
+							},
+						],
+					},
+				});
+				tx.sign(
+					validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					validMixvoteTransactionScenario.testCases.input.account.passphrase,
+				);
+				const sender = {
+					...defaultAccount,
+					nonce: BigInt(validMixvoteTransactionScenario.testCases.output.nonce),
+					address:
+						validMixvoteTransactionScenario.testCases.input.account.address,
+					balance: senderBalnce,
+					totalVotesReceived: voteAmount * BigInt(-1),
+					username: 'delegate_0',
+					votes: [
+						{
+							delegateAddress:
+								validMixvoteTransactionScenario.testCases.input.account.address,
+							amount: voteAmount * BigInt(-1),
+						},
+					],
+					unlocking: [],
+				};
+				store = new StateStoreMock([sender], {
+					lastBlockHeader: { height: 10 } as any,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+				});
+			});
+
+			it('should update votes, totalVotesReceived and unlocking', async () => {
+				// Act
+				await tx.apply(store);
+
+				// Assert
+				const updatedSender = await store.account.get(
+					validMixvoteTransactionScenario.testCases.input.account.address,
+				);
+				expect(updatedSender.totalVotesReceived.toString()).toEqual('0');
+				expect(updatedSender.votes).toHaveLength(0);
+				expect(updatedSender.unlocking).toHaveLength(1);
+				expect(updatedSender.unlocking[0].unvoteHeight).toEqual(11);
+				expect(updatedSender.unlocking[0].amount.toString()).toEqual(
+					(voteAmount * BigInt(-1)).toString(),
+				);
+				expect(updatedSender.balance.toString()).toEqual(
+					(senderBalnce - tx.fee).toString(),
 				);
 			});
 		});
@@ -1427,7 +1496,7 @@ describe('Vote transaction', () => {
 				});
 			});
 
-			it('should update votes and totalVotesReceived properly', async () => {
+			it('should update votes and totalVotesReceived', async () => {
 				// Act
 				await tx.undo(store);
 
@@ -1437,6 +1506,74 @@ describe('Vote transaction', () => {
 				);
 				expect(updatedSender.totalVotesReceived.toString()).toEqual('0');
 				expect(updatedSender.votes).toHaveLength(0);
+				expect(updatedSender.balance.toString()).toEqual(
+					senderBalnce.toString(),
+				);
+			});
+		});
+
+		describe('when asset.votes contains self-downvote', () => {
+			const senderBalnce = BigInt('1230000000000');
+			const voteAmount = BigInt('-1000000000000');
+
+			beforeEach(async () => {
+				tx = new VoteTransaction({
+					...validMixvoteTransactionScenario.testCases.output,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					asset: {
+						votes: [
+							{
+								delegateAddress:
+									validMixvoteTransactionScenario.testCases.input.account
+										.address,
+								amount: voteAmount.toString(),
+							},
+						],
+					},
+				});
+				tx.sign(
+					validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+					validMixvoteTransactionScenario.testCases.input.account.passphrase,
+				);
+				const sender = {
+					...defaultAccount,
+					nonce: BigInt(validMixvoteTransactionScenario.testCases.output.nonce),
+					address:
+						validMixvoteTransactionScenario.testCases.input.account.address,
+					balance: senderBalnce - tx.fee,
+					totalVotesReceived: BigInt(0),
+					votes: [],
+					username: 'delegate_0',
+					unlocking: [
+						{
+							delegateAddress:
+								validMixvoteTransactionScenario.testCases.input.account.address,
+							amount: voteAmount * BigInt(-1),
+							unvoteHeight: 11,
+						},
+					],
+				};
+				store = new StateStoreMock([sender], {
+					lastBlockHeader: { height: 10 } as any,
+					networkIdentifier:
+						validMixvoteTransactionScenario.testCases.input.networkIdentifier,
+				});
+			});
+
+			it('should update votes, totalVotesReceived and unlocking', async () => {
+				// Act
+				await tx.undo(store);
+
+				// Assert
+				const updatedSender = await store.account.get(
+					validMixvoteTransactionScenario.testCases.input.account.address,
+				);
+				expect(updatedSender.totalVotesReceived.toString()).toEqual(
+					(voteAmount * BigInt(-1)).toString(),
+				);
+				expect(updatedSender.votes).toHaveLength(1);
+				expect(updatedSender.unlocking).toHaveLength(0);
 				expect(updatedSender.balance.toString()).toEqual(
 					senderBalnce.toString(),
 				);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5077 

### How was it solved?

- Re-fetch delegate account after setting the sender each time

### How was it tested?

- Added the self vote scenario test
