### PR TITLE
Add lisk-codec package - Closes #5214

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ templates/
 types/
 examples/
 **/*.d.ts
+jest.config.js

--- a/elements/lisk-codec/.eslintignore
+++ b/elements/lisk-codec/.eslintignore
@@ -1,0 +1,2 @@
+dist-node
+jest.config.js

--- a/elements/lisk-codec/.eslintrc.js
+++ b/elements/lisk-codec/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: '../../.eslintrc.js',
+	parserOptions: {
+		project: './tsconfig.json',
+		tsconfigRootDir: __dirname,
+	},
+};

--- a/elements/lisk-codec/.npmignore
+++ b/elements/lisk-codec/.npmignore
@@ -1,0 +1,1 @@
+../../templates/.npmignore.tmpl

--- a/elements/lisk-codec/.npmrc
+++ b/elements/lisk-codec/.npmrc
@@ -1,0 +1,1 @@
+../../templates/.npmrc.tmpl

--- a/elements/lisk-codec/.prettierignore
+++ b/elements/lisk-codec/.prettierignore
@@ -1,0 +1,1 @@
+../../templates/.prettierignore.tmpl

--- a/elements/lisk-codec/.prettierrc.json
+++ b/elements/lisk-codec/.prettierrc.json
@@ -1,0 +1,1 @@
+../../templates/.prettierrc.json.tmpl

--- a/elements/lisk-codec/README.md
+++ b/elements/lisk-codec/README.md
@@ -1,0 +1,40 @@
+# @liskhq/lisk-codec
+
+@liskhq/lisk-codec implements decoder and encoder using Lisk JSON schema according to the Lisk protocol.
+
+## Installation
+
+```sh
+$ npm install --save @liskhq/lisk-codec
+```
+
+## License
+
+Copyright 2016-2019 Lisk Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+---
+
+Copyright © 2016-2019 Lisk Foundation
+
+Copyright © 2015 Crypti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[lisk core github]: https://github.com/LiskHQ/lisk
+[lisk documentation site]: https://lisk.io/documentation/lisk-elements

--- a/elements/lisk-codec/jest.config.js
+++ b/elements/lisk-codec/jest.config.js
@@ -1,0 +1,1 @@
+../../templates/jest.config.js.tmpl

--- a/elements/lisk-codec/package.json
+++ b/elements/lisk-codec/package.json
@@ -1,14 +1,14 @@
 {
-	"name": "@liskhq/{PACKAGE}",
+	"name": "@liskhq/lisk-codec",
 	"version": "0.1.0",
-	"description": "Library according to the Lisk protocol",
+	"description": "Implementation of decoder and encoder using Lisk JSON schema according to the Lisk protocol",
 	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",
 		"blockchain"
 	],
-	"homepage": "https://github.com/LiskHQ/lisk-sdk/tree/master/elements/{PACKAGE}#readme",
+	"homepage": "https://github.com/LiskHQ/lisk-sdk/tree/master/elements/lisk-codec#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/LiskHQ/lisk-sdk.git"
@@ -33,8 +33,7 @@
 		"build:check": "node -e \"require('./dist-node')\"",
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
-	"dependencies": {
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@types/node": "12.12.11",
 		"@types/jest": "25.1.3",

--- a/elements/lisk-codec/scripts
+++ b/elements/lisk-codec/scripts
@@ -1,0 +1,1 @@
+../../templates/scripts.tmpl

--- a/elements/lisk-codec/src/codec.ts
+++ b/elements/lisk-codec/src/codec.ts
@@ -12,4 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export * from './codec';
+export class Codec {
+	// eslint-disable-next-line
+	public addSchema(_schema: object): void {}
+
+	// eslint-disable-next-line
+	public encode(_schema: object, _message: any): Buffer {
+		return Buffer.alloc(0);
+	}
+
+	// eslint-disable-next-line
+	public decode<T>(_schema: object, _message: Buffer): T {
+		return {} as T;
+	}
+}
+
+export const codec = new Codec();

--- a/elements/lisk-codec/test/.eslintrc.js
+++ b/elements/lisk-codec/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	extends: '../../../.eslintrc.test.js',
+	parserOptions: {
+		project: './tsconfig.json',
+		tsconfigRootDir: __dirname,
+	},
+};

--- a/elements/lisk-codec/test/_setup.js
+++ b/elements/lisk-codec/test/_setup.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+require('jest-extended');
+
+// @todo extend jest to have "toHaveBeenCalledOnceWith" matcher.
+
+process.env.NODE_ENV = 'test';

--- a/elements/lisk-codec/test/_setup.js
+++ b/elements/lisk-codec/test/_setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2020 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/elements/lisk-codec/test/add_schema.spec.ts
+++ b/elements/lisk-codec/test/add_schema.spec.ts
@@ -12,4 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export * from './codec';
+describe('addSchema', () => {
+	it.todo('it should add schema and and cache them');
+});

--- a/elements/lisk-codec/test/decode.spec.ts
+++ b/elements/lisk-codec/test/decode.spec.ts
@@ -12,4 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export * from './codec';
+describe('decode', () => {
+	it.todo('it should decode an Buffer to an object');
+});

--- a/elements/lisk-codec/test/encode.spec.ts
+++ b/elements/lisk-codec/test/encode.spec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2020 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -12,6 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-describe('empty', () => {
-	it.todo('template');
+describe('encode', () => {
+	it.todo('it should encode an object to Buffer');
 });

--- a/elements/lisk-codec/test/index.spec.ts
+++ b/elements/lisk-codec/test/index.spec.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+describe('empty', () => {
+	it.todo('template');
+});

--- a/elements/lisk-codec/test/tsconfig.json
+++ b/elements/lisk-codec/test/tsconfig.json
@@ -1,0 +1,1 @@
+../../../templates/test/tsconfig.json.tmpl

--- a/elements/lisk-codec/tsconfig.json
+++ b/elements/lisk-codec/tsconfig.json
@@ -1,0 +1,1 @@
+../../templates/tsconfig.json.tmpl


### PR DESCRIPTION
### What was the problem?

This PR resolves #5214 

### How was it solved?

- Add empty package for the `lisk-codec`

### How was it tested?

`yarn; yarn build` should not complain and all existing test should pass
