### PR TITLE
Remove call to getForgerPublicKeysForRound - Closes #5109 and #5105

### DIFF
--- a/framework/src/application/application.js
+++ b/framework/src/application/application.js
@@ -398,7 +398,7 @@ class Application {
 		storage.registerEntity('TempBlock', TempBlockEntity);
 
 		storage.entities.Account.extendDefaultOptions({
-			limit: this.constants.activeDelegates,
+			limit: this.constants.activeDelegates + this.constants.standbyDelegates,
 		});
 
 		return storage;
@@ -468,9 +468,9 @@ class Application {
 				calculateReward: {
 					handler: action => this._node.actions.calculateReward(action),
 				},
-				getForgerPublicKeysForRound: {
+				getForgerAddressesForRound: {
 					handler: async action =>
-						this._node.actions.getForgerPublicKeysForRound(action),
+						this._node.actions.getForgerAddressesForRound(action),
 				},
 				updateForgingStatus: {
 					handler: async action =>

--- a/framework/src/application/node/node.js
+++ b/framework/src/application/node/node.js
@@ -200,8 +200,8 @@ module.exports = class Node {
 				this.chain.blockReward.calculateMilestone(action.params.height),
 			calculateReward: action =>
 				this.chain.blockReward.calculateReward(action.params.height),
-			getForgerPublicKeysForRound: async action =>
-				this.dpos.getForgerPublicKeysForRound(action.params.round),
+			getForgerAddressesForRound: async action =>
+				this.dpos.getForgerAddressesForRound(action.params.round),
 			updateForgingStatus: async action =>
 				this.forger.updateForgingStatus(
 					action.params.publicKey,

--- a/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
+++ b/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const { getAddressFromPublicKey } = require('@liskhq/lisk-cryptography');
 const { BaseSynchronizer } = require('./base_synchronizer');
 const {
 	clearBlocksTempTable,
@@ -101,11 +102,11 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		}
 
 		const blockRound = this.dpos.rounds.calcRound(receivedBlock.height);
-		const delegateList = await this.dpos.getForgerPublicKeysForRound(
-			blockRound,
-		);
+		const delegateList = await this.dpos.getForgerAddressesForRound(blockRound);
 
-		return delegateList.includes(receivedBlock.generatorPublicKey);
+		return delegateList.includes(
+			getAddressFromPublicKey(receivedBlock.generatorPublicKey),
+		);
 	}
 
 	async _requestBlocksWithinIDs(peerId, fromId, toId) {

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -462,7 +462,7 @@ paths:
           type: integer
           format: int32
           minimum: 1
-          maximum: 101
+          maximum: 103
           default: 10
         - name: search
           in: query
@@ -523,7 +523,7 @@ paths:
           type: integer
           format: int32
           minimum: 1
-          maximum: 101
+          maximum: 103
           default: 10
         - name: offset
           in: query
@@ -724,7 +724,7 @@ paths:
           type: integer
           format: int32
           minimum: 1
-          maximum: 101
+          maximum: 10
           default: 10
         - in: query
           name: sort
@@ -1238,7 +1238,7 @@ definitions:
             type: integer
             format: int32
             minimum: 1
-            maximum: 101
+            maximum: 103
             default: 10
       links:
         type: object
@@ -1270,7 +1270,7 @@ definitions:
             type: integer
             format: int32
             minimum: 1
-            maximum: 101
+            maximum: 103
             default: 10
           currentSlot:
             description: Currently active slot.
@@ -1657,7 +1657,7 @@ definitions:
             type: integer
             format: int32
             minimum: 1
-            maximum: 101
+            maximum: 10
             default: 10
       links:
         type: object

--- a/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/delegates.js
@@ -413,9 +413,9 @@ describe('delegates/api', () => {
 			);
 		});
 
-		it('should call channel.invoke with app:getForgerPublicKeysForRound action', async () => {
+		it('should call channel.invoke with app:getForgerAddressesForRound action', async () => {
 			expect(channelStub.invoke.getCall(4)).to.be.calledWith(
-				'app:getForgerPublicKeysForRound',
+				'app:getForgerAddressesForRound',
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5109 
This PR resolves #5105 

### How was it solved?

- Replace the usage of `getForgerPublicKeysForRound` with `getForgerAddressesForRound`
- Set the maximum limit for the API to 103

### How was it tested?

- Call `Call http://localhost:4000/api/delegates/forgers`
- Sync with other running node
