### PR TITLE
Add command to create pom transaction - Closes #4973

### DIFF
--- a/commander/src/commands/transaction/create.ts
+++ b/commander/src/commands/transaction/create.ts
@@ -20,6 +20,7 @@ import { flags as commonFlags } from '../../utils/flags';
 
 import DelegateCommand from './create/delegate';
 import MultisignatureCommand from './create/multisignature';
+import PoMCommand from './create/pom';
 import TransferCommand from './create/transfer';
 import UnlockCommand from './create/unlock';
 import VoteCommand from './create/vote';
@@ -34,6 +35,7 @@ const typeNumberMap: TypeNumberMap = {
 	'12': 'multisignature',
 	'13': 'vote',
 	'14': 'unlock',
+	'15': 'pom',
 };
 
 const options = Object.entries(typeNumberMap).reduce(
@@ -55,6 +57,7 @@ const typeClassMap: TypeClassMap = {
 	delegate: DelegateCommand,
 	multisignature: MultisignatureCommand,
 	unlock: UnlockCommand,
+	pom: PoMCommand,
 };
 
 const resolveFlags = (

--- a/commander/src/commands/transaction/create/pom.ts
+++ b/commander/src/commands/transaction/create/pom.ts
@@ -1,0 +1,223 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import {
+	TransactionJSON,
+	utils as transactionUtils,
+} from '@liskhq/lisk-transactions';
+import { isValidFee, isValidNonce } from '@liskhq/lisk-validator';
+import { flags as flagParser } from '@oclif/command';
+
+import BaseCommand from '../../../base';
+import { ValidationError } from '../../../utils/error';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getNetworkIdentifierWithInput } from '../../../utils/network_identifier';
+import { getPassphraseFromPrompt } from '../../../utils/reader';
+
+interface PomInput {
+	readonly nonce: string;
+	readonly fee: string;
+	readonly networkIdentifier: string;
+	readonly header1: RawHeader;
+	readonly header2: RawHeader;
+	readonly passphrase?: string;
+}
+
+const reportMisbehavior = ({
+	nonce,
+	fee,
+	networkIdentifier,
+	header1,
+	header2,
+	passphrase,
+}: PomInput): Partial<TransactionJSON> => {
+	// tslint:disable-next-line no-console
+	console.log({
+		nonce,
+		fee,
+		networkIdentifier,
+		header1,
+		header2,
+		passphrase,
+	});
+
+	// tslint:disable-next-line
+	return {} as Partial<TransactionJSON>;
+};
+
+interface RawHeader {
+	readonly id: string;
+	readonly height: number;
+	readonly version: number;
+	readonly timestamp: number;
+	readonly previousBlockId?: string | null;
+	readonly blockSignature: string;
+	readonly seedReveal: string;
+	readonly generatorPublicKey: string;
+	readonly numberOfTransactions: number;
+	readonly payloadLength: number;
+	readonly payloadHash: string;
+	readonly totalAmount: string;
+	readonly totalFee: string;
+	readonly reward: string;
+	readonly maxHeightPreviouslyForged: number;
+	readonly maxHeightPrevoted: number;
+}
+
+const processInputs = (
+	nonce: string,
+	fee: string,
+	networkIdentifier: string,
+	header1: RawHeader,
+	header2: RawHeader,
+	passphrase?: string,
+) =>
+	reportMisbehavior({
+		nonce,
+		fee,
+		networkIdentifier,
+		passphrase,
+		header1,
+		header2,
+	});
+
+interface Args {
+	readonly nonce: string;
+	readonly fee: string;
+	readonly header1: string;
+	readonly header2: string;
+}
+
+export default class PoMCommand extends BaseCommand {
+	static args = [
+		{
+			name: 'nonce',
+			required: true,
+			description: 'Nonce of the transaction.',
+		},
+		{
+			name: 'fee',
+			required: true,
+			description: 'Transaction fee in LSK.',
+		},
+		{
+			name: 'header1',
+			required: true,
+			description: 'Contradicting block header in JSON string.',
+		},
+		{
+			name: 'header2',
+			required: true,
+			description: 'Contradicting block header in JSON string.',
+		},
+	];
+	static description = `
+	Creates a transaction which will report misbehavior of delegate by providing contradicting 2 block headers.
+	`;
+
+	static examples = [
+		'transaction:create:pom 1 100 "{"height": 3, "version": 2, "maxHeightPrevoted": 30, "blockSignature": "xxx"}" "{"height": 3, "version": 2, "maxHeightPrevoted": 31, "blockSignature": "yyy"}"',
+	];
+
+	static flags = {
+		...BaseCommand.flags,
+		networkIdentifier: flagParser.string(commonFlags.networkIdentifier),
+		passphrase: flagParser.string(commonFlags.passphrase),
+		'no-signature': flagParser.boolean(commonFlags.noSignature),
+	};
+
+	async run(): Promise<void> {
+		const {
+			args,
+			flags: {
+				networkIdentifier: networkIdentifierSource,
+				passphrase: passphraseSource,
+				'no-signature': noSignature,
+			},
+		} = this.parse(PoMCommand);
+
+		const {
+			nonce,
+			fee,
+			header1: header1Str,
+			header2: header2Str,
+		} = args as Args;
+
+		if (!isValidNonce(nonce)) {
+			throw new ValidationError('Enter a valid nonce in number string format.');
+		}
+
+		if (Number.isNaN(Number(fee))) {
+			throw new ValidationError('Enter a valid fee in number string format.');
+		}
+
+		const normalizedFee = transactionUtils.convertLSKToBeddows(fee);
+
+		if (!isValidFee(normalizedFee)) {
+			throw new ValidationError('Enter a valid fee in number string format.');
+		}
+
+		// tslint:disable-next-line no-let
+		let header1: RawHeader;
+		try {
+			header1 = JSON.parse(header1Str);
+		} catch (error) {
+			throw new Error(
+				`Invalid block header 1. Fail to parse the input. ${error.message}`,
+			);
+		}
+
+		// tslint:disable-next-line no-let
+		let header2: RawHeader;
+		try {
+			header2 = JSON.parse(header2Str);
+		} catch (error) {
+			throw new Error(
+				`Invalid block header 1. Fail to parse the input. ${error.message}`,
+			);
+		}
+
+		const networkIdentifier = getNetworkIdentifierWithInput(
+			networkIdentifierSource,
+			this.userConfig.api.network,
+		);
+
+		if (noSignature) {
+			const noSignatureResult = processInputs(
+				nonce,
+				normalizedFee,
+				networkIdentifier,
+				header1,
+				header2,
+			);
+			this.print(noSignatureResult);
+
+			return;
+		}
+
+		const passphrase =
+			passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+
+		const result = processInputs(
+			nonce,
+			normalizedFee,
+			networkIdentifier,
+			header1,
+			header2,
+			passphrase,
+		);
+		this.print(result);
+	}
+}

--- a/commander/src/commands/transaction/create/pom.ts
+++ b/commander/src/commands/transaction/create/pom.ts
@@ -14,7 +14,7 @@
  *
  */
 import {
-	TransactionJSON,
+	reportMisbehavior,
 	utils as transactionUtils,
 } from '@liskhq/lisk-transactions';
 import { isValidFee, isValidNonce } from '@liskhq/lisk-validator';
@@ -26,43 +26,12 @@ import { flags as commonFlags } from '../../../utils/flags';
 import { getNetworkIdentifierWithInput } from '../../../utils/network_identifier';
 import { getPassphraseFromPrompt } from '../../../utils/reader';
 
-interface PomInput {
-	readonly nonce: string;
-	readonly fee: string;
-	readonly networkIdentifier: string;
-	readonly header1: RawHeader;
-	readonly header2: RawHeader;
-	readonly passphrase?: string;
-}
-
-const reportMisbehavior = ({
-	nonce,
-	fee,
-	networkIdentifier,
-	header1,
-	header2,
-	passphrase,
-}: PomInput): Partial<TransactionJSON> => {
-	// tslint:disable-next-line no-console
-	console.log({
-		nonce,
-		fee,
-		networkIdentifier,
-		header1,
-		header2,
-		passphrase,
-	});
-
-	// tslint:disable-next-line
-	return {} as Partial<TransactionJSON>;
-};
-
 interface RawHeader {
 	readonly id: string;
 	readonly height: number;
 	readonly version: number;
 	readonly timestamp: number;
-	readonly previousBlockId?: string | null;
+	readonly previousBlockId: string;
 	readonly blockSignature: string;
 	readonly seedReveal: string;
 	readonly generatorPublicKey: string;

--- a/commander/src/commands/transaction/create/pom.ts
+++ b/commander/src/commands/transaction/create/pom.ts
@@ -27,7 +27,6 @@ import { getNetworkIdentifierWithInput } from '../../../utils/network_identifier
 import { getPassphraseFromPrompt } from '../../../utils/reader';
 
 interface RawHeader {
-	readonly id: string;
 	readonly height: number;
 	readonly version: number;
 	readonly timestamp: number;

--- a/commander/src/commands/transaction/create/pom.ts
+++ b/commander/src/commands/transaction/create/pom.ts
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-commander
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2020 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -115,16 +115,16 @@ export default class PoMCommand extends BaseCommand {
 		{
 			name: 'header1',
 			required: true,
-			description: 'Contradicting block header in JSON string.',
+			description: 'Contradicting block header as JSON string.',
 		},
 		{
 			name: 'header2',
 			required: true,
-			description: 'Contradicting block header in JSON string.',
+			description: 'Contradicting block header as JSON string.',
 		},
 	];
 	static description = `
-	Creates a transaction which will report misbehavior of delegate by providing contradicting 2 block headers.
+	Creates a transaction which will report misbehavior of delegate by providing 2 contradicting block headers.
 	`;
 
 	static examples = [

--- a/commander/test/commands/transaction/create/pom.test.ts
+++ b/commander/test/commands/transaction/create/pom.test.ts
@@ -1,0 +1,191 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import * as sandbox from 'sinon';
+import { expect, test } from '@oclif/test';
+import * as transactions from '@liskhq/lisk-transactions';
+import * as config from '../../../../src/utils/config';
+import * as printUtils from '../../../../src/utils/print';
+import * as readerUtils from '../../../../src/utils/reader';
+
+describe('transaction:create:pom', () => {
+	const defaultHeader1 = {
+		version: 2,
+		timestamp: 2000000,
+		previousBlockId: '10620616195853047363',
+		seedReveal: 'c8c557b5dba8527c0e760124128fd15c',
+		height: 300000,
+		maxHeightPreviouslyForged: 90000,
+		maxHeightPrevoted: 100000,
+		numberOfTransactions: 0,
+		totalAmount: '0',
+		totalFee: '10000000000',
+		reward: '10000000000',
+		payloadLength: 0,
+		payloadHash:
+			'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+		generatorPublicKey:
+			'addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9',
+		blockSignature:
+			'd87f2eafb2f8022d4a1171fa5735466f5fa5749dfc6d2a3978d69d266aadfe4929a65925daaf380c1323d34049bc0aef5d5ad12916ab137c8829ef42f12d400b',
+	};
+	const defaultHeader2 = {
+		version: 2,
+		timestamp: 3000000,
+		previousBlockId: '10620616195853047363',
+		seedReveal: 'c8c557b5dba8527c0e760124128fd15c',
+		height: 200000,
+		maxHeightPreviouslyForged: 100000,
+		maxHeightPrevoted: 100000,
+		numberOfTransactions: 0,
+		totalAmount: '0',
+		totalFee: '10000000000',
+		reward: '10000000000',
+		payloadLength: 0,
+		payloadHash:
+			'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+		generatorPublicKey:
+			'addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca9',
+		blockSignature:
+			'c86e638c27d39c033cc8bb107c5a5a19f6e95361314d2d74b715d96ddfac6d156ea77d798dbd34203920e33525c5645ac01931043e3c0021a6da068048fa770a',
+	};
+
+	const defaultInputs = '123';
+	const defaultTransaction = {
+		nonce: '0',
+		fee: '10000000',
+		amount: '10000000000',
+		senderPublicKey: null,
+		timestamp: 66492418,
+		type: 15,
+		asset: {},
+	};
+	const testnetNetworkIdentifier =
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
+
+	const printMethodStub = sandbox.stub();
+
+	const setupTest = () =>
+		test
+			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
+			.stub(
+				config,
+				'getConfig',
+				sandbox.stub().returns({ api: { network: 'test' } }),
+			)
+			.stub(
+				transactions,
+				'reportMisbehavior',
+				sandbox.stub().returns(defaultTransaction),
+			)
+			.stub(
+				readerUtils,
+				'getPassphraseFromPrompt',
+				sandbox.stub().resolves(defaultInputs),
+			)
+			.stdout();
+
+	describe('transaction:create:pom', () => {
+		setupTest()
+			.command(['transaction:create:pom'])
+			.catch(error => {
+				return expect(error.message).to.contain('Missing 4 required arg');
+			})
+			.it('should throw an error');
+	});
+
+	describe('transaction:create:delegate nonce fee header1 header2', () => {
+		setupTest()
+			.command([
+				'transaction:create:delegate',
+				'1',
+				'100',
+				JSON.stringify(defaultHeader1),
+				JSON.stringify(defaultHeader2),
+			])
+			.it('create a transaction with the header 1 and header 2', () => {
+				expect(readerUtils.getPassphraseFromPrompt).to.be.calledWithExactly(
+					'passphrase',
+					true,
+				);
+				expect(transactions.reportMisbehavior).to.be.calledWithExactly({
+					nonce: '1',
+					fee: '10000000000',
+					networkIdentifier: testnetNetworkIdentifier,
+					passphrase: defaultInputs,
+					header1: defaultHeader1,
+					header2: defaultHeader2,
+				});
+				return expect(printMethodStub).to.be.calledWithExactly(
+					defaultTransaction,
+				);
+			});
+	});
+
+	describe('transaction:create:pom nonce fee header1 header2 --passphrase=xxx', () => {
+		setupTest()
+			.command([
+				'transaction:create:pom',
+				'1',
+				'100',
+				JSON.stringify(defaultHeader1),
+				JSON.stringify(defaultHeader2),
+				'--passphrase=123',
+			])
+			.it(
+				'create a transaction with the headers with the passphrase from flag',
+				() => {
+					expect(readerUtils.getPassphraseFromPrompt).not.to.be.called;
+					expect(transactions.registerDelegate).to.be.calledWithExactly({
+						nonce: '1',
+						fee: '10000000000',
+						networkIdentifier: testnetNetworkIdentifier,
+						passphrase: defaultInputs,
+						header1: defaultHeader1,
+						header2: defaultHeader2,
+					});
+					return expect(printMethodStub).to.be.calledWithExactly(
+						defaultTransaction,
+					);
+				},
+			);
+	});
+
+	describe('transaction:create:pom nonce fee header1 header2 --no-signature', () => {
+		setupTest()
+			.command([
+				'transaction:create:delegate',
+				'1',
+				'100',
+				JSON.stringify(defaultHeader1),
+				JSON.stringify(defaultHeader2),
+				'--no-signature',
+			])
+			.it('create a transaction with the username without signature', () => {
+				expect(transactions.reportMisbehavior).to.be.calledWithExactly({
+					nonce: '1',
+					fee: '10000000000',
+					networkIdentifier: testnetNetworkIdentifier,
+					passphrase: undefined,
+					header1: defaultHeader1,
+					header2: defaultHeader2,
+				});
+				expect(readerUtils.getPassphraseFromPrompt).not.to.be.called;
+				return expect(printMethodStub).to.be.calledWithExactly(
+					defaultTransaction,
+				);
+			});
+	});
+});

--- a/commander/test/commands/transaction/create/pom.test.ts
+++ b/commander/test/commands/transaction/create/pom.test.ts
@@ -109,7 +109,7 @@ describe('transaction:create:pom', () => {
 	describe('transaction:create:delegate nonce fee header1 header2', () => {
 		setupTest()
 			.command([
-				'transaction:create:delegate',
+				'transaction:create:pom',
 				'1',
 				'100',
 				JSON.stringify(defaultHeader1),
@@ -148,7 +148,7 @@ describe('transaction:create:pom', () => {
 				'create a transaction with the headers with the passphrase from flag',
 				() => {
 					expect(readerUtils.getPassphraseFromPrompt).not.to.be.called;
-					expect(transactions.registerDelegate).to.be.calledWithExactly({
+					expect(transactions.reportMisbehavior).to.be.calledWithExactly({
 						nonce: '1',
 						fee: '10000000000',
 						networkIdentifier: testnetNetworkIdentifier,
@@ -166,7 +166,7 @@ describe('transaction:create:pom', () => {
 	describe('transaction:create:pom nonce fee header1 header2 --no-signature', () => {
 		setupTest()
 			.command([
-				'transaction:create:delegate',
+				'transaction:create:pom',
 				'1',
 				'100',
 				JSON.stringify(defaultHeader1),

--- a/elements/lisk-transactions/src/15_proof_of_misbehavior_transaction.ts
+++ b/elements/lisk-transactions/src/15_proof_of_misbehavior_transaction.ts
@@ -137,7 +137,7 @@ export interface ProofOfMisbehaviorAsset {
 	readonly header1: BlockHeaderJSON;
 	readonly header2: BlockHeaderJSON;
 	// tslint:disable-next-line readonly-keyword
-	reward?: bigint | string;
+	reward: bigint;
 }
 
 export class ProofOfMisbehaviorTransaction extends BaseTransaction {
@@ -156,11 +156,11 @@ export class ProofOfMisbehaviorTransaction extends BaseTransaction {
 				: BigInt(0);
 	}
 
-	public assetToJSON(): ProofOfMisbehaviorAsset {
+	public assetToJSON(): object {
 		return {
 			header1: this.asset.header1,
 			header2: this.asset.header2,
-			reward: this.asset.reward ? this.asset.reward.toString() : '0',
+			reward: this.asset.reward.toString(),
 		};
 	}
 
@@ -230,14 +230,14 @@ export class ProofOfMisbehaviorTransaction extends BaseTransaction {
 		/*
             Check for BFT violations:
                 1. Double forging
-                2. Disjointness 
+                2. Disjointness
                 3. Branch is not the one with largest maxHeighPrevoted
         */
 
 		// tslint:disable-next-line no-let
-		let b1 = asset.header1;
+		let b1 = this.asset.header1;
 		// tslint:disable-next-line no-let
-		let b2 = asset.header2;
+		let b2 = this.asset.header2;
 
 		// Order the two block headers such that b1 must be forged first
 		if (
@@ -248,8 +248,8 @@ export class ProofOfMisbehaviorTransaction extends BaseTransaction {
 				b1.maxHeightPrevoted === b2.maxHeightPrevoted &&
 				b1.height > b2.height)
 		) {
-			b1 = asset.header2;
-			b2 = asset.header1;
+			b1 = this.asset.header2;
+			b2 = this.asset.header1;
 		}
 
 		if (
@@ -359,8 +359,8 @@ export class ProofOfMisbehaviorTransaction extends BaseTransaction {
 			);
 		}
 
-		/* 
-			Check block signatures validity 
+		/*
+			Check block signatures validity
 		*/
 
 		const blockHeader1Bytes = Buffer.concat([
@@ -447,7 +447,7 @@ export class ProofOfMisbehaviorTransaction extends BaseTransaction {
 		/*
 			Update sender account
 		*/
-		senderAccount.balance -= this.asset.reward as bigint;
+		senderAccount.balance -= this.asset.reward;
 		store.account.set(senderAccount.address, senderAccount);
 
 		/*
@@ -466,7 +466,7 @@ export class ProofOfMisbehaviorTransaction extends BaseTransaction {
 			delegateAccount.delegate.isBanned = false;
 		}
 
-		delegateAccount.balance += this.asset.reward as bigint;
+		delegateAccount.balance += this.asset.reward;
 		store.account.set(delegateAccount.address, delegateAccount);
 
 		return [];

--- a/elements/lisk-transactions/src/index.ts
+++ b/elements/lisk-transactions/src/index.ts
@@ -17,6 +17,7 @@ import { DelegateTransaction } from './10_delegate_transaction';
 import { MultisignatureTransaction } from './12_multisignature_transaction';
 import { VoteTransaction } from './13_vote_transaction';
 import { UnlockTransaction } from './14_unlock_transaction';
+import { ProofOfMisbehaviorTransaction } from './15_proof_of_misbehavior_transaction';
 import { TransferTransaction } from './8_transfer_transaction';
 import {
 	BaseTransaction,
@@ -32,6 +33,7 @@ import {
 } from './errors';
 import { registerDelegate } from './register_delegate';
 import { registerMultisignature } from './register_multisignature_account';
+import { reportMisbehavior } from './report_misbehavior';
 import { createResponse, Status, TransactionResponse } from './response';
 import { transactionInterface } from './schema';
 import { signMultiSignatureTransaction } from './sign_multi_signature_transaction';
@@ -80,7 +82,9 @@ export {
 	MultisignatureTransaction,
 	UnlockTransaction,
 	unlockToken,
+	reportMisbehavior,
 	createResponse,
+	ProofOfMisbehaviorTransaction,
 	registerMultisignature,
 	signMultiSignatureTransaction,
 	Status,

--- a/elements/lisk-transactions/src/report_misbehavior.ts
+++ b/elements/lisk-transactions/src/report_misbehavior.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import {
+	isValidFee,
+	isValidNonce,
+	validateNetworkIdentifier,
+} from '@liskhq/lisk-validator';
+
+import { ProofOfMisbehaviorTransaction } from './15_proof_of_misbehavior_transaction';
+import { BlockHeaderJSON, TransactionJSON } from './transaction_types';
+import { createBaseTransaction } from './utils';
+
+export interface ReportMisbehaviorInputs {
+	readonly fee: string;
+	readonly nonce: string;
+	readonly networkIdentifier: string;
+	readonly senderPublicKey?: string;
+	readonly passphrase?: string;
+	readonly header1: BlockHeaderJSON;
+	readonly header2: BlockHeaderJSON;
+}
+
+const validateInputs = ({
+	networkIdentifier,
+	fee,
+	nonce,
+	header1,
+	header2,
+}: ReportMisbehaviorInputs): void => {
+	if (!isValidNonce(nonce)) {
+		throw new Error('Nonce must be a valid number in string format.');
+	}
+
+	if (!isValidFee(fee)) {
+		throw new Error('Fee must be a valid number in string format.');
+	}
+
+	validateNetworkIdentifier(networkIdentifier);
+
+	if (!header1) {
+		throw new Error('Header 1 is required for poof of misbehavior');
+	}
+
+	if (!header2) {
+		throw new Error('Header 2 is required for poof of misbehavior');
+	}
+};
+
+export const reportMisbehavior = (
+	inputs: ReportMisbehaviorInputs,
+): Partial<TransactionJSON> => {
+	validateInputs(inputs);
+	const { passphrase, networkIdentifier, header1, header2 } = inputs;
+
+	const transaction = {
+		...createBaseTransaction(inputs),
+		type: 15,
+		asset: {
+			header1,
+			header2,
+		},
+	};
+
+	if (!passphrase) {
+		return transaction;
+	}
+
+	const transactionWithSenderInfo = {
+		...transaction,
+		senderPublicKey: transaction.senderPublicKey as string,
+		asset: {
+			...transaction.asset,
+		},
+	};
+
+	const pomTransaction = new ProofOfMisbehaviorTransaction(
+		transactionWithSenderInfo,
+	);
+
+	pomTransaction.sign(networkIdentifier, passphrase);
+
+	const { errors } = pomTransaction.validate();
+	if (errors.length > 0) {
+		throw new Error(errors.toString());
+	}
+
+	return pomTransaction.toJSON();
+};

--- a/elements/lisk-transactions/src/report_misbehavior.ts
+++ b/elements/lisk-transactions/src/report_misbehavior.ts
@@ -18,8 +18,11 @@ import {
 	validateNetworkIdentifier,
 } from '@liskhq/lisk-validator';
 
-import { ProofOfMisbehaviorTransaction } from './15_proof_of_misbehavior_transaction';
-import { BlockHeaderJSON, TransactionJSON } from './transaction_types';
+import {
+	BlockHeaderJSON,
+	ProofOfMisbehaviorTransaction,
+} from './15_proof_of_misbehavior_transaction';
+import { TransactionJSON } from './transaction_types';
 import { createBaseTransaction } from './utils';
 
 export interface ReportMisbehaviorInputs {

--- a/elements/lisk-transactions/src/transaction_types.ts
+++ b/elements/lisk-transactions/src/transaction_types.ts
@@ -59,7 +59,6 @@ export interface Delegate {
 }
 
 export interface BlockHeader {
-	readonly id: string;
 	readonly height: number;
 	readonly version: number;
 	readonly timestamp: number;

--- a/elements/lisk-transactions/test/report_misbehavior.spec.ts
+++ b/elements/lisk-transactions/test/report_misbehavior.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import * as validPoMTransactionScenario from '../fixtures/proof_of_misbehavior_transaction/proof_of_misbehavior_transaction_scenario_1.json';
+
+import { reportMisbehavior } from '../src/report_misbehavior';
+import { TransactionJSON } from '../src/transaction_types';
+
+describe('#reportMisbehavior transaction', () => {
+	let reportMisbehaviorTransaction: Partial<TransactionJSON>;
+
+	describe('when the transaction is created with one passphrase and the contradicting headers', () => {
+		beforeEach(async () => {
+			reportMisbehaviorTransaction = reportMisbehavior({
+				passphrase:
+					validPoMTransactionScenario.testCases.input.reportingAccount
+						.passphrase,
+				networkIdentifier:
+					validPoMTransactionScenario.testCases.input.networkIdentifier,
+				fee: validPoMTransactionScenario.testCases.output.fee,
+				nonce: validPoMTransactionScenario.testCases.output.nonce,
+				header1: validPoMTransactionScenario.testCases.output.asset.header1,
+				header2: validPoMTransactionScenario.testCases.output.asset.header2,
+			});
+		});
+
+		it('should create a report misbehavior transaction', async () => {
+			expect(reportMisbehaviorTransaction.id).toEqual(
+				validPoMTransactionScenario.testCases.output.id,
+			);
+			expect(reportMisbehaviorTransaction.signatures).toStrictEqual(
+				validPoMTransactionScenario.testCases.output.signatures,
+			);
+		});
+	});
+
+	describe('when the proof of misbehavior transaction is created with the invalid header input', () => {
+		it('should throw error when votes was not provided', () => {
+			return expect(() =>
+				reportMisbehavior({
+					passphrase:
+						validPoMTransactionScenario.testCases.input.reportingAccount
+							.passphrase,
+					header1: undefined as any,
+					header2: undefined as any,
+					networkIdentifier:
+						validPoMTransactionScenario.testCases.input.networkIdentifier,
+					fee: validPoMTransactionScenario.testCases.output.fee,
+					nonce: validPoMTransactionScenario.testCases.output.nonce,
+				}),
+			).toThrowError('Header 1 is required for poof of misbehavior');
+		});
+	});
+
+	describe('unsigned misbehavior transaction', () => {
+		describe('when the proof of misbehavior transaction is created without a passphrase', () => {
+			beforeEach(async () => {
+				reportMisbehaviorTransaction = reportMisbehavior({
+					header1: validPoMTransactionScenario.testCases.output.asset.header1,
+					header2: validPoMTransactionScenario.testCases.output.asset.header2,
+					networkIdentifier:
+						validPoMTransactionScenario.testCases.input.networkIdentifier,
+					fee: validPoMTransactionScenario.testCases.output.fee,
+					nonce: validPoMTransactionScenario.testCases.output.nonce,
+				});
+			});
+
+			it('should have the type', () => {
+				return expect(reportMisbehaviorTransaction).toHaveProperty('type', 15);
+			});
+
+			it('should not have the sender public key', () => {
+				return expect(reportMisbehaviorTransaction).toHaveProperty(
+					'senderPublicKey',
+					undefined,
+				);
+			});
+
+			it('should have the asset with the header 1 and header 2', () => {
+				expect(reportMisbehaviorTransaction.asset).toHaveProperty('header1');
+				expect(reportMisbehaviorTransaction.asset).toHaveProperty('header2');
+			});
+
+			it('should not have the signatures', () => {
+				return expect(reportMisbehaviorTransaction).not.toHaveProperty(
+					'signatures',
+				);
+			});
+
+			it('should not have the id', () => {
+				return expect(reportMisbehaviorTransaction).not.toHaveProperty('id');
+			});
+		});
+	});
+});

--- a/framework/src/application/application.js
+++ b/framework/src/application/application.js
@@ -21,6 +21,7 @@ const {
 	VoteTransaction,
 	UnlockTransaction,
 	MultisignatureTransaction,
+	ProofOfMisbehaviorTransaction,
 	transactionInterface,
 } = require('@liskhq/lisk-transactions');
 const { getNetworkIdentifier } = require('@liskhq/lisk-cryptography');
@@ -149,6 +150,7 @@ class Application {
 		this.registerTransaction(MultisignatureTransaction);
 		this.registerTransaction(VoteTransaction);
 		this.registerTransaction(UnlockTransaction);
+		this.registerTransaction(ProofOfMisbehaviorTransaction);
 
 		this.registerModule(HttpAPIModule);
 		this.overrideModuleOptions(HttpAPIModule.alias, {

--- a/framework/test/jest/unit/specs/application/application.spec.js
+++ b/framework/test/jest/unit/specs/application/application.spec.js
@@ -51,7 +51,7 @@ jest.mock('@liskhq/lisk-validator', () => ({
 // eslint-disable-next-line
 describe('Application', () => {
 	// Arrange
-	const frameworkTxTypes = ['8', '10', '12', '13', '14'];
+	const frameworkTxTypes = ['8', '10', '12', '13', '14', '15'];
 	const loggerMock = {
 		info: jest.fn(),
 		error: jest.fn(),
@@ -329,11 +329,11 @@ describe('Application', () => {
 
 			// Act
 			class Sample extends Base {}
-			Sample.TYPE = 15;
+			Sample.TYPE = 99;
 			app.registerTransaction(Sample);
 
 			// Assert
-			expect(app.getTransaction(15)).toBe(Sample);
+			expect(app.getTransaction(99)).toBe(Sample);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4973 

### How was it solved?

- Add function to create PoM transaction in commander

### How was it tested?

- Added unit test
- run `./bin/run transaction:create:pom 1 100 "{\"height\": 3, \"version\": 2, \"maxHeightPrevoted\": 30, \"blockSignature\": \"xxx\"}" "{\"height\": 3, \"version\": 2, \"maxHeightPrevoted\": 31, \"blockSignature\": \"yyy\"}"` where header should be real one (it is using valid header in the test}
