### PR TITLE
Add varint reader/writer - Closes #5219 & #5221 & #5229 & #5230

### DIFF
--- a/elements/lisk-codec/.eslintignore
+++ b/elements/lisk-codec/.eslintignore
@@ -1,2 +1,3 @@
 dist-node
 jest.config.js
+benchmark

--- a/elements/lisk-codec/benchmark/varint.js
+++ b/elements/lisk-codec/benchmark/varint.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+const { Suite } = require('benchmark');
+const {
+    writeVarInt,
+    readVarInt,
+    writeSignedVarInt,
+    readSignedVarInt,
+} = require('../dist-node/varint');
+
+const suite = new Suite();
+
+suite
+    .add('writeVarInt#uint32', () => {
+        writeVarInt(2147483647, { dataType: 'uint32' });
+    })
+    .add('writeVarInt#uint64', () => {
+        writeVarInt(BigInt('8294967295'), { dataType: 'uint64' });
+    })
+    .add('writeSignedVarInt#sint32', () => {
+        writeSignedVarInt(2147483647, { dataType: 'sint32' });
+    })
+    .add('writeSignedVarInt#sint64', () => {
+        writeSignedVarInt(BigInt('9223372036854775807'), {
+            dataType: 'sint64',
+        });
+    })
+    .add('readVarInt#uint32', () => {
+        readVarInt(Buffer.from('ffffffff0f', 'hex'), { dataType: 'uint32' });
+    })
+    .add('readVarInt#uint64', () => {
+        readVarInt(Buffer.from('ffffffffffffffffff01', 'hex'), {
+            dataType: 'uint64',
+        });
+    })
+    .add('readSignedVarInt#sint32', () => {
+        readSignedVarInt(Buffer.from('feffffff0f', 'hex'), {
+            dataType: 'sint32',
+        });
+    })
+    .add('readSignedVarInt#sint64', () => {
+        readSignedVarInt(Buffer.from('ffffffffffffffffff01', 'hex'), {
+            dataType: 'sint64',
+        });
+    })
+    .on('cycle', function (event) {
+        console.log(String(event.target));
+    })
+    .run({ async: true });

--- a/elements/lisk-codec/package.json
+++ b/elements/lisk-codec/package.json
@@ -35,11 +35,12 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"@types/node": "12.12.11",
 		"@types/jest": "25.1.3",
 		"@types/jest-when": "2.7.0",
+		"@types/node": "12.12.11",
 		"@typescript-eslint/eslint-plugin": "2.28.0",
 		"@typescript-eslint/parser": "2.28.0",
+		"benchmark": "2.1.4",
 		"eslint": "6.8.0",
 		"eslint-config-lisk-base": "1.2.2",
 		"eslint-config-prettier": "6.10.0",

--- a/elements/lisk-codec/src/varint.ts
+++ b/elements/lisk-codec/src/varint.ts
@@ -35,7 +35,6 @@ const writeVarIntNumber = (value: number, _schema: SchemaProperty): Buffer => {
 	}
 
 	result[index] = value;
-	index += 1;
 
 	return Buffer.from(result);
 };
@@ -50,7 +49,6 @@ const writeVarIntBigInt = (value: bigint, _schema: SchemaProperty): Buffer => {
 	}
 
 	result[Number(index)] = Number(value);
-	index += 1;
 
 	return Buffer.from(result);
 };

--- a/elements/lisk-codec/src/varint.ts
+++ b/elements/lisk-codec/src/varint.ts
@@ -25,7 +25,7 @@ interface SchemaProperty {
 	readonly dataType: string;
 }
 
-const writeVarIntNumber = (value: number, _schema: SchemaProperty): Buffer => {
+const writeVarIntNumber = (value: number): Buffer => {
 	const result: number[] = [];
 	let index = 0;
 	while (value > rest) {
@@ -39,7 +39,7 @@ const writeVarIntNumber = (value: number, _schema: SchemaProperty): Buffer => {
 	return Buffer.from(result);
 };
 
-const writeVarIntBigInt = (value: bigint, _schema: SchemaProperty): Buffer => {
+const writeVarIntBigInt = (value: bigint): Buffer => {
 	const result: number[] = [];
 	let index = 0;
 	while (value > BigInt(rest)) {
@@ -53,10 +53,8 @@ const writeVarIntBigInt = (value: bigint, _schema: SchemaProperty): Buffer => {
 	return Buffer.from(result);
 };
 
-export const writeVarInt = (value: int, schema: SchemaProperty): Buffer =>
-	isNumber(value)
-		? writeVarIntNumber(value, schema)
-		: writeVarIntBigInt(value, schema);
+export const writeVarInt = (value: int): Buffer =>
+	isNumber(value) ? writeVarIntNumber(value) : writeVarIntBigInt(value);
 
 export const writeSignedVarInt = (
 	value: int,
@@ -64,13 +62,13 @@ export const writeSignedVarInt = (
 ): Buffer => {
 	if (schema.dataType === 'sint32') {
 		const number = Number(value);
-		return writeVarIntNumber(((number << 1) ^ (number >> 31)) >>> 0, schema);
+		return writeVarIntNumber(((number << 1) ^ (number >> 31)) >>> 0);
 	}
 	const number = BigInt(value);
-	return writeVarInt((number << BigInt(1)) ^ (number >> BigInt(63)), schema);
+	return writeVarInt((number << BigInt(1)) ^ (number >> BigInt(63)));
 };
 
-const readVarIntNumber = (buffer: Buffer, _schema: SchemaProperty): number => {
+const readVarIntNumber = (buffer: Buffer): number => {
 	let result = 0;
 	let index = 0;
 	for (let shift = 0; shift < 32; shift += 7) {
@@ -87,7 +85,7 @@ const readVarIntNumber = (buffer: Buffer, _schema: SchemaProperty): number => {
 	throw new Error('Out of range');
 };
 
-const readVarIntBigInt = (buffer: Buffer, _schema: SchemaProperty): bigint => {
+const readVarIntBigInt = (buffer: Buffer): bigint => {
 	let result = BigInt(0);
 	let index = 0;
 	for (let shift = BigInt(0); shift < BigInt(64); shift += BigInt(7)) {
@@ -106,25 +104,19 @@ const readVarIntBigInt = (buffer: Buffer, _schema: SchemaProperty): bigint => {
 
 export const readVarInt = (buffer: Buffer, schema: SchemaProperty): int =>
 	schema.dataType === 'uint32' || schema.dataType === 'sint32'
-		? readVarIntNumber(buffer, schema)
-		: readVarIntBigInt(buffer, schema);
+		? readVarIntNumber(buffer)
+		: readVarIntBigInt(buffer);
 
-const readSignedVarIntNumber = (
-	buffer: Buffer,
-	schema: SchemaProperty,
-): number => {
-	const varInt = readVarIntNumber(buffer, schema);
+const readSignedVarIntNumber = (buffer: Buffer): number => {
+	const varInt = readVarIntNumber(buffer);
 	if (varInt % 2 === 0) {
 		return varInt / 2;
 	}
 	return -(varInt + 1) / 2;
 };
 
-const readSignedVarIntBigInt = (
-	buffer: Buffer,
-	schema: SchemaProperty,
-): bigint => {
-	const varInt = readVarIntBigInt(buffer, schema);
+const readSignedVarIntBigInt = (buffer: Buffer): bigint => {
+	const varInt = readVarIntBigInt(buffer);
 	if (varInt % BigInt(2) === BigInt(0)) {
 		return varInt / BigInt(2);
 	}
@@ -133,5 +125,5 @@ const readSignedVarIntBigInt = (
 
 export const readSignedVarInt = (buffer: Buffer, schema: SchemaProperty): int =>
 	schema.dataType === 'sint32'
-		? readSignedVarIntNumber(buffer, schema)
-		: readSignedVarIntBigInt(buffer, schema);
+		? readSignedVarIntNumber(buffer)
+		: readSignedVarIntBigInt(buffer);

--- a/elements/lisk-codec/src/varint.ts
+++ b/elements/lisk-codec/src/varint.ts
@@ -103,6 +103,9 @@ const readVarIntBigInt = (buffer: Buffer): bigint => {
 		}
 		const bit = BigInt(buffer[index]);
 		index += 1;
+		if (index === 10 && bit > 0x01) {
+			throw new Error('Value out of range of uint64');
+		}
 		result |= (bit & BigInt(rest)) << shift;
 		if ((bit & BigInt(msg)) === BigInt(0)) {
 			return result;

--- a/elements/lisk-codec/src/varint.ts
+++ b/elements/lisk-codec/src/varint.ts
@@ -53,7 +53,7 @@ const writeVarIntBigInt = (value: bigint): Buffer => {
 	return Buffer.from(result);
 };
 
-export const writeVarInt = (value: int): Buffer =>
+export const writeVarInt = (value: int, _schema: SchemaProperty): Buffer =>
 	isNumber(value) ? writeVarIntNumber(value) : writeVarIntBigInt(value);
 
 export const writeSignedVarInt = (
@@ -65,7 +65,7 @@ export const writeSignedVarInt = (
 		return writeVarIntNumber(((number << 1) ^ (number >> 31)) >>> 0);
 	}
 	const number = BigInt(value);
-	return writeVarInt((number << BigInt(1)) ^ (number >> BigInt(63)));
+	return writeVarInt((number << BigInt(1)) ^ (number >> BigInt(63)), schema);
 };
 
 const readVarIntNumber = (buffer: Buffer): number => {
@@ -82,7 +82,7 @@ const readVarIntNumber = (buffer: Buffer): number => {
 			return result;
 		}
 	}
-	throw new Error('Out of range');
+	throw new Error('Value out of range for uint32');
 };
 
 const readVarIntBigInt = (buffer: Buffer): bigint => {
@@ -99,7 +99,7 @@ const readVarIntBigInt = (buffer: Buffer): bigint => {
 			return result;
 		}
 	}
-	throw new Error('Out of range');
+	throw new Error('Value out of range for uint64');
 };
 
 export const readVarInt = (buffer: Buffer, schema: SchemaProperty): int =>

--- a/elements/lisk-codec/src/varint.ts
+++ b/elements/lisk-codec/src/varint.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+/* eslint-disable no-bitwise */
+/* eslint-disable no-param-reassign */
+
+const msg = 0x80;
+const rest = 0x7f;
+
+type int = bigint | number;
+
+const isNumber = (val: int): val is number => typeof val === 'number';
+
+interface SchemaProperty {
+	readonly dataType: string;
+}
+
+const writeVarIntNumber = (value: number, _schema: SchemaProperty): Buffer => {
+	const result: number[] = [];
+	let index = 0;
+	while (value > rest) {
+		result[index] = msg | ((value & rest) >>> 0);
+		value = (value >>> 7) >>> 0;
+		index += 1;
+	}
+
+	result[index] = value;
+	index += 1;
+
+	return Buffer.from(result);
+};
+
+const writeVarIntBigInt = (value: bigint, _schema: SchemaProperty): Buffer => {
+	const result: number[] = [];
+	let index = 0;
+	while (value > BigInt(rest)) {
+		result[index] = Number(BigInt(msg) | (value & BigInt(rest)));
+		value >>= BigInt(7);
+		index += 1;
+	}
+
+	result[Number(index)] = Number(value);
+	index += 1;
+
+	return Buffer.from(result);
+};
+
+export const writeVarInt = (value: int, schema: SchemaProperty): Buffer =>
+	isNumber(value)
+		? writeVarIntNumber(value, schema)
+		: writeVarIntBigInt(value, schema);
+
+export const writeSignedVarInt = (
+	value: int,
+	schema: SchemaProperty,
+): Buffer => {
+	if (schema.dataType === 'sint32') {
+		const number = Number(value);
+		return writeVarIntNumber(((number << 1) ^ (number >> 31)) >>> 0, schema);
+	}
+	const number = BigInt(value);
+	return writeVarInt((number << BigInt(1)) ^ (number >> BigInt(63)), schema);
+};
+
+const readVarIntNumber = (buffer: Buffer, _schema: SchemaProperty): number => {
+	let result = 0;
+	let index = 0;
+	for (let shift = 0; shift < 32; shift += 7) {
+		if (index >= buffer.length) {
+			throw new Error('Invalid buffer length');
+		}
+		const bit = buffer[index];
+		index += 1;
+		result = (result | ((bit & rest) << shift)) >>> 0;
+		if ((bit & msg) === 0) {
+			return result;
+		}
+	}
+	throw new Error('Out of range');
+};
+
+const readVarIntBigInt = (buffer: Buffer, _schema: SchemaProperty): bigint => {
+	let result = BigInt(0);
+	let index = 0;
+	for (let shift = BigInt(0); shift < BigInt(64); shift += BigInt(7)) {
+		if (index >= buffer.length) {
+			throw new Error('Invalid buffer length');
+		}
+		const bit = BigInt(buffer[index]);
+		index += 1;
+		result |= (bit & BigInt(rest)) << shift;
+		if ((bit & BigInt(msg)) === BigInt(0)) {
+			return result;
+		}
+	}
+	throw new Error('Out of range');
+};
+
+export const readVarInt = (buffer: Buffer, schema: SchemaProperty): int =>
+	schema.dataType === 'uint32' || schema.dataType === 'sint32'
+		? readVarIntNumber(buffer, schema)
+		: readVarIntBigInt(buffer, schema);
+
+const readSignedVarIntNumber = (
+	buffer: Buffer,
+	schema: SchemaProperty,
+): number => {
+	const varInt = readVarIntNumber(buffer, schema);
+	if (varInt % 2 === 0) {
+		return varInt / 2;
+	}
+	return -(varInt + 1) / 2;
+};
+
+const readSignedVarIntBigInt = (
+	buffer: Buffer,
+	schema: SchemaProperty,
+): bigint => {
+	const varInt = readVarIntBigInt(buffer, schema);
+	if (varInt % BigInt(2) === BigInt(0)) {
+		return varInt / BigInt(2);
+	}
+	return -(varInt + BigInt(1)) / BigInt(2);
+};
+
+export const readSignedVarInt = (buffer: Buffer, schema: SchemaProperty): int =>
+	schema.dataType === 'sint32'
+		? readSignedVarIntNumber(buffer, schema)
+		: readSignedVarIntBigInt(buffer, schema);

--- a/elements/lisk-codec/test/varint.spec.ts
+++ b/elements/lisk-codec/test/varint.spec.ts
@@ -21,27 +21,39 @@ import {
 describe('varint', () => {
 	describe('writer', () => {
 		it('should encode uint32', () => {
-			expect(writeVarInt(0)).toEqual(Buffer.from('00', 'hex'));
-			expect(writeVarInt(300)).toEqual(Buffer.from('ac02', 'hex'));
-			expect(writeVarInt(2147483647)).toEqual(Buffer.from('ffffffff07', 'hex'));
-			expect(writeVarInt(4294967295)).toEqual(Buffer.from('ffffffff0f', 'hex'));
+			expect(writeVarInt(0, { dataType: 'uint32' })).toEqual(
+				Buffer.from('00', 'hex'),
+			);
+			expect(writeVarInt(300, { dataType: 'uint32' })).toEqual(
+				Buffer.from('ac02', 'hex'),
+			);
+			expect(writeVarInt(2147483647, { dataType: 'uint32' })).toEqual(
+				Buffer.from('ffffffff07', 'hex'),
+			);
+			expect(writeVarInt(4294967295, { dataType: 'uint32' })).toEqual(
+				Buffer.from('ffffffff0f', 'hex'),
+			);
 		});
 
 		it('should encode uint64', () => {
-			expect(writeVarInt(BigInt(0))).toEqual(Buffer.from('00', 'hex'));
-			expect(writeVarInt(BigInt(300))).toEqual(Buffer.from('ac02', 'hex'));
-			expect(writeVarInt(BigInt(2147483647))).toEqual(
+			expect(writeVarInt(BigInt(0), { dataType: 'uint64' })).toEqual(
+				Buffer.from('00', 'hex'),
+			);
+			expect(writeVarInt(BigInt(300), { dataType: 'uint64' })).toEqual(
+				Buffer.from('ac02', 'hex'),
+			);
+			expect(writeVarInt(BigInt(2147483647), { dataType: 'uint64' })).toEqual(
 				Buffer.from('ffffffff07', 'hex'),
 			);
-			expect(writeVarInt(BigInt(4294967295))).toEqual(
+			expect(writeVarInt(BigInt(4294967295), { dataType: 'uint64' })).toEqual(
 				Buffer.from('ffffffff0f', 'hex'),
 			);
-			expect(writeVarInt(BigInt('8294967295'))).toEqual(
+			expect(writeVarInt(BigInt('8294967295'), { dataType: 'uint64' })).toEqual(
 				Buffer.from('ffcfacf31e', 'hex'),
 			);
-			expect(writeVarInt(BigInt('18446744073709551615'))).toEqual(
-				Buffer.from('ffffffffffffffffff01', 'hex'),
-			);
+			expect(
+				writeVarInt(BigInt('18446744073709551615'), { dataType: 'uint64' }),
+			).toEqual(Buffer.from('ffffffffffffffffff01', 'hex'));
 		});
 
 		it('should encode sint32', () => {

--- a/elements/lisk-codec/test/varint.spec.ts
+++ b/elements/lisk-codec/test/varint.spec.ts
@@ -119,6 +119,12 @@ describe('varint', () => {
 			).toEqual(4294967295);
 		});
 
+		it('should fail to decode uint32 when input is out of range', () => {
+			expect(() =>
+				readVarInt(Buffer.from('ffffffff7f', 'hex'), { dataType: 'uint32' }),
+			).toThrow('Value out of range of uint32');
+		});
+
 		it('should decode uint64', () => {
 			expect(
 				readVarInt(Buffer.from('00', 'hex'), { dataType: 'uint64' }),

--- a/elements/lisk-codec/test/varint.spec.ts
+++ b/elements/lisk-codec/test/varint.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import {
+	writeVarInt,
+	readVarInt,
+	readSignedVarInt,
+	writeSignedVarInt,
+} from '../src/varint';
+
+describe('varint', () => {
+	describe('writer', () => {
+		it('should encode uint32', () => {
+			expect(writeVarInt(0, { dataType: 'uint32' })).toEqual(
+				Buffer.from('00', 'hex'),
+			);
+			expect(writeVarInt(300, { dataType: 'uint32' })).toEqual(
+				Buffer.from('ac02', 'hex'),
+			);
+			expect(writeVarInt(2147483647, { dataType: 'uint32' })).toEqual(
+				Buffer.from('ffffffff07', 'hex'),
+			);
+			expect(writeVarInt(4294967295, { dataType: 'uint32' })).toEqual(
+				Buffer.from('ffffffff0f', 'hex'),
+			);
+		});
+
+		it('should encode uint64', () => {
+			expect(writeVarInt(BigInt(0), { dataType: 'uint64' })).toEqual(
+				Buffer.from('00', 'hex'),
+			);
+			expect(writeVarInt(BigInt(300), { dataType: 'uint64' })).toEqual(
+				Buffer.from('ac02', 'hex'),
+			);
+			expect(writeVarInt(BigInt(2147483647), { dataType: 'uint64' })).toEqual(
+				Buffer.from('ffffffff07', 'hex'),
+			);
+			expect(writeVarInt(BigInt(4294967295), { dataType: 'uint64' })).toEqual(
+				Buffer.from('ffffffff0f', 'hex'),
+			);
+			expect(writeVarInt(BigInt('8294967295'), { dataType: 'uint64' })).toEqual(
+				Buffer.from('ffcfacf31e', 'hex'),
+			);
+			expect(
+				writeVarInt(BigInt('18446744073709551615'), { dataType: 'uint64' }),
+			).toEqual(Buffer.from('ffffffffffffffffff01', 'hex'));
+		});
+
+		it('should encode sint32', () => {
+			expect(writeSignedVarInt(0, { dataType: 'sint32' })).toEqual(
+				Buffer.from('00', 'hex'),
+			);
+			expect(writeSignedVarInt(1300, { dataType: 'sint32' })).toEqual(
+				Buffer.from('a814', 'hex'),
+			);
+			expect(writeSignedVarInt(-1300, { dataType: 'sint32' })).toEqual(
+				Buffer.from('a714', 'hex'),
+			);
+			expect(writeSignedVarInt(2147483647, { dataType: 'sint32' })).toEqual(
+				Buffer.from('feffffff0f', 'hex'),
+			);
+			expect(writeSignedVarInt(-2147483648, { dataType: 'sint32' })).toEqual(
+				Buffer.from('ffffffff0f', 'hex'),
+			);
+		});
+
+		it('should encode sint64', () => {
+			expect(writeSignedVarInt(BigInt(0), { dataType: 'sint64' })).toEqual(
+				Buffer.from('00', 'hex'),
+			);
+			expect(writeSignedVarInt(BigInt(1300), { dataType: 'sint64' })).toEqual(
+				Buffer.from('a814', 'hex'),
+			);
+			expect(writeSignedVarInt(BigInt(-1300), { dataType: 'sint64' })).toEqual(
+				Buffer.from('a714', 'hex'),
+			);
+			expect(
+				writeSignedVarInt(BigInt(2147483647), { dataType: 'sint64' }),
+			).toEqual(Buffer.from('feffffff0f', 'hex'));
+			expect(
+				writeSignedVarInt(BigInt(-2147483648), { dataType: 'sint64' }),
+			).toEqual(Buffer.from('ffffffff0f', 'hex'));
+			expect(
+				writeSignedVarInt(BigInt('9223372036854775807'), {
+					dataType: 'sint64',
+				}),
+			).toEqual(Buffer.from('feffffffffffffffff01', 'hex'));
+			expect(
+				writeSignedVarInt(BigInt('-9223372036854775808'), {
+					dataType: 'sint64',
+				}),
+			).toEqual(Buffer.from('ffffffffffffffffff01', 'hex'));
+		});
+	});
+
+	describe('reader', () => {
+		it('should decode uint32', () => {
+			expect(
+				readVarInt(Buffer.from('00', 'hex'), { dataType: 'uint32' }),
+			).toEqual(0);
+			expect(
+				readVarInt(Buffer.from('ac02', 'hex'), { dataType: 'uint32' }),
+			).toEqual(300);
+			expect(
+				readVarInt(Buffer.from('ffffffff07', 'hex'), { dataType: 'uint32' }),
+			).toEqual(2147483647);
+			expect(
+				readVarInt(Buffer.from('ffffffff0f', 'hex'), { dataType: 'uint32' }),
+			).toEqual(4294967295);
+		});
+
+		it('should decode uint64', () => {
+			expect(
+				readVarInt(Buffer.from('00', 'hex'), { dataType: 'uint64' }),
+			).toEqual(BigInt(0));
+			expect(
+				readVarInt(Buffer.from('ac02', 'hex'), { dataType: 'uint64' }),
+			).toEqual(BigInt(300));
+			expect(
+				readVarInt(Buffer.from('ffffffff07', 'hex'), { dataType: 'uint64' }),
+			).toEqual(BigInt(2147483647));
+			expect(
+				readVarInt(Buffer.from('ffffffff0f', 'hex'), { dataType: 'uint64' }),
+			).toEqual(BigInt(4294967295));
+			expect(
+				readVarInt(Buffer.from('ffcfacf31e', 'hex'), { dataType: 'uint64' }),
+			).toEqual(BigInt(8294967295));
+			expect(
+				readVarInt(Buffer.from('ffffffffffffffffff01', 'hex'), {
+					dataType: 'uint64',
+				}),
+			).toEqual(BigInt('18446744073709551615'));
+		});
+
+		it('should decode sint32', () => {
+			expect(
+				readSignedVarInt(Buffer.from('00', 'hex'), { dataType: 'sint32' }),
+			).toEqual(0);
+			expect(
+				readSignedVarInt(Buffer.from('a814', 'hex'), { dataType: 'sint32' }),
+			).toEqual(1300);
+			expect(
+				readSignedVarInt(Buffer.from('a714', 'hex'), { dataType: 'sint32' }),
+			).toEqual(-1300);
+			expect(
+				readSignedVarInt(Buffer.from('feffffff0f', 'hex'), {
+					dataType: 'sint32',
+				}),
+			).toEqual(2147483647);
+			expect(
+				readSignedVarInt(Buffer.from('ffffffff0f', 'hex'), {
+					dataType: 'sint32',
+				}),
+			).toEqual(-2147483648);
+		});
+
+		it('should decode sint64', () => {
+			expect(
+				readSignedVarInt(Buffer.from('00', 'hex'), { dataType: 'sint64' }),
+			).toEqual(BigInt(0));
+			expect(
+				readSignedVarInt(Buffer.from('a814', 'hex'), { dataType: 'sint64' }),
+			).toEqual(BigInt(1300));
+			expect(
+				readSignedVarInt(Buffer.from('a714', 'hex'), { dataType: 'sint64' }),
+			).toEqual(BigInt(-1300));
+			expect(
+				readSignedVarInt(Buffer.from('feffffff0f', 'hex'), {
+					dataType: 'sint64',
+				}),
+			).toEqual(BigInt(2147483647));
+			expect(
+				readSignedVarInt(Buffer.from('ffffffff0f', 'hex'), {
+					dataType: 'sint64',
+				}),
+			).toEqual(BigInt(-2147483648));
+			expect(
+				readSignedVarInt(Buffer.from('feffffffffffffffff01', 'hex'), {
+					dataType: 'sint64',
+				}),
+			).toEqual(BigInt('9223372036854775807'));
+			expect(
+				readSignedVarInt(Buffer.from('ffffffffffffffffff01', 'hex'), {
+					dataType: 'sint64',
+				}),
+			).toEqual(BigInt('-9223372036854775808'));
+		});
+	});
+});

--- a/elements/lisk-codec/test/varint.spec.ts
+++ b/elements/lisk-codec/test/varint.spec.ts
@@ -121,7 +121,7 @@ describe('varint', () => {
 
 		it('should fail to decode uint32 when input is out of range', () => {
 			expect(() =>
-				readVarInt(Buffer.from('ffffffff7f', 'hex'), { dataType: 'uint32' }),
+				readVarInt(Buffer.from('8080808010', 'hex'), { dataType: 'uint32' }),
 			).toThrow('Value out of range of uint32');
 		});
 
@@ -150,10 +150,10 @@ describe('varint', () => {
 
 		it('should fail to decode uint64 when input is out of range', () => {
 			expect(() =>
-				readVarInt(Buffer.from('ffffffffffffffffff02', 'hex'), {
-					dataType: 'uint32',
+				readVarInt(Buffer.from('80808080808080808002', 'hex'), {
+					dataType: 'uint64',
 				}),
-			).toThrow('Value out of range of uint32');
+			).toThrow('Value out of range of uint64');
 		});
 
 		it('should decode sint32', () => {

--- a/elements/lisk-codec/test/varint.spec.ts
+++ b/elements/lisk-codec/test/varint.spec.ts
@@ -21,39 +21,27 @@ import {
 describe('varint', () => {
 	describe('writer', () => {
 		it('should encode uint32', () => {
-			expect(writeVarInt(0, { dataType: 'uint32' })).toEqual(
-				Buffer.from('00', 'hex'),
-			);
-			expect(writeVarInt(300, { dataType: 'uint32' })).toEqual(
-				Buffer.from('ac02', 'hex'),
-			);
-			expect(writeVarInt(2147483647, { dataType: 'uint32' })).toEqual(
-				Buffer.from('ffffffff07', 'hex'),
-			);
-			expect(writeVarInt(4294967295, { dataType: 'uint32' })).toEqual(
-				Buffer.from('ffffffff0f', 'hex'),
-			);
+			expect(writeVarInt(0)).toEqual(Buffer.from('00', 'hex'));
+			expect(writeVarInt(300)).toEqual(Buffer.from('ac02', 'hex'));
+			expect(writeVarInt(2147483647)).toEqual(Buffer.from('ffffffff07', 'hex'));
+			expect(writeVarInt(4294967295)).toEqual(Buffer.from('ffffffff0f', 'hex'));
 		});
 
 		it('should encode uint64', () => {
-			expect(writeVarInt(BigInt(0), { dataType: 'uint64' })).toEqual(
-				Buffer.from('00', 'hex'),
-			);
-			expect(writeVarInt(BigInt(300), { dataType: 'uint64' })).toEqual(
-				Buffer.from('ac02', 'hex'),
-			);
-			expect(writeVarInt(BigInt(2147483647), { dataType: 'uint64' })).toEqual(
+			expect(writeVarInt(BigInt(0))).toEqual(Buffer.from('00', 'hex'));
+			expect(writeVarInt(BigInt(300))).toEqual(Buffer.from('ac02', 'hex'));
+			expect(writeVarInt(BigInt(2147483647))).toEqual(
 				Buffer.from('ffffffff07', 'hex'),
 			);
-			expect(writeVarInt(BigInt(4294967295), { dataType: 'uint64' })).toEqual(
+			expect(writeVarInt(BigInt(4294967295))).toEqual(
 				Buffer.from('ffffffff0f', 'hex'),
 			);
-			expect(writeVarInt(BigInt('8294967295'), { dataType: 'uint64' })).toEqual(
+			expect(writeVarInt(BigInt('8294967295'))).toEqual(
 				Buffer.from('ffcfacf31e', 'hex'),
 			);
-			expect(
-				writeVarInt(BigInt('18446744073709551615'), { dataType: 'uint64' }),
-			).toEqual(Buffer.from('ffffffffffffffffff01', 'hex'));
+			expect(writeVarInt(BigInt('18446744073709551615'))).toEqual(
+				Buffer.from('ffffffffffffffffff01', 'hex'),
+			);
 		});
 
 		it('should encode sint32', () => {

--- a/elements/lisk-codec/test/varint.spec.ts
+++ b/elements/lisk-codec/test/varint.spec.ts
@@ -148,6 +148,14 @@ describe('varint', () => {
 			).toEqual(BigInt('18446744073709551615'));
 		});
 
+		it('should fail to decode uint64 when input is out of range', () => {
+			expect(() =>
+				readVarInt(Buffer.from('ffffffffffffffffff02', 'hex'), {
+					dataType: 'uint32',
+				}),
+			).toThrow('Value out of range of uint32');
+		});
+
 		it('should decode sint32', () => {
 			expect(
 				readSignedVarInt(Buffer.from('00', 'hex'), { dataType: 'sint32' }),


### PR DESCRIPTION
### What was the problem?

This PR resolves #5219 , resolves #5221, resolves #5229 and #5230 

### How was it solved?

Add  reader and writer for varint and zigzag, which are used for sint and uint

### How was it tested?

- Add test cases for each of them


```
writeVarInt#uint32 x 4,865,062 ops/sec ±13.33% (82 runs sampled)
writeVarInt#uint64 x 432,718 ops/sec ±13.25% (78 runs sampled)
writeSignedVarInt#sint32 x 6,388,955 ops/sec ±1.44% (87 runs sampled)
writeSignedVarInt#sint64 x 274,677 ops/sec ±0.58% (91 runs sampled)
readVarInt#uint32 x 3,069,689 ops/sec ±0.52% (92 runs sampled)
readVarInt#uint64 x 183,194 ops/sec ±5.88% (85 runs sampled)
readSignedVarInt#sint32 x 3,136,256 ops/sec ±0.63% (86 runs sampled)
readSignedVarInt#sint64 x 182,973 ops/sec ±0.42% (91 runs sampled)
```