### PR TITLE
Remove crypti copyright from readme for new packages - Closes #5325

### DIFF
--- a/elements/lisk-api-client/README.md
+++ b/elements/lisk-api-client/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-api-client
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-bft/README.md
+++ b/elements/lisk-bft/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-bft
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-client/README.md
+++ b/elements/lisk-client/README.md
@@ -58,7 +58,7 @@ Or minified:
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -74,9 +74,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-codec/README.md
+++ b/elements/lisk-codec/README.md
@@ -14,18 +14,18 @@ The following are some benchmarks for version 0.1 of this library used for encod
 
 Node version used: v12.17.0. Computer Spec: SSD, 6 Core, 16 GB RAM. No special configuration for Node.
 
-| Object Type   | Encode (ops/sec)          | Decode (ops/sec) |
-| ------------- |:-------------:| -----:|
-| Account | 75,081 | 86,908 |
-| Transfer Transaction |225,229|   276,184 |
-| Multi-signature registration (64 Members)| 23,539 | 44,231 |
-| Block (15 KB payload)| 42,349 | 91,180 |
+| Object Type                               | Encode (ops/sec) | Decode (ops/sec) |
+| ----------------------------------------- | :--------------: | ---------------: |
+| Account                                   |      75,081      |           86,908 |
+| Transfer Transaction                      |     225,229      |          276,184 |
+| Multi-signature registration (64 Members) |      23,539      |           44,231 |
+| Block (15 KB payload)                     |      42,349      |           91,180 |
 
 This and additional benchmarks can be found in the `benchmarks` folder
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,9 +41,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-constants/README.md
+++ b/elements/lisk-constants/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-constants
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-cryptography/README.md
+++ b/elements/lisk-cryptography/README.md
@@ -35,7 +35,7 @@ Benchmark results for nacl functions:
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -51,9 +51,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-db/README.md
+++ b/elements/lisk-db/README.md
@@ -70,7 +70,7 @@ Benchmark results leveldb vs rocksdb (150,000 bytes):
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -86,9 +86,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-dpos/README.md
+++ b/elements/lisk-dpos/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-dpos
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-elements/README.md
+++ b/elements/lisk-elements/README.md
@@ -140,7 +140,7 @@ https://github.com/LiskHQ/lisk-elements/graphs/contributors
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -156,9 +156,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-p2p/README.md
+++ b/elements/lisk-p2p/README.md
@@ -113,7 +113,7 @@ Check [examples](examples/) folder for a few examples to demonstrate P2P library
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -129,9 +129,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-passphrase/README.md
+++ b/elements/lisk-passphrase/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-passphrase
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-transaction-pool/README.md
+++ b/elements/lisk-transaction-pool/README.md
@@ -26,7 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-transaction-pool/README.md
+++ b/elements/lisk-transaction-pool/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-transaction-pool
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ limitations under the License.
 ---
 
 Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-transactions/README.md
+++ b/elements/lisk-transactions/README.md
@@ -97,7 +97,7 @@ $ npm install --save @liskhq/lisk-transactions
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -113,9 +113,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-tree/README.md
+++ b/elements/lisk-tree/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-tree
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/elements/lisk-validator/README.md
+++ b/elements/lisk-validator/README.md
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/lisk-validator
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/templates/README.md.tmpl
+++ b/templates/README.md.tmpl
@@ -10,7 +10,7 @@ $ npm install --save @liskhq/{PACKAGE}
 
 ## License
 
-Copyright 2016-2019 Lisk Foundation
+Copyright 2016-2020 Lisk Foundation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ limitations under the License.
 
 ---
 
-Copyright © 2016-2019 Lisk Foundation
-
-Copyright © 2015 Crypti
+Copyright © 2016-2020 Lisk Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5325 

### How was it solved?

- Updated copyright to use range `2016-2020` for new elements packages
- Removed Crypti copyright from templated and new elements packages

### How was it tested?

NA