### PR TITLE
Update FCS to only trigger for the same round - Closes #5115

### DIFF
--- a/framework/src/application/node/node.js
+++ b/framework/src/application/node/node.js
@@ -371,7 +371,7 @@ module.exports = class Node {
 				});
 			}
 
-			this.logger.debug(
+			this.logger.info(
 				{
 					id: block.id,
 					height: block.height,

--- a/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
+++ b/framework/src/application/node/synchronizer/fast_chain_switching_mechanism.js
@@ -96,12 +96,12 @@ class FastChainSwitchingMechanism extends BaseSynchronizer {
 		const { lastBlock } = this.chain;
 
 		// 3. Step: Check whether B justifies fast chain switching mechanism
-		const twoRounds = this.dpos.delegatesPerRound * 2;
-		if (Math.abs(receivedBlock.height - lastBlock.height) > twoRounds) {
+		const blockRound = this.dpos.rounds.calcRound(receivedBlock.height);
+		const lastBlockRound = this.dpos.rounds.calcRound(lastBlock.height);
+		if (blockRound !== lastBlockRound) {
 			return false;
 		}
 
-		const blockRound = this.dpos.rounds.calcRound(receivedBlock.height);
 		const delegateList = await this.dpos.getForgerAddressesForRound(blockRound);
 
 		return delegateList.includes(

--- a/framework/test/jest/unit/specs/application/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.js
+++ b/framework/test/jest/unit/specs/application/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.js
@@ -139,6 +139,48 @@ describe('fast_chain_switching_mechanism', () => {
 		});
 	});
 
+	describe('isValidFor', () => {
+		beforeEach(async () => {
+			jest.spyOn(dposModule, 'getForgerAddressesForRound');
+		});
+
+		describe('when reveivedBlock is at the same round as the last block', () => {
+			it('should return true', async () => {
+				chainModule._lastBlock = { height: 340 };
+				dposModule.getForgerAddressesForRound.mockResolvedValue([
+					'11121761073292744822L',
+				]);
+				const isValid = await fastChainSwitchingMechanism.isValidFor(
+					{
+						generatorPublicKey:
+							'20d381308d9a809455567af249dddd68bd2e23753e69913961fe04ac07732594',
+						height: 400,
+					},
+					'peer-id',
+				);
+				expect(isValid).toEqual(true);
+			});
+		});
+
+		describe('when reveivedBlock is not at the same round as the last block', () => {
+			it('should return false', async () => {
+				chainModule._lastBlock = { height: 340 };
+				dposModule.getForgerAddressesForRound.mockResolvedValue([
+					'11121761073292744822L',
+				]);
+				const isValid = await fastChainSwitchingMechanism.isValidFor(
+					{
+						generatorPublicKey:
+							'20d381308d9a809455567af249dddd68bd2e23753e69913961fe04ac07732594',
+						height: 900,
+					},
+					'peer-id',
+				);
+				expect(isValid).toEqual(false);
+			});
+		});
+	});
+
 	describe('async run()', () => {
 		const aPeerId = '127.0.0.1:5000';
 		let aBlock;

--- a/framework/test/jest/unit/specs/application/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.js
+++ b/framework/test/jest/unit/specs/application/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.js
@@ -140,20 +140,25 @@ describe('fast_chain_switching_mechanism', () => {
 	});
 
 	describe('isValidFor', () => {
+		const defaultGenerator = {
+			address: '11121761073292744822L',
+			publicKey:
+				'20d381308d9a809455567af249dddd68bd2e23753e69913961fe04ac07732594',
+		};
+
 		beforeEach(async () => {
 			jest.spyOn(dposModule, 'getForgerAddressesForRound');
+			chainModule._lastBlock = { height: 340 };
+			dposModule.getForgerAddressesForRound.mockResolvedValue([
+				defaultGenerator.address,
+			]);
 		});
 
 		describe('when reveivedBlock is at the same round as the last block', () => {
 			it('should return true', async () => {
-				chainModule._lastBlock = { height: 340 };
-				dposModule.getForgerAddressesForRound.mockResolvedValue([
-					'11121761073292744822L',
-				]);
 				const isValid = await fastChainSwitchingMechanism.isValidFor(
 					{
-						generatorPublicKey:
-							'20d381308d9a809455567af249dddd68bd2e23753e69913961fe04ac07732594',
+						generatorPublicKey: defaultGenerator.publicKey,
 						height: 400,
 					},
 					'peer-id',
@@ -164,14 +169,9 @@ describe('fast_chain_switching_mechanism', () => {
 
 		describe('when reveivedBlock is not at the same round as the last block', () => {
 			it('should return false', async () => {
-				chainModule._lastBlock = { height: 340 };
-				dposModule.getForgerAddressesForRound.mockResolvedValue([
-					'11121761073292744822L',
-				]);
 				const isValid = await fastChainSwitchingMechanism.isValidFor(
 					{
-						generatorPublicKey:
-							'20d381308d9a809455567af249dddd68bd2e23753e69913961fe04ac07732594',
+						generatorPublicKey: defaultGenerator.publicKey,
 						height: 900,
 					},
 					'peer-id',


### PR DESCRIPTION
### What was the problem?

This PR resolves #5115 

### How was it solved?

- Update FCS to only trigger for the same round because it doesn't not know about the future rounds anymore

### How was it tested?

- Make one node behind for more than round, and check block sync is triggered
- Make one node behind for less than round, and check FCS is triggered
