### PR TITLE
Update diff history array format - Closes #5411

### DIFF
--- a/elements/lisk-chain/benchmark/calculate_diff.js
+++ b/elements/lisk-chain/benchmark/calculate_diff.js
@@ -54,8 +54,8 @@ const diff = calculateDiff(
 );
 
 /**
- * calculateDiff x 102,134 ops/sec ±0.99% (84 runs sampled)
- * undo x 50,906 ops/sec ±0.80% (91 runs sampled)
+ * calculateDiff x 119,928 ops/sec ±1.27% (86 runs sampled)
+ * undo x 50,030 ops/sec ±0.78% (89 runs sampled)
  */
 suite
 	.add('calculateDiff', () => {

--- a/elements/lisk-chain/test/unit/diff.spec.ts
+++ b/elements/lisk-chain/test/unit/diff.spec.ts
@@ -36,11 +36,11 @@ describe('diff', () => {
 			it('should return an array of edit history', () => {
 				const diff = calculateDiff(arr1Buffer, arr2Buffer);
 				const editHistory = [
-					['=', 1],
-					['-', 2],
-					['=', 1],
-					['+', 4],
-					['=', 2],
+					{ code: '=', line: 1 },
+					{ code: '-', line: 2 },
+					{ code: '=', line: 1 },
+					{ code: '+', line: 4 },
+					{ code: '=', line: 2 },
 				];
 				expect(diff).toEqual(editHistory);
 				expect(undo(arr2Buffer, diff)).toEqual(arr1Buffer);
@@ -48,7 +48,7 @@ describe('diff', () => {
 
 			it('should return history with only "=" operation equal to the number of values', () => {
 				const diff = calculateDiff(arr1Buffer, arr1Buffer);
-				const editHistory = [['=', 5]];
+				const editHistory = [{ code: '=', line: 5 }];
 				expect(diff).toEqual(editHistory);
 				expect(undo(arr1Buffer, diff)).toEqual(arr1Buffer);
 			});
@@ -56,11 +56,11 @@ describe('diff', () => {
 			it('should return history with "+" operators adding each new element of the new array', () => {
 				const diff = calculateDiff(Buffer.from([]), arr1Buffer);
 				const editHistory = [
-					['+', 1],
-					['+', 2],
-					['+', 3],
-					['+', 5],
-					['+', 6],
+					{ code: '+', line: 1 },
+					{ code: '+', line: 2 },
+					{ code: '+', line: 3 },
+					{ code: '+', line: 5 },
+					{ code: '+', line: 6 },
 				];
 				expect(diff).toEqual(editHistory);
 				expect(undo(arr1Buffer, diff)).toEqual(Buffer.from([]));


### PR DESCRIPTION
### What was the problem?

This PR resolves #5411

### How was it solved?

- Diff is of type `{ code: string, line: number }[]`

### How was it tested?

Run `npm run test diff.spec` under `elements/lisk-chain`
