### PR TITLE
Update lisk-bft to use encoded data - Closes #5267

### DIFF
--- a/elements/lisk-bft/package.json
+++ b/elements/lisk-bft/package.json
@@ -36,6 +36,7 @@
 	"dependencies": {
 		"@liskhq/lisk-cryptography": "2.5.0-alpha.0",
 		"@liskhq/lisk-validator": "0.4.0-alpha.0",
+		"@liskhq/lisk-codec": "0.1.0",
 		"@types/node": "12.12.11",
 		"debug": "4.1.1"
 	},

--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -44,6 +44,7 @@ export const BFTFinalizedHeightCodecSchema = {
 			fieldNumber: 1,
 		},
 	},
+	required: ['finalizedHeight'],
 };
 
 codec.addSchema(BFTFinalizedHeightCodecSchema);

--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -34,10 +34,10 @@ import {
 export const CONSENSUS_STATE_FINALIZED_HEIGHT_KEY = 'bft:finalizedHeight';
 export const EVENT_BFT_BLOCK_FINALIZED = 'EVENT_BFT_BLOCK_FINALIZED';
 
-export const BFTPersistedValuesSchema = {
+export const BFTFinalizedHeightCodecSchema = {
 	type: 'object',
-	$id: '/BFT',
-	title: 'LiskBFT',
+	$id: '/BFT/FinalizedHeight',
+	title: 'Lisk BFT Finalized Height',
 	properties: {
 		finalizedHeight: {
 			dataType: 'uint32',
@@ -46,7 +46,7 @@ export const BFTPersistedValuesSchema = {
 	},
 };
 
-codec.addSchema(BFTPersistedValuesSchema);
+codec.addSchema(BFTFinalizedHeightCodecSchema);
 
 /**
  * BFT class responsible to hold integration logic for finality manager with the framework
@@ -129,7 +129,7 @@ export class BFT extends EventEmitter {
 
 		stateStore.consensus.set(
 			CONSENSUS_STATE_FINALIZED_HEIGHT_KEY,
-			codec.encode(BFTPersistedValuesSchema, { finalizedHeight }),
+			codec.encode(BFTFinalizedHeightCodecSchema, { finalizedHeight }),
 		);
 	}
 
@@ -253,7 +253,7 @@ export class BFT extends EventEmitter {
 			storedFinalizedHeightBuffer === undefined
 				? 1
 				: codec.decode<BFTPersistedValues>(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						storedFinalizedHeightBuffer,
 				  ).finalizedHeight;
 

--- a/elements/lisk-bft/src/types.ts
+++ b/elements/lisk-bft/src/types.ts
@@ -100,3 +100,7 @@ export class BFTForkChoiceRuleError extends BFTError {
 }
 
 export class BFTInvalidAttributeError extends BFTError {}
+
+export interface BFTPersistedValues {
+	readonly finalizedHeight: number;
+}

--- a/elements/lisk-bft/test/unit/bft.spec.ts
+++ b/elements/lisk-bft/test/unit/bft.spec.ts
@@ -23,7 +23,7 @@ import {
 	Chain,
 	DPoS,
 	BFTPersistedValues,
-	BFTPersistedValuesSchema,
+	BFTFinalizedHeightCodecSchema,
 } from '../../src';
 import { StateStoreMock } from './state_store_mock';
 
@@ -153,7 +153,7 @@ describe('bft', () => {
 				const finalizedHeight = 5;
 				const stateStore = new StateStoreMock({
 					[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						{ finalizedHeight },
 					),
 				});
@@ -175,7 +175,7 @@ describe('bft', () => {
 			beforeEach(async () => {
 				stateStore = new StateStoreMock({
 					[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						{ finalizedHeight: lastFinalizedHeight },
 					),
 				});
@@ -195,7 +195,7 @@ describe('bft', () => {
 						)) ?? Buffer.from('00');
 
 					const { finalizedHeight } = codec.decode<BFTPersistedValues>(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						finalizedHeightBuffer,
 					);
 
@@ -211,7 +211,7 @@ describe('bft', () => {
 			beforeEach(async () => {
 				stateStore = new StateStoreMock({
 					[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						{ finalizedHeight: 1 },
 					),
 				});
@@ -238,7 +238,7 @@ describe('bft', () => {
 				bft = new BFT(bftParams);
 				stateStore = new StateStoreMock({
 					[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						{ finalizedHeight: 5 },
 					),
 				});
@@ -261,7 +261,7 @@ describe('bft', () => {
 				bft = new BFT(bftParams);
 				stateStore = new StateStoreMock({
 					[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						{ finalizedHeight: 5 },
 					),
 				});
@@ -297,7 +297,7 @@ describe('bft', () => {
 				// Arrange
 				const stateStore = new StateStoreMock({
 					[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						{ finalizedHeight: 5 },
 					),
 				});
@@ -350,7 +350,7 @@ describe('bft', () => {
 				bft = new BFT(bftParams);
 				stateStore = new StateStoreMock({
 					[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(
-						BFTPersistedValuesSchema,
+						BFTFinalizedHeightCodecSchema,
 						{ finalizedHeight: 1 },
 					),
 				});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5267

### How was it solved?

Used `lisk-codec` instead of `JSON.stringify` and `JSON.parse`

### How was it tested?

Run unit tests. 
