### PR TITLE
Update account response to include unlocking - Closes #5106 

### DIFF
--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -35,6 +35,8 @@ function accountFormatter(totalSupply, account) {
 		'asset',
 		'keys',
 		'votes',
+		'totalVotesReceived',
+		'unlocking',
 		'delegate',
 		'isDelegate',
 		'username',
@@ -42,6 +44,8 @@ function accountFormatter(totalSupply, account) {
 
 	if (account.isDelegate) {
 		formattedAccount.delegate = _.pick(account, [
+			'fees',
+			'rewards',
 			'rewards',
 			'producedBlocks',
 			'missedBlocks',

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -484,7 +484,7 @@ paths:
             - missedBlocks:desc
             - producedBlocks:asc
             - producedBlocks:desc
-            - voteWeight:asc
+            - totalVotesReceived:asc
             - totalVotesReceived:desc
           default: totalVotesReceived:desc
       responses:
@@ -1191,7 +1191,7 @@ definitions:
         description: List of accounts.
         type: array
         items:
-          $ref: '#/definitions/AccountExtended'
+          $ref: '#/definitions/Account'
       meta:
         $ref: '#/definitions/Meta'
       links:
@@ -2095,27 +2095,6 @@ definitions:
     required:
       - address
       - publicKey
-    properties:
-      address:
-        type: string
-        format: address
-        example: 12668885769632475474L
-        description: |
-          The Lisk address is the human readable representation of the accounts owners public key.
-          It consists of multiple numbers followed by a capital 'L' at the end.
-      publicKey:
-        type: string
-        format: publicKey
-        example: 968ba2fa993ea9dc27ed740da0daf49eddd740dbd7cb1cb4fc5db3a20baf341b
-        description: |
-          The public key is derived from the private key of the owner of the account.
-          It can be used to validate that the private key belongs to the owner, but not provide access to the owners private key.
-
-  AccountExtended:
-    type: object
-    required:
-      - address
-      - publicKey
       - balance
       - nonce
       - votes
@@ -2167,13 +2146,17 @@ definitions:
             $ref: '#/definitions/Unlocking'
       keys:
         $ref: '#/definitions/MultisignatureAsset'
-
+      totalVotesReceived:
+        type: string
+        example: 1081560729258
+        description: |
+          The total votes received by the delegate.
+          Represents the total amount of Lisk (in Beddows), that the delegates voters voted this delegate.
 
   Delegate:
     type: object
     required:
       - username
-      - voteWeight
     properties:
       username:
         type: string
@@ -2183,13 +2166,6 @@ definitions:
           The delegates username.
           A delegate chooses the username by registering a delegate on the Lisk network.
           It is unique and cannot be changed later.
-      voteWeight:
-        type: string
-        example: 1081560729258
-        description: |
-          The voters weight of the delegate.
-          Represents the total amount of Lisk (in Beddows), that the delegates voters own.
-          The voters weight decides which rank the delegate gets in relation to the other delegates and their voters weights.
       rewards:
         type: string
         example: 510000000

--- a/framework/test/mocha/unit/modules/http_api/controllers/accounts.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/accounts.js
@@ -89,6 +89,14 @@ describe('accounts/api', () => {
 					delegateAddress: '10045031187186962062L',
 				},
 			],
+			unlocking: [
+				{
+					amount: '10000000000',
+					delegateAddress: '10045031187186962062L',
+					unvoteHeight: 30,
+				},
+			],
+			totalVotesReceived: '990000000000',
 			keys: {
 				numberOfSignatures: 0,
 				mandatoryKeys: [],
@@ -147,6 +155,8 @@ describe('accounts/api', () => {
 				expect(account).to.have.property('nonce');
 				expect(account).to.have.property('asset');
 				expect(account).to.have.property('votes');
+				expect(account).to.have.property('totalVotesReceived');
+				expect(account).to.have.property('unlocking');
 				expect(account).to.have.property('delegate');
 			});
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5106 

### How was it solved?

- Add to pick the `unlocking` from the database
- Add to pick the `totalVotesReceived` from the database

### How was it tested?

- Call `http://localhost:4000/api/accounts` and check the response
- Add unit test

### Additional Information
- `http://localhost:4000/api/delegates` was working properly and including `unlocking`
