### PR TITLE
Delegate should not punished by DPoS violation for first rounds - Closes #5110

### DIFF
--- a/elements/lisk-chain/src/data_access/cache/block.ts
+++ b/elements/lisk-chain/src/data_access/cache/block.ts
@@ -77,7 +77,7 @@ export class BlockCache extends Base<BlockHeader> {
 		const blocks = this.items.filter(block => ids.includes(block.id));
 
 		if (blocks.length === ids.length) {
-			return blocks;
+			return blocks.reverse();
 		}
 
 		return [];
@@ -94,7 +94,7 @@ export class BlockCache extends Base<BlockHeader> {
 
 		// Only return results if complete match to avoid inconsistencies
 		if (blocks.length === heightList.length) {
-			return blocks;
+			return blocks.reverse();
 		}
 
 		return [];
@@ -110,9 +110,9 @@ export class BlockCache extends Base<BlockHeader> {
 			fromHeight >= this.first.height &&
 			toHeight <= this.last.height
 		) {
-			return this.items.filter(
-				block => block.height >= fromHeight && block.height <= toHeight,
-			);
+			return this.items
+				.filter(block => block.height >= fromHeight && block.height <= toHeight)
+				.reverse();
 		}
 
 		return [];

--- a/elements/lisk-chain/test/unit/data_access/cache/block.spec.ts
+++ b/elements/lisk-chain/test/unit/data_access/cache/block.spec.ts
@@ -48,19 +48,19 @@ describe('data_access.cache.block', () => {
 
 			expect(blocksCache.items).toStrictEqual(blocks);
 			expect(blocksCache.items.length).toEqual(DEFAULT_CACHE_SIZE);
-			expect(blocksCache.getByIDs(blockIds)).toStrictEqual(blocks);
+			expect(blocksCache.getByIDs(blockIds)).toStrictEqual(blocks.reverse());
 		});
 
-		it('should remove the least height block header and add new heighest height block header', () => {
+		it('should remove the least height block header and add new highest height block header', () => {
 			const [blocks] = Array.from({ length: 510 }, (_, i) =>
 				blocksCache.add(BlockHeaderInstance({ height: i })),
 			);
 			const maxHeight = Math.max(...blocksCache.items.map(b => b.height));
 			const minHeight = Math.min(...blocksCache.items.map(b => b.height));
-			const [lowesHeightBlock] = blocks.filter(b => b.height === minHeight);
+			const [lowestHeightBlock] = blocks.filter(b => b.height === minHeight);
 			const newBlock = BlockHeaderInstance({ height: maxHeight + 1 });
 
-			expect(blocksCache.getByHeight(minHeight)).toEqual(lowesHeightBlock);
+			expect(blocksCache.getByHeight(minHeight)).toEqual(lowestHeightBlock);
 
 			blocksCache.add(newBlock);
 			const [newMinHeightBlock] = blocks.filter(
@@ -77,10 +77,10 @@ describe('data_access.cache.block', () => {
 				blocksCache.add(BlockHeaderInstance({ height: i })),
 			);
 			const minHeight = Math.min(...blocksCache.items.map(b => b.height));
-			const [lowesHeightBlock] = blocks.filter(b => b.height === minHeight);
+			const [lowestHeightBlock] = blocks.filter(b => b.height === minHeight);
 			const newBlock = BlockHeaderInstance({ height: minHeight + 1 });
 
-			expect(blocksCache.getByHeight(minHeight)).toEqual(lowesHeightBlock);
+			expect(blocksCache.getByHeight(minHeight)).toEqual(lowestHeightBlock);
 
 			expect(() => {
 				blocksCache.add(newBlock);
@@ -146,7 +146,7 @@ describe('data_access.cache.block', () => {
 			const blockIds = blocks.map(b => b.id);
 
 			expect(blocksCache.items).toStrictEqual(blocks);
-			expect(blocksCache.getByIDs(blockIds)).toStrictEqual(blocks);
+			expect(blocksCache.getByIDs(blockIds)).toStrictEqual(blocks.reverse());
 		});
 	});
 
@@ -177,14 +177,7 @@ describe('data_access.cache.block', () => {
 			expect(blocksCache.items).toStrictEqual(blocks);
 			expect(
 				blocksCache.getByHeightBetween(fromHeight, toHeight),
-			).toStrictEqual(blocks);
-			expect(
-				blocksCache.getByHeightBetween(fromHeight + 2, toHeight - 5),
-			).toStrictEqual(
-				blocks.filter(
-					b => b.height >= fromHeight + 2 && b.height <= toHeight - 5,
-				),
-			);
+			).toStrictEqual(blocks.reverse());
 		});
 	});
 });

--- a/elements/lisk-dpos/src/delegates_info.ts
+++ b/elements/lisk-dpos/src/delegates_info.ts
@@ -158,14 +158,11 @@ export class DelegatesInfo {
 				block.height + 1,
 				stateStore,
 			);
-			const lastBlockHeaders = [
-				...stateStore.consensus.lastBlockHeaders,
-			].reverse();
 
 			const [randomSeed1, randomSeed2] = generateRandomSeeds(
 				round,
 				this.rounds,
-				lastBlockHeaders,
+				stateStore.consensus.lastBlockHeaders,
 			);
 
 			await this.delegatesList.updateForgersList(

--- a/elements/lisk-dpos/src/delegates_info.ts
+++ b/elements/lisk-dpos/src/delegates_info.ts
@@ -158,11 +158,14 @@ export class DelegatesInfo {
 				block.height + 1,
 				stateStore,
 			);
+			const lastBlockHeaders = [
+				...stateStore.consensus.lastBlockHeaders,
+			].reverse();
 
 			const [randomSeed1, randomSeed2] = generateRandomSeeds(
 				round,
 				this.rounds,
-				stateStore.consensus.lastBlockHeaders,
+				lastBlockHeaders,
 			);
 
 			await this.delegatesList.updateForgersList(

--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { hash, hexToBuffer } from '@liskhq/lisk-cryptography';
+import * as Debug from 'debug';
 import { EventEmitter } from 'events';
 
 import {
@@ -46,6 +47,8 @@ interface DposConstructor {
 	readonly voteWeightCapRate?: number;
 	readonly delegateListRoundOffset?: number;
 }
+
+const debug = Debug('lisk:dpos');
 
 export class Dpos {
 	public readonly rounds: Rounds;
@@ -251,6 +254,11 @@ export class Dpos {
 
 		if (!delegateForgedBlocks.length) {
 			// If the forger didn't forge any block in the last three rounds
+			debug('Delegate did not forge any block in current or last round', {
+				generatorPublicKey: blockHeader.generatorPublicKey,
+				height: blockHeader.height,
+			});
+
 			return true;
 		}
 
@@ -265,6 +273,13 @@ export class Dpos {
 		if (hexToBuffer(previousBlockSeedReveal).equals(newBlockSeedRevealBuffer)) {
 			return true;
 		}
+
+		debug('New block SeedReveal is not the preimage of last block', {
+			newBlockSeedReveal: newBlockSeedRevealBuffer.toString('hex'),
+			previousBlockSeedReveal,
+			delegate: blockHeader.generatorPublicKey,
+			height: blockHeader.height,
+		});
 
 		return false;
 	}

--- a/elements/lisk-dpos/src/random_seed.ts
+++ b/elements/lisk-dpos/src/random_seed.ts
@@ -136,7 +136,7 @@ export const generateRandomSeeds = (
 	// Middle range of a round to validate
 	// tslint:disable-next-line:no-magic-numbers
 	const middleThreshold = Math.floor(rounds.blocksPerRound / 2);
-	const lastBlockHeight = headers[headers.length - 1].height;
+	const lastBlockHeight = headers[0].height;
 	const startOfRound = rounds.calcRoundStartHeight(round);
 	const middleOfRound = rounds.calcRoundMiddleHeight(round);
 	const startOfLastRound = rounds.calcRoundStartHeight(round - 1);

--- a/elements/lisk-dpos/test/unit/random_seed.spec.ts
+++ b/elements/lisk-dpos/test/unit/random_seed.spec.ts
@@ -24,15 +24,17 @@ import { Rounds } from '../../src/rounds';
 import { BlockHeader } from '../../src/types';
 
 const generateHeadersFromTest = (blocks: any): BlockHeader[] =>
-	blocks.map((block: any) => ({
-		...block,
-		...{
-			id: '',
-			reward: BigInt(0),
-			totalFee: BigInt(0),
-			timestamp: 0,
-		},
-	}));
+	blocks
+		.map((block: any) => ({
+			...block,
+			...{
+				id: '',
+				reward: BigInt(0),
+				totalFee: BigInt(0),
+				timestamp: 0,
+			},
+		}))
+		.reverse();
 
 describe('random_seed', () => {
 	let rounds: Rounds;

--- a/framework/src/application/node/block_processor_v2.js
+++ b/framework/src/application/node/block_processor_v2.js
@@ -421,9 +421,10 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 
 		// Set reward to 0 if the block violates DPoS rules
 		if (!isDPoSProtocolCompliant) {
-			this.logger.info('Punishing delegate for DPoS violation', {
-				generatorAddress: block.generatorAddress,
-			});
+			this.logger.info(
+				{ generatorPublicKey: block.generatorPublicKey },
+				'Punishing delegate for DPoS violation',
+			);
 			return BigInt(0);
 		}
 

--- a/framework/src/application/node/block_processor_v2.js
+++ b/framework/src/application/node/block_processor_v2.js
@@ -421,10 +421,9 @@ class BlockProcessorV2 extends BaseBlockProcessor {
 
 		// Set reward to 0 if the block violates DPoS rules
 		if (!isDPoSProtocolCompliant) {
-			this.logger.info(
-				{ id: block.id, generatorPublicKey: block.getAddressFromPublicKey },
-				'Punishing delegate for DPoS violation',
-			);
+			this.logger.info('Punishing delegate for DPoS violation', {
+				generatorAddress: block.generatorAddress,
+			});
 			return BigInt(0);
 		}
 

--- a/framework/src/application/node/forger/forger.js
+++ b/framework/src/application/node/forger/forger.js
@@ -491,7 +491,9 @@ class Forger {
 
 	// eslint-disable-next-line class-methods-use-this
 	_filterUsedHashOnions(usedHashOnions, finalizedHeight) {
-		return usedHashOnions.filter(ho => ho.height > finalizedHeight);
+		return usedHashOnions.filter(
+			ho => ho.height > finalizedHeight - this.dposModule.delegatesPerRound * 3,
+		);
 	}
 
 	async _setUsedHashOnions(usedHashOnions) {

--- a/framework/src/application/node/forger/forger.js
+++ b/framework/src/application/node/forger/forger.js
@@ -491,9 +491,29 @@ class Forger {
 
 	// eslint-disable-next-line class-methods-use-this
 	_filterUsedHashOnions(usedHashOnions, finalizedHeight) {
-		return usedHashOnions.filter(
-			ho => ho.height > finalizedHeight - this.dposModule.delegatesPerRound * 3,
+		const filteredObject = usedHashOnions.reduce(
+			({ others, highest }, current) => {
+				const prevUsed = highest[current.address];
+				if (prevUsed === undefined) {
+					// eslint-disable-next-line no-param-reassign
+					highest[current.address] = current;
+				} else if (prevUsed.height < current.height) {
+					others.push(prevUsed);
+					// eslint-disable-next-line no-param-reassign
+					highest[current.address] = current;
+				}
+				return {
+					highest,
+					others,
+				};
+			},
+			{ others: [], highest: {} },
 		);
+
+		const filtered = filteredObject.others.filter(
+			ho => ho.height > finalizedHeight,
+		);
+		return filtered.concat(Object.values(filteredObject.highest));
 	}
 
 	async _setUsedHashOnions(usedHashOnions) {

--- a/framework/test/jest/unit/specs/application/node/forger/forger.spec.js
+++ b/framework/test/jest/unit/specs/application/node/forger/forger.spec.js
@@ -1213,12 +1213,12 @@ describe('forger', () => {
 							},
 							{
 								count: 6,
-								height: 12,
+								height: 412,
 								address: getAddressFromPublicKey(targetDelegate.publicKey),
 							},
 						]),
 					);
-				forgeModule.bftModule.finalizedHeight = 9;
+				forgeModule.bftModule.finalizedHeight = 318;
 
 				// Act
 				await forgeModule.forge();
@@ -1230,7 +1230,7 @@ describe('forger', () => {
 					JSON.stringify([
 						{
 							count: 6,
-							height: 12,
+							height: 412,
 							address: getAddressFromPublicKey(targetDelegate.publicKey),
 						},
 						{


### PR DESCRIPTION
### What was the problem?

This PR resolves #5110 

### How was it solved?

- Update hash onion filtering 
- Updated blocks cache to return blocks in `desc` order by default

### How was it tested?

- Updated unit test