### PR TITLE
Add consecutive missed block calculation - Closes #4934

### DIFF
--- a/elements/lisk-chain/src/slots.ts
+++ b/elements/lisk-chain/src/slots.ts
@@ -32,6 +32,10 @@ export class Slots {
 		return Math.floor((Date.now() - this._epochTime.getTime()) / SEC_IN_MS);
 	}
 
+	public blockTime(): number {
+		return this._interval;
+	}
+
 	public getRealTime(time: number): number {
 		return (
 			Math.floor(this._epochTime.getTime() / SEC_IN_MS) * SEC_IN_MS +

--- a/elements/lisk-dpos/src/delegates_info.ts
+++ b/elements/lisk-dpos/src/delegates_info.ts
@@ -192,10 +192,12 @@ export class DelegatesInfo {
 			const missedForgerAddress = expectedForgingAddresses[index];
 			const missedForger = await stateStore.account.get(missedForgerAddress);
 			missedForger.asset.delegate.consecutiveMissedBlocks += 1;
+			stateStore.account.set(missedForgerAddress, missedForger);
 		}
 		// Reset consecutive missed block
 		const forger = await stateStore.account.get(forgerAddress);
 		forger.asset.delegate.consecutiveMissedBlocks = 0;
+		stateStore.account.set(forgerAddress, forger);
 	}
 
 	private _isLastBlockOfTheRound(block: BlockHeader): boolean {

--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -97,8 +97,6 @@ export class Dpos {
 		this.delegatesInfo = new DelegatesInfo({
 			chain: this.chain,
 			rounds: this.rounds,
-			activeDelegates,
-			standbyDelegates,
 			events: this.events,
 			delegatesList: this.delegatesList,
 		});

--- a/elements/lisk-dpos/src/types.ts
+++ b/elements/lisk-dpos/src/types.ts
@@ -83,7 +83,10 @@ export interface DPoSProcessingOptions {
 }
 
 export interface Chain {
-	readonly slots: { readonly getSlotNumber: (epochTime?: number) => number };
+	readonly slots: {
+		readonly getSlotNumber: (epochTime?: number) => number;
+		readonly blockTime: () => number;
+	};
 	readonly dataAccess: {
 		getConsensusState(key: string): Promise<Buffer | undefined>;
 		getBlockHeadersByHeightBetween(

--- a/elements/lisk-dpos/test/unit/undo.spec.ts
+++ b/elements/lisk-dpos/test/unit/undo.spec.ts
@@ -36,6 +36,8 @@ describe('dpos.undo()', () => {
 		ACTIVE_DELEGATES + STANDBY_DELEGATES,
 	);
 
+	const defaultLastBlockHeader = { timestamp: 123 } as BlockHeader;
+
 	let dpos: Dpos;
 	let chainStub: any;
 	let stateStore: StateStoreMock;
@@ -53,7 +55,11 @@ describe('dpos.undo()', () => {
 		dpos = new Dpos({
 			chain: chainStub,
 		});
-		stateStore = new StateStoreMock([...delegateAccounts], {});
+		stateStore = new StateStoreMock(
+			[...delegateAccounts],
+			{},
+			{ lastBlockHeaders: [defaultLastBlockHeader] },
+		);
 	});
 
 	describe('Given block is the genesis block (height === 1)', () => {
@@ -66,7 +72,11 @@ describe('dpos.undo()', () => {
 			genesisBlock = {
 				height: 1,
 			} as BlockHeader;
-			stateStore = new StateStoreMock([generator, ...delegateAccounts], {});
+			stateStore = new StateStoreMock(
+				[generator, ...delegateAccounts],
+				{},
+				{ lastBlockHeaders: [defaultLastBlockHeader] },
+			);
 		});
 
 		it('should throw exception and NOT update "producedBlocks", "missedBlocks", "rewards", "fees", "votes"', async () => {
@@ -105,9 +115,13 @@ describe('dpos.undo()', () => {
 				forgerListObject,
 			);
 
-			stateStore = new StateStoreMock([generator, ...delegateAccounts], {
-				[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: forgersListBinary,
-			});
+			stateStore = new StateStoreMock(
+				[generator, ...delegateAccounts],
+				{
+					[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: forgersListBinary,
+				},
+				{ lastBlockHeaders: [defaultLastBlockHeader] },
+			);
 		});
 
 		it('should NOT update "missedBlocks"', async () => {
@@ -217,10 +231,14 @@ describe('dpos.undo()', () => {
 				forgerListObject,
 			);
 
-			stateStore = new StateStoreMock([...forgedDelegates, missedDelegate], {
-				[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: encodedDelegateVoteWeights,
-				[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: forgersListBinary,
-			});
+			stateStore = new StateStoreMock(
+				[...forgedDelegates, missedDelegate],
+				{
+					[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: encodedDelegateVoteWeights,
+					[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: forgersListBinary,
+				},
+				{ lastBlockHeaders: [defaultLastBlockHeader] },
+			);
 
 			lastBlockOfTheRoundNine = {
 				height: 927,
@@ -374,10 +392,14 @@ describe('dpos.undo()', () => {
 					forgerListObject,
 				);
 
-				stateStore = new StateStoreMock([...forgedDelegates], {
-					[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: encodedDelegateVoteWeights,
-					[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: forgersListBinary,
-				});
+				stateStore = new StateStoreMock(
+					[...forgedDelegates],
+					{
+						[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: encodedDelegateVoteWeights,
+						[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: forgersListBinary,
+					},
+					{ lastBlockHeaders: [defaultLastBlockHeader] },
+				);
 
 				lastBlockOfTheRoundNine = {
 					height: 927,


### PR DESCRIPTION
### What was the problem?

This PR resolves #4934 

### How was it solved?

- Add consecutive missed block calculation every block
- This does not consider undo assuming that this will be covered by #5232  

### How was it tested?
- Added unit test described in the issue
- Run application

