### PR TITLE
Fix inconsistent account api response - Closes #5141

### DIFF
--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -27,17 +27,13 @@ function AccountsController(scope) {
 }
 
 function accountFormatter(totalSupply, account) {
-	const formattedAccount = {
-		...account,
-		delegate: {
-			...account.delegate,
-			approval: calculateApproval(account.totalVotesReceived, totalSupply),
-		},
-	};
+	account.delegate.approval = calculateApproval(
+		account.totalVotesReceived,
+		totalSupply,
+	);
+	account.publicKey = account.publicKey || '';
 
-	formattedAccount.publicKey = formattedAccount.publicKey || '';
-
-	return formattedAccount;
+	return account;
 }
 
 AccountsController.getAccounts = async (context, next) => {

--- a/framework/src/modules/http_api/controllers/accounts.js
+++ b/framework/src/modules/http_api/controllers/accounts.js
@@ -27,42 +27,13 @@ function AccountsController(scope) {
 }
 
 function accountFormatter(totalSupply, account) {
-	const formattedAccount = _.pick(account, [
-		'address',
-		'publicKey',
-		'balance',
-		'nonce',
-		'asset',
-		'keys',
-		'votes',
-		'totalVotesReceived',
-		'unlocking',
-		'delegate',
-		'isDelegate',
-		'username',
-	]);
-
-	if (account.isDelegate) {
-		formattedAccount.delegate = _.pick(account, [
-			'fees',
-			'rewards',
-			'rewards',
-			'producedBlocks',
-			'missedBlocks',
-			'productivity',
-		]);
-
-		// Computed fields
-		formattedAccount.delegate.approval = calculateApproval(
-			formattedAccount.totalVotesReceived,
-			totalSupply,
-		);
-	}
-
-	// If an account is not multi signature, then do not include keys for response
-	if (formattedAccount.keys.numberOfSignatures === 0) {
-		delete formattedAccount.keys;
-	}
+	const formattedAccount = {
+		...account,
+		delegate: {
+			...account.delegate,
+			approval: calculateApproval(account.totalVotesReceived, totalSupply),
+		},
+	};
 
 	formattedAccount.publicKey = formattedAccount.publicKey || '';
 

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -27,28 +27,18 @@ let epochTime;
 let activeDelegates;
 let standbyDelegates;
 
-function delegateFormatter(totalSupply, delegate) {
-	const result = _.pick(delegate, [
-		'username',
-		'totalVotesReceived',
-		'rewards',
-		'producedBlocks',
-		'missedBlocks',
-		'productivity',
-		'address',
-		'publicKey',
-		'balance',
-		'nonce',
-		'asset',
-		'keys',
-		'votes',
-		'delegate',
-		'unlocking',
-	]);
+function delegateFormatter(totalSupply, account) {
+	const formattedAccount = {
+		...account,
+		delegate: {
+			...account.delegate,
+			approval: calculateApproval(account.totalVotesReceived, totalSupply),
+		},
+	};
 
-	result.approval = calculateApproval(result.totalVotesReceived, totalSupply);
+	formattedAccount.publicKey = formattedAccount.publicKey || '';
 
-	return result;
+	return formattedAccount;
 }
 
 async function _getDelegates(filters, options) {

--- a/framework/src/modules/http_api/controllers/delegates.js
+++ b/framework/src/modules/http_api/controllers/delegates.js
@@ -28,17 +28,13 @@ let activeDelegates;
 let standbyDelegates;
 
 function delegateFormatter(totalSupply, account) {
-	const formattedAccount = {
-		...account,
-		delegate: {
-			...account.delegate,
-			approval: calculateApproval(account.totalVotesReceived, totalSupply),
-		},
-	};
+	account.delegate.approval = calculateApproval(
+		account.totalVotesReceived,
+		totalSupply,
+	);
+	account.publicKey = account.publicKey || '';
 
-	formattedAccount.publicKey = formattedAccount.publicKey || '';
-
-	return formattedAccount;
+	return account;
 }
 
 async function _getDelegates(filters, options) {

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -1225,7 +1225,7 @@ definitions:
         description: List of delegates.
         type: array
         items:
-          $ref: '#/definitions/DelegateWithAccount'
+          $ref: '#/definitions/Account'
       meta:
         type: object
         required:
@@ -2153,119 +2153,50 @@ definitions:
         description: |
           The total votes received by the delegate.
           Represents the total amount of Lisk (in Beddows), that the delegates voters voted this delegate.
+      rewards:
+        type: string
+        example: 510000000
+        description: Total sum of block rewards that the delegate has forged.
+      producedBlocks:
+        type: integer
+        example: 20131
+        description: Total number of blocks that the delegate has forged.
+      missedBlocks:
+        type: integer
+        example: 427
+        description: Total number of blocks that the delegate has missed.
+      productivity:
+        type: number
+        example: 96.41
+        description: |
+          Productivity rate.
+          Percentage of successfully forged blocks (not missed), by the delegate.
 
   Delegate:
     type: object
-    required:
-      - username
     properties:
-      username:
-        type: string
-        example: isabella
-        format: username
-        description: |
-          The delegates username.
-          A delegate chooses the username by registering a delegate on the Lisk network.
-          It is unique and cannot be changed later.
-      rewards:
-        type: string
-        example: 510000000
-        description: Total sum of block rewards that the delegate has forged.
-      producedBlocks:
+      lastForgedHeight:
         type: integer
-        example: 20131
-        description: Total number of blocks that the delegate has forged.
-      missedBlocks:
+        example: 100
+        description: Height of the block which delegate forged last time.
+      consecutiveMissedBlocks:
         type: integer
-        example: 427
-        description: Total number of blocks that the delegate has missed.
+        example: 10
+        description: Number of blocks that the delegate missed consecutively.
+      isBanned:
+        type: boolean
+        example: false
+        description: Whether the delegate is banned or not.
+      pomHeights:
+        type: array
+        description: Height of blocks where delegate has been reported for misbehavior.
+        items:
+          type: integer
       approval:
         type: number
         example: 14.22
         description: Percentage of the voters weight that the delegate owns in relation to the total supply of Lisk.
-      productivity:
-        type: number
-        example: 96.41
-        description: |
-          Productivity rate.
-          Percentage of successfully forged blocks (not missed), by the delegate.
 
-
-  DelegateWithAccount:
-    type: object
-    required:
-      - username
-      - totalVotesReceived
-    properties:
-      username:
-        type: string
-        example: isabella
-        format: username
-        description: |
-          The delegates username.
-          A delegate chooses the username by registering a delegate on the Lisk network.
-          It is unique and cannot be changed later.
-      totalVotesReceived:
-        type: string
-        example: 1081560729258
-        description: |
-          The total votes received by the delegate.
-          Represents the total amount of Lisk (in Beddows), that the delegates voters voted this delegate.
-      rewards:
-        type: string
-        example: 510000000
-        description: Total sum of block rewards that the delegate has forged.
-      producedBlocks:
-        type: integer
-        example: 20131
-        description: Total number of blocks that the delegate has forged.
-      missedBlocks:
-        type: integer
-        example: 427
-        description: Total number of blocks that the delegate has missed.
-      productivity:
-        type: number
-        example: 96.41
-        description: |
-          Productivity rate.
-          Percentage of successfully forged blocks (not missed), by the delegate.
-      address:
-        type: string
-        example: 10016685355739180605L
-        description: The LISK address for the delegate.
-      publicKey:
-        type: string
-        example: c678d19210ebf71914652d6644da5ee42e0c80948c4b520dba9f3d4514b213b2
-        description: The public key for the delegate.
-      balance:
-        type: string
-        example: 7000000000
-        description: The LISK balance for the delegate.
-      nonce:
-        type: string
-        example: 154
-        description: The current nonce associated to account for transaction processing.
-      asset:
-        type: object
-        description: The asset object for the account.
-      keys:
-        type: object
-        description: Multisignature information for the account.
-      votes:
-        type: array
-        items:
-          $ref: '#/definitions/Vote'
-      delegate:
-        type: object
-        description: Delegate propertiees associated with the account.
-      approval:
-        type: number
-        example: 14.22
-        description: Percentage of the voters weight that the delegate owns in relation to the total supply of Lisk.
-      unlocking:
-        type: array
-        items:
-          $ref: '#/definitions/Unlocking'
 
   DelegateWithVoters:
     type: object

--- a/framework/src/modules/http_api/schema/swagger.yml
+++ b/framework/src/modules/http_api/schema/swagger.yml
@@ -2100,6 +2100,7 @@ definitions:
       - votes
       - delegate
       - unlocking
+      - keys
     properties:
       address:
         type: string

--- a/framework/test/mocha/unit/modules/http_api/controllers/accounts.js
+++ b/framework/test/mocha/unit/modules/http_api/controllers/accounts.js
@@ -104,7 +104,6 @@ describe('accounts/api', () => {
 			},
 			delegate: {
 				lastForgedHeight: 0,
-				registeredHeight: 0,
 				consecutiveMissedBlocks: 0,
 				isBanned: false,
 				pomHeights: [],
@@ -120,8 +119,13 @@ describe('accounts/api', () => {
 		};
 
 		channelStub = {
-			invoke: sinonSandbox.stub().resolves({ height: 1 }),
+			invoke: sinonSandbox.stub(),
 		};
+
+		channelStub.invoke.withArgs('app:getLastBlock').resolves({ height: 1 });
+		channelStub.invoke
+			.withArgs('app:calculateSupply')
+			.resolves('10000000000000');
 
 		new AccountsController({
 			components: {
@@ -158,6 +162,14 @@ describe('accounts/api', () => {
 				expect(account).to.have.property('totalVotesReceived');
 				expect(account).to.have.property('unlocking');
 				expect(account).to.have.property('delegate');
+				expect(account.delegate).to.have.property('lastForgedHeight');
+				expect(account.delegate).to.have.property('consecutiveMissedBlocks');
+				expect(account.delegate).to.have.property('isBanned');
+				expect(account.delegate).to.have.property('pomHeights');
+				expect(account).to.have.property('keys');
+				expect(account.keys).to.have.property('numberOfSignatures');
+				expect(account.keys).to.have.property('mandatoryKeys');
+				expect(account.keys).to.have.property('optionalKeys');
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5141 

### How was it solved?
- Fix not to have partial formatting
- Keep approval calculation under delegate property


### How was it tested?

- Call `/api/accounts` endpoint
- Add unit test
