### PR TITLE
Assign a new array to fields to new Account object - Closes #5134

### DIFF
--- a/elements/lisk-chain/src/account.ts
+++ b/elements/lisk-chain/src/account.ts
@@ -115,14 +115,16 @@ export class Account {
 			consecutiveMissedBlocks:
 				accountInfo.delegate?.consecutiveMissedBlocks ?? 0,
 			isBanned: accountInfo.delegate?.isBanned ?? false,
-			pomHeights: accountInfo.delegate?.pomHeights ?? [],
+			pomHeights: accountInfo.delegate?.pomHeights
+				? [...accountInfo.delegate.pomHeights]
+				: [],
 		};
 		this.keys = {
 			mandatoryKeys: accountInfo.keys?.mandatoryKeys?.length
-				? accountInfo.keys?.mandatoryKeys
+				? [...accountInfo.keys?.mandatoryKeys]
 				: [],
 			optionalKeys: accountInfo.keys?.optionalKeys?.length
-				? accountInfo.keys?.optionalKeys
+				? [...accountInfo.keys?.optionalKeys]
 				: [],
 			numberOfSignatures: accountInfo.keys?.numberOfSignatures || 0,
 		};

--- a/elements/lisk-chain/src/account.ts
+++ b/elements/lisk-chain/src/account.ts
@@ -121,10 +121,10 @@ export class Account {
 		};
 		this.keys = {
 			mandatoryKeys: accountInfo.keys?.mandatoryKeys?.length
-				? [...accountInfo.keys?.mandatoryKeys]
+				? [...accountInfo.keys.mandatoryKeys]
 				: [],
 			optionalKeys: accountInfo.keys?.optionalKeys?.length
-				? [...accountInfo.keys?.optionalKeys]
+				? [...accountInfo.keys.optionalKeys]
 				: [],
 			numberOfSignatures: accountInfo.keys?.numberOfSignatures || 0,
 		};

--- a/elements/lisk-chain/test/unit/account.spec.ts
+++ b/elements/lisk-chain/test/unit/account.spec.ts
@@ -49,6 +49,76 @@ describe('account', () => {
 				pomHeights: [],
 			});
 		});
+		it('should create an Account object with supplied account object in the constructor', () => {
+			const pomHeights = [1090, 1900, 2888];
+			const mandatoryKeys = ['x', 'y'];
+			const optionalKeys = ['z'];
+			const accountJSON = {
+				address: accountAddress1,
+				publicKey: undefined,
+				balance: '0',
+				username: null,
+				nonce: '0',
+				producedBlocks: 0,
+				fees: '0',
+				rewards: '0',
+				totalVotesReceived: '0',
+				votes: [],
+				unlocking: [],
+				delegate: {
+					lastForgedHeight: 0,
+					consecutiveMissedBlocks: 0,
+					isBanned: false,
+					pomHeights,
+				},
+				asset: {},
+				keys: {
+					mandatoryKeys,
+					optionalKeys,
+					numberOfSignatures: 0,
+				},
+				missedBlocks: 0,
+				isDelegate: 0,
+			};
+			const accountObj = new Account(accountJSON);
+
+			// Check for delegate.pomHeights array
+			accountObj.delegate.pomHeights.push(900);
+			expect(accountObj.delegate.pomHeights as number[]).toIncludeAnyMembers([
+				900,
+			]);
+			// Make sure the original object's value is not modified
+			expect(
+				accountJSON.delegate.pomHeights as number[],
+			).not.toIncludeAnyMembers([900]);
+
+			// Check for keys.mandatoryKeys array
+			accountObj.keys.mandatoryKeys.push('xx');
+			expect(accountObj.keys.mandatoryKeys).toIncludeAnyMembers(['xx']);
+			// Make sure the original object's value is not modified
+			expect(accountJSON.keys.mandatoryKeys).not.toIncludeAnyMembers(['xx']);
+
+			// Check for votes array
+			const voteObject = {
+				delegateAddress: 'xx',
+				amount: BigInt(100),
+			};
+			accountObj.votes.push(voteObject);
+			expect(accountObj.votes).toIncludeAnyMembers([voteObject]);
+			// Make sure the original object's value is not modified
+			expect(accountJSON.votes).toEqual([]);
+
+			// Check for unlocking array
+			const unlockingObject = {
+				delegateAddress: 'xx',
+				amount: BigInt(100),
+				unvoteHeight: 100,
+			};
+			accountObj.unlocking.push(unlockingObject);
+			expect(accountObj.unlocking).toIncludeAnyMembers([unlockingObject]);
+			// Make sure the original object's value is not modified
+			expect(accountJSON.unlocking).toEqual([]);
+		});
 	});
 
 	describe('getDefaultAccount', () => {

--- a/elements/lisk-chain/test/unit/account.spec.ts
+++ b/elements/lisk-chain/test/unit/account.spec.ts
@@ -49,6 +49,7 @@ describe('account', () => {
 				pomHeights: [],
 			});
 		});
+
 		it('should create an Account object with supplied account object in the constructor', () => {
 			const pomHeights = [1090, 1900, 2888];
 			const mandatoryKeys = ['x', 'y'];
@@ -97,6 +98,12 @@ describe('account', () => {
 			expect(accountObj.keys.mandatoryKeys).toIncludeAnyMembers(['xx']);
 			// Make sure the original object's value is not modified
 			expect(accountJSON.keys.mandatoryKeys).not.toIncludeAnyMembers(['xx']);
+
+			// Check for keys.optionalKeys array
+			accountObj.keys.optionalKeys.push('zz');
+			expect(accountObj.keys.optionalKeys).toIncludeAnyMembers(['zz']);
+			// Make sure the original object's value is not modified
+			expect(accountJSON.keys.optionalKeys).not.toIncludeAnyMembers(['zz']);
 
 			// Check for votes array
 			const voteObject = {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5134

### How was it solved?

Assign a new array to populate old values for a field in the constructor of Account class

### How was it tested?

1. Create a pom trx
2. Broadcast the trx
3. Check if the pomHeights value is updated for the reported delegate
