### PR TITLE
Update transport constants - Closes #4974

### DIFF
--- a/framework/src/application/node/transport/schemas.js
+++ b/framework/src/application/node/transport/schemas.js
@@ -149,7 +149,7 @@ module.exports = {
 					format: 'id',
 				},
 				minItems: 1,
-				maxItems: 25,
+				maxItems: 100,
 			},
 		},
 	},

--- a/framework/src/application/node/transport/transport.js
+++ b/framework/src/application/node/transport/transport.js
@@ -22,7 +22,7 @@ const schemas = require('./schemas');
 
 const DEFAULT_RATE_RESET_TIME = 10000;
 const DEFAULT_RATE_LIMIT_FREQUENCY = 3;
-const DEFAULT_RELEASE_LIMIT = 25;
+const DEFAULT_RELEASE_LIMIT = 100;
 const DEFAULT_RELEASE_INTERVAL = 5000;
 
 class Transport {
@@ -115,7 +115,8 @@ class Transport {
 		const lastBlockHeight = lastBlock.height;
 
 		// Calculate max block height for database query
-		const fetchUntilHeight = lastBlockHeight + 34;
+		// 15kb * 103 is about 1.5MB where it's half of 3MB payload limit
+		const fetchUntilHeight = lastBlockHeight + 103;
 
 		const blocks = await this.chainModule.dataAccess.getBlocksByHeightBetween(
 			lastBlockHeight + 1,

--- a/framework/test/jest/unit/specs/application/node/transport/transport.spec.js
+++ b/framework/test/jest/unit/specs/application/node/transport/transport.spec.js
@@ -23,7 +23,7 @@ const jobsQueue = require('../../../../../../../src/application/node/utils/jobs_
 
 describe('Transport', () => {
 	const defaultBroadcastInterval = 5000;
-	const defaultReleaseLimit = 25;
+	const defaultReleaseLimit = 100;
 
 	let transport;
 	let transactionPoolStub;
@@ -398,7 +398,9 @@ describe('Transport', () => {
 		});
 
 		describe('when it is called without ids, but exceeds maximum', () => {
-			const ids = new Array(30).fill(0).map((_, v) => `100000000000000000${v}`);
+			const ids = new Array(defaultReleaseLimit + 10)
+				.fill(0)
+				.map((_, v) => `10000000000000000${v}`);
 
 			it('should throw an error', async () => {
 				await expect(

--- a/framework/test/jest/unit/specs/application/transport/transport.spec.js
+++ b/framework/test/jest/unit/specs/application/transport/transport.spec.js
@@ -560,7 +560,7 @@ describe('transport', () => {
 							).toHaveBeenCalledWith(query.blockId);
 							return expect(
 								transportModule.chainModule.dataAccess.getBlocksByHeightBetween,
-							).toHaveBeenCalledWith(3, 36);
+							).toHaveBeenCalledWith(3, 105);
 						});
 					});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4974 

### How was it solved?

- Update release limit of the transaction to 100 which corresponds to maximum of 700kb of data per communication
- Update # receive block  for syncing to 103, which corresponds to maximum of 1.5Mb

### How was it tested?

- Created network of 110 nodes and check with the stress test
