### PR TITLE
Update lisk-dpos to use encoded data - Closes #5266

### DIFF
--- a/elements/lisk-dpos/package.json
+++ b/elements/lisk-dpos/package.json
@@ -34,6 +34,7 @@
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
 	"dependencies": {
+		"@liskhq/lisk-codec": "0.1.0",
 		"@liskhq/lisk-cryptography": "2.5.0-alpha.0",
 		"@types/node": "12.12.11",
 		"debug": "4.1.1"

--- a/elements/lisk-dpos/src/delegates_list.ts
+++ b/elements/lisk-dpos/src/delegates_list.ts
@@ -16,7 +16,7 @@ import { getAddressFromPublicKey, hash } from '@liskhq/lisk-cryptography';
 import { codec, Schema, GenericObject } from '@liskhq/lisk-codec';
 
 import * as Debug from 'debug';
-import { voteWeightsSchema } from './schemas';
+import { forgerListSchema, voteWeightsSchema } from './schemas';
 
 import {
 	CHAIN_STATE_DELEGATE_USERNAMES,
@@ -83,17 +83,12 @@ const _setForgersList = (
 	stateStore: StateStore,
 	forgersList: ForgersList,
 ): void => {
-	const stringifyableForgersList = forgersList.map(fl => ({
-		round: fl.round,
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		delegates: fl.delegates ? fl.delegates.map(d => d.toString('binary')) : [],
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		standby: fl.standby ? fl.standby.map(d => d.toString('binary')) : [],
-	}));
-	const forgersListStr = JSON.stringify(stringifyableForgersList);
 	stateStore.consensus.set(
 		CONSENSUS_STATE_DELEGATE_FORGERS_LIST,
-		Buffer.from(forgersListStr, 'utf8'),
+		codec.encode(
+			(forgerListSchema as unknown) as Schema,
+			({ forgersList } as unknown) as GenericObject,
+		),
 	);
 };
 

--- a/elements/lisk-dpos/src/delegates_list.ts
+++ b/elements/lisk-dpos/src/delegates_list.ts
@@ -284,6 +284,7 @@ export class DelegatesList {
 		);
 
 		let usernames = { registeredDelegates: [] } as ChainStateUsernames;
+
 		if (usernamesBuffer) {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const parsedUsername = JSON.parse(usernamesBuffer.toString('utf8'));

--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -12,8 +12,10 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { hash } from '@liskhq/lisk-cryptography';
+import { codec, Schema } from '@liskhq/lisk-codec';
 import * as Debug from 'debug';
 import { EventEmitter } from 'events';
+import { voteWeightsSchema } from './schemas';
 
 import {
 	CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS,
@@ -29,7 +31,6 @@ import {
 	deleteForgersListUntilRound,
 	deleteVoteWeightsUntilRound,
 	getForgersList,
-	decodeVoteWeights,
 } from './delegates_list';
 import { Rounds } from './rounds';
 import {
@@ -38,7 +39,7 @@ import {
 	DPoSProcessingOptions,
 	ForgersList,
 	StateStore,
-	VoteWeights,
+	DecodedVoteWeights,
 } from './types';
 
 interface DposConstructor {
@@ -165,9 +166,12 @@ export class Dpos {
 			CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS,
 		);
 
-		const voteWeights: VoteWeights = voteWeightsBuffer
-			? decodeVoteWeights(voteWeightsBuffer)
-			: [];
+		const voteWeightsDecoded = codec.decode(
+			(voteWeightsSchema as unknown) as Schema,
+			voteWeightsBuffer as Buffer,
+		);
+
+		const { voteWeights } = voteWeightsDecoded as DecodedVoteWeights;
 
 		const voteWeight = voteWeights.find(
 			roundRecord => roundRecord.round === relevantRound,

--- a/elements/lisk-dpos/src/schemas.ts
+++ b/elements/lisk-dpos/src/schemas.ts
@@ -1,5 +1,5 @@
 export const voteWeightsSchema = {
-	$id: '/voteWeightsSchema',
+	$id: '/dpos/voteWeights',
 	type: 'object',
 	properties: {
 		voteWeights: {
@@ -34,4 +34,39 @@ export const voteWeightsSchema = {
 		},
 	},
 	required: ['voteWeights'],
+};
+
+export const forgerListSchema = {
+	$id: '/dpos/forgerList',
+	type: 'object',
+	properties: {
+		forgersList: {
+			type: 'array',
+			fieldNumber: 1,
+			items: {
+				type: 'object',
+				properties: {
+					round: {
+						dataType: 'uint32',
+						fieldNumber: 1,
+					},
+					delegates: {
+						type: 'array',
+						fieldNumber: 2,
+						items: {
+							dataType: 'bytes',
+						},
+					},
+					standby: {
+						type: 'array',
+						fieldNumber: 3,
+						items: {
+							dataType: 'bytes',
+						},
+					},
+				},
+			},
+		},
+	},
+	required: ['forgersList'],
 };

--- a/elements/lisk-dpos/src/schemas.ts
+++ b/elements/lisk-dpos/src/schemas.ts
@@ -1,0 +1,37 @@
+export const voteWeightsSchema = {
+	$id: '/voteWeightsSchema',
+	type: 'object',
+	properties: {
+		voteWeights: {
+			type: 'array',
+			fieldNumber: 1,
+			items: {
+				type: 'object',
+				properties: {
+					round: {
+						dataType: 'uint32',
+						fieldNumber: 1,
+					},
+					delegates: {
+						type: 'array',
+						fieldNumber: 2,
+						items: {
+							type: 'object',
+							properties: {
+								address: {
+									dataType: 'bytes',
+									fieldNumber: 1,
+								},
+								voteWeight: {
+									dataType: 'uint64',
+									fieldNumber: 2,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	required: ['voteWeights'],
+};

--- a/elements/lisk-dpos/src/types.ts
+++ b/elements/lisk-dpos/src/types.ts
@@ -134,3 +134,7 @@ export interface ChainStateRegisteredDelegate {
 export interface ChainStateUsernames {
 	readonly registeredDelegates: ChainStateRegisteredDelegate[];
 }
+
+export interface DecodedVoteWeights {
+	voteWeights: VoteWeight[];
+}

--- a/elements/lisk-dpos/test/unit/get_min_height_active.spec.ts
+++ b/elements/lisk-dpos/test/unit/get_min_height_active.spec.ts
@@ -13,6 +13,8 @@
  */
 
 import { Slots } from '@liskhq/lisk-chain';
+import { codec, Schema } from '@liskhq/lisk-codec';
+import { forgerListSchema } from '../../src/schemas';
 import { Dpos } from '../../src';
 import {
 	DELEGATE_LIST_ROUND_OFFSET,
@@ -26,8 +28,13 @@ import { CONSENSUS_STATE_DELEGATE_FORGERS_LIST } from '../../src/constants';
 import { ForgersList } from '../../src/types';
 
 const createStateStore = (list: ForgersList = []): StateStoreMock => {
+	const binaryForgerList = codec.encode(
+		(forgerListSchema as unknown) as Schema,
+		{ forgersList: list as any },
+	);
+
 	return new StateStoreMock([], {
-		[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: Buffer.from(JSON.stringify(list)),
+		[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: binaryForgerList,
 	});
 };
 

--- a/elements/lisk-dpos/test/unit/is_standby_delegate.spec.ts
+++ b/elements/lisk-dpos/test/unit/is_standby_delegate.spec.ts
@@ -13,6 +13,8 @@
  */
 import { Slots } from '@liskhq/lisk-chain';
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
+import { codec, Schema } from '@liskhq/lisk-codec';
+import { forgerListSchema } from '../../src/schemas';
 import {
 	generateDelegateLists,
 	generateDelegateListsWithStandby,
@@ -30,8 +32,13 @@ import { StateStoreMock } from '../utils/state_store_mock';
 import { CONSENSUS_STATE_DELEGATE_FORGERS_LIST } from '../../src/constants';
 
 const createStateStore = (list: ForgersList = []): StateStoreMock => {
+	const binaryForgerList = codec.encode(
+		(forgerListSchema as unknown) as Schema,
+		{ forgersList: list as any },
+	);
+
 	return new StateStoreMock([], {
-		[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: Buffer.from(JSON.stringify(list)),
+		[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: binaryForgerList,
 	});
 };
 
@@ -65,7 +72,7 @@ describe('dpos.isStandbyDelegate', () => {
 		// Height in round 17
 		const height = 17 * ACTIVE_DELEGATES;
 
-		it('should return true if its a standby delegate', async () => {
+		it('should return true if it is a standby delegate', async () => {
 			const lists = generateDelegateListsWithStandby({
 				address: standByAddress,
 				activeRounds,

--- a/elements/lisk-dpos/test/unit/vote_weight_snapshot.spec.ts
+++ b/elements/lisk-dpos/test/unit/vote_weight_snapshot.spec.ts
@@ -13,6 +13,8 @@
  */
 
 import { Slots } from '@liskhq/lisk-chain';
+import { codec, GenericObject, Schema } from '@liskhq/lisk-codec';
+import { forgerListSchema, voteWeightsSchema } from '../../src/schemas';
 import * as randomSeedModule from '../../src/random_seed';
 import { Dpos } from '../../src';
 import {
@@ -32,7 +34,11 @@ import {
 import { randomBigIntWithPowerof8 } from '../utils/random_int';
 
 const convertVoteWeight = (buffer: Buffer): VoteWeights => {
-	const parsedVoteWeights = JSON.parse(buffer.toString('utf8'));
+	const { voteWeights: parsedVoteWeights } = codec.decode(
+		(voteWeightsSchema as unknown) as Schema,
+		buffer,
+	);
+
 	const voteWeights = parsedVoteWeights.map((vw: any) => ({
 		round: vw.round,
 		delegates: vw.delegates.map((d: any) => ({
@@ -77,6 +83,7 @@ describe('Vote weight snapshot', () => {
 			for (const delegate of delegates) {
 				delegate.asset.delegate.totalVotesReceived = BigInt(10) ** BigInt(12);
 			}
+
 			genesisBlock = {
 				id: Buffer.from('genesis-block'),
 				timestamp: 10,
@@ -99,9 +106,12 @@ describe('Vote weight snapshot', () => {
 				const voteWeightsBuffer = await stateStore.consensus.get(
 					CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS,
 				);
-				const voteWeights = JSON.parse(
-					(voteWeightsBuffer as Buffer).toString('utf8'),
+
+				const { voteWeights } = codec.decode(
+					(voteWeightsSchema as unknown) as Schema,
+					voteWeightsBuffer as Buffer,
 				);
+
 				expect(voteWeights).toHaveLength(3);
 				expect(voteWeights[0].round).toEqual(1);
 				expect(voteWeights[1].round).toEqual(2);
@@ -165,13 +175,16 @@ describe('Vote weight snapshot', () => {
 						amount: delegate.asset.delegate.totalVotesReceived,
 					});
 				}
+
 				[updatedDelegate] = getDelegateAccounts(1);
+
 				updatedDelegate.asset.delegate.totalVotesReceived =
 					BigInt(6000) * BigInt(10) ** BigInt(9);
 				updatedDelegate.asset.sentVotes.push({
 					delegateAddress: updatedDelegate.address,
 					amount: updatedDelegate.asset.delegate.totalVotesReceived,
 				});
+
 				block = {
 					id: Buffer.from('random-block'),
 					timestamp: 10100,
@@ -182,6 +195,7 @@ describe('Vote weight snapshot', () => {
 						seedReveal: Buffer.from('00000000000000000000000000000000', 'hex'),
 					},
 				} as BlockHeader;
+
 				chainStub.dataAccess.getDelegates.mockResolvedValue([
 					...delegates,
 					updatedDelegate,
@@ -198,24 +212,39 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [...forgers.map(d => d.address).slice(0, 102)],
-					},
-				]);
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
+
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
+
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
 
 				const updatedVote = BigInt(100) * BigInt(10) ** BigInt(8);
 
@@ -264,9 +293,12 @@ describe('Vote weight snapshot', () => {
 				const voteWeightsBuffer = await stateStore.consensus.get(
 					CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS,
 				);
-				const voteWeights = JSON.parse(
-					(voteWeightsBuffer as Buffer).toString('utf8'),
+
+				const { voteWeights } = codec.decode(
+					(voteWeightsSchema as unknown) as Schema,
+					voteWeightsBuffer as Buffer,
 				);
+
 				expect(voteWeights).toHaveLength(2);
 				expect(voteWeights[1].round).toEqual(13);
 				const updateddelegateInList = voteWeights[1].delegates.find(
@@ -289,6 +321,7 @@ describe('Vote weight snapshot', () => {
 						amount: delegate.asset.delegate.totalVotesReceived,
 					});
 				}
+
 				block = {
 					id: Buffer.from('random-block'),
 					timestamp: 10100,
@@ -307,30 +340,44 @@ describe('Vote weight snapshot', () => {
 						height: 928 + i,
 					}))
 					.slice(0, 102);
+
 				chainStub.dataAccess.getBlockHeadersByHeightBetween.mockResolvedValue(
 					forgedBlocks,
 				);
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 102),
-						],
-					},
-				]);
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
+
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
+
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
 
 				const mockedDelegateUsernames = JSON.stringify({
 					registeredDelegates: [
@@ -458,26 +505,39 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 102),
-						],
-					},
-				]);
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
+
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
+
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
 
 				stateStore = new StateStoreMock(
 					[...delegates, ...additionalDelegates, forgers[0]],
@@ -586,36 +646,45 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 102),
-						],
-					},
-				]);
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
+
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
+
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
 
 				stateStore = new StateStoreMock(
 					[...delegates, ...additionalDelegates, forgers[0]],
 					{
-						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: Buffer.from(
-							mockedForgersList,
-						),
-						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: Buffer.from(
-							mockedVoteWeights,
-						),
+						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: mockedForgersList,
+						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: mockedVoteWeights,
 					},
 					{
 						chainData: {
@@ -722,26 +791,39 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 102),
-						],
-					},
-				]);
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
+
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
+
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
 
 				stateStore = new StateStoreMock(
 					[...delegates, ...additionalDelegates, forgers[0]],
@@ -854,36 +936,45 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 102),
-						],
-					},
-				]);
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
+
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
+
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
 
 				stateStore = new StateStoreMock(
 					[...delegates, ...additionalDelegates, forgers[0]],
 					{
-						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: Buffer.from(
-							mockedForgersList,
-						),
-						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: Buffer.from(
-							mockedVoteWeights,
-						),
+						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: mockedForgersList,
+						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: mockedVoteWeights,
 					},
 					{
 						chainData: {
@@ -975,45 +1066,45 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 100),
-						],
-						standby: [
-							...forgers.map(d => d.address.toString('binary')).slice(101, 102),
-						],
-					},
-				]);
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 100)],
+							standby: [...forgers.map(d => d.address).slice(101, 102)],
+						},
+					],
+				};
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.slice(0, 100).map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-						standby: [
-							...delegates.slice(101, 102).map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
+
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.slice(0, 100).map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
+
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
 
 				stateStore = new StateStoreMock(
 					[...delegates, forgers[0]],
 					{
-						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: Buffer.from(
-							mockedForgersList,
-						),
-						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: Buffer.from(
-							mockedVoteWeights,
-						),
+						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: mockedForgersList,
+						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: mockedVoteWeights,
 					},
 					{
 						chainData: {
@@ -1113,36 +1204,45 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 102),
-						],
-					},
-				]);
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
 
-				const mockedVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: [
-							...delegates.map(d => ({
-								address: d.address.toString('binary'),
-								voteWeight: d.asset.delegate.totalVotesReceived.toString(),
-							})),
-						],
-					},
-				]);
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
+
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: [
+								...delegates.map(d => ({
+									address: d.address,
+									voteWeight: BigInt(d.asset.delegate.totalVotesReceived),
+								})),
+							],
+						},
+					],
+				};
+
+				const mockedVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
 
 				stateStore = new StateStoreMock(
 					[...delegates, ...additionalDelegates, forgers[0]],
 					{
-						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: Buffer.from(
-							mockedForgersList,
-						),
-						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: Buffer.from(
-							mockedVoteWeights,
-						),
+						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: mockedForgersList,
+						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: mockedVoteWeights,
 					},
 					{
 						chainData: {
@@ -1208,67 +1308,76 @@ describe('Vote weight snapshot', () => {
 					forgedBlocks,
 				);
 
-				const existingVoteWeights = JSON.stringify([
-					{
-						round: 11,
-						delegates: delegates.map(d => ({
-							address: d.address.toString('binary'),
-							voteWeight: '0',
-						})),
-					},
-					{
-						round: 12,
-						delegates: delegates.map(d => ({
-							address: d.address.toString('binary'),
-							voteWeight: '0',
-						})),
-					},
-					{
-						round: 13,
-						delegates: delegates.map(d => ({
-							address: d.address.toString('binary'),
-							voteWeight: '0',
-						})),
-					},
-					{
-						round: 14,
-						delegates: delegates.map(d => ({
-							address: d.address.toString('binary'),
-							voteWeight: '0',
-						})),
-					},
-					{
-						round: 15,
-						delegates: delegates.map(d => ({
-							address: d.address.toString('binary'),
-							voteWeight: '0',
-						})),
-					},
-					{
-						round: 16,
-						delegates: delegates.map(d => ({
-							address: d.address.toString('binary'),
-							voteWeight: '0',
-						})),
-					},
-				]);
+				const voteWeightsObject = {
+					voteWeights: [
+						{
+							round: 11,
+							delegates: delegates.map(d => ({
+								address: d.address,
+								voteWeight: BigInt(0),
+							})),
+						},
+						{
+							round: 12,
+							delegates: delegates.map(d => ({
+								address: d.address,
+								voteWeight: BigInt(0),
+							})),
+						},
+						{
+							round: 13,
+							delegates: delegates.map(d => ({
+								address: d.address,
+								voteWeight: BigInt(0),
+							})),
+						},
+						{
+							round: 14,
+							delegates: delegates.map(d => ({
+								address: d.address,
+								voteWeight: BigInt(0),
+							})),
+						},
+						{
+							round: 15,
+							delegates: delegates.map(d => ({
+								address: d.address,
+								voteWeight: BigInt(0),
+							})),
+						},
+						{
+							round: 16,
+							delegates: delegates.map(d => ({
+								address: d.address,
+								voteWeight: BigInt(0),
+							})),
+						},
+					],
+				};
 
-				const mockedForgersList = JSON.stringify([
-					{
-						round: 10,
-						delegates: [
-							...forgers.map(d => d.address.toString('binary')).slice(0, 102),
-						],
-					},
-				]);
+				const existingVoteWeights = codec.encode(
+					(voteWeightsSchema as unknown) as Schema,
+					(voteWeightsObject as unknown) as GenericObject,
+				);
+
+				const forgerListObject = {
+					forgersList: [
+						{
+							round: 10,
+							delegates: [...forgers.map(d => d.address).slice(0, 102)],
+							standby: [],
+						},
+					],
+				};
+
+				const mockedForgersList = codec.encode(
+					(forgerListSchema as unknown) as Schema,
+					(forgerListObject as unknown) as GenericObject,
+				);
 
 				stateStore = new StateStoreMock([forgers[0]], {
-					[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: Buffer.from(
-						mockedForgersList,
-					),
-					[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: Buffer.from(
-						existingVoteWeights,
-					),
+					[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: mockedForgersList,
+					[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: existingVoteWeights,
 				});
 			});
 

--- a/elements/lisk-dpos/test/utils/delegates.ts
+++ b/elements/lisk-dpos/test/utils/delegates.ts
@@ -16,23 +16,159 @@ import { deepFreeze } from './deep_freeze';
 import { ForgerList, ForgersList } from '../../src/types';
 
 export const delegateLists = deepFreeze([
-	{ round: 17, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 16, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 15, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 14, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 13, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 12, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 11, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 10, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 9, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 8, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 7, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 6, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 5, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 4, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 3, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 2, delegates: ['a', 'b', 'c'], standby: [] },
-	{ round: 1, delegates: ['a', 'b', 'c'], standby: [] },
+	{
+		round: 17,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 16,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 15,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 14,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 13,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 12,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 11,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 10,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 9,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 8,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 7,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 6,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 5,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 4,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 3,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 2,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
+	{
+		round: 1,
+		delegates: [
+			Buffer.from('a', 'hex'),
+			Buffer.from('b', 'hex'),
+			Buffer.from('c', 'hex'),
+		],
+		standby: [],
+	},
 ]);
 
 interface ActiveDelegateList {

--- a/elements/lisk-dpos/test/utils/search_buffer_array.ts
+++ b/elements/lisk-dpos/test/utils/search_buffer_array.ts
@@ -1,0 +1,11 @@
+export const searchBufferArray = (
+	search: Buffer,
+	collection: Buffer[],
+): boolean => {
+	for (const buffer of collection) {
+		if (buffer.compare(search) === 0) {
+			return true;
+		}
+	}
+	return false;
+};


### PR DESCRIPTION
### What was the problem?

This PR resolves #5266

### How was it solved?

- By removing usage of JSON and replacing with lisk-codec
- By adding schemas for voteWeights
- By adding schemas for forgersList

### How was it tested?

Unit tests
