### PR TITLE
Update framework forger to store encoded data - Closes #5265

### DIFF
--- a/framework/src/application/node/forger/data_access.ts
+++ b/framework/src/application/node/forger/data_access.ts
@@ -13,14 +13,89 @@
  */
 
 import { KVStore } from '@liskhq/lisk-db';
+import { codec, Schema, GenericObject } from '@liskhq/lisk-codec';
 import { BufferMap } from '@liskhq/lisk-chain';
 import {
 	DB_KEY_FORGER_USED_HASH_ONION,
 	DB_KEY_FORGER_REGISTERED_HASH_ONION_SEEDS,
 } from './constant';
 
+export const registeredHashOnionsStoreSchema = ({
+	title: 'Used hash onion',
+	$id: '/node/forger/registered_hash_onion',
+	type: 'object',
+	required: ['registeredHashOnions'],
+	properties: {
+		registeredHashOnions: {
+			type: 'array',
+			fieldNumber: 1,
+			items: {
+				type: 'object',
+				required: ['address', 'seedHash'],
+				properties: {
+					address: {
+						dataType: 'bytes',
+						fieldNumber: 1,
+					},
+					seedHash: {
+						dataType: 'bytes',
+						fieldNumber: 2,
+					},
+				},
+			},
+		},
+	},
+} as never) as Schema;
+
+export const usedHashOnionsStoreSchema = ({
+	title: 'Used hash onion',
+	$id: '/node/forger/used_hash_onion',
+	type: 'object',
+	required: ['usedHashOnions'],
+	properties: {
+		usedHashOnions: {
+			type: 'array',
+			fieldNumber: 1,
+			items: {
+				type: 'object',
+				required: ['address', 'count', 'height'],
+				properties: {
+					address: {
+						dataType: 'bytes',
+						fieldNumber: 1,
+					},
+					count: {
+						dataType: 'uint32',
+						fieldNumber: 2,
+					},
+					height: {
+						dataType: 'uint32',
+						fieldNumber: 3,
+					},
+				},
+			},
+		},
+	},
+} as never) as Schema;
+
+codec.addSchema(registeredHashOnionsStoreSchema);
+
+codec.addSchema(usedHashOnionsStoreSchema);
+
 export interface RegisteredHash {
 	[key: string]: Buffer;
+}
+
+export interface RegisteredHashOnionStoreObject {
+	readonly registeredHashOnions: RegisteredHashOnion[];
+}
+export interface RegisteredHashOnion {
+	readonly address: Buffer;
+	readonly seedHash: Buffer;
+}
+
+export interface UsedHashOnionStoreObject {
+	readonly usedHashOnions: UsedHashOnion[];
 }
 
 export interface UsedHashOnion {
@@ -39,19 +114,16 @@ export const getRegisteredHashOnionSeeds = async (
 	db: KVStore,
 ): Promise<BufferMap<Buffer>> => {
 	try {
-		const registeredHashOnionSeedsBuffer = await db.get(
-			DB_KEY_FORGER_REGISTERED_HASH_ONION_SEEDS,
+		const registeredHashes = codec.decode<RegisteredHashOnionStoreObject>(
+			registeredHashOnionsStoreSchema,
+			await db.get(DB_KEY_FORGER_REGISTERED_HASH_ONION_SEEDS),
 		);
-		const registeredHash = JSON.parse(
-			registeredHashOnionSeedsBuffer.toString('utf8'),
-		) as { [key: string]: string };
+
 		const result = new BufferMap<Buffer>();
-		for (const key of Object.keys(registeredHash)) {
-			result.set(
-				Buffer.from(key, 'binary'),
-				Buffer.from(registeredHash[key], 'binary'),
-			);
+		for (const registeredHash of registeredHashes.registeredHashOnions) {
+			result.set(registeredHash.address, registeredHash.seedHash);
 		}
+
 		return result;
 	} catch (error) {
 		return new BufferMap<Buffer>();
@@ -62,14 +134,24 @@ export const setRegisteredHashOnionSeeds = async (
 	db: KVStore,
 	registeredHashOnionSeeds: BufferMap<Buffer>,
 ): Promise<void> => {
-	const savingData: { [key: string]: string } = {};
-	for (const [key, value] of registeredHashOnionSeeds.entries()) {
-		savingData[key.toString('binary')] = value.toString('binary');
+	const savingData: RegisteredHashOnionStoreObject = {
+		registeredHashOnions: [],
+	};
+
+	for (const [address, seedHash] of registeredHashOnionSeeds.entries()) {
+		savingData.registeredHashOnions.push({
+			address,
+			seedHash,
+		});
 	}
-	const registeredHashOnionSeedsStr = JSON.stringify(savingData);
+	const registeredHashOnionSeedsBuffer = codec.encode(
+		registeredHashOnionsStoreSchema,
+		(savingData as never) as GenericObject,
+	);
+
 	await db.put(
 		DB_KEY_FORGER_REGISTERED_HASH_ONION_SEEDS,
-		Buffer.from(registeredHashOnionSeedsStr, 'utf8'),
+		registeredHashOnionSeedsBuffer,
 	);
 };
 
@@ -77,20 +159,10 @@ export const getUsedHashOnions = async (
 	db: KVStore,
 ): Promise<UsedHashOnion[]> => {
 	try {
-		const usedHashOnionsBuffer = await db.get(DB_KEY_FORGER_USED_HASH_ONION);
-
-		const usedHashOnionsJSON = JSON.parse(
-			usedHashOnionsBuffer.toString('utf8'),
-		) as { address: string; count: number; height: number }[];
-		const reuslt = [];
-		for (const ho of usedHashOnionsJSON) {
-			reuslt.push({
-				address: Buffer.from(ho.address, 'binary'),
-				count: ho.count,
-				height: ho.height,
-			});
-		}
-		return reuslt;
+		return codec.decode<UsedHashOnionStoreObject>(
+			usedHashOnionsStoreSchema,
+			await db.get(DB_KEY_FORGER_USED_HASH_ONION),
+		).usedHashOnions;
 	} catch (error) {
 		return [];
 	}
@@ -100,17 +172,13 @@ export const setUsedHashOnions = async (
 	db: KVStore,
 	usedHashOnions: UsedHashOnion[],
 ): Promise<void> => {
-	const encodedUsedHashOnion = [];
-	for (const ho of usedHashOnions) {
-		encodedUsedHashOnion.push({
-			address: ho.address.toString('binary'),
-			count: ho.count,
-			height: ho.height,
-		});
-	}
-	const usedHashOnionsStr = JSON.stringify(encodedUsedHashOnion);
+	const usedHashOnionObject: UsedHashOnionStoreObject = { usedHashOnions };
+
 	await db.put(
 		DB_KEY_FORGER_USED_HASH_ONION,
-		Buffer.from(usedHashOnionsStr, 'utf8'),
+		codec.encode(
+			usedHashOnionsStoreSchema,
+			(usedHashOnionObject as never) as GenericObject,
+		),
 	);
 };

--- a/framework/src/application/node/forger/data_access.ts
+++ b/framework/src/application/node/forger/data_access.ts
@@ -45,7 +45,7 @@ export const registeredHashOnionsStoreSchema = ({
 			},
 		},
 	},
-} as never) as Schema;
+} as unknown) as Schema;
 
 export const usedHashOnionsStoreSchema = ({
 	title: 'Used hash onion',
@@ -76,7 +76,7 @@ export const usedHashOnionsStoreSchema = ({
 			},
 		},
 	},
-} as never) as Schema;
+} as unknown) as Schema;
 
 codec.addSchema(registeredHashOnionsStoreSchema);
 
@@ -146,7 +146,7 @@ export const setRegisteredHashOnionSeeds = async (
 	}
 	const registeredHashOnionSeedsBuffer = codec.encode(
 		registeredHashOnionsStoreSchema,
-		(savingData as never) as GenericObject,
+		(savingData as unknown) as GenericObject,
 	);
 
 	await db.put(
@@ -178,7 +178,7 @@ export const setUsedHashOnions = async (
 		DB_KEY_FORGER_USED_HASH_ONION,
 		codec.encode(
 			usedHashOnionsStoreSchema,
-			(usedHashOnionObject as never) as GenericObject,
+			(usedHashOnionObject as unknown) as GenericObject,
 		),
 	);
 };

--- a/framework/test/unit/specs/application/node/forger/forger.spec.ts
+++ b/framework/test/unit/specs/application/node/forger/forger.spec.ts
@@ -850,8 +850,6 @@ describe('forger', () => {
 					registeredHashOnions: [{ address, seedHash: newSeed }],
 				};
 				const registeredHashOnionsBuffer = codec.encode(
-					// eslint-disable-next-line
-					// @ts-ignore
 					registeredHashOnionsStoreSchema,
 					registeredHashOnions,
 				);
@@ -884,9 +882,6 @@ describe('forger', () => {
 				);
 				expect(dbStub.put).toHaveBeenCalledWith(
 					DB_KEY_FORGER_REGISTERED_HASH_ONION_SEEDS,
-
-					// eslint-disable-next-line
-					// @ts-ignore
 					codec.encode(registeredHashOnionsStoreSchema, originalKey),
 				);
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5265

### How was it solved?

Updated forger to use encoding schema. 

### How was it tested?

Run unit tests for framework. 
