### PR TITLE
Endpoint for votes not validating filter - Closes #5128

### DIFF
--- a/framework/src/modules/http_api/controllers/voters.js
+++ b/framework/src/modules/http_api/controllers/voters.js
@@ -134,9 +134,6 @@ VotersController.getVotes = async (context, next) => {
 	}
 
 	try {
-		// TODO: To keep the consistent behavior of functional tests
-		// not test the account for being a delegate
-		// const delegateFilters = { isDelegate: true, ...filters };
 		const delegateFilters = { ...filters };
 
 		const account = await storage.entities.Account.getOne(delegateFilters);
@@ -154,10 +151,12 @@ VotersController.getVotes = async (context, next) => {
 			aVote => aVote.delegateAddress,
 		);
 
-		const votedDelegates = await storage.entities.Account.get(
-			{ address_in: votedDelegatesAddresses },
-			options,
-		);
+		const votedDelegates = votedDelegatesAddresses.length
+			? await storage.entities.Account.get(
+					{ address_in: votedDelegatesAddresses },
+					options,
+			  )
+			: [];
 
 		data.votes.forEach(aVote => {
 			const { username, totalVotesReceived, delegate } = votedDelegates.find(

--- a/framework/test/mocha/unit/modules/http_api/controllers/voters.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/voters.js
@@ -14,11 +14,9 @@
 
 'use strict';
 
-const rewire = require('rewire');
+const { cloneDeep } = require('lodash');
 
-const VotersController = rewire(
-	'../../../../../../src/modules/http_api/controllers/voters',
-);
+const VotersController = require('../../../../../../src/modules/http_api/controllers/voters');
 
 describe('voters/api', () => {
 	let storageStub;
@@ -166,6 +164,26 @@ describe('voters/api', () => {
 					'totalVotesReceived',
 				);
 				expect(account.votes[0].delegate).to.have.property('delegate');
+			});
+		});
+
+		it('should not fail when account has not casted votes', async () => {
+			const accountWithNoVotes = cloneDeep(mockAccount);
+			accountWithNoVotes.votes = [];
+
+			storageStub.entities.Account.getOne.resolves(accountWithNoVotes);
+
+			await VotersController.getVotes(contextStub, (err, res) => {
+				expect(err).to.eql(null);
+
+				const account = res.data;
+
+				expect(account).to.have.property('address');
+				expect(account).to.have.property('publicKey');
+				expect(account).to.have.property('balance');
+				expect(account)
+					.to.have.property('votes')
+					.to.be.an.empty('array');
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5128

### How was it solved?

By adding a check for the existence of delegate address voted for and either pulling delegates or setting the voted delegates to an empty array

### How was it tested?

- Create an account
- Open http://localhost:4000/api/votes?address=<address of the created account> it should not fail and votes should be an empty array
- Vote a delegate with the account
- Open http://localhost:4000/api/votes?address=<address of the created account> votes should display the casted vote
