### PR TITLE
Create bytes reader writer - Closes #5224 & #5225

### DIFF
--- a/elements/lisk-codec/benchmark/bytes.js
+++ b/elements/lisk-codec/benchmark/bytes.js
@@ -38,3 +38,8 @@ suite
         console.log(String(event.target));
     })
     .run({ async: true });
+
+/**
+ * Bytes write benchmark results
+ * writeBytes x 2,234,203 ops/sec ±0.68% (89 runs sampled)
+ */

--- a/elements/lisk-codec/benchmark/bytes.js
+++ b/elements/lisk-codec/benchmark/bytes.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+const { Suite } = require('benchmark');
+const bytesEncodingOutput = require('../fixtures/validBytesEncodings.json')
+const {
+    readBytes,
+    writeBytes,
+} = require('../dist-node/bytes');
+const { writeVarInt } = require('../dist-node/varint')
+const suite = new Suite();
+const data = bytesEncodingOutput.testCases[0].input.bytes.object.address.data;
+const dataBuffer = Buffer.from(data);
+const dataEncodedBuffer = Buffer.concat([
+    writeVarInt(dataBuffer.length, { dataType: 'uint32' }),
+    dataBuffer,
+]);
+
+suite
+    .add('readBytes', () => {
+        readBytes(dataEncodedBuffer, { dataType: 'bytes' });
+    })
+    .add('writeBytes', () => {
+        writeBytes(dataBuffer, { dataType: 'bytes' });
+    })
+    .on('cycle', function (event) {
+        console.log(String(event.target));
+    })
+    .run({ async: true });

--- a/elements/lisk-codec/benchmark/string.js
+++ b/elements/lisk-codec/benchmark/string.js
@@ -19,10 +19,11 @@ const {
 } = require('../dist-node/string');
 
 const suite = new Suite();
+const stringBuffer = Buffer.from('>!test@123test#', 'utf8');
 
 suite
     .add('readString', () => {
-        readString(Buffer.from('>!test@123test#', 'utf8'), { dataType: 'string' });
+        readString(stringBuffer, { dataType: 'string' });
     })
     .add('writeString', () => {
         writeString('>!test@123test#', { dataType: 'utf8' });
@@ -31,3 +32,8 @@ suite
         console.log(String(event.target));
     })
     .run({ async: true });
+
+/**
+ * String write benchmark results
+ * writeString x 1,808,985 ops/sec ±1.03% (87 runs sampled)
+ */

--- a/elements/lisk-codec/fixtures/validBytesEncodings.json
+++ b/elements/lisk-codec/fixtures/validBytesEncodings.json
@@ -1,0 +1,1 @@
+../../../protocol-specs/generator_outputs/lisk_codec/validBytesEncodings.json

--- a/elements/lisk-codec/src/bytes.ts
+++ b/elements/lisk-codec/src/bytes.ts
@@ -18,10 +18,7 @@ interface SchemaProperty {
 }
 
 export const writeBytes = (bytes: Buffer, _schema: SchemaProperty): Buffer =>
-	Buffer.concat([
-		writeVarInt(Buffer.from(bytes).length, { dataType: 'uint32' }),
-		bytes,
-	]);
+	Buffer.concat([writeVarInt(bytes.length, { dataType: 'uint32' }), bytes]);
 
 export const readBytes = (buffer: Buffer, _schema: SchemaProperty): Buffer =>
 	buffer.slice(1, buffer.length);

--- a/elements/lisk-codec/src/bytes.ts
+++ b/elements/lisk-codec/src/bytes.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { writeVarInt } from './varint';
+
+interface SchemaProperty {
+	readonly dataType: string;
+}
+
+export const writeBytes = (bytes: Buffer, _schema: SchemaProperty): Buffer =>
+	Buffer.concat([
+		writeVarInt(Buffer.from(bytes).length, { dataType: 'uint32' }),
+		bytes,
+	]);
+
+export const readBytes = (buffer: Buffer, _schema: SchemaProperty): Buffer =>
+	buffer.slice(1, buffer.length);

--- a/elements/lisk-codec/test/bytes.spec.ts
+++ b/elements/lisk-codec/test/bytes.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { writeBytes, readBytes } from '../src/bytes';
+import { testCases } from '../fixtures/validBytesEncodings.json';
+
+describe('bytes', () => {
+	describe('writer', () => {
+		it('should encode bytes', () => {
+			const testCaseOneInput = testCases[0].input.bytes;
+			const testCaseOneOutput = testCases[0].output.bytes;
+			expect(
+				writeBytes(
+					Buffer.from(testCaseOneInput.object.address.data),
+					testCaseOneInput.schema.properties.address,
+				).toString('hex'),
+			).toEqual(testCaseOneOutput.slice(2, testCaseOneOutput.length)); // Ignoring the key part
+
+			const testCaseSecondInput = testCases[0].input.emptyBytes;
+			const testCaseSecondOutput = testCases[0].output.emptyBytes;
+			expect(
+				writeBytes(
+					Buffer.from(testCaseSecondInput.object.address.data),
+					testCaseSecondInput.schema.properties.data,
+				).toString('hex'),
+			).toEqual(testCaseSecondOutput.slice(2, testCaseOneOutput.length)); // Ignoring the key part
+		});
+	});
+
+	describe('reader', () => {
+		it('should decode bytes', () => {
+			const testCaseOneInput = testCases[0].input.bytes;
+			expect(
+				readBytes(
+					writeBytes(
+						Buffer.from(testCaseOneInput.object.address.data),
+						testCaseOneInput.schema.properties.address,
+					),
+					testCaseOneInput.schema.properties.address,
+				),
+			).toEqual(Buffer.from(testCaseOneInput.object.address.data));
+
+			const testCaseSecondInput = testCases[0].input.bytes;
+			expect(
+				readBytes(
+					writeBytes(
+						Buffer.from(testCaseSecondInput.object.address.data),
+						testCaseSecondInput.schema.properties.address,
+					),
+					testCaseSecondInput.schema.properties.address,
+				),
+			).toEqual(Buffer.from(testCaseSecondInput.object.address.data));
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5224 & #5225 

### How was it solved?

- Creater writer `bytesWriter = (buffer, schema) => buffer`
- Created reader `bytesReader = (buffer, schema) => buffer`
- Added unit tests
- Added benchmark

### How was it tested?

Run `npm t` under `elements/lisk-codec`
