### PR TITLE
Incorrect subscription of the channel event - Closes #5108

### DIFF
--- a/framework/src/application/node/node.js
+++ b/framework/src/application/node/node.js
@@ -535,9 +535,12 @@ module.exports = class Node {
 	}
 
 	_subscribeToEvents() {
-		this.channel.subscribe('app:broadcast', async ({ data: { block } }) => {
-			await this.transport.handleBroadcastBlock(block);
-		});
+		this.channel.subscribe(
+			'app:block:broadcast',
+			async ({ data: { block } }) => {
+				await this.transport.handleBroadcastBlock(block);
+			},
+		);
 
 		this.channel.subscribe('app:chain:sync', ({ data: { block, peerId } }) => {
 			this.synchronizer.run(block, peerId).catch(err => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5108 

### How was it solved?

- Update the event name
### How was it tested?

- Run two nodes and observer if the block broadcasted is received in another syncing node