### PR TITLE
Update cryptography to consistent interface - Closes #5403

### DIFF
--- a/commander/src/commands/account/create.ts
+++ b/commander/src/commands/account/create.ts
@@ -35,10 +35,7 @@ const createAccount = (): AccountInfo => {
 	const passphrase = createMnemonicPassphrase();
 	const { privateKey, publicKey } = getKeys(passphrase);
 	const binaryAddress = getAddressFromPublicKey(publicKey);
-	const address = getBase32AddressFromPublicKey(
-		publicKey.toString('hex'),
-		'lsk',
-	);
+	const address = getBase32AddressFromPublicKey(publicKey, 'lsk');
 
 	return {
 		passphrase,

--- a/commander/src/commands/account/show.ts
+++ b/commander/src/commands/account/show.ts
@@ -34,10 +34,7 @@ const processInput = (
 } => {
 	const { privateKey, publicKey } = getKeys(passphrase);
 	const binaryAddress = getAddressFromPublicKey(publicKey);
-	const address = getBase32AddressFromPublicKey(
-		publicKey.toString('hex'),
-		'lsk',
-	);
+	const address = getBase32AddressFromPublicKey(publicKey, 'lsk');
 
 	return {
 		privateKey: privateKey.toString('base64'),

--- a/commander/src/commands/message/decrypt.ts
+++ b/commander/src/commands/message/decrypt.ts
@@ -45,7 +45,7 @@ const processInputs = (
 		message,
 		nonce,
 		passphrase,
-		senderPublicKey,
+		Buffer.from(senderPublicKey, 'hex'),
 	);
 };
 

--- a/commander/src/commands/message/encrypt.ts
+++ b/commander/src/commands/message/encrypt.ts
@@ -40,7 +40,11 @@ const processInputs = (
 	}
 
 	return {
-		...encryptMessageWithPassphrase(message, passphrase, recipientPublicKey),
+		...encryptMessageWithPassphrase(
+			message,
+			passphrase,
+			Buffer.from(recipientPublicKey, 'hex'),
+		),
 		recipientPublicKey,
 	};
 };

--- a/commander/src/commands/network-identifier.ts
+++ b/commander/src/commands/network-identifier.ts
@@ -52,9 +52,9 @@ export default class NetworkIdentifierCommand extends BaseCommand {
 			args: { genesisBlockTransactionRoot },
 		} = this.parse(NetworkIdentifierCommand);
 		const networkIdentifier = getNetworkIdentifier(
-			genesisBlockTransactionRoot as string,
+			Buffer.from(genesisBlockTransactionRoot, 'hex'),
 			communityIdentifier,
 		);
-		this.print({ networkIdentifier });
+		this.print({ networkIdentifier: networkIdentifier.toString('base64') });
 	}
 }

--- a/commander/src/utils/cryptography.ts
+++ b/commander/src/utils/cryptography.ts
@@ -26,7 +26,11 @@ export const encryptMessage = ({
 	passphrase,
 	recipient,
 }: EncryptMessageInputs): cryptography.EncryptedMessageWithNonce =>
-	cryptography.encryptMessageWithPassphrase(message, passphrase, recipient);
+	cryptography.encryptMessageWithPassphrase(
+		message,
+		passphrase,
+		Buffer.from(recipient, 'hex'),
+	);
 
 interface DecryptMessageInputs {
 	readonly cipher: string;
@@ -45,7 +49,7 @@ export const decryptMessage = ({
 		cipher,
 		nonce,
 		passphrase,
-		senderPublicKey,
+		Buffer.from(senderPublicKey, 'hex'),
 	),
 });
 

--- a/commander/src/utils/network_identifier.ts
+++ b/commander/src/utils/network_identifier.ts
@@ -23,7 +23,10 @@ export const getNetworkIdentifierWithInput = (
 	networkConfig: string | undefined,
 ): string => {
 	if (input !== undefined && Object.keys(NETHASHES).includes(input)) {
-		return getNetworkIdentifier(NETHASHES[input], COMMUNITY_IDENTIFIER);
+		return getNetworkIdentifier(
+			Buffer.from(NETHASHES[input], 'hex'),
+			COMMUNITY_IDENTIFIER,
+		).toString('hex');
 	}
 	if (input !== undefined) {
 		if (!isHexString(input)) {
@@ -37,7 +40,10 @@ export const getNetworkIdentifierWithInput = (
 		networkConfig !== undefined &&
 		Object.keys(NETHASHES).includes(networkConfig)
 	) {
-		return getNetworkIdentifier(NETHASHES[networkConfig], COMMUNITY_IDENTIFIER);
+		return getNetworkIdentifier(
+			Buffer.from(NETHASHES[networkConfig], 'hex'),
+			COMMUNITY_IDENTIFIER,
+		).toString('hex');
 	}
 	throw new Error('Invalid network identifier');
 };

--- a/commander/test/commands/account/create.test.ts
+++ b/commander/test/commands/account/create.test.ts
@@ -84,7 +84,7 @@ describe('account:create', () => {
 							.getKeys(defaultMnemonic)
 							.privateKey.toString('base64'),
 						address: cryptography.getBase32AddressFromPublicKey(
-							cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
+							cryptography.getKeys(defaultMnemonic).publicKey,
 							'lsk',
 						),
 						binaryAddress: cryptography
@@ -111,7 +111,7 @@ describe('account:create', () => {
 							.getKeys(defaultMnemonic)
 							.privateKey.toString('base64'),
 						address: cryptography.getBase32AddressFromPublicKey(
-							cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
+							cryptography.getKeys(defaultMnemonic).publicKey,
 							'lsk',
 						),
 						binaryAddress: cryptography
@@ -127,9 +127,7 @@ describe('account:create', () => {
 							.getKeys(secondDefaultMnemonic)
 							.privateKey.toString('base64'),
 						address: cryptography.getBase32AddressFromPublicKey(
-							cryptography
-								.getKeys(secondDefaultMnemonic)
-								.publicKey.toString('hex'),
+							cryptography.getKeys(secondDefaultMnemonic).publicKey,
 							'lsk',
 						),
 						binaryAddress: cryptography

--- a/commander/test/commands/account/show.test.ts
+++ b/commander/test/commands/account/show.test.ts
@@ -55,7 +55,7 @@ describe('account:show', () => {
 						.getKeys(passphraseInput)
 						.publicKey.toString('base64'),
 					address: cryptography.getBase32AddressFromPublicKey(
-						cryptography.getKeys(passphraseInput).publicKey.toString('hex'),
+						cryptography.getKeys(passphraseInput).publicKey,
 						'lsk',
 					),
 					binaryAddress: cryptography
@@ -78,9 +78,7 @@ describe('account:show', () => {
 						.getKeys(secondDefaultMnemonic)
 						.publicKey.toString('base64'),
 					address: cryptography.getBase32AddressFromPublicKey(
-						cryptography
-							.getKeys(secondDefaultMnemonic)
-							.publicKey.toString('hex'),
+						cryptography.getKeys(secondDefaultMnemonic).publicKey,
 						'lsk',
 					),
 					binaryAddress: cryptography

--- a/commander/test/commands/message/decrypt.test.ts
+++ b/commander/test/commands/message/decrypt.test.ts
@@ -22,8 +22,10 @@ import * as readerUtils from '../../../src/utils/reader';
 
 describe('message:decrypt', () => {
 	const message = 'Hello World';
-	const defaultSenderPublicKey =
-		'bba7e2e6a4639c431b68e31115a71ffefcb4e025a4d1656405dfdcd8384719e0';
+	const defaultSenderPublicKey = Buffer.from(
+		'bba7e2e6a4639c431b68e31115a71ffefcb4e025a4d1656405dfdcd8384719e0',
+		'hex',
+	);
 	const defaultNonce = '0ec64b2146336a62c9938475308411f00688f9d12c5d33a0';
 	const defaultEncryptedMessage =
 		'c9d369291997bf34abe505d48ac394175b68fc90f8f1d16fd1351e';
@@ -61,7 +63,7 @@ describe('message:decrypt', () => {
 
 	describe('message:decrypt senderPublicKey', () => {
 		setupTest()
-			.command(['message:decrypt', defaultSenderPublicKey])
+			.command(['message:decrypt', defaultSenderPublicKey.toString('hex')])
 			.catch((error: Error) => {
 				return expect(error.message).to.contain('Missing 1 required arg');
 			})
@@ -70,7 +72,11 @@ describe('message:decrypt', () => {
 
 	describe('message:decrypt senderPublicKey nonce', () => {
 		setupTest()
-			.command(['message:decrypt', defaultSenderPublicKey, defaultNonce])
+			.command([
+				'message:decrypt',
+				defaultSenderPublicKey.toString('hex'),
+				defaultNonce,
+			])
 			.catch((error: Error) => {
 				return expect(error.message).to.contain('No message was provided.');
 			})
@@ -81,7 +87,7 @@ describe('message:decrypt', () => {
 		setupTest()
 			.command([
 				'message:decrypt',
-				defaultSenderPublicKey,
+				defaultSenderPublicKey.toString('hex'),
 				defaultNonce,
 				defaultEncryptedMessage,
 			])
@@ -105,7 +111,7 @@ describe('message:decrypt', () => {
 		setupTest()
 			.command([
 				'message:decrypt',
-				defaultSenderPublicKey,
+				defaultSenderPublicKey.toString('hex'),
 				defaultNonce,
 				'--message=file:./message.txt',
 			])
@@ -136,7 +142,7 @@ describe('message:decrypt', () => {
 		setupTest()
 			.command([
 				'message:decrypt',
-				defaultSenderPublicKey,
+				defaultSenderPublicKey.toString('hex'),
 				defaultNonce,
 				'--message=file:./message.txt',
 				'--passphrase=card earn shift valley learn scorpion cage select help title control satoshi',

--- a/commander/test/commands/message/encrypt.test.ts
+++ b/commander/test/commands/message/encrypt.test.ts
@@ -22,8 +22,10 @@ import * as readerUtils from '../../../src/utils/reader';
 
 describe('message:encrypt', () => {
 	const message = 'Hello World';
-	const defaultRecipientPublicKey =
-		'bba7e2e6a4639c431b68e31115a71ffefcb4e025a4d1656405dfdcd8384719e0';
+	const defaultRecipientPublicKey = Buffer.from(
+		'bba7e2e6a4639c431b68e31115a71ffefcb4e025a4d1656405dfdcd8384719e0',
+		'hex',
+	);
 	const defaultEncryptedMessage = {
 		nonce: '0ec64b2146336a62c9938475308411f00688f9d12c5d33a0',
 		message: 'c9d369291997bf34abe505d48ac394175b68fc90f8f1d16fd1351e',
@@ -62,7 +64,7 @@ describe('message:encrypt', () => {
 
 	describe('message:encrypt recipientPublicKey', () => {
 		setupTest()
-			.command(['message:encrypt', defaultRecipientPublicKey])
+			.command(['message:encrypt', defaultRecipientPublicKey.toString('hex')])
 			.catch((error: Error) => {
 				return expect(error.message).to.contain('No message was provided.');
 			})
@@ -71,7 +73,11 @@ describe('message:encrypt', () => {
 
 	describe('message:encrypt recipientPublicKey message', () => {
 		setupTest()
-			.command(['message:encrypt', defaultRecipientPublicKey, message])
+			.command([
+				'message:encrypt',
+				defaultRecipientPublicKey.toString('hex'),
+				message,
+			])
 			.it('should encrypt the message with the arg', () => {
 				expect(readerUtils.getPassphraseFromPrompt).to.be.calledWithExactly(
 					'passphrase',
@@ -87,7 +93,7 @@ describe('message:encrypt', () => {
 				);
 				return expect(printMethodStub).to.be.calledWithExactly({
 					...defaultEncryptedMessage,
-					recipientPublicKey: defaultRecipientPublicKey,
+					recipientPublicKey: defaultRecipientPublicKey.toString('hex'),
 				});
 			});
 	});
@@ -96,7 +102,7 @@ describe('message:encrypt', () => {
 		setupTest()
 			.command([
 				'message:encrypt',
-				defaultRecipientPublicKey,
+				defaultRecipientPublicKey.toString('hex'),
 				'--message=file:./message.txt',
 			])
 			.it(
@@ -118,7 +124,7 @@ describe('message:encrypt', () => {
 					);
 					return expect(printMethodStub).to.be.calledWithExactly({
 						...defaultEncryptedMessage,
-						recipientPublicKey: defaultRecipientPublicKey,
+						recipientPublicKey: defaultRecipientPublicKey.toString('hex'),
 					});
 				},
 			);
@@ -128,7 +134,7 @@ describe('message:encrypt', () => {
 		setupTest()
 			.command([
 				'message:encrypt',
-				defaultRecipientPublicKey,
+				defaultRecipientPublicKey.toString('hex'),
 				'--message=file:./message.txt',
 				'--passphrase=card earn shift valley learn scorpion cage select help title control satoshi',
 			])
@@ -150,7 +156,7 @@ describe('message:encrypt', () => {
 					);
 					return expect(printMethodStub).to.be.calledWithExactly({
 						...defaultEncryptedMessage,
-						recipientPublicKey: defaultRecipientPublicKey,
+						recipientPublicKey: defaultRecipientPublicKey.toString('hex'),
 					});
 				},
 			);

--- a/commander/test/commands/network-identifier.test.ts
+++ b/commander/test/commands/network-identifier.test.ts
@@ -17,25 +17,18 @@ import * as sandbox from 'sinon';
 import { expect, test } from '@oclif/test';
 import * as config from '../../src/utils/config';
 import * as printUtils from '../../src/utils/print';
-import NetworkIdentifierCommand from '../../src/commands/network-identifier';
 
 describe('network-identifier command', () => {
 	const networkIdentifier = {
-		networkIdentifier:
-			'7dbdc2b4694bd5ab6663c4d078aa628ae032cb91ce0fe03a5077d7ef3ba2e8bc',
+		networkIdentifier: 'A2k/MSa50N8wlsTr1Z5cQq9Kfw4xPNfJage26fj1SSQ=',
 	};
 
-	const networkIdentifierStub = sandbox.stub();
 	const printMethodStub = sandbox.stub();
 
 	const setupTest = () =>
 		test
 			.stub(printUtils, 'print', sandbox.stub().returns(printMethodStub))
 			.stub(config, 'getConfig', sandbox.stub().returns({}))
-			.stub(
-				NetworkIdentifierCommand,
-				sandbox.stub().returns(networkIdentifierStub),
-			)
 			.stdout();
 
 	describe('network-identifier', () => {

--- a/commander/test/tsconfig.json
+++ b/commander/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
+		"rootDir": "../",
 		"allowJs": true
 	},
 	"include": ["../src/**/*", "./**/*"]

--- a/commander/test/utils/cryptography.ts
+++ b/commander/test/utils/cryptography.ts
@@ -23,10 +23,15 @@ describe('crypto utils', () => {
 		const result = {
 			result: 'result',
 		};
+
+		const recipientAddress = Buffer.from(
+			'b56b53b205287d52ae63c688bf62e86ad81e8e1e5dd9aaef2e68711152b7a58a',
+			'hex',
+		);
 		const input = {
 			message: 'msg',
 			passphrase: 'random-passphrase',
-			recipient: 'recipient',
+			recipient: recipientAddress.toString('hex'),
 		};
 
 		beforeEach(() => {
@@ -42,7 +47,7 @@ describe('crypto utils', () => {
 			).to.be.calledWithExactly(
 				input.message,
 				input.passphrase,
-				input.recipient,
+				recipientAddress,
 			);
 		});
 
@@ -54,11 +59,15 @@ describe('crypto utils', () => {
 
 	describe('#decryptMessage', () => {
 		const result = 'message';
+		const senderPublicKey = Buffer.from(
+			'b56b53b205287d52ae63c688bf62e86ad81e8e1e5dd9aaef2e68711152b7a58a',
+			'hex',
+		);
 		const input = {
 			cipher: 'cipher',
 			nonce: 'nonce',
 			passphrase: 'random-passphrase',
-			senderPublicKey: 'recipient',
+			senderPublicKey: senderPublicKey.toString('hex'),
 		};
 
 		beforeEach(() => {
@@ -75,7 +84,7 @@ describe('crypto utils', () => {
 				input.cipher,
 				input.nonce,
 				input.passphrase,
-				input.senderPublicKey,
+				senderPublicKey,
 			);
 		});
 
@@ -190,13 +199,13 @@ describe('crypto utils', () => {
 	});
 
 	describe('#getAddressFromPublicKey', () => {
-		const result = 'address';
+		const result = '90215077294ac1c727b357978df9291b';
 		const input = 'publicKey';
 
 		beforeEach(() => {
 			return sandbox
 				.stub(cryptographyModule, 'getAddressFromPublicKey')
-				.returns(result);
+				.returns(Buffer.from(result, 'hex'));
 		});
 
 		it('address should equal to the result of getAddressFromPublicKey', () => {

--- a/commander/test/utils/network_identifier.ts
+++ b/commander/test/utils/network_identifier.ts
@@ -19,9 +19,9 @@ import { getNetworkIdentifierWithInput } from '../../src/utils/network_identifie
 describe('network identifier utils', () => {
 	describe('getNetworkIdentifierWithInput', () => {
 		const mainnetNetworkIdentifier =
-			'9ee11e9df416b18bf69dbd1a920442e08c6ca319e69926bc843a561782ca17ee';
+			'5a59db36ca7de3cbb4bf27f95665e86952ccc66f8bf7ce8f6f6b3561b920f801';
 		const testnetNetworkIdentifier =
-			'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255';
+			'10f236f6d00a8f565bbe43c4ef0e3818f488bf4abefbe041155a3d019ef9a947';
 		const defaultNetworkIdentifier =
 			'7777777777777777777777777777777777777777777777777777777777777777';
 

--- a/elements/lisk-cryptography/src/buffer.ts
+++ b/elements/lisk-cryptography/src/buffer.ts
@@ -65,11 +65,6 @@ export const intToBuffer = (
 	return buffer;
 };
 
-export const bufferToIntAsString = (buffer: Buffer): string =>
-	buffer.length <= MAX_NUMBER_BYTE_LENGTH
-		? buffer.readIntBE(0, buffer.length).toString()
-		: buffer.readBigUInt64BE().toString();
-
 export const bufferToHex = (buffer: Buffer): string =>
 	Buffer.from(buffer).toString('hex');
 

--- a/elements/lisk-cryptography/src/convert.ts
+++ b/elements/lisk-cryptography/src/convert.ts
@@ -18,7 +18,6 @@ import * as querystring from 'querystring';
 
 // eslint-disable-next-line import/no-cycle
 import { EncryptedPassphraseObject } from './encrypt';
-import { hash } from './hash';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import reverse = require('buffer-reverse');
@@ -60,19 +59,6 @@ export const convertUIntArray = (
 export const convertUInt5ToBase32 = (uint5Array: number[]): string =>
 	uint5Array.map((val: number) => CHARSET[val]).join('');
 
-export const getFirstNBytes = (
-	input: string | Buffer,
-	size: number,
-): Buffer => {
-	// Union type arguments on overloaded functions do not work in typescript.
-	// Relevant discussion: https://github.com/Microsoft/TypeScript/issues/23155
-	if (typeof input === 'string') {
-		return Buffer.from(input, 'hex').slice(0, size);
-	}
-
-	return Buffer.from(input).slice(0, size);
-};
-
 export const getFirstEightBytesReversed = (input: string | Buffer): Buffer => {
 	const BUFFER_SIZE = 8;
 	// Union type arguments on overloaded functions do not work in typescript.
@@ -83,20 +69,6 @@ export const getFirstEightBytesReversed = (input: string | Buffer): Buffer => {
 
 	return reverse(Buffer.from(input).slice(0, BUFFER_SIZE));
 };
-
-export const toAddress = (buffer: Buffer): Buffer => {
-	const BUFFER_SIZE = 20;
-	const truncatedBuffer = getFirstNBytes(buffer, BUFFER_SIZE);
-
-	if (truncatedBuffer.length !== BUFFER_SIZE) {
-		throw new Error('The Lisk addresses must contains exactly 20 bytes');
-	}
-
-	return truncatedBuffer;
-};
-
-export const getAddressFromPublicKey = (publicKey: Buffer): Buffer =>
-	toAddress(hash(publicKey, 'hex'));
 
 export const convertPublicKeyEd2Curve = ed2curve.convertPublicKey;
 

--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -35,7 +35,7 @@ export interface EncryptedMessageWithNonce {
 export const encryptMessageWithPassphrase = (
 	message: string,
 	passphrase: string,
-	recipientPublicKey: string,
+	recipientPublicKey: Buffer,
 ): EncryptedMessageWithNonce => {
 	const {
 		privateKey: senderPrivateKeyBytes,
@@ -43,11 +43,10 @@ export const encryptMessageWithPassphrase = (
 	const convertedPrivateKey = Buffer.from(
 		convertPrivateKeyEd2Curve(senderPrivateKeyBytes),
 	);
-	const recipientPublicKeyBytes = hexToBuffer(recipientPublicKey);
 	const messageInBytes = Buffer.from(message, 'utf8');
 	const nonceSize = 24;
 	const nonce = getRandomBytes(nonceSize);
-	const publicKeyUint8Array = convertPublicKeyEd2Curve(recipientPublicKeyBytes);
+	const publicKeyUint8Array = convertPublicKeyEd2Curve(recipientPublicKey);
 
 	// This cannot be reproduced, but external library have type union with null
 	if (publicKeyUint8Array === null) {
@@ -76,7 +75,7 @@ export const decryptMessageWithPassphrase = (
 	cipherHex: string,
 	nonce: string,
 	passphrase: string,
-	senderPublicKey: string,
+	senderPublicKey: Buffer,
 ): string => {
 	const {
 		privateKey: recipientPrivateKeyBytes,
@@ -84,11 +83,10 @@ export const decryptMessageWithPassphrase = (
 	const convertedPrivateKey = Buffer.from(
 		convertPrivateKeyEd2Curve(recipientPrivateKeyBytes),
 	);
-	const senderPublicKeyBytes = hexToBuffer(senderPublicKey);
 	const cipherBytes = hexToBuffer(cipherHex);
 	const nonceBytes = hexToBuffer(nonce);
 
-	const publicKeyUint8Array = convertPublicKeyEd2Curve(senderPublicKeyBytes);
+	const publicKeyUint8Array = convertPublicKeyEd2Curve(senderPublicKey);
 
 	// This cannot be reproduced, but external library have type union with null
 	if (publicKeyUint8Array === null) {

--- a/elements/lisk-cryptography/src/hash.ts
+++ b/elements/lisk-cryptography/src/hash.ts
@@ -47,9 +47,12 @@ export const hash = (data: Buffer | string, format?: string): Buffer => {
 };
 
 export const getNetworkIdentifier = (
-	genesisBlockTransactionRoot: string,
+	genesisBlockTransactionRoot: Buffer,
 	communityIdentifier: string,
-): string =>
-	hash(genesisBlockTransactionRoot + communityIdentifier, 'utf8').toString(
-		'hex',
+): Buffer =>
+	hash(
+		Buffer.concat([
+			genesisBlockTransactionRoot,
+			Buffer.from(communityIdentifier, 'utf8'),
+		]),
 	);

--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -14,11 +14,7 @@
  */
 import { BINARY_ADDRESS_LENGTH } from './constants';
 // eslint-disable-next-line import/no-cycle
-import {
-	getAddressFromPublicKey,
-	convertUInt5ToBase32,
-	convertUIntArray,
-} from './convert';
+import { convertUInt5ToBase32, convertUIntArray } from './convert';
 import { hash } from './hash';
 import { getKeyPair, getPublicKey } from './nacl';
 import { Keypair } from './types';
@@ -31,6 +27,17 @@ export const getPrivateAndPublicKeyFromPassphrase = (
 };
 
 export const getKeys = getPrivateAndPublicKeyFromPassphrase;
+
+export const getAddressFromPublicKey = (publicKey: Buffer): Buffer => {
+	const buffer = hash(publicKey);
+	const truncatedBuffer = buffer.slice(0, BINARY_ADDRESS_LENGTH);
+
+	if (truncatedBuffer.length !== BINARY_ADDRESS_LENGTH) {
+		throw new Error('The Lisk addresses must contains exactly 20 bytes');
+	}
+
+	return truncatedBuffer;
+};
 
 export const getAddressAndPublicKeyFromPassphrase = (
 	passphrase: string,
@@ -78,11 +85,6 @@ const polymod = (uint5Array: number[]): number => {
 	return chk;
 };
 
-export const getBinaryAddressFromPublicKey = (publicKey: string): Buffer => {
-	const publicKeyBuffer = Buffer.from(publicKey, 'hex');
-	return hash(publicKeyBuffer).slice(0, BINARY_ADDRESS_LENGTH);
-};
-
 export const createChecksum = (uint5Array: number[]): number[] => {
 	const values = uint5Array.concat([0, 0, 0, 0, 0, 0]);
 	// eslint-disable-next-line no-bitwise
@@ -99,10 +101,10 @@ export const verifyChecksum = (integerSequence: number[]): boolean =>
 	polymod(integerSequence) === 1;
 
 export const getBase32AddressFromPublicKey = (
-	publicKey: string,
+	publicKey: Buffer,
 	prefix: string,
 ): string => {
-	const binaryAddress = getBinaryAddressFromPublicKey(publicKey);
+	const binaryAddress = getAddressFromPublicKey(publicKey);
 	const byteSequence = [];
 	for (const b of binaryAddress) {
 		byteSequence.push(b);

--- a/elements/lisk-cryptography/src/legacy_address.ts
+++ b/elements/lisk-cryptography/src/legacy_address.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { hash } from './hash';
+import { getKeys } from './keys';
+import { getFirstEightBytesReversed } from './convert';
+import { getPublicKey } from './nacl';
+
+export const getLegacyAddressFromPublicKey = (publicKey: Buffer): string => {
+	const publicKeyHash = hash(publicKey);
+	const publicKeyTransform = getFirstEightBytesReversed(publicKeyHash);
+
+	return `${publicKeyTransform.readBigUInt64BE().toString()}L`;
+};
+
+export const getLegacyAddressAndPublicKeyFromPassphrase = (
+	passphrase: string,
+): { readonly address: string; readonly publicKey: Buffer } => {
+	const { publicKey } = getKeys(passphrase);
+	const address = getLegacyAddressFromPublicKey(publicKey);
+
+	return {
+		address,
+		publicKey,
+	};
+};
+
+export const getLegacyAddressFromPassphrase = (passphrase: string): string => {
+	const { publicKey } = getKeys(passphrase);
+
+	return getLegacyAddressFromPublicKey(publicKey);
+};
+
+export const getLegacyAddressFromPrivateKey = (privateKey: Buffer): string => {
+	const publicKey = getPublicKey(privateKey);
+
+	return getLegacyAddressFromPublicKey(publicKey);
+};

--- a/elements/lisk-cryptography/test/buffer.spec.ts
+++ b/elements/lisk-cryptography/test/buffer.spec.ts
@@ -12,12 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import {
-	bufferToHex,
-	bufferToIntAsString,
-	hexToBuffer,
-	intToBuffer,
-} from '../src/buffer';
+import { bufferToHex, hexToBuffer, intToBuffer } from '../src/buffer';
 
 describe('buffer', () => {
 	const defaultBuffer = Buffer.from('\xe5\xe4\xf6');
@@ -187,46 +182,6 @@ describe('buffer', () => {
 			const expectedBuffer = Buffer.from('00cebcaa8d34153d', 'hex');
 
 			expect(intToBuffer(value, size)).toEqual(expectedBuffer);
-		});
-	});
-
-	describe('#bufferToIntAsString', () => {
-		it('should convert a 1 byte buffer to a integer as string', () => {
-			const value = 127;
-
-			const size = 1;
-			const buffer = Buffer.alloc(size);
-			buffer.writeInt8(value, 0);
-
-			expect(bufferToIntAsString(buffer)).toBe(value.toString());
-		});
-
-		it('should convert a 2 bytes buffer to a integer as string', () => {
-			const value = 32767;
-
-			const size = 2;
-			const buffer = Buffer.alloc(size);
-			buffer.writeInt16BE(value, 0);
-
-			expect(bufferToIntAsString(buffer)).toBe(value.toString());
-		});
-
-		it('should convert a 4 bytes buffer to a integer as string', () => {
-			const value = 2147483647;
-
-			const size = 4;
-			const buffer = Buffer.alloc(size);
-			buffer.writeInt32BE(value, 0);
-
-			expect(bufferToIntAsString(buffer)).toBe(value.toString());
-		});
-
-		it('should convert a 8 bytes buffer to a integer as string', () => {
-			const value = '58191285901858109';
-
-			const buffer = Buffer.from('00cebcaa8d34153d', 'hex');
-
-			expect(bufferToIntAsString(buffer)).toBe(value);
 		});
 	});
 });

--- a/elements/lisk-cryptography/test/convert.spec.ts
+++ b/elements/lisk-cryptography/test/convert.spec.ts
@@ -14,17 +14,13 @@
  */
 import {
 	getFirstEightBytesReversed,
-	toAddress,
-	getAddressFromPublicKey,
 	convertPublicKeyEd2Curve,
 	convertPrivateKeyEd2Curve,
 	stringifyEncryptedPassphrase,
 	parseEncryptedPassphrase,
-	getFirstNBytes,
 } from '../src/convert';
 // Require is used for stubbing
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-var-requires
-const hashModule = require('../src/hash');
 
 describe('convert', () => {
 	// keys for passphrase 'secret';
@@ -32,10 +28,6 @@ describe('convert', () => {
 		'2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09';
 	const defaultPublicKey = Buffer.from(
 		'5d036a858ce89f844491762eb89e2bfbd50a4a0a0da658e4b2628b25b117ae09',
-		'hex',
-	);
-	const defaultPublicKeyHash = Buffer.from(
-		'3a971fd02b4a07fc20aad1936d3cb1d263b96e0ffd938625e5c0db1ad8ba2a29',
 		'hex',
 	);
 	const defaultPrivateKeyCurve = Buffer.from(
@@ -46,13 +38,8 @@ describe('convert', () => {
 		'6f9d780305bda43dd47a291d897f2d8845a06160632d82fb1f209fdd46ed3c1e',
 		'hex',
 	);
-	const defaultAddress = Buffer.from(
-		'3a971fd02b4a07fc20aad1936d3cb1d263b96e0f',
-		'hex',
-	);
 	const defaultStringWithMoreThanEightCharacters = '0123456789';
 	const defaultFirstEightCharactersReversed = '76543210';
-	const defaultDataForBuffer = 'Hello Lisk SDK - Bring the app to life!';
 
 	describe('#getFirstEightBytesReversed', () => {
 		it('should get the first eight bytes reversed from a Buffer', () => {
@@ -70,45 +57,6 @@ describe('convert', () => {
 			expect(reversedAndCut).toEqual(
 				Buffer.from(defaultFirstEightCharactersReversed),
 			);
-		});
-	});
-
-	describe('#toAddress', () => {
-		it('should create address bytes from a buffer of 20 bytes', () => {
-			const bufferInit = Buffer.from(defaultDataForBuffer);
-			const firstTwentyBytes = getFirstNBytes(bufferInit, 20);
-			const address = toAddress(firstTwentyBytes);
-			expect(address).toEqual(firstTwentyBytes);
-		});
-
-		it('should create truncated address bytes from a buffer of more than 20 bytes ', () => {
-			const bufferInit = Buffer.from(defaultDataForBuffer);
-			const firstTwentyBytes = getFirstNBytes(bufferInit, 20);
-			const address = toAddress(getFirstNBytes(bufferInit, 25));
-			expect(address).toEqual(firstTwentyBytes);
-		});
-
-		it('should throw on less than 20 bytes as input', () => {
-			const bufferExceedError =
-				'The Lisk addresses must contains exactly 20 bytes';
-			const bufferInit = Buffer.from(defaultDataForBuffer);
-			const firstNineteenBytes = getFirstNBytes(bufferInit, 19);
-			expect(toAddress.bind(null, firstNineteenBytes)).toThrow(
-				bufferExceedError,
-			);
-		});
-	});
-
-	describe('#getAddressFromPublicKey', () => {
-		beforeEach(() => {
-			return jest
-				.spyOn(hashModule, 'hash')
-				.mockReturnValue(defaultPublicKeyHash);
-		});
-
-		it('should generate address from publicKey', () => {
-			const address = getAddressFromPublicKey(defaultPublicKey);
-			expect(address).toEqual(defaultAddress);
 		});
 	});
 

--- a/elements/lisk-cryptography/test/encrypt.spec.ts
+++ b/elements/lisk-cryptography/test/encrypt.spec.ts
@@ -33,10 +33,14 @@ describe('encrypt', () => {
 	const ENCRYPTION_VERSION = '1';
 	const defaultPassphrase =
 		'minute omit local rare sword knee banner pair rib museum shadow juice';
-	const defaultPrivateKey =
-		'314852d7afb0d4c283692fef8a2cb40e30c7a5df2ed79994178c10ac168d6d977ef45cd525e95b7a86244bbd4eb4550914ad06301013958f4dd64d32ef7bc588';
-	const defaultPublicKey =
-		'7ef45cd525e95b7a86244bbd4eb4550914ad06301013958f4dd64d32ef7bc588';
+	const defaultPrivateKey = Buffer.from(
+		'314852d7afb0d4c283692fef8a2cb40e30c7a5df2ed79994178c10ac168d6d977ef45cd525e95b7a86244bbd4eb4550914ad06301013958f4dd64d32ef7bc588',
+		'hex',
+	);
+	const defaultPublicKey = Buffer.from(
+		'7ef45cd525e95b7a86244bbd4eb4550914ad06301013958f4dd64d32ef7bc588',
+		'hex',
+	);
 	const defaultMessage = 'Some default text.';
 	const defaultPassword = 'myTotal53cr3t%&';
 	const customIterations = 12;
@@ -72,8 +76,8 @@ describe('encrypt', () => {
 			.spyOn(keys, 'getAddressAndPublicKeyFromPassphrase')
 			.mockImplementation(() => {
 				return {
-					privateKey: Buffer.from(defaultPrivateKey, 'hex'),
-					publicKey: Buffer.from(defaultPublicKey, 'hex'),
+					privateKey: defaultPrivateKey,
+					publicKey: defaultPublicKey,
 				};
 			});
 

--- a/elements/lisk-cryptography/test/hash.spec.ts
+++ b/elements/lisk-cryptography/test/hash.spec.ts
@@ -60,11 +60,15 @@ describe('hash', () => {
 	});
 
 	describe('#getNetworkIdentifier', () => {
-		const genesisBlockTransactionRoot =
-			'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511';
+		const genesisBlockTransactionRoot = Buffer.from(
+			'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511',
+			'hex',
+		);
 		const communityIdentifier = 'LISK';
-		const expectedHash =
-			'30d7505655f5a04d9238aa324b38ef729d1139791b67815c5e6306328b6a44a2';
+		const expectedHash = Buffer.from(
+			'6f201e72e20571b93ed42470caa94af1ace79dc9930ab5bb144ddd5df5753e73',
+			'hex',
+		);
 
 		it('should generate a sha256 hash from genesis block transaction root and community identifier', () => {
 			const networkIdentifier = getNetworkIdentifier(

--- a/elements/lisk-cryptography/test/keys.spec.ts
+++ b/elements/lisk-cryptography/test/keys.spec.ts
@@ -13,8 +13,8 @@
  *
  */
 import {
+	getAddressFromPublicKey,
 	getBase32AddressFromPublicKey,
-	getBinaryAddressFromPublicKey,
 	getPrivateAndPublicKeyFromPassphrase,
 	getKeys,
 	getAddressAndPublicKeyFromPassphrase,
@@ -45,6 +45,7 @@ describe('keys', () => {
 		'2bb80d537b1da3e38bd30361aa855686bde0eacd',
 		'hex',
 	);
+
 	const defaultAddressAndPublicKey = {
 		publicKey: defaultPublicKey,
 		address: defaultAddress,
@@ -114,29 +115,18 @@ describe('keys', () => {
 		});
 	});
 
-	describe('#getBinaryAddressFromPublicKey', () => {
-		const publicKey =
-			'0eb0a6d7b862dc35c856c02c47fde3b4f60f2f3571a888b9a8ca7540c6793243';
-		const hash = 'c247a42e09e6aafd818821f75b2f5b0de47c8235';
-		const expectedBinaryAddress = 'c247a42e09e6aafd818821f75b2f5b0de47c8235';
-		beforeEach(() => {
-			return jest
-				.spyOn(hashModule, 'hash')
-				.mockReturnValue(Buffer.from(hash, 'hex'));
-		});
-
+	describe('#getAddressFromPublicKey', () => {
 		it('should generate address from publicKey', () => {
-			const address = getBinaryAddressFromPublicKey(publicKey);
-
-			expect(address.compare(Buffer.from(expectedBinaryAddress, 'hex'))).toBe(
-				0,
-			);
+			const address = getAddressFromPublicKey(defaultPublicKey);
+			expect(address).toEqual(defaultAddress);
 		});
 	});
 
 	describe('#getBase32AddressFromPublicKey', () => {
-		const publicKey =
-			'0eb0a6d7b862dc35c856c02c47fde3b4f60f2f3571a888b9a8ca7540c6793243';
+		const publicKey = Buffer.from(
+			'0eb0a6d7b862dc35c856c02c47fde3b4f60f2f3571a888b9a8ca7540c6793243',
+			'hex',
+		);
 		const hash = 'c247a42e09e6aafd818821f75b2f5b0de47c8235';
 		const expectedBase32Address = 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 		beforeEach(() => {

--- a/elements/lisk-cryptography/test/legacy_address.ts
+++ b/elements/lisk-cryptography/test/legacy_address.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import {
+	getLegacyAddressAndPublicKeyFromPassphrase,
+	getLegacyAddressFromPassphrase,
+	getLegacyAddressFromPrivateKey,
+	getLegacyAddressFromPublicKey,
+} from '../src/legacy_address';
+
+describe('Legacy address', () => {
+	const defaultPassphrase =
+		'purity retire hamster gold unfold stadium hunt truth movie walnut gun bean';
+	const defaultPrivateKey = Buffer.from(
+		'bf338d9da23ccbc140e440f7da96718eb3f8b84ba4fe57e0a7a91f8c602e8015b56b53b205287d52ae63c688bf62e86ad81e8e1e5dd9aaef2e68711152b7a58a',
+		'hex',
+	);
+	const defaultPublicKey = Buffer.from(
+		'b56b53b205287d52ae63c688bf62e86ad81e8e1e5dd9aaef2e68711152b7a58a',
+		'hex',
+	);
+	const defaultAddress = '7115442636316065252L';
+
+	describe('#getLegacyAddressAndPublicKeyFromPassphrase', () => {
+		it('should return expected address', () => {
+			expect(
+				getLegacyAddressAndPublicKeyFromPassphrase(defaultPassphrase),
+			).toEqual({
+				address: defaultAddress,
+				publicKey: defaultPublicKey,
+			});
+		});
+	});
+
+	describe('#getLegacyAddressFromPassphrase', () => {
+		it('should return expected address', () => {
+			expect(getLegacyAddressFromPassphrase(defaultPassphrase)).toEqual(
+				defaultAddress,
+			);
+		});
+	});
+
+	describe('#getLegacyAddressFromPrivateKey', () => {
+		it('should return expected address', () => {
+			expect(getLegacyAddressFromPrivateKey(defaultPrivateKey)).toEqual(
+				defaultAddress,
+			);
+		});
+	});
+
+	describe('#getLegacyAddressFromPublicKey', () => {
+		it('should return expected address', () => {
+			expect(getLegacyAddressFromPublicKey(defaultPublicKey)).toEqual(
+				defaultAddress,
+			);
+		});
+	});
+});

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -359,9 +359,9 @@ export class Application {
 	private _compileAndValidateConfigurations(): void {
 		const modules = this.getModules();
 		this.config.networkId = getNetworkIdentifier(
-			this._genesisBlock.header.transactionRoot,
+			Buffer.from(this._genesisBlock.header.transactionRoot, 'hex'),
 			this._genesisBlock.communityIdentifier,
-		);
+		).toString('base64');
 
 		const appConfigToShareWithModules = {
 			version: this.config.version,

--- a/framework/src/application/node/block_processor_v2.ts
+++ b/framework/src/application/node/block_processor_v2.ts
@@ -35,7 +35,7 @@ import { ForgedInfo } from './forger/data_access';
 import { DB_KEY_FORGER_PREVIOUSLY_FORGED } from './forger/constant';
 
 interface BlockProcessorInput {
-	readonly networkIdentifier: string;
+	readonly networkIdentifier: Buffer;
 	readonly chainModule: Chain;
 	readonly bftModule: BFT;
 	readonly dposModule: Dpos;
@@ -96,7 +96,7 @@ export class BlockProcessorV2 extends BaseBlockProcessor {
 
 	public readonly version = 2;
 
-	private readonly networkIdentifier: string;
+	private readonly networkIdentifier: Buffer;
 	private readonly chainModule: Chain;
 	private readonly bftModule: BFT;
 	private readonly dposModule: Dpos;
@@ -297,10 +297,7 @@ export class BlockProcessorV2 extends BaseBlockProcessor {
 			true,
 		);
 		const signature = signDataWithPrivateKey(
-			Buffer.concat([
-				Buffer.from(this.networkIdentifier, 'hex'),
-				headerBytesWithoutSignature,
-			]),
+			Buffer.concat([this.networkIdentifier, headerBytesWithoutSignature]),
 			keypair.privateKey,
 		);
 		const headerBytes = this.chainModule.dataAccess.encodeBlockHeader({

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -237,7 +237,7 @@ export class Node {
 	private readonly _blockchainDB: KVStore;
 	private readonly _applicationState: ApplicationState;
 	private _sequence!: Sequence;
-	private _networkIdentifier!: string;
+	private _networkIdentifier!: Buffer;
 	private _chain!: Chain;
 	private _bft!: BFT;
 	private _dpos!: Dpos;
@@ -279,11 +279,6 @@ export class Node {
 					`forging.waitThreshold=${this._options.forging.waitThreshold} is greater or equal to genesisConfig.blockTime=${this._options.constants.blockTime}. It impacts the forging and propagation of blocks. Please use a smaller value for forging.waitThreshold`,
 				);
 			}
-
-			this._networkIdentifier = getNetworkIdentifier(
-				this._options.genesisBlock.header.transactionRoot,
-				this._options.genesisBlock.communityIdentifier,
-			);
 
 			this._sequence = new Sequence({
 				onWarning: (current: number): void => {
@@ -579,6 +574,10 @@ export class Node {
 
 	private _initModules(): void {
 		const genesisBlock = convertGenesisBlock(this._options.genesisBlock);
+		this._networkIdentifier = getNetworkIdentifier(
+			genesisBlock.header.transactionRoot,
+			this._options.genesisBlock.communityIdentifier,
+		);
 		this._chain = new Chain({
 			db: this._blockchainDB,
 			genesisBlock,
@@ -590,7 +589,7 @@ export class Node {
 			registeredBlocks: {
 				2: BlockProcessorV2.schema,
 			},
-			networkIdentifier: Buffer.from(this._networkIdentifier, 'hex'),
+			networkIdentifier: this._networkIdentifier,
 			maxPayloadLength: this._options.constants.maxPayloadLength,
 			rewardDistance: this._options.constants.rewards.distance,
 			rewardOffset: this._options.constants.rewards.offset,

--- a/framework/test/fixtures/blocks.ts
+++ b/framework/test/fixtures/blocks.ts
@@ -32,6 +32,7 @@ import { BlockProcessorV2 } from '../../src/application/node/block_processor_v2'
 
 export const defaultNetworkIdentifier = Buffer.from(
 	'93d00fe5be70d90e7ae247936a2e7d83b50809c79b73fa14285f02c842348b3e',
+	'hex',
 );
 
 const getKeyPair = (): { publicKey: Buffer; privateKey: Buffer } => {

--- a/framework/test/fixtures/node.ts
+++ b/framework/test/fixtures/node.ts
@@ -19,7 +19,7 @@ export const cacheConfig = 'aCacheConfig';
 export const nodeOptions = {
 	rootPath: '~/.lisk',
 	label: 'default',
-	genesisBlock: genesisBlock(),
+	genesisBlock: { ...genesisBlock(), communityIdentifier: 'Lisk' },
 	network: {
 		enabled: false,
 	},

--- a/framework/test/integration/specs/application/node/matcher.spec.ts
+++ b/framework/test/integration/specs/application/node/matcher.spec.ts
@@ -129,7 +129,7 @@ describe('Matcher', () => {
 				const account = nodeUtils.createAccount();
 				const tx = createRawCustomTransaction({
 					passphrase: account.passphrase,
-					networkIdentifier: Buffer.from(node['_networkIdentifier'], 'hex'),
+					networkIdentifier: node['_networkIdentifier'],
 					senderPublicKey: account.publicKey,
 					nonce: BigInt(0),
 				});
@@ -162,10 +162,7 @@ describe('Matcher', () => {
 					},
 					fee: BigInt(10000000),
 				});
-				aCustomTransation.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				aCustomTransation.sign(node['_networkIdentifier'], genesis.passphrase);
 				newBlock = await nodeUtils.createBlock(node, [aCustomTransation]);
 			});
 

--- a/framework/test/integration/specs/application/node/processor/delete_block.spec.ts
+++ b/framework/test/integration/specs/application/node/processor/delete_block.spec.ts
@@ -76,10 +76,7 @@ describe('Delete block', () => {
 						data: '',
 					},
 				});
-				transaction.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				transaction.sign(node['_networkIdentifier'], genesis.passphrase);
 				newBlock = await nodeUtils.createBlock(node, [transaction]);
 				await node['_processor'].process(newBlock);
 				await node['_processor'].deleteLastBlock();

--- a/framework/test/integration/specs/application/node/processor/process_block.spec.ts
+++ b/framework/test/integration/specs/application/node/processor/process_block.spec.ts
@@ -66,10 +66,7 @@ describe('Process block', () => {
 						data: '',
 					},
 				});
-				transaction.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				transaction.sign(node['_networkIdentifier'], genesis.passphrase);
 				newBlock = await nodeUtils.createBlock(node, [transaction]);
 				await node['_processor'].process(newBlock);
 			});
@@ -136,10 +133,7 @@ describe('Process block', () => {
 						data: '',
 					},
 				});
-				transaction.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				transaction.sign(node['_networkIdentifier'], genesis.passphrase);
 				newBlock = await nodeUtils.createBlock(node, [transaction]);
 				await node['_processor'].process(newBlock);
 			});
@@ -235,10 +229,7 @@ describe('Process block', () => {
 					username: 'number1',
 				},
 			});
-			transaction.sign(
-				Buffer.from(node['_networkIdentifier'], 'hex'),
-				account.passphrase,
-			);
+			transaction.sign(node['_networkIdentifier'], account.passphrase);
 			newBlock = await nodeUtils.createBlock(node, [transaction]);
 			await node['_processor'].process(newBlock);
 		});
@@ -260,10 +251,7 @@ describe('Process block', () => {
 						username: 'number1',
 					},
 				});
-				transaction.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					account.passphrase,
-				);
+				transaction.sign(node['_networkIdentifier'], account.passphrase);
 				invalidBlock = await nodeUtils.createBlock(node, [invalidTx]);
 				try {
 					await node['_processor'].process(invalidBlock);

--- a/framework/test/integration/specs/application/node/processor/transaction_order.spec.ts
+++ b/framework/test/integration/specs/application/node/processor/transaction_order.spec.ts
@@ -64,10 +64,7 @@ describe('Transaction order', () => {
 						data: '',
 					},
 				});
-				fundingTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				fundingTx.sign(node['_networkIdentifier'], genesis.passphrase);
 				const returningTx = new TransferTransaction({
 					nonce: BigInt(0),
 					fee: BigInt('200000'),
@@ -79,7 +76,7 @@ describe('Transaction order', () => {
 					},
 				});
 				returningTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
+					node['_networkIdentifier'],
 					accountWithoutBalance.passphrase,
 				);
 				newBlock = await nodeUtils.createBlock(node, [fundingTx, returningTx]);
@@ -112,10 +109,7 @@ describe('Transaction order', () => {
 						data: '',
 					},
 				});
-				fundingTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				fundingTx.sign(node['_networkIdentifier'], genesis.passphrase);
 				const registerDelegateTx = new DelegateTransaction({
 					nonce: BigInt(0),
 					fee: BigInt('1100000000'),
@@ -125,7 +119,7 @@ describe('Transaction order', () => {
 					},
 				});
 				registerDelegateTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
+					node['_networkIdentifier'],
 					newAccount.passphrase,
 				);
 				const selfVoteTx = new VoteTransaction({
@@ -141,10 +135,7 @@ describe('Transaction order', () => {
 						],
 					},
 				});
-				selfVoteTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					newAccount.passphrase,
-				);
+				selfVoteTx.sign(node['_networkIdentifier'], newAccount.passphrase);
 				newBlock = await nodeUtils.createBlock(node, [
 					fundingTx,
 					registerDelegateTx,
@@ -180,10 +171,7 @@ describe('Transaction order', () => {
 						data: '',
 					},
 				});
-				fundingTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				fundingTx.sign(node['_networkIdentifier'], genesis.passphrase);
 				const optionalKeys = [
 					...multiSignatureMembers.map(acc => acc.publicKey),
 				];
@@ -199,7 +187,7 @@ describe('Transaction order', () => {
 					},
 				});
 				registerMultisigTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
+					node['_networkIdentifier'],
 					newAccount.passphrase,
 					[
 						newAccount.passphrase,
@@ -222,7 +210,7 @@ describe('Transaction order', () => {
 					},
 				});
 				transferTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
+					node['_networkIdentifier'],
 					undefined,
 					[newAccount.passphrase, multiSignatureMembers[0].passphrase],
 					{
@@ -265,10 +253,7 @@ describe('Transaction order', () => {
 						data: '',
 					},
 				});
-				fundingTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				fundingTx.sign(node['_networkIdentifier'], genesis.passphrase);
 				const optionalKeys = [
 					...multiSignatureMembers.map(acc => acc.publicKey),
 				];
@@ -284,7 +269,7 @@ describe('Transaction order', () => {
 					},
 				});
 				registerMultisigTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
+					node['_networkIdentifier'],
 					newAccount.passphrase,
 					[
 						newAccount.passphrase,
@@ -306,10 +291,7 @@ describe('Transaction order', () => {
 						data: '',
 					},
 				});
-				transferTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					newAccount.passphrase,
-				);
+				transferTx.sign(node['_networkIdentifier'], newAccount.passphrase);
 				newBlock = await nodeUtils.createBlock(node, [
 					fundingTx,
 					registerMultisigTx,
@@ -350,10 +332,7 @@ describe('Transaction order', () => {
 						data: '',
 					},
 				});
-				fundingTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				fundingTx.sign(node['_networkIdentifier'], genesis.passphrase);
 				const spendingTx = new TransferTransaction({
 					nonce: BigInt(0),
 					senderPublicKey: accountWithoutBalance.publicKey,
@@ -365,7 +344,7 @@ describe('Transaction order', () => {
 					},
 				});
 				spendingTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
+					node['_networkIdentifier'],
 					accountWithoutBalance.passphrase,
 				);
 				const refundingTx = new TransferTransaction({
@@ -378,10 +357,7 @@ describe('Transaction order', () => {
 						data: '',
 					},
 				});
-				refundingTx.sign(
-					Buffer.from(node['_networkIdentifier'], 'hex'),
-					genesis.passphrase,
-				);
+				refundingTx.sign(node['_networkIdentifier'], genesis.passphrase);
 				newBlock = await nodeUtils.createBlock(node, [
 					fundingTx,
 					spendingTx,

--- a/framework/test/unit/specs/application/node/block_processor_v2.spec.ts
+++ b/framework/test/unit/specs/application/node/block_processor_v2.spec.ts
@@ -89,9 +89,7 @@ describe('block processor v2', () => {
 		};
 
 		blockProcessor = new BlockProcessorV2({
-			networkIdentifier: defaultAdditionalData.networkIdentifier.toString(
-				'hex',
-			),
+			networkIdentifier: defaultAdditionalData.networkIdentifier,
 			chainModule: chainModuleStub,
 			bftModule: bftModuleStub,
 			dposModule: dposModuleStub,

--- a/framework/test/unit/specs/application/node/forger/forger.spec.ts
+++ b/framework/test/unit/specs/application/node/forger/forger.spec.ts
@@ -1064,7 +1064,10 @@ describe('forger', () => {
 			it('should not wait if threshold time passed and last block not received', async () => {
 				jest
 					.spyOn(forgeModule as any, '_getDelegateKeypairForCurrentSlot')
-					.mockResolvedValue(testDelegate);
+					.mockResolvedValue({
+						publicKey: Buffer.from(testDelegate.publicKey, 'hex'),
+						privateKey: Buffer.from(testDelegate.privateKey, 'hex'),
+					});
 				const currentSlotTime = new Date(2019, 0, 1, 0, 0, 0).getTime();
 				const currentTime = new Date(2019, 0, 1, 0, 0, 3).getTime();
 
@@ -1088,7 +1091,10 @@ describe('forger', () => {
 			it('should not wait if threshold remaining but last block already received', async () => {
 				jest
 					.spyOn(forgeModule as any, '_getDelegateKeypairForCurrentSlot')
-					.mockResolvedValue(testDelegate);
+					.mockResolvedValue({
+						publicKey: Buffer.from(testDelegate.publicKey, 'hex'),
+						privateKey: Buffer.from(testDelegate.privateKey, 'hex'),
+					});
 				const currentSlotTime = new Date(2019, 0, 1, 0, 0, 0).getTime();
 				const currentTime = new Date(2019, 0, 1, 0, 0, 1).getTime();
 
@@ -1112,7 +1118,10 @@ describe('forger', () => {
 				// Arrange
 				jest
 					.spyOn(forgeModule as any, '_getDelegateKeypairForCurrentSlot')
-					.mockResolvedValue(testDelegate);
+					.mockResolvedValue({
+						publicKey: Buffer.from(testDelegate.publicKey, 'hex'),
+						privateKey: Buffer.from(testDelegate.privateKey, 'hex'),
+					});
 
 				// Act
 				await forgeModule.forge();
@@ -1126,7 +1135,10 @@ describe('forger', () => {
 				const targetDelegate = genesisDelegates.delegates[0];
 				jest
 					.spyOn(forgeModule as any, '_getDelegateKeypairForCurrentSlot')
-					.mockResolvedValue(targetDelegate);
+					.mockResolvedValue({
+						publicKey: Buffer.from(testDelegate.publicKey, 'hex'),
+						privateKey: Buffer.from(testDelegate.privateKey, 'hex'),
+					});
 				(forgeModule as any)._config.forging.delegates =
 					genesisDelegates.delegates;
 
@@ -1177,7 +1189,10 @@ describe('forger', () => {
 				const targetDelegate = genesisDelegates.delegates[0];
 				jest
 					.spyOn(forgeModule as any, '_getDelegateKeypairForCurrentSlot')
-					.mockResolvedValue(targetDelegate);
+					.mockResolvedValue({
+						publicKey: Buffer.from(targetDelegate.publicKey, 'hex'),
+						privateKey: Buffer.from(targetDelegate.privateKey, 'hex'),
+					});
 				(forgeModule as any)._config.forging.delegates =
 					genesisDelegates.delegates;
 
@@ -1335,7 +1350,10 @@ describe('forger', () => {
 				const targetDelegate = genesisDelegates.delegates[0];
 				jest
 					.spyOn(forgeModule as any, '_getDelegateKeypairForCurrentSlot')
-					.mockResolvedValue(targetDelegate);
+					.mockResolvedValue({
+						publicKey: Buffer.from(targetDelegate.publicKey, 'hex'),
+						privateKey: Buffer.from(targetDelegate.privateKey, 'hex'),
+					});
 				(forgeModule as any)._config.forging.delegates =
 					genesisDelegates.delegates;
 
@@ -1403,7 +1421,10 @@ describe('forger', () => {
 				const targetDelegate = genesisDelegates.delegates[0];
 				jest
 					.spyOn(forgeModule as any, '_getDelegateKeypairForCurrentSlot')
-					.mockResolvedValue(targetDelegate);
+					.mockResolvedValue({
+						publicKey: Buffer.from(targetDelegate.publicKey, 'hex'),
+						privateKey: Buffer.from(targetDelegate.privateKey, 'hex'),
+					});
 				(forgeModule as any)._config.forging.delegates =
 					genesisDelegates.delegates;
 				const maxCount = (forgeModule as any)._config.forging.delegates.find(

--- a/framework/test/unit/specs/application/node/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
+++ b/framework/test/unit/specs/application/node/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
@@ -144,7 +144,7 @@ describe('block_synchronization_mechanism', () => {
 		});
 
 		blockProcessorV2 = new BlockProcessorV2({
-			networkIdentifier: '',
+			networkIdentifier: defaultNetworkIdentifier,
 			forgerDB,
 			chainModule,
 			bftModule,
@@ -241,13 +241,11 @@ describe('block_synchronization_mechanism', () => {
 
 		highestCommonBlock = genesisBlock.header;
 		requestedBlocks = [
-			...new Array(10)
-				.fill(0)
-				.map((_, index) =>
-					createValidDefaultBlock({
-						header: { height: highestCommonBlock.height + 1 + index },
-					}),
-				),
+			...new Array(10).fill(0).map((_, index) =>
+				createValidDefaultBlock({
+					header: { height: highestCommonBlock.height + 1 + index },
+				}),
+			),
 			aBlock,
 		];
 
@@ -522,13 +520,11 @@ describe('block_synchronization_mechanism', () => {
 				});
 
 				requestedBlocks = [
-					...new Array(10)
-						.fill(0)
-						.map((_, index) =>
-							createValidDefaultBlock({
-								header: { height: highestCommonBlock.height + 1 + index },
-							}),
-						),
+					...new Array(10).fill(0).map((_, index) =>
+						createValidDefaultBlock({
+							header: { height: highestCommonBlock.height + 1 + index },
+						}),
+					),
 					receivedBlock,
 				];
 
@@ -604,7 +600,7 @@ describe('block_synchronization_mechanism', () => {
 
 				expectApplyPenaltyAndRestartIsCalled(
 					aBlock,
-					"Peer did not provide its last block",
+					'Peer did not provide its last block',
 				);
 			});
 		});
@@ -728,13 +724,11 @@ describe('block_synchronization_mechanism', () => {
 						height: bftModule.finalizedHeight - 1,
 					}) as any; // height: 0
 					requestedBlocks = [
-						...new Array(10)
-							.fill(0)
-							.map((_, index) =>
-								createValidDefaultBlock({
-									header: { height: highestCommonBlock.height + 1 + index },
-								}),
-							),
+						...new Array(10).fill(0).map((_, index) =>
+							createValidDefaultBlock({
+								header: { height: highestCommonBlock.height + 1 + index },
+							}),
+						),
 						aBlock,
 					];
 
@@ -833,13 +827,11 @@ describe('block_synchronization_mechanism', () => {
 			it('should request blocks and apply them', async () => {
 				requestedBlocks = [
 					// From height 2 (highestCommonBlock.height + 1) to 9 (aBlock.height - 1)
-					...new Array(8)
-						.fill(0)
-						.map((_, index) =>
-							createValidDefaultBlock({
-								header: { height: highestCommonBlock.height + 1 + index },
-							}),
-						),
+					...new Array(8).fill(0).map((_, index) =>
+						createValidDefaultBlock({
+							header: { height: highestCommonBlock.height + 1 + index },
+						}),
+					),
 					aBlock,
 					...new Array(10) // Extra blocks. They will be truncated
 						.fill(0)
@@ -963,21 +955,17 @@ describe('block_synchronization_mechanism', () => {
 					});
 
 					requestedBlocks = [
-						...new Array(10)
-							.fill(0)
-							.map((_, index) =>
-								createValidDefaultBlock({
-									header: { height: highestCommonBlock.height + 1 + index },
-								}),
-							),
+						...new Array(10).fill(0).map((_, index) =>
+							createValidDefaultBlock({
+								header: { height: highestCommonBlock.height + 1 + index },
+							}),
+						),
 						aBlock,
-						...new Array(10)
-							.fill(0)
-							.map((_, index) =>
-								createValidDefaultBlock({
-									header: { height: aBlock.header.height + 1 + index },
-								}),
-							),
+						...new Array(10).fill(0).map((_, index) =>
+							createValidDefaultBlock({
+								header: { height: aBlock.header.height + 1 + index },
+							}),
+						),
 					];
 
 					const tempTableBlocks = [
@@ -1122,21 +1110,17 @@ describe('block_synchronization_mechanism', () => {
 					});
 
 					requestedBlocks = [
-						...new Array(10)
-							.fill(0)
-							.map((_, index) =>
-								createValidDefaultBlock({
-									header: { height: highestCommonBlock.height + 1 + index },
-								}),
-							),
+						...new Array(10).fill(0).map((_, index) =>
+							createValidDefaultBlock({
+								header: { height: highestCommonBlock.height + 1 + index },
+							}),
+						),
 						aBlock,
-						...new Array(10)
-							.fill(0)
-							.map((_, index) =>
-								createValidDefaultBlock({
-									header: { height: aBlock.header.height + 1 + index },
-								}),
-							),
+						...new Array(10).fill(0).map((_, index) =>
+							createValidDefaultBlock({
+								header: { height: aBlock.header.height + 1 + index },
+							}),
+						),
 					];
 
 					for (const expectedPeer of peersList.expectedSelection) {

--- a/framework/test/unit/specs/application/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
+++ b/framework/test/unit/specs/application/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
@@ -130,7 +130,7 @@ describe('fast_chain_switching_mechanism', () => {
 		});
 
 		blockProcessorV2 = new BlockProcessorV2({
-			networkIdentifier: '',
+			networkIdentifier: defaultNetworkIdentifier,
 			forgerDB,
 			chainModule,
 			bftModule,

--- a/framework/test/unit/specs/application/node/synchronizer/synchronizer.spec.ts
+++ b/framework/test/unit/specs/application/node/synchronizer/synchronizer.spec.ts
@@ -131,7 +131,7 @@ describe('Synchronizer', () => {
 		});
 
 		blockProcessorV2 = new BlockProcessorV2({
-			networkIdentifier: '',
+			networkIdentifier: defaultNetworkIdentifier,
 			forgerDB,
 			chainModule,
 			bftModule,

--- a/framework/test/utils/network_identifier.ts
+++ b/framework/test/utils/network_identifier.ts
@@ -15,13 +15,13 @@
 import { getNetworkIdentifier as getNetworkID } from '@liskhq/lisk-cryptography';
 
 interface NetworkIdentifierable {
-	readonly transactionRoot: string;
+	readonly transactionRoot: Buffer;
 	readonly communityIdentifier: string;
 }
 
 export const getNetworkIdentifier = (
 	genesisBlock: NetworkIdentifierable,
-): string =>
+): Buffer =>
 	getNetworkID(genesisBlock.transactionRoot, genesisBlock.communityIdentifier);
 
 export const devnetNetworkIdentifier =


### PR DESCRIPTION
### What was the problem?

This PR resolves #5403 

### How was it solved?

- Update network identifier to use Buffer
- Revert and update the name of legacy address format functions
- All public key and private key to be Buffer

### How was it tested?

- Update all the unit test and integration test
- Check test_app can run
