### PR TITLE
Update generic and specific schema validation in lisk-transactions - Closes #5370

### DIFF
--- a/elements/lisk-transactions/src/10_delegate_transaction.ts
+++ b/elements/lisk-transactions/src/10_delegate_transaction.ts
@@ -91,7 +91,7 @@ export class DelegateTransaction extends BaseTransaction {
 				),
 			);
 		}
-		return [];
+		return errors;
 	}
 
 	protected async applyAsset(

--- a/elements/lisk-transactions/src/10_delegate_transaction.ts
+++ b/elements/lisk-transactions/src/10_delegate_transaction.ts
@@ -44,6 +44,29 @@ export const delegateRegistrationAssetSchema = {
 	},
 };
 
+const isNullCharacterIncluded = (input: string): boolean =>
+	new RegExp(/\0|\\u0000|\\x00/).test(input);
+
+const isUsername = (username: string): boolean => {
+	if (isNullCharacterIncluded(username)) {
+		return false;
+	}
+
+	if (username !== username.trim().toLowerCase()) {
+		return false;
+	}
+
+	if (/^[0-9]{1,21}[L|l]$/g.test(username)) {
+		return false;
+	}
+
+	if (!/^[a-z0-9!@$&_.]+$/g.test(username)) {
+		return false;
+	}
+
+	return true;
+};
+
 export class DelegateTransaction extends BaseTransaction {
 	public static TYPE = 10;
 	public static NAME_FEE = BigInt(DELEGATE_NAME_FEE);
@@ -54,6 +77,21 @@ export class DelegateTransaction extends BaseTransaction {
 		super(transaction);
 
 		this.asset = transaction.asset;
+	}
+
+	protected validateAsset(): ReadonlyArray<TransactionError> {
+		const errors = [];
+		if (!isUsername(this.asset.username)) {
+			errors.push(
+				new TransactionError(
+					'The username is in unsupported format',
+					this.id,
+					'.asset.username',
+					this.asset.username,
+				),
+			);
+		}
+		return [];
 	}
 
 	protected async applyAsset(
@@ -132,7 +170,9 @@ export class DelegateTransaction extends BaseTransaction {
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	private async _getRegisteredDelegates(store: StateStore): Promise<ChainUsernames> {
+	private async _getRegisteredDelegates(
+		store: StateStore,
+	): Promise<ChainUsernames> {
 		const usernamesBuffer = await store.chain.get(
 			CHAIN_STATE_DELEGATE_USERNAMES,
 		);
@@ -142,22 +182,30 @@ export class DelegateTransaction extends BaseTransaction {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const parsedUsernames = JSON.parse(usernamesBuffer.toString('utf8'));
 		// eslint-disable-next-line
-		parsedUsernames.registeredDelegates = parsedUsernames.registeredDelegates.map((value: { address: string, username: string }) => ({
-			username: value.username,
-			address: Buffer.from(value.address, 'binary'),
-		}));
+		parsedUsernames.registeredDelegates = parsedUsernames.registeredDelegates.map(
+			(value: { address: string; username: string }) => ({
+				username: value.username,
+				address: Buffer.from(value.address, 'binary'),
+			}),
+		);
 
 		return parsedUsernames as ChainUsernames;
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	private _setRegisteredDelegates(store: StateStore, input: ChainUsernames): void {
-		const updatingObject = Buffer.from(JSON.stringify({
-			registeredDelegates: input.registeredDelegates.map(value => ({ address: value.address.toString('binary'), username: value.username })),
-		}), 'utf8');
-		store.chain.set(
-			CHAIN_STATE_DELEGATE_USERNAMES,
-			updatingObject,
+	private _setRegisteredDelegates(
+		store: StateStore,
+		input: ChainUsernames,
+	): void {
+		const updatingObject = Buffer.from(
+			JSON.stringify({
+				registeredDelegates: input.registeredDelegates.map(value => ({
+					address: value.address.toString('binary'),
+					username: value.username,
+				})),
+			}),
+			'utf8',
 		);
+		store.chain.set(CHAIN_STATE_DELEGATE_USERNAMES, updatingObject);
 	}
 }

--- a/elements/lisk-transactions/src/12_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/12_multisignature_transaction.ts
@@ -39,6 +39,8 @@ export const multisigRegAssetSchema = {
 		numberOfSignatures: {
 			dataType: 'uint32',
 			fieldNumber: 1,
+			minimum: 1,
+			maximum: 64,
 		},
 		mandatoryKeys: {
 			type: 'array',
@@ -46,6 +48,8 @@ export const multisigRegAssetSchema = {
 				dataType: 'bytes',
 			},
 			fieldNumber: 2,
+			minItems: 0,
+			maxItems: 64,
 			minLength: 32,
 			maxLength: 32,
 		},
@@ -55,6 +59,8 @@ export const multisigRegAssetSchema = {
 				dataType: 'bytes',
 			},
 			fieldNumber: 3,
+			minItems: 0,
+			maxItems: 64,
 			minLength: 32,
 			maxLength: 32,
 		},

--- a/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
+++ b/elements/lisk-transactions/test/10_delegate_transaction.spec.ts
@@ -93,6 +93,37 @@ describe('Delegate registration transaction class', () => {
 		});
 	});
 
+	describe('#validateAsset', () => {
+		it('should return true when valid username is provided', () => {
+			(validTestTransaction as any).asset.username = 'obelisk';
+			return expect((validTestTransaction as any).validateAsset()).toBeEmpty();
+		});
+
+		it('should return false when username includes capital letter', () => {
+			(validTestTransaction as any).asset.username = 'Obelisk';
+			const errors = (validTestTransaction as any).validateAsset();
+			return expect(errors[0].dataPath).toBe('.asset.username');
+		});
+
+		it('should return false when username is like address', () => {
+			(validTestTransaction as any).asset.username = '17670127987160191762l';
+			const errors = (validTestTransaction as any).validateAsset();
+			return expect(errors[0].dataPath).toBe('.asset.username');
+		});
+
+		it('should return false when username includes forbidden character', () => {
+			(validTestTransaction as any).asset.username = 'obe^lisk';
+			const errors = (validTestTransaction as any).validateAsset();
+			return expect(errors[0].dataPath).toBe('.asset.username');
+		});
+
+		it('should return false when username includes forbidden null character', () => {
+			(validTestTransaction as any).asset.username = 'obe\0lisk';
+			const errors = (validTestTransaction as any).validateAsset();
+			return expect(errors[0].dataPath).toBe('.asset.username');
+		});
+	});
+
 	describe('#minFee', () => {
 		it('should set the minFee to nameFee plus minFeePerByte times bytelength', () => {
 			const byteLength = BigInt(validTestTransaction.getBytes().length);

--- a/elements/lisk-validator/src/formats.ts
+++ b/elements/lisk-validator/src/formats.ts
@@ -8,7 +8,6 @@ import {
 	isSignature,
 	isUint32,
 	isUint64,
-	isUsername,
 	isValidFee,
 	isValidNonce,
 	isValidNonTransferAmount,
@@ -105,8 +104,6 @@ export const signedPublicKey = (data: string): boolean => {
 };
 
 export const transferAmount = isValidTransferAmount;
-
-export const username = isUsername;
 
 export const transferData = (data: string): boolean =>
 	!isNullCharacterIncluded(data) && isValidTransferData(data);

--- a/elements/lisk-validator/src/validation.ts
+++ b/elements/lisk-validator/src/validation.ts
@@ -36,26 +36,6 @@ import {
 export const isNullCharacterIncluded = (input: string): boolean =>
 	new RegExp(/\0|\\u0000|\\x00/).test(input);
 
-export const isUsername = (username: string): boolean => {
-	if (isNullCharacterIncluded(username)) {
-		return false;
-	}
-
-	if (username !== username.trim().toLowerCase()) {
-		return false;
-	}
-
-	if (/^[0-9]{1,21}[L|l]$/g.test(username)) {
-		return false;
-	}
-
-	if (!/^[a-z0-9!@$&_.]+$/g.test(username)) {
-		return false;
-	}
-
-	return true;
-};
-
 export const isSignature = (signature: string): boolean =>
 	/^[a-f0-9]{128}$/i.test(signature);
 

--- a/elements/lisk-validator/test/validation.spec.ts
+++ b/elements/lisk-validator/test/validation.spec.ts
@@ -37,7 +37,6 @@ import {
 	isHexString,
 	isStringBufferLessThan,
 	hasNoDuplicate,
-	isUsername,
 	isCsv,
 	isSignature,
 	isValidTransferData,
@@ -317,29 +316,6 @@ describe('validation', () => {
 
 		it('should return true when negative integer was provided', () => {
 			return expect(isValidInteger(-6)).toBeTrue();
-		});
-	});
-
-	describe('#isUsername', () => {
-		it('should return true when valid username is provided', () => {
-			expect(isUsername('4miners.net')).toBeTrue();
-			expect(isUsername('hello111_lisk!')).toBeTrue();
-		});
-
-		it('should return false when username includes capirtal', () => {
-			return expect(isUsername('4miners.Net')).toBeFalse();
-		});
-
-		it('should return false when username is like address', () => {
-			return expect(isUsername('17670127987160191762l')).toBeFalse();
-		});
-
-		it('should return false when username includes forbidden character', () => {
-			return expect(isUsername('4miners^net')).toBeFalse();
-		});
-
-		it('should return false when username includes forbidden null character', () => {
-			return expect(isUsername('4miners\0net')).toBeFalse();
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5370 

### How was it solved?
- Include asset specific validation in custom transaction

### How was it tested?

- Added unit test
