### PR TITLE
Fix variable naming with spelling mistakes - Closes #5093

### DIFF
--- a/commander/src/base.ts
+++ b/commander/src/base.ts
@@ -27,10 +27,10 @@ process.env.PM2_HOME = defaultLiskPm2Path;
 export const defaultConfigFolder = '.lisk';
 
 const jsonDescription =
-	'Prints output in JSON format. You can change the default behaviour in your config.json file.';
+	'Prints output in JSON format. You can change the default behavior in your config.json file.';
 
 const prettyDescription =
-	'Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table. You can change the default behaviour in your config.json file.';
+	'Prints JSON in pretty format rather than condensed. Has no effect if the output is set to table. You can change the default behavior in your config.json file.';
 
 interface PrintFlags {
 	readonly json?: boolean;

--- a/commander/src/utils/core/commons.ts
+++ b/commander/src/utils/core/commons.ts
@@ -160,7 +160,7 @@ export const upgradeLisk = async (
 	fsExtra.mkdirSync(LISK_PG, MODE);
 	fsExtra.copySync(LISK_OLD_PG, LISK_PG);
 
-	// TODO: Use latest 2.0.0 config utils to get config insted of scripts/update_config.js
+	// TODO: Use latest 2.0.0 config utils to get config instead of scripts/update_config.js
 	const { stderr }: ExecResult = await exec(
 		`${installDir}/bin/node ${installDir}/scripts/update_config.js --network ${network} --output ${installDir}/config.json ${LISK_BACKUP}/config.json ${currentVersion}`,
 	);

--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -315,13 +315,13 @@ export class FinalityManager extends EventEmitter {
 	}
 
 	public async recompute(
-		recompteUptoHeight: number,
+		recomputeUptoHeight: number,
 		stateStore: StateStore,
 	): Promise<void> {
 		this.reset();
 
 		const blockHeaders = await this.getBFTApplicableBlockHeaders(
-			recompteUptoHeight,
+			recomputeUptoHeight,
 		);
 		if (!blockHeaders.length) {
 			throw new Error('Cannot find a block to recompute');
@@ -381,10 +381,10 @@ export class FinalityManager extends EventEmitter {
 		let earlierBlock = delegateLastBlock;
 		// tslint:disable-next-line no-let
 		let laterBlock = blockHeader;
-		const higherMaxHeightPreviouslyForgerd =
+		const higherMaxHeightPreviouslyForged =
 			earlierBlock.maxHeightPreviouslyForged >
 			laterBlock.maxHeightPreviouslyForged;
-		const sameMaxHeightPreviouslyForgerd =
+		const sameMaxHeightPreviouslyForged =
 			earlierBlock.maxHeightPreviouslyForged ===
 			laterBlock.maxHeightPreviouslyForged;
 		const higherMaxHeightPrevoted =
@@ -393,9 +393,9 @@ export class FinalityManager extends EventEmitter {
 			earlierBlock.maxHeightPrevoted === laterBlock.maxHeightPrevoted;
 		const higherHeight = earlierBlock.height > laterBlock.height;
 		if (
-			higherMaxHeightPreviouslyForgerd ||
-			(sameMaxHeightPreviouslyForgerd && higherMaxHeightPrevoted) ||
-			(sameMaxHeightPreviouslyForgerd && sameMaxHeightPrevoted && higherHeight)
+			higherMaxHeightPreviouslyForged ||
+			(sameMaxHeightPreviouslyForged && higherMaxHeightPrevoted) ||
+			(sameMaxHeightPreviouslyForged && sameMaxHeightPrevoted && higherHeight)
 		) {
 			[earlierBlock, laterBlock] = [laterBlock, earlierBlock];
 		}

--- a/elements/lisk-bft/src/fork_choice_rule.ts
+++ b/elements/lisk-bft/src/fork_choice_rule.ts
@@ -29,7 +29,7 @@ export const isLastAppliedBlockReceivedWithinForgingSlot = (
 	slots: Slots,
 	lastAppliedBlock: BlockHeader,
 ): boolean => {
-	/* If the block doesn't have the property `receivedAt` it meants it was forged
+	/* If the block doesn't have the property `receivedAt` it means it was forged
 	 or synced, therefore we assume it was "received in the correct slot" */
 	if (!lastAppliedBlock.receivedAt) {
 		return true;

--- a/elements/lisk-bft/src/types.ts
+++ b/elements/lisk-bft/src/types.ts
@@ -74,7 +74,7 @@ export class BFTError extends Error {}
 export class BFTChainDisjointError extends BFTError {
 	public constructor() {
 		super(
-			'Violation of disjointness condition. If delegate forged a block of higher height earlier and later the block with lower height',
+			'Violation of disjointedness condition. If delegate forged a block of higher height earlier and later the block with lower height',
 		);
 	}
 }

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -312,7 +312,7 @@ describe('finality_manager', () => {
 					}
 				} catch (error) {
 					expect(error.message).toContain(
-						'Violation of disjointness condition.',
+						'Violation of disjointedness condition.',
 					);
 				}
 			});

--- a/elements/lisk-chain/src/block_reward.ts
+++ b/elements/lisk-chain/src/block_reward.ts
@@ -161,7 +161,7 @@ export const applyFeeAndRewards = async (
 	// Generator only gets total fee - min fee
 	const givenFee = totalFee - totalMinFee;
 	// This is necessary only for genesis block case, where total fee is 0, which is invalid
-	// Also, genesis block channot be reverted
+	// Also, genesis block cannot be reverted
 	generator.balance += givenFee > 0 ? givenFee : BigInt(0);
 	const totalFeeBurntStr = await stateStore.chain.get(CHAIN_STATE_BURNT_FEE);
 	// tslint:disable-next-line no-let

--- a/elements/lisk-chain/src/data_access/cache/block.ts
+++ b/elements/lisk-chain/src/data_access/cache/block.ts
@@ -45,7 +45,7 @@ export class BlockCache extends Base<BlockHeader> {
 		return this.items;
 	}
 
-	// Refills cache up to maxCachedItems when minCachedItems is reachead
+	// Refills cache up to maxCachedItems when minCachedItems is reached
 	public refill(blockHeaders: BlockHeader[]): BlockHeader[] {
 		this.items.unshift(...blockHeaders);
 		this.needsRefill = false;

--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -245,7 +245,7 @@ export class DataAccess {
 	): Promise<BlockInstance[]> {
 		// Calculate toHeight
 		const toHeight = offset + limit;
-		// To Preserve LessThan logic we are substracting by 1
+		// To Preserve LessThan logic we are subtracting by 1
 		const toHeightLT = toHeight - 1;
 
 		// Loads extended blocks from storage

--- a/elements/lisk-chain/src/state_store/chain_state_store.ts
+++ b/elements/lisk-chain/src/state_store/chain_state_store.ts
@@ -14,7 +14,7 @@
 
 import { BlockHeader, ChainStateEntity, StorageTransaction } from '../types';
 
-interface AdditionalInformtion {
+interface AdditionalInformation {
 	readonly lastBlockHeader: BlockHeader;
 	readonly networkIdentifier: string;
 }
@@ -36,7 +36,7 @@ export class ChainStateStore {
 
 	public constructor(
 		chainStateEntity: ChainStateEntity,
-		additionalInformation: AdditionalInformtion,
+		additionalInformation: AdditionalInformation,
 	) {
 		this._chainState = chainStateEntity;
 		this._lastBlockHeader = additionalInformation.lastBlockHeader;

--- a/elements/lisk-chain/src/state_store/consensus_state_store.ts
+++ b/elements/lisk-chain/src/state_store/consensus_state_store.ts
@@ -23,7 +23,7 @@ interface KeyValuePair {
 	[key: string]: string;
 }
 
-interface AdditionalInformtion {
+interface AdditionalInformation {
 	readonly lastBlockHeaders: ReadonlyArray<BlockHeader>;
 }
 
@@ -38,10 +38,10 @@ export class ConsensusStateStore {
 
 	public constructor(
 		consensusStateEntity: ConsensusStateEntity,
-		additionalInformtion: AdditionalInformtion,
+		additionalInformation: AdditionalInformation,
 	) {
 		this._consensusState = consensusStateEntity;
-		this._lastBlockHeaders = additionalInformtion.lastBlockHeaders;
+		this._lastBlockHeaders = additionalInformation.lastBlockHeaders;
 		this._data = {};
 		this._originalData = {};
 		this._updatedKeys = new Set();

--- a/elements/lisk-dpos/src/delegates_info.ts
+++ b/elements/lisk-dpos/src/delegates_info.ts
@@ -101,11 +101,11 @@ export class DelegatesInfo {
 		{ delegateListRoundOffset, undo }: DPoSProcessingOptions,
 	): Promise<boolean> {
 		if (_isGenesisBlock(block)) {
-			const intialRound = 1;
+			const initialRound = 1;
 			for (
 				// tslint:disable-next-line no-let
-				let i = intialRound;
-				i <= intialRound + delegateListRoundOffset;
+				let i = initialRound;
+				i <= initialRound + delegateListRoundOffset;
 				i += 1
 			) {
 				// Height is 1, but to create round 1-3, round offset should start from 0 - 2
@@ -116,7 +116,7 @@ export class DelegatesInfo {
 				);
 			}
 			await this.delegatesList.updateForgersList(
-				intialRound,
+				initialRound,
 				[zeroRandomSeed, zeroRandomSeed],
 				stateStore,
 			);

--- a/elements/lisk-dpos/src/delegates_list.ts
+++ b/elements/lisk-dpos/src/delegates_list.ts
@@ -336,7 +336,7 @@ export class DelegatesList {
 			}
 
 			// From here, it's below threshold
-			// Below threshold, but prepared array does not have enough slected delegate
+			// Below threshold, but prepared array does not have enough selected delegate
 			if (standbyDelegates.length < this.standbyDelegates) {
 				// In case there was 1 standby delegate who has more than threshold
 				standbyDelegates.push({

--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -251,7 +251,7 @@ export class Dpos {
 		);
 
 		if (!delegateForgedBlocks.length) {
-			// If the forger din't forge any block in the last three rounds
+			// If the forger didn't forge any block in the last three rounds
 			return true;
 		}
 

--- a/elements/lisk-elements/src/index.ts
+++ b/elements/lisk-elements/src/index.ts
@@ -17,7 +17,7 @@ import * as constants from '@liskhq/lisk-constants';
 import * as cryptography from '@liskhq/lisk-cryptography';
 import * as p2p from '@liskhq/lisk-p2p';
 import * as passphrase from '@liskhq/lisk-passphrase';
-import * as transacationPool from '@liskhq/lisk-transaction-pool';
+import * as transactionPool from '@liskhq/lisk-transaction-pool';
 import * as transactions from '@liskhq/lisk-transactions';
 import * as validator from '@liskhq/lisk-validator';
 
@@ -28,6 +28,6 @@ export {
 	passphrase,
 	p2p,
 	transactions,
-	transacationPool,
+	transactionPool,
 	validator,
 };

--- a/elements/lisk-elements/test/index.spec.ts
+++ b/elements/lisk-elements/test/index.spec.ts
@@ -18,7 +18,7 @@ import {
 	cryptography,
 	p2p,
 	passphrase,
-	transacationPool,
+	transactionPool,
 	transactions,
 	validator,
 } from '../src';
@@ -45,7 +45,7 @@ describe('lisk-elements', () => {
 	});
 
 	it('transactionPool should be an object', () => {
-		return expect(transacationPool).toBeObject();
+		return expect(transactionPool).toBeObject();
 	});
 
 	it('transactions should be an object', () => {

--- a/elements/lisk-p2p/README.md
+++ b/elements/lisk-p2p/README.md
@@ -53,7 +53,7 @@ It provides simple interface to send, request, broadcast information and many mo
 - `p2p.getConnectedPeers()`: get all the connected peers that are connected to your node in the network.
 - `p2p.getDisconnectedPeers()`: get all the disconnected peers that are part of the network but not connected to you.
 - `p2p.request(packet: P2PRequestPacket)`: request information from the network that will run the peer selection and finds an appropriate peer for you to request information.
-- `p2p.send(message: P2PMessagePacket)`: sends information to 16 connected peers choosen by peer selection for send.
+- `p2p.send(message: P2PMessagePacket)`: sends information to 16 connected peers chosen by peer selection for send.
 - `p2p.broadcast(message: P2PMessagePacket)`: broadcast information to all the connected peers.
 - `p2p.requestFromPeer(packet: P2PRequestPacket,peerId: string)`: request from a specific peers in the network.
 - `p2p.sendToPeer(message: P2PMessagePacket, peerId: string)`: sends information to a specific peer in the connected peers.

--- a/elements/lisk-p2p/src/utils/misc.ts
+++ b/elements/lisk-p2p/src/utils/misc.ts
@@ -193,7 +193,7 @@ export const getBucketId = (options: {
 		throw Error('IP address is unsupported.');
 	}
 
-	// Seperate buckets for local and private addresses
+	// Separate buckets for local and private addresses
 	if (network !== NETWORK.NET_IPV4) {
 		return (
 			hash(Buffer.concat([secretBytes, networkBytes])).readUInt32BE(0) %

--- a/elements/lisk-transactions/README.md
+++ b/elements/lisk-transactions/README.md
@@ -40,7 +40,7 @@ The lifecycle of a transaction in Lisk SDK can be summarized as follows:
    6a. Based on workflow executing `apply` and `applyAsset` functions, the state in memory is either saved to the blockchain or discarded. For instance, if the transaction is being executed within the process of saving new a block in the blockchain, the changes in the memory are saved in the database. In the other case, when the transaction is executed within the domain of the transaction pool, the changes of state in memory are discarded.
 7. It is probable, especially shortly after a block is applied, that due to the decentralized network conditions a node does the `undo` step and the block containing all of the included transactions get reverted in favour of a competing block.
 
-While implementing a custom transaction, it is necessary to implement some of the mentioned steps. For most of them, a base transaction implements a default behaviour. As you feel more confident in using Lisk SDK, it is more likely for developers to override most of the base transaction methods, so the implementation is well-tailored and implemented with the best possible performance to the application's use case.
+While implementing a custom transaction, it is necessary to implement some of the mentioned steps. For most of them, a base transaction implements a default behavior. As you feel more confident in using Lisk SDK, it is more likely for developers to override most of the base transaction methods, so the implementation is well-tailored and implemented with the best possible performance to the application's use case.
 
 ### Interface
 

--- a/elements/lisk-transactions/src/12_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/12_multisignature_transaction.ts
@@ -232,7 +232,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 			return errors;
 		}
 
-		// Check if the lenght of mandatory, optional and sender keys matches the lenght of signatures
+		// Check if the length of mandatory, optional and sender keys matches the length of signatures
 		if (
 			mandatoryKeys.length + optionalKeys.length + 1 !==
 			this.signatures.length

--- a/elements/lisk-transactions/src/base_transaction.ts
+++ b/elements/lisk-transactions/src/base_transaction.ts
@@ -407,7 +407,7 @@ export abstract class BaseTransaction {
 		if (passphrases && keys) {
 			if (!this.senderPublicKey) {
 				throw new Error(
-					'Transaction senderPublicKey needs to be set befor signing',
+					'Transaction senderPublicKey needs to be set before signing',
 				);
 			}
 

--- a/elements/lisk-transactions/src/register_multisignature_account.ts
+++ b/elements/lisk-transactions/src/register_multisignature_account.ts
@@ -101,10 +101,13 @@ const validateInputs = ({
 	}
 
 	// Check key duplication between sets
-	const repatedKeys = findRepeatedKeys(optionalPublicKeys, mandatoryPublicKeys);
-	if (repatedKeys.length > 0) {
+	const repeatedKeys = findRepeatedKeys(
+		optionalPublicKeys,
+		mandatoryPublicKeys,
+	);
+	if (repeatedKeys.length > 0) {
 		throw new Error(
-			`There are repeated values in optional and mandatory keys: '${repatedKeys.join(
+			`There are repeated values in optional and mandatory keys: '${repeatedKeys.join(
 				', ',
 			)}'`,
 		);

--- a/framework/README.md
+++ b/framework/README.md
@@ -108,7 +108,7 @@ npm run jest:<testType> -- [testPathPattern] [jestCliOptions]
 
 ### API Performance and APM
 
-To access the API Peformance of your Lisk Instance, navigate to `http://localhost:4000/http-stats/ui`. The APM doesn't store any of the performance metrics, neither it forwards to any external services. The stats are served from the point on the instance is up and running, once the instance is restarted it will not hold any stats.
+To access the API Performance of your Lisk Instance, navigate to `http://localhost:4000/http-stats/ui`. The APM doesn't store any of the performance metrics, neither it forwards to any external services. The stats are served from the point on the instance is up and running, once the instance is restarted it will not hold any stats.
 
 To access the stats, follow the steps below:
 

--- a/framework/src/application/application.js
+++ b/framework/src/application/application.js
@@ -339,7 +339,7 @@ class Application {
 			buildVersion: this.config.app.buildVersion,
 		};
 
-		// TODO: move this configuration to module especific config file
+		// TODO: move this configuration to module specific config file
 		const childProcessModules = process.env.LISK_CHILD_PROCESS_MODULES
 			? process.env.LISK_CHILD_PROCESS_MODULES.split(',')
 			: [];

--- a/framework/src/application/node/node.js
+++ b/framework/src/application/node/node.js
@@ -382,7 +382,7 @@ module.exports = class Node {
 				});
 			}
 
-			this.logger.info(
+			this.logger.debug(
 				{
 					id: block.id,
 					height: block.height,

--- a/framework/src/application/node/synchronizer/block_synchronization_mechanism.js
+++ b/framework/src/application/node/synchronizer/block_synchronization_mechanism.js
@@ -117,7 +117,7 @@ class BlockSynchronizationMechanism extends BaseSynchronizer {
 			); // Note that the block matching lastFetchedID is not returned but only higher blocks.
 
 			if (blocks && blocks.length) {
-				// Sort blocks with height in ascending order because blocks are returned in decending order
+				// Sort blocks with height in ascending order because blocks are returned in descending order
 				blocks.sort((a, b) => a.height - b.height);
 				[{ id: lastFetchedID }] = blocks.slice(-1);
 				const index = blocks.findIndex(block => block.id === toId);
@@ -158,7 +158,7 @@ class BlockSynchronizationMechanism extends BaseSynchronizer {
 
 	/**
 	 * When there is a failure applying blocks received from the peer,
-	 * it's needede to check whether the tip of the temp block chain has
+	 * it's required to check whether the tip of the temp block chain has
 	 * preference over the current tip. If so, the temporary chain is restored
 	 * on top of the current chain and the blocks temp table is cleaned up
 	 */

--- a/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
+++ b/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
@@ -126,7 +126,7 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 			); // Note that the block matching lastFetchedID is not returned but only higher blocks.
 
 			if (chunkOfBlocks && chunkOfBlocks.length) {
-				// Sort blocks with height in ascending order because blocks are returned in decending order
+				// Sort blocks with height in ascending order because blocks are returned in descending order
 				chunkOfBlocks.sort((a, b) => a.height - b.height);
 				blocks.push(...chunkOfBlocks);
 				[{ id: lastFetchedID }] = chunkOfBlocks.slice(-1);

--- a/framework/src/application/schema/application_config_schema.js
+++ b/framework/src/application/schema/application_config_schema.js
@@ -94,7 +94,7 @@ module.exports = {
 								'Timestamp indicating the start of Lisk Core (`Date.toISOString()`)',
 						},
 						// NOTICE: blockTime and maxPayloadLength are related and it's values
-						// need to be changed togeter as per recommendations noted in https://github.com/LiskHQ/lisk-sdk/issues/3151
+						// need to be changed together as per recommendations noted in https://github.com/LiskHQ/lisk-sdk/issues/3151
 						// TODO this recommendations need to be updated now that we changed to a byte size block
 						blockTime: {
 							type: 'number',
@@ -102,7 +102,7 @@ module.exports = {
 							description: 'Slot time interval in seconds',
 						},
 						// NOTICE: blockTime and maxPayloadLength are related and it's values
-						// need to be changed togeter as per recommendations noted in https://github.com/LiskHQ/lisk-sdk/issues/3151
+						// need to be changed together as per recommendations noted in https://github.com/LiskHQ/lisk-sdk/issues/3151
 						// TODO this recommendations need to be updated now that we changed to a byte size block
 						maxPayloadLength: {
 							type: 'integer',

--- a/framework/src/components/README.md
+++ b/framework/src/components/README.md
@@ -13,7 +13,7 @@ This component provides basic caching capabilities, generic enough for any modul
 ### Logger
 
 Logger is responsible for all application-level logging activity.
-The logger component can be passed to any module, where it can be extended by adding module-specific behaviour.
+The logger component can be passed to any module, where it can be extended by adding module-specific behavior.
 
 ### Storage
 
@@ -29,6 +29,6 @@ Configuration options for each component are located in `framework/src/component
 Each `config.js` file consists of 2 parts:
 
 1. JSON-schema specification for all available config options.
-2. Default values for the available config options for this specific compoment.
+2. Default values for the available config options for this specific component.
 
 Please don't change the default values in these files directly as they will be overwritten on software updates, instead define the custom configuration options inside your blockchain application.

--- a/framework/src/components/cache/cache.js
+++ b/framework/src/components/cache/cache.js
@@ -35,12 +35,12 @@ class Cache {
 
 	async bootstrap() {
 		// TODO: implement retry_strategy
-		// TOFIX: app crashes with FTL error when launchin app with CACHE_ENABLE=true
+		// FIXME: app crashes with FTL error when launching app with CACHE_ENABLE=true
 		// but cache server is not available.
 		return new Promise(resolve => {
 			this.client = redis.createClient(this.options);
 			this.client.once('error', err => {
-				// Called if the "error" event occured before "ready" event
+				// Called if the "error" event occurred before "ready" event
 				this.logger.warn({ err }, 'App was unable to connect to Cache server');
 				// Error handler needs to exist to ignore the error
 				this.client.on('error', () => {});

--- a/framework/src/components/storage/README.md
+++ b/framework/src/components/storage/README.md
@@ -32,7 +32,7 @@ const filters = {};
 const options = { sort: 'height:desc', limit: 1 };
 const lastBlock = await storage.entities.Block.get(filters, options);
 
-// Uptading an account
+// Updating an account
 const filter = { address: '123L' };
 const data = { publicKey: '0123456789ABCDEF' };
 await storage.entities.Account.update(filter, data);
@@ -104,7 +104,7 @@ You can register a `CUSTOM` filter, by defining your own key and a function whic
 
 ## How to create entity?
 
-This storage implementation was designed to be flexible and extensible. In order to achive that, a `BaseEntity` was implemented with some common methods and attributes that provides a generic structure to manage the entity.
+This storage implementation was designed to be flexible and extensible. In order to achieve that, a `BaseEntity` was implemented with some common methods and attributes that provides a generic structure to manage the entity.
 New entities are created by extending the `BaseEntity` and implementing the required interfaces.
 
 ## Conventions

--- a/framework/src/components/storage/adapters/pgp_adapter.js
+++ b/framework/src/components/storage/adapters/pgp_adapter.js
@@ -162,7 +162,7 @@ class PgpAdapter extends BaseAdapter {
 
 		if (qf.error) {
 			this.logger.error({ err: qf.error }, 'SQL query file error'); // Something is wrong with our query file
-			throw qf.error; // throw pg-promisse QueryFileError error
+			throw qf.error; // throw pg-promise QueryFileError error
 		}
 
 		_private.queryFiles[fullPath] = qf;

--- a/framework/src/modules/http_api/helpers/swagger.js
+++ b/framework/src/modules/http_api/helpers/swagger.js
@@ -26,7 +26,7 @@ const { formats } = require('../../../application/validator');
 let resolvedSwaggerSpec = null;
 
 function getValidator() {
-	// Get validator instace attached to Swagger
+	// Get validator instance attached to Swagger
 	const validator = SwayHelpers.getJSONSchemaValidator();
 
 	// Register lisk formats with swagger

--- a/framework/src/modules/http_api/init_steps/bootstrap_swagger.js
+++ b/framework/src/modules/http_api/init_steps/bootstrap_swagger.js
@@ -266,11 +266,11 @@ function bootstrapSwagger(app, config, logger, scope, cb) {
 		// To be used in test cases or getting configuration runtime
 		app.swaggerRunner = runner;
 
-		// Managing all the queries which were not caught by previous middlewares.
+		// Managing all the queries which were not caught by previous middleware.
 		app.use((req, res, next) => {
-			// We need to check if the response is already handled by some other middlewares/fittings/controllers
+			// We need to check if the response is already handled by some other middleware/fittings/controllers
 			// In case not, we consider it as 404 and send default response
-			// res.headersSent is a patch, and only works if above middlewares set some header no matter the status code
+			// res.headersSent is a patch, and only works if above middleware set some header no matter the status code
 			// Another possible workaround would be res.bodySize === 0
 			if (!res.headersSent) {
 				res.status(404);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5093 

### How was it solved?

- Updated the new block event logger to `debug`
- Fixed spelling mistakes
