### PR TITLE
Add edge case test for pom transaction - Closes #5157

### DIFF
--- a/elements/lisk-transactions/test/15_pom_transaction.spec.ts
+++ b/elements/lisk-transactions/test/15_pom_transaction.spec.ts
@@ -379,6 +379,18 @@ describe('Proof-of-misbehavior transaction', () => {
 
 			expect(updatedDelegate.delegate.isBanned).toBeTrue();
 		});
+
+		it('should not return balance related errors with valid transactions from same sender and delegate account', async () => {
+			const sameAccountTransaction = new ProofOfMisbehaviorTransaction({
+				...validProofOfMisbehaviorTransactionScenario1.testCases.output,
+				senderPublicKey: delegate.publicKey,
+			});
+
+			const { errors } = await sameAccountTransaction.apply(store);
+
+			// returned errors here are unrelated to the tested issue: nonce and signature
+			expect(errors.length).toEqual(2);
+		});
 	});
 
 	describe('undoAsset', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5157

### How was it solved?

Added test case in which a delegate account sends a pom tx to themselves.

### How was it tested?

Added missing test case in lisk-transactions
