### PR TITLE
Update cryptography to use buffer instead of string - Closes #5358

### DIFF
--- a/elements/lisk-cryptography/src/convert.ts
+++ b/elements/lisk-cryptography/src/convert.ts
@@ -84,7 +84,7 @@ export const getFirstEightBytesReversed = (input: string | Buffer): Buffer => {
 	return reverse(Buffer.from(input).slice(0, BUFFER_SIZE));
 };
 
-export const toAddress = (buffer: Buffer): string => {
+export const toAddress = (buffer: Buffer): Buffer => {
 	const BUFFER_SIZE = 20;
 	const truncatedBuffer = getFirstNBytes(buffer, BUFFER_SIZE);
 
@@ -92,10 +92,10 @@ export const toAddress = (buffer: Buffer): string => {
 		throw new Error('The Lisk addresses must contains exactly 20 bytes');
 	}
 
-	return truncatedBuffer.toString('hex');
+	return truncatedBuffer;
 };
 
-export const getAddressFromPublicKey = (publicKey: string): string =>
+export const getAddressFromPublicKey = (publicKey: Buffer): Buffer =>
 	toAddress(hash(publicKey, 'hex'));
 
 export const convertPublicKeyEd2Curve = ed2curve.convertPublicKey;

--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -18,7 +18,7 @@ import { bufferToHex, hexToBuffer } from './buffer';
 // eslint-disable-next-line import/no-cycle
 import { convertPrivateKeyEd2Curve, convertPublicKeyEd2Curve } from './convert';
 // eslint-disable-next-line import/no-cycle
-import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
+import { getPrivateAndPublicKeyFromPassphrase } from './keys';
 // eslint-disable-next-line import/no-cycle
 import { box, getRandomBytes, openBox } from './nacl';
 
@@ -38,8 +38,8 @@ export const encryptMessageWithPassphrase = (
 	recipientPublicKey: string,
 ): EncryptedMessageWithNonce => {
 	const {
-		privateKeyBytes: senderPrivateKeyBytes,
-	} = getPrivateAndPublicKeyBytesFromPassphrase(passphrase);
+		privateKey: senderPrivateKeyBytes,
+	} = getPrivateAndPublicKeyFromPassphrase(passphrase);
 	const convertedPrivateKey = Buffer.from(
 		convertPrivateKeyEd2Curve(senderPrivateKeyBytes),
 	);
@@ -79,8 +79,8 @@ export const decryptMessageWithPassphrase = (
 	senderPublicKey: string,
 ): string => {
 	const {
-		privateKeyBytes: recipientPrivateKeyBytes,
-	} = getPrivateAndPublicKeyBytesFromPassphrase(passphrase);
+		privateKey: recipientPrivateKeyBytes,
+	} = getPrivateAndPublicKeyFromPassphrase(passphrase);
 	const convertedPrivateKey = Buffer.from(
 		convertPrivateKeyEd2Curve(recipientPrivateKeyBytes),
 	);

--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { bufferToHex, hexToBuffer } from './buffer';
 import { BINARY_ADDRESS_LENGTH } from './constants';
 // eslint-disable-next-line import/no-cycle
 import {
@@ -21,50 +20,21 @@ import {
 	convertUIntArray,
 } from './convert';
 import { hash } from './hash';
-// eslint-disable-next-line import/no-cycle
 import { getKeyPair, getPublicKey } from './nacl';
-
-export interface KeypairBytes {
-	readonly privateKeyBytes: Buffer;
-	readonly publicKeyBytes: Buffer;
-}
-
-export interface Keypair {
-	readonly privateKey: string;
-	readonly publicKey: string;
-}
-
-export const getPrivateAndPublicKeyBytesFromPassphrase = (
-	passphrase: string,
-): KeypairBytes => {
-	const hashed = hash(passphrase, 'utf8');
-	const { publicKeyBytes, privateKeyBytes } = getKeyPair(hashed);
-
-	return {
-		privateKeyBytes,
-		publicKeyBytes,
-	};
-};
+import { Keypair } from './types';
 
 export const getPrivateAndPublicKeyFromPassphrase = (
 	passphrase: string,
 ): Keypair => {
-	const {
-		privateKeyBytes,
-		publicKeyBytes,
-	} = getPrivateAndPublicKeyBytesFromPassphrase(passphrase);
-
-	return {
-		privateKey: bufferToHex(privateKeyBytes),
-		publicKey: bufferToHex(publicKeyBytes),
-	};
+	const hashed = hash(passphrase, 'utf8');
+	return getKeyPair(hashed);
 };
 
 export const getKeys = getPrivateAndPublicKeyFromPassphrase;
 
 export const getAddressAndPublicKeyFromPassphrase = (
 	passphrase: string,
-): { readonly address: string; readonly publicKey: string } => {
+): { readonly address: Buffer; readonly publicKey: Buffer } => {
 	const { publicKey } = getKeys(passphrase);
 	const address = getAddressFromPublicKey(publicKey);
 
@@ -74,15 +44,14 @@ export const getAddressAndPublicKeyFromPassphrase = (
 	};
 };
 
-export const getAddressFromPassphrase = (passphrase: string): string => {
+export const getAddressFromPassphrase = (passphrase: string): Buffer => {
 	const { publicKey } = getKeys(passphrase);
 
 	return getAddressFromPublicKey(publicKey);
 };
 
-export const getAddressFromPrivateKey = (privateKey: string): string => {
-	const publicKeyBytes = getPublicKey(hexToBuffer(privateKey));
-	const publicKey = bufferToHex(publicKeyBytes);
+export const getAddressFromPrivateKey = (privateKey: Buffer): Buffer => {
+	const publicKey = getPublicKey(privateKey);
 
 	return getAddressFromPublicKey(publicKey);
 };

--- a/elements/lisk-cryptography/src/nacl/fast.ts
+++ b/elements/lisk-cryptography/src/nacl/fast.ts
@@ -91,14 +91,14 @@ export const getRandomBytes: NaclInterface['getRandomBytes'] = length => {
 };
 
 export const getKeyPair: NaclInterface['getKeyPair'] = hashedSeed => {
-	const publicKeyBytes = Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES);
-	const privateKeyBytes = Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES);
+	const publicKey = Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES);
+	const privateKey = Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES);
 
-	sodium.crypto_sign_seed_keypair(publicKeyBytes, privateKeyBytes, hashedSeed);
+	sodium.crypto_sign_seed_keypair(publicKey, privateKey, hashedSeed);
 
 	return {
-		publicKeyBytes,
-		privateKeyBytes,
+		publicKey,
+		privateKey,
 	};
 };
 

--- a/elements/lisk-cryptography/src/nacl/nacl_types.ts
+++ b/elements/lisk-cryptography/src/nacl/nacl_types.ts
@@ -12,8 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-// eslint-disable-next-line import/no-cycle
-import { KeypairBytes } from '../keys';
+import { Keypair } from '../types';
 
 export interface NaclInterface {
 	box: (
@@ -22,7 +21,7 @@ export interface NaclInterface {
 		convertedPublicKey: Buffer,
 		convertedPrivateKey: Buffer,
 	) => Buffer;
-	getKeyPair: (hashedSeed: Buffer) => KeypairBytes;
+	getKeyPair: (hashedSeed: Buffer) => Keypair;
 	getPublicKey: (privateKey: Buffer) => Buffer;
 	getRandomBytes: (length: number) => Buffer;
 	openBox: (

--- a/elements/lisk-cryptography/src/nacl/slow.ts
+++ b/elements/lisk-cryptography/src/nacl/slow.ts
@@ -67,8 +67,8 @@ export const getKeyPair: NaclInterface['getKeyPair'] = hashedSeed => {
 	const { publicKey, secretKey } = tweetnacl.sign.keyPair.fromSeed(hashedSeed);
 
 	return {
-		privateKeyBytes: Buffer.from(secretKey),
-		publicKeyBytes: Buffer.from(publicKey),
+		privateKey: Buffer.from(secretKey),
+		publicKey: Buffer.from(publicKey),
 	};
 };
 

--- a/elements/lisk-cryptography/src/sign.ts
+++ b/elements/lisk-cryptography/src/sign.ts
@@ -17,7 +17,7 @@ import { encode as encodeVarInt } from 'varuint-bitcoin';
 import { bufferToHex, hexToBuffer } from './buffer';
 import { SIGNED_MESSAGE_PREFIX } from './constants';
 import { hash } from './hash';
-import { getPrivateAndPublicKeyBytesFromPassphrase } from './keys';
+import { getPrivateAndPublicKeyFromPassphrase } from './keys';
 import {
 	NACL_SIGN_PUBLICKEY_LENGTH,
 	NACL_SIGN_SIGNATURE_LENGTH,
@@ -58,15 +58,14 @@ export const signMessageWithPassphrase = (
 	passphrase: string,
 ): SignedMessageWithOnePassphrase => {
 	const msgBytes = digestMessage(message);
-	const {
-		privateKeyBytes,
-		publicKeyBytes,
-	} = getPrivateAndPublicKeyBytesFromPassphrase(passphrase);
-	const signature = signDetached(msgBytes, privateKeyBytes);
+	const { privateKey, publicKey } = getPrivateAndPublicKeyFromPassphrase(
+		passphrase,
+	);
+	const signature = signDetached(msgBytes, privateKey);
 
 	return {
 		message,
-		publicKey: bufferToHex(publicKeyBytes),
+		publicKey: bufferToHex(publicKey),
 		signature: bufferToHex(signature),
 	};
 };
@@ -141,11 +140,9 @@ export const signDataWithPassphrase = (
 	data: Buffer,
 	passphrase: string,
 ): string => {
-	const { privateKeyBytes } = getPrivateAndPublicKeyBytesFromPassphrase(
-		passphrase,
-	);
+	const { privateKey } = getPrivateAndPublicKeyFromPassphrase(passphrase);
 
-	return signDataWithPrivateKey(data, privateKeyBytes);
+	return signDataWithPrivateKey(data, privateKey);
 };
 
 export const signData = signDataWithPassphrase;

--- a/elements/lisk-cryptography/src/types.ts
+++ b/elements/lisk-cryptography/src/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+export interface Keypair {
+	readonly privateKey: Buffer;
+	readonly publicKey: Buffer;
+}

--- a/elements/lisk-cryptography/src/types.ts
+++ b/elements/lisk-cryptography/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2020 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/elements/lisk-cryptography/test/convert.spec.ts
+++ b/elements/lisk-cryptography/test/convert.spec.ts
@@ -30,8 +30,10 @@ describe('convert', () => {
 	// keys for passphrase 'secret';
 	const defaultPrivateKey =
 		'2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
-	const defaultPublicKey =
-		'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
+	const defaultPublicKey = Buffer.from(
+		'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
+		'hex',
+	);
 	const defaultPublicKeyHash = Buffer.from(
 		'3a971fd02b4a07fc20aad1936d3cb1d263b96e0ffd938625e5c0db1ad8ba2a29',
 		'hex',
@@ -44,7 +46,10 @@ describe('convert', () => {
 		'6f9d780305bda43dd47a291d897f2d8845a06160632d82fb1f209fdd46ed3c1e',
 		'hex',
 	);
-	const defaultAddress = '3a971fd02b4a07fc20aad1936d3cb1d263b96e0f';
+	const defaultAddress = Buffer.from(
+		'3a971fd02b4a07fc20aad1936d3cb1d263b96e0f',
+		'hex',
+	);
 	const defaultStringWithMoreThanEightCharacters = '0123456789';
 	const defaultFirstEightCharactersReversed = '76543210';
 	const defaultDataForBuffer = 'Hello Lisk SDK - Bring the app to life!';
@@ -73,14 +78,14 @@ describe('convert', () => {
 			const bufferInit = Buffer.from(defaultDataForBuffer);
 			const firstTwentyBytes = getFirstNBytes(bufferInit, 20);
 			const address = toAddress(firstTwentyBytes);
-			expect(address).toEqual(firstTwentyBytes.toString('hex'));
+			expect(address).toEqual(firstTwentyBytes);
 		});
 
 		it('should create truncated address bytes from a buffer of more than 20 bytes ', () => {
 			const bufferInit = Buffer.from(defaultDataForBuffer);
 			const firstTwentyBytes = getFirstNBytes(bufferInit, 20);
 			const address = toAddress(getFirstNBytes(bufferInit, 25));
-			expect(address).toEqual(firstTwentyBytes.toString('hex'));
+			expect(address).toEqual(firstTwentyBytes);
 		});
 
 		it('should throw on less than 20 bytes as input', () => {
@@ -103,15 +108,13 @@ describe('convert', () => {
 
 		it('should generate address from publicKey', () => {
 			const address = getAddressFromPublicKey(defaultPublicKey);
-			expect(address).toBe(defaultAddress);
+			expect(address).toEqual(defaultAddress);
 		});
 	});
 
 	describe('#convertPublicKeyEd2Curve', () => {
 		it('should convert publicKey ED25519 to Curve25519 key', () => {
-			const result = convertPublicKeyEd2Curve(
-				Buffer.from(defaultPublicKey, 'hex'),
-			);
+			const result = convertPublicKeyEd2Curve(defaultPublicKey);
 			expect(result).not.toBeNull();
 			const curveRepresentation = result as Buffer;
 			expect(

--- a/elements/lisk-cryptography/test/encrypt.spec.ts
+++ b/elements/lisk-cryptography/test/encrypt.spec.ts
@@ -69,7 +69,7 @@ describe('encrypt', () => {
 			);
 
 		jest
-			.spyOn(keys, 'getPrivateAndPublicKeyBytesFromPassphrase')
+			.spyOn(keys, 'getAddressAndPublicKeyFromPassphrase')
 			.mockImplementation(() => {
 				return {
 					privateKey: Buffer.from(defaultPrivateKey, 'hex'),

--- a/elements/lisk-cryptography/test/helpers/index.ts
+++ b/elements/lisk-cryptography/test/helpers/index.ts
@@ -12,7 +12,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export const makeInvalid = (str: string): string => {
-	const char = str.startsWith('0') ? '1' : '0';
-	return `${char}${str.slice(1)}`;
+export const makeInvalid = (buffer: Buffer): Buffer => {
+	const replace = buffer[0] % 2 === 0 ? 1 : 2;
+	// eslint-disable-next-line no-param-reassign
+	buffer[0] = replace;
+	return buffer;
 };

--- a/elements/lisk-cryptography/test/keys.spec.ts
+++ b/elements/lisk-cryptography/test/keys.spec.ts
@@ -13,18 +13,16 @@
  *
  */
 import {
-	Keypair,
-	KeypairBytes,
 	getBase32AddressFromPublicKey,
 	getBinaryAddressFromPublicKey,
 	getPrivateAndPublicKeyFromPassphrase,
-	getPrivateAndPublicKeyBytesFromPassphrase,
 	getKeys,
 	getAddressAndPublicKeyFromPassphrase,
 	getAddressFromPassphrase,
 	getAddressFromPrivateKey,
 	validateBase32Address,
 } from '../src/keys';
+import { Keypair } from '../src/types';
 // Require is used for stubbing
 // eslint-disable-next-line
 const buffer = require('../src/buffer');
@@ -35,11 +33,18 @@ describe('keys', () => {
 	const defaultPassphrase = 'secret';
 	const defaultPassphraseHash =
 		'2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b';
-	const defaultPrivateKey =
-		'2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
-	const defaultPublicKey =
-		'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
-	const defaultAddress = '2bb80d537b1da3e38bd30361aa855686bde0eacd';
+	const defaultPrivateKey = Buffer.from(
+		'2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
+		'hex',
+	);
+	const defaultPublicKey = Buffer.from(
+		'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
+		'hex',
+	);
+	const defaultAddress = Buffer.from(
+		'2bb80d537b1da3e38bd30361aa855686bde0eacd',
+		'hex',
+	);
 	const defaultAddressAndPublicKey = {
 		publicKey: defaultPublicKey,
 		address: defaultAddress,
@@ -51,26 +56,6 @@ describe('keys', () => {
 		jest
 			.spyOn(hashModule, 'hash')
 			.mockReturnValue(Buffer.from(defaultPassphraseHash, 'hex'));
-	});
-
-	describe('#getPrivateAndPublicKeyBytesFromPassphrase', () => {
-		let keyPair: KeypairBytes;
-
-		beforeEach(() => {
-			keyPair = getPrivateAndPublicKeyBytesFromPassphrase(defaultPassphrase);
-		});
-
-		it('should create buffer publicKey', () => {
-			expect(Buffer.from(keyPair.publicKeyBytes).toString('hex')).toBe(
-				defaultPublicKey,
-			);
-		});
-
-		it('should create buffer privateKey', () => {
-			expect(Buffer.from(keyPair.privateKeyBytes).toString('hex')).toBe(
-				defaultPrivateKey,
-			);
-		});
 	});
 
 	describe('#getPrivateAndPublicKeyFromPassphrase', () => {
@@ -115,13 +100,15 @@ describe('keys', () => {
 
 	describe('#getAddressFromPassphrase', () => {
 		it('should create correct address', () => {
-			expect(getAddressFromPassphrase(defaultPassphrase)).toBe(defaultAddress);
+			expect(getAddressFromPassphrase(defaultPassphrase)).toEqual(
+				defaultAddress,
+			);
 		});
 	});
 
 	describe('#getAddressFromPrivateKey', () => {
 		it('should create correct address', () => {
-			expect(getAddressFromPrivateKey(defaultPrivateKey.slice(0, 64))).toBe(
+			expect(getAddressFromPrivateKey(defaultPrivateKey.slice(0, 64))).toEqual(
 				defaultAddress,
 			);
 		});

--- a/elements/lisk-cryptography/test/nacl/nacl.spec.ts
+++ b/elements/lisk-cryptography/test/nacl/nacl.spec.ts
@@ -178,7 +178,7 @@ describe('nacl', () => {
 				it('should return false if the signature is invalid', () => {
 					const verification = verifyDetached(
 						Buffer.from(defaultDigest, 'hex'),
-						Buffer.from(makeInvalid(defaultSignature), 'hex'),
+						makeInvalid(Buffer.from(defaultSignature, 'hex')),
 						Buffer.from(defaultPublicKey, 'hex'),
 					);
 					expect(verification).toBe(false);

--- a/elements/lisk-cryptography/test/nacl/nacl.spec.ts
+++ b/elements/lisk-cryptography/test/nacl/nacl.spec.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { KeypairBytes } from '../../src/keys';
+import { Keypair } from '../../src/types';
 import { makeInvalid } from '../helpers';
 import { NaclInterface } from '../../src/nacl/nacl_types';
 import * as fast from '../../src/nacl/fast';
@@ -87,7 +87,7 @@ describe('nacl', () => {
 			});
 
 			describe('#getKeyPair', () => {
-				let signedKeys: KeypairBytes;
+				let signedKeys: Keypair;
 
 				beforeEach(async () => {
 					signedKeys = getKeyPair(Buffer.from(defaultHash, 'hex'));
@@ -95,27 +95,27 @@ describe('nacl', () => {
 				});
 
 				it('should create a publicKey', () => {
-					expect(
-						Buffer.from(signedKeys.publicKeyBytes).toString('hex'),
-					).toEqual(defaultPublicKey);
+					expect(Buffer.from(signedKeys.publicKey).toString('hex')).toEqual(
+						defaultPublicKey,
+					);
 				});
 
 				it('should create a publicKey of type uint8array', () => {
-					expect(
-						Object.prototype.toString.call(signedKeys.publicKeyBytes),
-					).toEqual('[object Uint8Array]');
+					expect(Object.prototype.toString.call(signedKeys.publicKey)).toEqual(
+						'[object Uint8Array]',
+					);
 				});
 
 				it('should create a privateKey', () => {
-					expect(
-						Buffer.from(signedKeys.privateKeyBytes).toString('hex'),
-					).toEqual(defaultPrivateKey);
+					expect(Buffer.from(signedKeys.privateKey).toString('hex')).toEqual(
+						defaultPrivateKey,
+					);
 				});
 
 				it('should create a privateKey of type uint8array', () => {
-					expect(
-						Object.prototype.toString.call(signedKeys.privateKeyBytes),
-					).toEqual('[object Uint8Array]');
+					expect(Object.prototype.toString.call(signedKeys.privateKey)).toEqual(
+						'[object Uint8Array]',
+					);
 				});
 			});
 

--- a/elements/lisk-cryptography/test/sign.spec.ts
+++ b/elements/lisk-cryptography/test/sign.spec.ts
@@ -66,11 +66,11 @@ ${defaultSignature}
 		};
 
 		jest
-			.spyOn(keys, 'getPrivateAndPublicKeyBytesFromPassphrase')
+			.spyOn(keys, 'getAddressAndPublicKeyFromPassphrase')
 			.mockImplementation(() => {
 				return {
-					privateKeyBytes: Buffer.from(defaultPrivateKey, 'hex'),
-					publicKeyBytes: Buffer.from(defaultPublicKey, 'hex'),
+					privateKey: Buffer.from(defaultPrivateKey, 'hex'),
+					publicKey: Buffer.from(defaultPublicKey, 'hex'),
 				};
 			});
 	});

--- a/elements/lisk-cryptography/test/sign.spec.ts
+++ b/elements/lisk-cryptography/test/sign.spec.ts
@@ -29,7 +29,8 @@ import {
 // eslint-disable-next-line
 const keys = require('../src/keys');
 
-const changeLength = (str: string): string => `00${str}`;
+const changeLength = (buffer: Buffer): Buffer =>
+	Buffer.concat([Buffer.from('00', 'hex'), buffer]);
 
 describe('sign', () => {
 	const defaultPassphrase =
@@ -61,8 +62,8 @@ ${defaultSignature}
 	beforeEach(() => {
 		defaultSignedMessage = {
 			message: defaultMessage,
-			publicKey: defaultPublicKey,
-			signature: defaultSignature,
+			publicKey: Buffer.from(defaultPublicKey, 'hex'),
+			signature: Buffer.from(defaultSignature, 'hex'),
 		};
 
 		jest
@@ -129,8 +130,8 @@ ${defaultSignature}
 			expect(
 				verifyMessageWithPublicKey.bind(null, {
 					message: defaultMessage,
-					signature: defaultSignature,
-					publicKey: changeLength(defaultPublicKey),
+					signature: Buffer.from(defaultSignature, 'hex'),
+					publicKey: changeLength(Buffer.from(defaultPublicKey, 'hex')),
 				}),
 			).toThrow('Invalid publicKey, expected 32-byte publicKey');
 		});
@@ -139,8 +140,8 @@ ${defaultSignature}
 			expect(
 				verifyMessageWithPublicKey.bind(null, {
 					message: defaultMessage,
-					signature: changeLength(defaultSignature),
-					publicKey: defaultPublicKey,
+					signature: changeLength(Buffer.from(defaultSignature, 'hex')),
+					publicKey: Buffer.from(defaultPublicKey, 'hex'),
 				}),
 			).toThrow('Invalid signature length, expected 64-byte signature');
 		});
@@ -148,8 +149,8 @@ ${defaultSignature}
 		it('should return false if the signature is invalid', () => {
 			const verification = verifyMessageWithPublicKey({
 				message: defaultMessage,
-				signature: makeInvalid(defaultSignature),
-				publicKey: defaultPublicKey,
+				signature: makeInvalid(Buffer.from(defaultSignature, 'hex')),
+				publicKey: Buffer.from(defaultPublicKey, 'hex'),
 			});
 			expect(verification).toBe(false);
 		});
@@ -164,8 +165,8 @@ ${defaultSignature}
 		it('should wrap a single signed message into a printed Lisk template', () => {
 			const printedMessage = printSignedMessage({
 				message: defaultMessage,
-				signature: defaultSignature,
-				publicKey: defaultPublicKey,
+				signature: Buffer.from(defaultSignature, 'hex'),
+				publicKey: Buffer.from(defaultPublicKey, 'hex'),
 			});
 			expect(printedMessage).toBe(defaultPrintedMessage);
 		});
@@ -182,7 +183,7 @@ ${defaultSignature}
 	});
 
 	describe('#signData', () => {
-		let signature: string;
+		let signature: Buffer;
 
 		beforeEach(async () => {
 			signature = signData(defaultData, defaultPassphrase);
@@ -190,12 +191,12 @@ ${defaultSignature}
 		});
 
 		it('should sign a transaction', () => {
-			expect(signature).toBe(defaultDataSignature);
+			expect(signature).toEqual(Buffer.from(defaultDataSignature, 'hex'));
 		});
 	});
 
 	describe('#signDataWithPassphrase', () => {
-		let signature: string;
+		let signature: Buffer;
 
 		beforeEach(async () => {
 			signature = signDataWithPassphrase(defaultData, defaultPassphrase);
@@ -203,12 +204,12 @@ ${defaultSignature}
 		});
 
 		it('should sign a transaction', () => {
-			expect(signature).toBe(defaultDataSignature);
+			expect(signature).toEqual(Buffer.from(defaultDataSignature, 'hex'));
 		});
 	});
 
 	describe('#signDataWithPrivateKey', () => {
-		let signature: string;
+		let signature: Buffer;
 
 		beforeEach(async () => {
 			signature = signDataWithPrivateKey(
@@ -219,7 +220,7 @@ ${defaultSignature}
 		});
 
 		it('should sign a transaction', () => {
-			expect(signature).toBe(defaultDataSignature);
+			expect(signature).toEqual(Buffer.from(defaultDataSignature, 'hex'));
 		});
 	});
 
@@ -227,8 +228,8 @@ ${defaultSignature}
 		it('should return false for an invalid signature', () => {
 			const verification = verifyData(
 				defaultData,
-				makeInvalid(defaultDataSignature),
-				defaultPublicKey,
+				makeInvalid(Buffer.from(defaultDataSignature, 'hex')),
+				Buffer.from(defaultPublicKey, 'hex'),
 			);
 			expect(verification).toBe(false);
 		});
@@ -236,8 +237,8 @@ ${defaultSignature}
 		it('should return true for a valid signature', () => {
 			const verification = verifyData(
 				defaultData,
-				defaultDataSignature,
-				defaultPublicKey,
+				Buffer.from(defaultDataSignature, 'hex'),
+				Buffer.from(defaultPublicKey, 'hex'),
 			);
 			expect(verification).toBe(true);
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5358 

### How was it solved?

- Update public key, private key, address to be buffer

### How was it tested?

- All the lisk-cryptography tests are updated
