### PR TITLE
Update to remove tslint from cryptography - Partially Closes #4696

### DIFF
--- a/.eslintrc.test.js
+++ b/.eslintrc.test.js
@@ -4,7 +4,9 @@ module.exports = {
 		'arrow-body-style': 'off',
 		'@typescript-eslint/no-magic-numbers': 'off',
 		'@typescript-eslint/no-require-imports': 'off',
-		'@typescript-eslint/no-unsafe-member-access': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
+		'@typescript-eslint/no-unsafe-assignment': 'off',
+		'@typescript-eslint/no-unsafe-member-access': 'off',
+		'@typescript-eslint/no-unsafe-call': 'off',
 	},
 };

--- a/elements/lisk-cryptography/.eslintignore
+++ b/elements/lisk-cryptography/.eslintignore
@@ -1,0 +1,4 @@
+dist-node
+jest.config.js
+types
+benchmark

--- a/elements/lisk-cryptography/.eslintrc.js
+++ b/elements/lisk-cryptography/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: '../../.eslintrc.js',
+	parserOptions: {
+		project: './tsconfig.json',
+		tsconfigRootDir: __dirname,
+	},
+};

--- a/elements/lisk-cryptography/.nycrc
+++ b/elements/lisk-cryptography/.nycrc
@@ -1,1 +1,0 @@
-../../templates/.nycrc-ts.tmpl

--- a/elements/lisk-cryptography/package.json
+++ b/elements/lisk-cryptography/package.json
@@ -24,8 +24,8 @@
 	"scripts": {
 		"clean": "./scripts/clean.sh",
 		"format": "prettier --write '**/*'",
-		"lint": "tslint --format verbose --project .",
-		"lint:fix": "npm run lint -- --fix",
+		"lint": "eslint . --ext .js,.ts",
+		"lint:fix": "eslint --fix --ext .js,.ts .",
 		"test": "jest",
 		"test:watch": "npm test -- --watch",
 		"prebuild": "rm -r dist-node/* || mkdir dist-node || true",
@@ -47,7 +47,14 @@
 		"@types/jest": "25.1.3",
 		"@types/jest-when": "2.7.0",
 		"@types/node": "12.12.11",
+		"@typescript-eslint/eslint-plugin": "2.28.0",
+		"@typescript-eslint/parser": "2.28.0",
 		"benchmark": "2.1.4",
+		"eslint": "6.8.0",
+		"eslint-config-lisk-base": "1.2.2",
+		"eslint-config-prettier": "6.10.0",
+		"eslint-plugin-import": "2.20.1",
+		"eslint-plugin-jest": "23.8.2",
 		"jest": "25.1.0",
 		"jest-extended": "0.11.5",
 		"jest-when": "2.7.0",
@@ -55,8 +62,6 @@
 		"source-map-support": "0.5.16",
 		"ts-node": "8.6.2",
 		"tsconfig-paths": "3.9.0",
-		"tslint": "6.0.0",
-		"tslint-immutable": "6.0.1",
 		"typescript": "3.8.3"
 	}
 }

--- a/elements/lisk-cryptography/src/buffer.ts
+++ b/elements/lisk-cryptography/src/buffer.ts
@@ -20,9 +20,9 @@ const MAX_NUMBER_BYTE_LENGTH = 6;
 export const intToBuffer = (
 	value: number | string,
 	byteLength: number,
-	endianness: string = BIG_ENDIAN,
-	signed: boolean = false,
-) => {
+	endianness = BIG_ENDIAN,
+	signed = false,
+): Buffer => {
 	if (![BIG_ENDIAN, LITTLE_ENDIAN].includes(endianness)) {
 		throw new Error(
 			`Endianness must be either ${BIG_ENDIAN} or ${LITTLE_ENDIAN}`,
@@ -37,6 +37,7 @@ export const intToBuffer = (
 				buffer.writeUIntBE(Number(value), 0, byteLength);
 			}
 		} else {
+			// eslint-disable-next-line no-lonely-if
 			if (signed) {
 				buffer.writeBigInt64BE(BigInt(value));
 			} else {
@@ -44,6 +45,7 @@ export const intToBuffer = (
 			}
 		}
 	} else {
+		// eslint-disable-next-line no-lonely-if
 		if (byteLength <= MAX_NUMBER_BYTE_LENGTH) {
 			if (signed) {
 				buffer.writeIntLE(Number(value), 0, byteLength);
@@ -51,6 +53,7 @@ export const intToBuffer = (
 				buffer.writeUIntLE(Number(value), 0, byteLength);
 			}
 		} else {
+			// eslint-disable-next-line no-lonely-if
 			if (signed) {
 				buffer.writeBigInt64LE(BigInt(value));
 			} else {
@@ -75,7 +78,8 @@ export const hexToBuffer = (hex: string, argumentName = 'Argument'): Buffer => {
 	if (typeof hex !== 'string') {
 		throw new TypeError(`${argumentName} must be a string.`);
 	}
-	const matchedHex = (hex.match(hexRegex) || [])[0];
+	// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+	const matchedHex = (hex.match(hexRegex) ?? [])[0];
 	if (!matchedHex || matchedHex.length !== hex.length) {
 		throw new TypeError(`${argumentName} must be a valid hex string.`);
 	}

--- a/elements/lisk-cryptography/src/convert.ts
+++ b/elements/lisk-cryptography/src/convert.ts
@@ -13,14 +13,16 @@
  *
  */
 // Required because first level function export
-// tslint:disable-next-line no-require-imports
-import reverse = require('buffer-reverse');
 import * as ed2curve from 'ed2curve';
 import * as querystring from 'querystring';
 
 import { bufferToIntAsString } from './buffer';
+// eslint-disable-next-line import/no-cycle
 import { EncryptedPassphraseObject } from './encrypt';
 import { hash } from './hash';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import reverse = require('buffer-reverse');
 
 export const getFirstEightBytesReversed = (input: string | Buffer): Buffer => {
 	const BUFFER_SIZE = 8;

--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -15,8 +15,11 @@
 import * as crypto from 'crypto';
 
 import { bufferToHex, hexToBuffer } from './buffer';
+// eslint-disable-next-line import/no-cycle
 import { convertPrivateKeyEd2Curve, convertPublicKeyEd2Curve } from './convert';
+// eslint-disable-next-line import/no-cycle
 import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
+// eslint-disable-next-line import/no-cycle
 import { box, getRandomBytes, openBox } from './nacl';
 
 const PBKDF2_ITERATIONS = 1e6;
@@ -105,7 +108,8 @@ export const decryptMessageWithPassphrase = (
 		return Buffer.from(decoded).toString();
 	} catch (error) {
 		if (
-			error.message.match(
+			// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+			(error as Error).message.match(
 				/bad nonce size|nonce must be a buffer of size crypto_box_NONCEBYTES/,
 			)
 		) {
@@ -131,14 +135,13 @@ const getKeyFromPassword = (
 	);
 
 export interface EncryptedPassphraseObject {
+	readonly [key: string]: string | number | undefined;
 	readonly cipherText: string;
 	readonly iterations?: number;
 	readonly iv: string;
 	readonly salt: string;
 	readonly tag: string;
 	readonly version: string;
-	// tslint:disable-next-line no-mixed-interface
-	readonly [key: string]: string | number | undefined;
 }
 
 const encryptAES256GCMWithPassword = (

--- a/elements/lisk-cryptography/src/hash.ts
+++ b/elements/lisk-cryptography/src/hash.ts
@@ -41,12 +41,13 @@ export const hash = (data: Buffer | string, format?: string): Buffer => {
 	}
 
 	throw new Error(
-		`Unsupported data:${data} and format:${format}. Currently only Buffers or hex and utf8 strings are supported.`,
+		`Unsupported data:${data} and format:${format ??
+			'undefined'}. Currently only Buffers or hex and utf8 strings are supported.`,
 	);
 };
 
 export const getNetworkIdentifier = (
 	genesisBlockPayloadHash: string,
 	communityIdentifier: string,
-) =>
+): string =>
 	hash(genesisBlockPayloadHash + communityIdentifier, 'utf8').toString('hex');

--- a/elements/lisk-cryptography/src/hash_onion.ts
+++ b/elements/lisk-cryptography/src/hash_onion.ts
@@ -21,7 +21,7 @@ const INPUT_SIZE = 64;
 const defaultCount = 1000000;
 const defaultDistance = 1000;
 
-export const generateHashOnionSeed = () =>
+export const generateHashOnionSeed = (): Buffer =>
 	hash(getRandomBytes(INPUT_SIZE)).slice(0, HASH_SIZE);
 
 export const hashOnion = (

--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -13,8 +13,10 @@
  *
  */
 import { bufferToHex, hexToBuffer } from './buffer';
+// eslint-disable-next-line import/no-cycle
 import { getAddressFromPublicKey } from './convert';
 import { hash } from './hash';
+// eslint-disable-next-line import/no-cycle
 import { getKeyPair, getPublicKey } from './nacl';
 
 export interface KeypairBytes {

--- a/elements/lisk-cryptography/src/nacl/fast.ts
+++ b/elements/lisk-cryptography/src/nacl/fast.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-// tslint:disable-next-line no-implicit-dependencies
+// eslint-disable-next-line import/no-extraneous-dependencies
 import * as sodium from 'sodium-native';
 
 import { NaclInterface } from './nacl_types';

--- a/elements/lisk-cryptography/src/nacl/index.ts
+++ b/elements/lisk-cryptography/src/nacl/index.ts
@@ -12,18 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+// eslint-disable-next-line import/no-cycle
 import { NaclInterface } from './nacl_types';
 
-// tslint:disable-next-line no-let no-require-imports no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
 let lib: NaclInterface = require('./slow');
 
 // Use try/catch for browser fallback support
 try {
 	if (process.env.NACL_FAST !== 'disable') {
-		// tslint:disable-next-line no-var-requires no-require-imports
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-require-imports,global-require
 		lib = require('./fast');
 	}
-	// tslint:disable-next-line no-empty
+	// eslint-disable-next-line no-empty
 } catch (err) {}
 
 export const NACL_SIGN_PUBLICKEY_LENGTH = 32;

--- a/elements/lisk-cryptography/src/nacl/nacl_types.ts
+++ b/elements/lisk-cryptography/src/nacl/nacl_types.ts
@@ -1,25 +1,40 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+// eslint-disable-next-line import/no-cycle
 import { KeypairBytes } from '../keys';
 
 export interface NaclInterface {
-	box(
+	box: (
 		messageInBytes: Buffer,
 		nonceInBytes: Buffer,
 		convertedPublicKey: Buffer,
 		convertedPrivateKey: Buffer,
-	): Buffer;
-	getKeyPair(hashedSeed: Buffer): KeypairBytes;
-	getPublicKey(privateKey: Buffer): Buffer;
-	getRandomBytes(length: number): Buffer;
-	openBox(
+	) => Buffer;
+	getKeyPair: (hashedSeed: Buffer) => KeypairBytes;
+	getPublicKey: (privateKey: Buffer) => Buffer;
+	getRandomBytes: (length: number) => Buffer;
+	openBox: (
 		cipherBytes: Buffer,
 		nonceBytes: Buffer,
 		convertedPublicKey: Buffer,
 		convertedPrivateKey: Buffer,
-	): Buffer;
-	signDetached(messageBytes: Buffer, privateKeyBytes: Buffer): Buffer;
-	verifyDetached(
+	) => Buffer;
+	signDetached: (messageBytes: Buffer, privateKeyBytes: Buffer) => Buffer;
+	verifyDetached: (
 		messageBytes: Buffer,
 		signatureBytes: Buffer,
 		publicKeyBytes: Buffer,
-	): boolean;
+	) => boolean;
 }

--- a/elements/lisk-cryptography/src/nacl/slow.ts
+++ b/elements/lisk-cryptography/src/nacl/slow.ts
@@ -57,7 +57,7 @@ export const signDetached: NaclInterface['signDetached'] = (
 ) => Buffer.from(tweetnacl.sign.detached(messageBytes, privateKeyBytes));
 
 export const verifyDetached: NaclInterface['verifyDetached'] =
-	// tslint:disable-next-line no-unbound-method
+	// eslint-disable-next-line @typescript-eslint/unbound-method
 	tweetnacl.sign.detached.verify;
 
 export const getRandomBytes: NaclInterface['getRandomBytes'] = length =>

--- a/elements/lisk-cryptography/src/sign.ts
+++ b/elements/lisk-cryptography/src/sign.ts
@@ -82,13 +82,13 @@ export const verifyMessageWithPublicKey = ({
 
 	if (publicKeyBytes.length !== NACL_SIGN_PUBLICKEY_LENGTH) {
 		throw new Error(
-			`Invalid publicKey, expected ${NACL_SIGN_PUBLICKEY_LENGTH}-byte publicKey`,
+			`Invalid publicKey, expected ${NACL_SIGN_PUBLICKEY_LENGTH.toString()}-byte publicKey`,
 		);
 	}
 
 	if (signatureBytes.length !== NACL_SIGN_SIGNATURE_LENGTH) {
 		throw new Error(
-			`Invalid signature length, expected ${NACL_SIGN_SIGNATURE_LENGTH}-byte signature`,
+			`Invalid signature length, expected ${NACL_SIGN_SIGNATURE_LENGTH.toString()}-byte signature`,
 		);
 	}
 

--- a/elements/lisk-cryptography/test/.eslintrc.js
+++ b/elements/lisk-cryptography/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: '../../../.eslintrc.test.js',
+	parserOptions: {
+		project: './tsconfig.json',
+		tsconfigRootDir: __dirname,
+	},
+};

--- a/elements/lisk-cryptography/test/buffer.spec.ts
+++ b/elements/lisk-cryptography/test/buffer.spec.ts
@@ -37,47 +37,47 @@ describe('buffer', () => {
 		});
 
 		it('should throw TypeError with number', () => {
-			expect(hexToBuffer.bind(null, 123 as any)).toThrowError(TypeError);
+			expect(hexToBuffer.bind(null, 123 as any)).toThrow(TypeError);
 		});
 
 		it('should throw TypeError with object', () => {
-			expect(hexToBuffer.bind(null, {} as any)).toThrowError(TypeError);
+			expect(hexToBuffer.bind(null, {} as any)).toThrow(TypeError);
 		});
 
 		it('should throw an error for a non-string input with custom argument name', () => {
-			expect(hexToBuffer.bind(null, {} as any, 'Custom')).toThrowError(
+			expect(hexToBuffer.bind(null, {} as any, 'Custom')).toThrow(
 				'Custom must be a string.',
 			);
 		});
 
 		it('should throw TypeError with non hex string', () => {
-			expect(hexToBuffer.bind(null, 'yKJj')).toThrowError(TypeError);
+			expect(hexToBuffer.bind(null, 'yKJj')).toThrow(TypeError);
 		});
 
 		it('should throw TypeError with partially correct hex string', () => {
-			expect(hexToBuffer.bind(null, 'Abxzzzz')).toThrowError(TypeError);
+			expect(hexToBuffer.bind(null, 'Abxzzzz')).toThrow(TypeError);
 		});
 
 		it('should throw TypeError with odd number of string with partially correct hex string', () => {
-			expect(hexToBuffer.bind(null, 'Abxzzab')).toThrowError(TypeError);
+			expect(hexToBuffer.bind(null, 'Abxzzab')).toThrow(TypeError);
 		});
 
 		it('should throw TypeError with odd number hex string with invalid hex', () => {
-			expect(hexToBuffer.bind(null, '123xxxx')).toThrowError(TypeError);
+			expect(hexToBuffer.bind(null, '123xxxx')).toThrow(TypeError);
 		});
 
 		it('should throw an error for a non-hex string input with custom argument name', () => {
-			expect(hexToBuffer.bind(null, 'yKJj', 'Custom')).toThrowError(
+			expect(hexToBuffer.bind(null, 'yKJj', 'Custom')).toThrow(
 				'Custom must be a valid hex string.',
 			);
 		});
 
 		it('should throw TypeError with odd-length hex string', () => {
-			expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a')).toThrowError(TypeError);
+			expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a')).toThrow(TypeError);
 		});
 
 		it('should throw an error for an odd-length hex string input with custom argument name', () => {
-			expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a', 'Custom')).toThrowError(
+			expect(hexToBuffer.bind(null, 'c3a5c3a4c3b6a', 'Custom')).toThrow(
 				'Custom must have a valid length of hex string.',
 			);
 		});

--- a/elements/lisk-cryptography/test/convert.spec.ts
+++ b/elements/lisk-cryptography/test/convert.spec.ts
@@ -22,6 +22,7 @@ import {
 	parseEncryptedPassphrase,
 } from '../src/convert';
 // Require is used for stubbing
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-var-requires
 const hashModule = require('../src/hash');
 
 describe('convert', () => {
@@ -78,7 +79,7 @@ describe('convert', () => {
 			const bufferExceedError =
 				'The buffer for Lisk addresses must not have more than 8 bytes';
 			const bufferInit = Buffer.from(defaultStringWithMoreThanEightCharacters);
-			expect(toAddress.bind(null, bufferInit)).toThrowError(bufferExceedError);
+			expect(toAddress.bind(null, bufferInit)).toThrow(bufferExceedError);
 		});
 	});
 
@@ -125,7 +126,7 @@ describe('convert', () => {
 				'salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
 			expect(
 				stringifyEncryptedPassphrase.bind(null, encryptedPassphrase as any),
-			).toThrowError('Encrypted passphrase to stringify must be an object.');
+			).toThrow('Encrypted passphrase to stringify must be an object.');
 		});
 
 		it('should format an encrypted passphrase as a string', () => {
@@ -170,7 +171,7 @@ describe('convert', () => {
 					null,
 					stringifiedEncryptedPassphrase as any,
 				),
-			).toThrowError('Encrypted passphrase to parse must be a string.');
+			).toThrow('Encrypted passphrase to parse must be a string.');
 		});
 
 		it('should throw an error if iterations is present but not a valid number', () => {
@@ -178,7 +179,7 @@ describe('convert', () => {
 				'iterations=null&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
 			expect(
 				parseEncryptedPassphrase.bind(null, stringifiedEncryptedPassphrase),
-			).toThrowError('Could not parse iterations.');
+			).toThrow('Could not parse iterations.');
 		});
 
 		it('should throw an error if multiple values are in a key', () => {
@@ -186,7 +187,7 @@ describe('convert', () => {
 				'salt=xxx&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
 			expect(
 				parseEncryptedPassphrase.bind(null, stringifiedEncryptedPassphrase),
-			).toThrowError(
+			).toThrow(
 				'Encrypted passphrase to parse must have only one value per key.',
 			);
 		});

--- a/elements/lisk-cryptography/test/encrypt.spec.ts
+++ b/elements/lisk-cryptography/test/encrypt.spec.ts
@@ -20,12 +20,15 @@ import {
 	decryptPassphraseWithPassword,
 } from '../src/encrypt';
 // Require is used for stubbing
+// eslint-disable-next-line
 const convert = require('../src/convert');
+// eslint-disable-next-line
 const keys = require('../src/keys');
+// eslint-disable-next-line
 const hashModule = require('../src/hash');
 
 describe('encrypt', () => {
-	const regHexadecimal: RegExp = /[0-9A-Za-z]/g;
+	const regHexadecimal = /[0-9A-Za-z]/g;
 	const PBKDF2_ITERATIONS = 1e6;
 	const ENCRYPTION_VERSION = '1';
 	const defaultPassphrase =
@@ -42,7 +45,7 @@ describe('encrypt', () => {
 
 	let hashStub: any;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		defaultEncryptedMessageWithNonce = {
 			encryptedMessage:
 				'299390b9cbb92fe6a43daece2ceaecbacd01c7c03cfdba51d693b5c0e2b65c634115',
@@ -88,7 +91,7 @@ describe('encrypt', () => {
 	describe('#encryptMessageWithPassphrase', () => {
 		let encryptedMessage: EncryptedMessageWithNonce;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			encryptedMessage = encryptMessageWithPassphrase(
 				defaultMessage,
 				defaultPassphrase,
@@ -103,7 +106,7 @@ describe('encrypt', () => {
 		});
 
 		it('should output the nonce', () => {
-			expect(encryptedMessage);
+			expect(encryptedMessage).not.toBeUndefined();
 			expect(encryptedMessage).toHaveProperty('nonce');
 			expect(regHexadecimal.test(encryptedMessage.nonce)).toBe(true);
 		});
@@ -130,7 +133,7 @@ describe('encrypt', () => {
 					defaultPassphrase,
 					defaultPublicKey,
 				),
-			).toThrowError('Expected nonce to be 24 bytes.');
+			).toThrow('Expected nonce to be 24 bytes.');
 		});
 
 		it('should inform the user if something goes wrong during decryption', () => {
@@ -142,7 +145,7 @@ describe('encrypt', () => {
 					defaultPassphrase,
 					defaultPublicKey,
 				),
-			).toThrowError(
+			).toThrow(
 				'Something went wrong during decryption. Is this the full encrypted message?',
 			);
 		});
@@ -161,7 +164,7 @@ describe('encrypt', () => {
 		describe('#encryptPassphraseWithPassword', () => {
 			let encryptedPassphrase: EncryptedPassphraseObject;
 
-			beforeEach(() => {
+			beforeEach(async () => {
 				encryptedPassphrase = encryptPassphraseWithPassword(
 					defaultPassphrase,
 					defaultPassword,
@@ -220,7 +223,7 @@ describe('encrypt', () => {
 		});
 
 		describe('#decryptPassphraseWithPassword', () => {
-			let encryptedPassphrase = {
+			const encryptedPassphrase = {
 				iterations: undefined,
 				cipherText:
 					'5cfd7bcc13022a482e7c8bd250cd73ef3eb7c49c849d5e761ce717608293f777cca8e0e18587ee307beab65bcc1b273caeb23d4985010b675391b354c38f8e84e342c1e7aa',
@@ -249,7 +252,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithoutCipherText as any,
 						defaultPassword,
 					),
-				).toThrowError('Cipher text must be a string.');
+				).toThrow('Cipher text must be a string.');
 			});
 
 			it('should inform the user if iv is missing', () => {
@@ -260,7 +263,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithoutIv as any,
 						defaultPassword,
 					),
-				).toThrowError('IV must be a string.');
+				).toThrow('IV must be a string.');
 			});
 
 			it('should inform the user if salt is missing', () => {
@@ -271,7 +274,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithoutSalt as any,
 						defaultPassword,
 					),
-				).toThrowError('Salt must be a string.');
+				).toThrow('Salt must be a string.');
 			});
 
 			it('should inform the user if tag is missing', () => {
@@ -282,7 +285,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithoutTag as any,
 						defaultPassword,
 					),
-				).toThrowError('Tag must be a string.');
+				).toThrow('Tag must be a string.');
 			});
 
 			it('should inform the user if the salt has been altered', () => {
@@ -297,7 +300,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithAlteredSalt,
 						defaultPassword,
 					),
-				).toThrowError('Unsupported state or unable to authenticate data');
+				).toThrow('Unsupported state or unable to authenticate data');
 			});
 
 			it('should inform the user if the tag has been shortened', () => {
@@ -312,7 +315,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithAlteredTag,
 						defaultPassword,
 					),
-				).toThrowError('Tag must be 16 bytes.');
+				).toThrow('Tag must be 16 bytes.');
 			});
 
 			it('should inform the user if the tag is not a hex string', () => {
@@ -327,7 +330,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithAlteredTag,
 						defaultPassword,
 					),
-				).toThrowError('Tag must be a valid hex string.');
+				).toThrow('Tag must be a valid hex string.');
 			});
 
 			it('should inform the user if the tag has been altered', () => {
@@ -342,7 +345,7 @@ describe('encrypt', () => {
 						encryptedPassphraseWithAlteredTag,
 						defaultPassword,
 					),
-				).toThrowError('Unsupported state or unable to authenticate data');
+				).toThrow('Unsupported state or unable to authenticate data');
 			});
 
 			it('should decrypt a passphrase with a password and a custom number of iterations', () => {

--- a/elements/lisk-cryptography/test/hash.spec.ts
+++ b/elements/lisk-cryptography/test/hash.spec.ts
@@ -20,7 +20,7 @@ describe('hash', () => {
 		let arrayToHash: ReadonlyArray<number>;
 		let defaultHash: Buffer;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			defaultHash = Buffer.from(
 				'7607d6792843d6003c12495b54e34517a508d2a8622526aff1884422c5478971',
 				'hex',
@@ -47,13 +47,13 @@ describe('hash', () => {
 		});
 
 		it('should throw on unknown format when trying a string with format "utf32"', () => {
-			expect(hashFunction.bind(null, defaultText, 'utf32')).toThrowError(
+			expect(hashFunction.bind(null, defaultText, 'utf32')).toThrow(
 				'Unsupported string format. Currently only `hex` and `utf8` are supported.',
 			);
 		});
 
 		it('should throw on unknown format when using an array', () => {
-			expect(hashFunction.bind(null, arrayToHash as any)).toThrowError(
+			expect(hashFunction.bind(null, arrayToHash as any)).toThrow(
 				'Unsupported data:1,2,3 and format:undefined. Currently only Buffers or hex and utf8 strings are supported.',
 			);
 		});

--- a/elements/lisk-cryptography/test/hash_onion.spec.ts
+++ b/elements/lisk-cryptography/test/hash_onion.spec.ts
@@ -32,7 +32,7 @@ describe('hash onion', () => {
 	describe('#hashOnion', () => {
 		let seed: Buffer;
 		let hashOnionBuffers: ReadonlyArray<Buffer>;
-		beforeAll(async () => {
+		beforeAll(() => {
 			seed = generateHashOnionSeed();
 			hashOnionBuffers = hashOnion(seed);
 		});

--- a/elements/lisk-cryptography/test/helpers/index.ts
+++ b/elements/lisk-cryptography/test/helpers/index.ts
@@ -13,6 +13,6 @@
  *
  */
 export const makeInvalid = (str: string): string => {
-	const char = str[0] === '0' ? '1' : '0';
+	const char = str.startsWith('0') ? '1' : '0';
 	return `${char}${str.slice(1)}`;
 };

--- a/elements/lisk-cryptography/test/keys.spec.ts
+++ b/elements/lisk-cryptography/test/keys.spec.ts
@@ -23,7 +23,9 @@ import {
 	getAddressFromPrivateKey,
 } from '../src/keys';
 // Require is used for stubbing
+// eslint-disable-next-line
 const buffer = require('../src/buffer');
+// eslint-disable-next-line
 const hashModule = require('../src/hash');
 
 describe('keys', () => {

--- a/elements/lisk-cryptography/test/nacl/index.spec.ts
+++ b/elements/lisk-cryptography/test/nacl/index.spec.ts
@@ -14,9 +14,10 @@
  */
 import { when } from 'jest-when';
 // Require is used for stubbing
+// eslint-disable-next-line
 const moduleLibrary = require('module');
 
-const resetTest = () => {
+const resetTest = (): void => {
 	// Reset environment variable
 	delete process.env.NACL_FAST;
 	// Delete require cache to force it to re-load module
@@ -47,40 +48,43 @@ describe('nacl index.js', () => {
 			resetTest();
 		});
 
-		it('should load nacl fast if process.env.NACL_FAST is set to enable', async () => {
+		it('should load nacl fast if process.env.NACL_FAST is set to enable', () => {
 			// Arrange
 			process.env.NACL_FAST = 'enable';
-			const requireMock = jest.spyOn(moduleLibrary.prototype as any, 'require');
+			const requireMock = jest.spyOn(moduleLibrary.prototype, 'require');
 			// Act
+			// eslint-disable-next-line global-require
 			require('../../src/nacl');
 			// Assert
 			// Loading chain of Sodium-native module
-			expect(requireMock).toBeCalledWith('fs');
-			expect(requireMock).toBeCalledWith('path');
-			expect(requireMock).toBeCalledWith('os');
+			expect(requireMock).toHaveBeenCalledWith('fs');
+			expect(requireMock).toHaveBeenCalledWith('path');
+			expect(requireMock).toHaveBeenCalledWith('os');
 		});
 
-		it('should load nacl slow if process.env.NACL_FAST is set to disable', async () => {
+		it('should load nacl slow if process.env.NACL_FAST is set to disable', () => {
 			// Arrange
 			process.env.NACL_FAST = 'disable';
-			const requireMock = jest.spyOn(moduleLibrary.prototype as any, 'require');
+			const requireMock = jest.spyOn(moduleLibrary.prototype, 'require');
 			// Act
+			// eslint-disable-next-line global-require
 			require('../../src/nacl');
 			// Assert
-			expect(requireMock).toBeCalledWith('crypto');
+			expect(requireMock).toHaveBeenCalledWith('crypto');
 		});
 
-		it('should load nacl fast if process.env.NACL_FAST is undefined', async () => {
+		it('should load nacl fast if process.env.NACL_FAST is undefined', () => {
 			// Arrange
 			process.env.NACL_FAST = undefined;
-			const requireMock = jest.spyOn(moduleLibrary.prototype as any, 'require');
+			const requireMock = jest.spyOn(moduleLibrary.prototype, 'require');
 			// Act
+			// eslint-disable-next-line global-require
 			require('../../src/nacl');
 			// Assert
 			// Loading chain of Sodium-native module
-			expect(requireMock).toBeCalledWith('fs');
-			expect(requireMock).toBeCalledWith('path');
-			expect(requireMock).toBeCalledWith('os');
+			expect(requireMock).toHaveBeenCalledWith('fs');
+			expect(requireMock).toHaveBeenCalledWith('path');
+			expect(requireMock).toHaveBeenCalledWith('os');
 		});
 	});
 
@@ -91,8 +95,8 @@ describe('nacl index.js', () => {
 			resetTest();
 		});
 
-		it('should not set process.env.NACL_FAST to disable', async () => {
-			const requireMock = jest.spyOn(moduleLibrary.prototype as any, 'require');
+		it('should not set process.env.NACL_FAST to disable', () => {
+			const requireMock = jest.spyOn(moduleLibrary.prototype, 'require');
 
 			when(requireMock)
 				.calledWith('fs')
@@ -100,20 +104,22 @@ describe('nacl index.js', () => {
 					throw moduleNotFoundError;
 				});
 
+			// eslint-disable-next-line global-require
 			require('../../src/nacl');
 			expect(process.env.NACL_FAST).not.toEqual('disable');
 		});
 
-		it('should load nacl slow if process.env.NACL_FAST is set to disable', async () => {
+		it('should load nacl slow if process.env.NACL_FAST is set to disable', () => {
 			// Arrange
 			process.env.NACL_FAST = 'disable';
-			const requireMock = jest.spyOn(moduleLibrary.prototype as any, 'require');
+			const requireMock = jest.spyOn(moduleLibrary.prototype, 'require');
 
 			// Act
+			// eslint-disable-next-line global-require
 			require('../../src/nacl');
 
 			// Assert
-			expect(requireMock).toBeCalledWith('crypto');
+			expect(requireMock).toHaveBeenCalledWith('crypto');
 		});
 	});
 });

--- a/elements/lisk-cryptography/test/nacl/nacl.spec.ts
+++ b/elements/lisk-cryptography/test/nacl/nacl.spec.ts
@@ -70,7 +70,7 @@ describe('nacl', () => {
 				const size = 24;
 				let randomBuffer: Buffer;
 
-				beforeEach(() => {
+				beforeEach(async () => {
 					randomBuffer = getRandomBytes(size);
 					return Promise.resolve();
 				});
@@ -82,14 +82,14 @@ describe('nacl', () => {
 				});
 
 				it('should return an uint8array of size 24', () => {
-					expect(randomBuffer.length).toEqual(24);
+					expect(randomBuffer).toHaveLength(24);
 				});
 			});
 
 			describe('#getKeyPair', () => {
 				let signedKeys: KeypairBytes;
 
-				beforeEach(() => {
+				beforeEach(async () => {
 					signedKeys = getKeyPair(Buffer.from(defaultHash, 'hex'));
 					return Promise.resolve();
 				});
@@ -122,7 +122,7 @@ describe('nacl', () => {
 			describe('#getPublicKey', () => {
 				let publicKey: Buffer;
 
-				beforeEach(() => {
+				beforeEach(async () => {
 					publicKey = getPublicKey(Buffer.from(defaultPrivateKey, 'hex'));
 
 					return Promise.resolve();
@@ -153,7 +153,7 @@ describe('nacl', () => {
 			describe('#signDetached', () => {
 				let signatureBytes: Buffer;
 
-				beforeEach(() => {
+				beforeEach(async () => {
 					signatureBytes = signDetached(
 						Buffer.from(defaultDigest, 'hex'),
 						Buffer.from(defaultPrivateKey, 'hex'),
@@ -197,7 +197,7 @@ describe('nacl', () => {
 			describe('#box', () => {
 				let encryptedMessageBytes: Buffer;
 
-				beforeEach(() => {
+				beforeEach(async () => {
 					encryptedMessageBytes = box(
 						Buffer.from(defaultMessage, 'utf8'),
 						Buffer.from(defaultNonce, 'hex'),
@@ -217,7 +217,7 @@ describe('nacl', () => {
 			describe('#openBox', () => {
 				let decryptedMessageBytes: Buffer;
 
-				beforeEach(() => {
+				beforeEach(async () => {
 					decryptedMessageBytes = openBox(
 						Buffer.from(defaultEncryptedMessage, 'hex'),
 						Buffer.from(defaultNonce, 'hex'),
@@ -245,7 +245,7 @@ describe('nacl', () => {
 							Buffer.from(defaultConvertedPublicKeyEd2Curve, 'hex'),
 							Buffer.from(defaultConvertedPrivateKeyEd2Curve, 'hex'),
 						),
-					).toThrowError(Error);
+					).toThrow(Error);
 				});
 			});
 

--- a/elements/lisk-cryptography/test/sign.spec.ts
+++ b/elements/lisk-cryptography/test/sign.spec.ts
@@ -26,6 +26,7 @@ import {
 	digestMessage,
 } from '../src/sign';
 // Require is used for stubbing
+// eslint-disable-next-line
 const keys = require('../src/keys');
 
 const changeLength = (str: string): string => `00${str}`;
@@ -131,7 +132,7 @@ ${defaultSignature}
 					signature: defaultSignature,
 					publicKey: changeLength(defaultPublicKey),
 				}),
-			).toThrowError('Invalid publicKey, expected 32-byte publicKey');
+			).toThrow('Invalid publicKey, expected 32-byte publicKey');
 		});
 
 		it('should detect invalid signatures', () => {
@@ -141,7 +142,7 @@ ${defaultSignature}
 					signature: changeLength(defaultSignature),
 					publicKey: defaultPublicKey,
 				}),
-			).toThrowError('Invalid signature length, expected 64-byte signature');
+			).toThrow('Invalid signature length, expected 64-byte signature');
 		});
 
 		it('should return false if the signature is invalid', () => {
@@ -183,7 +184,7 @@ ${defaultSignature}
 	describe('#signData', () => {
 		let signature: string;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			signature = signData(defaultData, defaultPassphrase);
 			return Promise.resolve();
 		});
@@ -196,7 +197,7 @@ ${defaultSignature}
 	describe('#signDataWithPassphrase', () => {
 		let signature: string;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			signature = signDataWithPassphrase(defaultData, defaultPassphrase);
 			return Promise.resolve();
 		});
@@ -209,7 +210,7 @@ ${defaultSignature}
 	describe('#signDataWithPrivateKey', () => {
 		let signature: string;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			signature = signDataWithPrivateKey(
 				defaultData,
 				Buffer.from(defaultPrivateKey, 'hex'),

--- a/elements/lisk-cryptography/test/tslint.json
+++ b/elements/lisk-cryptography/test/tslint.json
@@ -1,1 +1,0 @@
-../../../templates/test/tslint.json.tmpl

--- a/elements/lisk-cryptography/tslint.json
+++ b/elements/lisk-cryptography/tslint.json
@@ -1,1 +1,0 @@
-../../templates/tslint.json.tmpl

--- a/framework/src/controller/bus.js
+++ b/framework/src/controller/bus.js
@@ -228,7 +228,7 @@ class Bus extends EventEmitter2 {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
-	async leanup() {
+	async cleanup() {
 		if (this.pubSocket) {
 			this.pubSocket.close();
 		}


### PR DESCRIPTION
### What was the problem?

This PR partially resolves #4696 

### How was it solved?

- Remove tslint from lisk-cryptography

### How was it tested?
- All the linting should work
- no source code changes

