### PR TITLE
Add buffer library and inject into client package - Closes #5305

### DIFF
--- a/elements/lisk-client/index.html
+++ b/elements/lisk-client/index.html
@@ -8,6 +8,6 @@
 		Open the console to get started with Lisk Client.
 		<div id="output"></div>
 
-		<script src="dist-browser/index.min.js"></script>
+		<script src="dist-browser/index.js"></script>
 	</body>
 </html>

--- a/elements/lisk-client/package.json
+++ b/elements/lisk-client/package.json
@@ -25,7 +25,7 @@
 		"prestart": "./scripts/prestart.sh",
 		"start": "./scripts/start.sh",
 		"browserify": "browserify ./dist-node/index.js -o ./dist-browser/index.js -s lisk",
-		"uglify": "uglifyjs -nm -o ./dist-browser/index.min.js ./dist-browser/index.js",
+		"uglify": "terser -nm -o ./dist-browser/index.min.js ./dist-browser/index.js",
 		"clean": "./scripts/clean.sh",
 		"format": "prettier --write '**/*'",
 		"lint": "tslint --format verbose --project .",
@@ -48,7 +48,8 @@
 		"@liskhq/lisk-cryptography": "2.5.0-alpha.0",
 		"@liskhq/lisk-passphrase": "3.0.1-alpha.0",
 		"@liskhq/lisk-transactions": "4.0.0-alpha.0",
-		"@types/node": "12.12.11"
+		"@types/node": "12.12.11",
+		"buffer": "liskHQ/buffer#4d498e6"
 	},
 	"devDependencies": {
 		"@types/jest": "25.1.3",
@@ -65,6 +66,6 @@
 		"tslint-config-prettier": "1.18.0",
 		"tslint-immutable": "6.0.1",
 		"typescript": "3.8.3",
-		"uglify-es": "3.3.9"
+		"terser": "4.7.0"
 	}
 }

--- a/elements/lisk-client/src/index.ts
+++ b/elements/lisk-client/src/index.ts
@@ -31,7 +31,7 @@ export const constants = constantsModule;
 export const cryptography = cryptographyModule;
 export const passphrase = passphraseModule;
 export const transactions = transactionsModule;
-// Also export as `transacation` for backward compatibility.
+// Also export as `transaction` for backward compatibility.
 // See https://github.com/LiskHQ/lisk-sdk/issues/3925#issuecomment-508664703
 export const transaction = transactionsModule;
 
@@ -43,7 +43,7 @@ export default {
 	passphrase,
 	transactions,
 	Buffer,
-	// Also export as `transacation` for backward compatibility.
+	// Also export as `transaction` for backward compatibility.
 	// See https://github.com/LiskHQ/lisk-sdk/issues/3925#issuecomment-508664703
 	transaction: transactions,
 };

--- a/elements/lisk-client/src/index.ts
+++ b/elements/lisk-client/src/index.ts
@@ -17,6 +17,13 @@ import * as constantsModule from '@liskhq/lisk-constants';
 import * as cryptographyModule from '@liskhq/lisk-cryptography';
 import * as passphraseModule from '@liskhq/lisk-passphrase';
 import * as transactionsModule from '@liskhq/lisk-transactions';
+import { Buffer as BrowserBuffer } from 'buffer';
+
+if (!global.Buffer) {
+	global.Buffer = BrowserBuffer;
+}
+
+export const { Buffer } = global;
 
 // tslint:disable-next-line variable-name
 export const APIClient = APIClientModule;
@@ -35,6 +42,7 @@ export default {
 	cryptography,
 	passphrase,
 	transactions,
+	Buffer,
 	// Also export as `transacation` for backward compatibility.
 	// See https://github.com/LiskHQ/lisk-sdk/issues/3925#issuecomment-508664703
 	transaction: transactions,

--- a/elements/lisk-p2p/package.json
+++ b/elements/lisk-p2p/package.json
@@ -71,7 +71,6 @@
 		"tslint": "6.0.0",
 		"tslint-config-prettier": "1.18.0",
 		"tslint-immutable": "6.0.1",
-		"typescript": "3.8.3",
-		"uglify-es": "3.3.9"
+		"typescript": "3.8.3"
 	}
 }

--- a/elements/lisk-p2p/test/config/jest.config.base.js
+++ b/elements/lisk-p2p/test/config/jest.config.base.js
@@ -27,8 +27,6 @@ module.exports = {
 	},
 	setupFilesAfterEnv: ['<rootDir>/test/config/setup.js'],
 	collectCoverageFrom: ['<rootDir>/src/**'],
-	coveragePathIgnorePatterns: ['/dist-node/', '/test/'],
-
 	transform: {
 		'^.+\\.(ts|tsx)$': 'ts-jest',
 	},

--- a/templates/jest.config.js.tmpl
+++ b/templates/jest.config.js.tmpl
@@ -1,4 +1,5 @@
 module.exports = {
+	testEnvironment: 'node',
 	globals: {
 		'ts-jest': {
 			tsConfig: './test/tsconfig.json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,8 +3057,14 @@ buffer-xor@^1.0.3:
 
 buffer@^5.0.2, buffer@^5.2.1:
   version "5.4.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
-  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
+  resolved "https://codeload.github.com/fanatid/buffer/tar.gz/d8b713321bfd93c1249f30a9883d5fa91f39528f"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@liskHQ/buffer#4d498e6:
+  version "5.6.0"
+  resolved "https://codeload.github.com/liskHQ/buffer/tar.gz/4d498e6acd7f2a20073b10d31961b86c6be530b8"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -3625,7 +3631,7 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-commander@^2.12.1, commander@^2.7.1, commander@~2.20.3:
+commander@^2.12.1, commander@^2.20.0, commander@^2.7.1, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3634,11 +3640,6 @@ commander@^4.0.1, commander@~4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
-commander@~2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
-  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
 
 commander@~2.19.0:
   version "2.19.0"
@@ -11496,6 +11497,14 @@ source-map-support@0.5.16, source-map-support@^0.5.6:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map-support@~0.5.12:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -12160,6 +12169,15 @@ terminal-link@^2.0.0:
     ansi-escapes "^4.2.1"
     supports-hyperlinks "^2.0.0"
 
+terser@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.7.0.tgz#15852cf1a08e3256a80428e865a2fa893ffba006"
+  integrity sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -12576,14 +12594,6 @@ typescript@3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-uglify-es@3.3.9:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
-  integrity sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==
-  dependencies:
-    commander "~2.13.0"
-    source-map "~0.6.1"
 
 uglify-js@^3.1.4:
   version "3.8.1"


### PR DESCRIPTION
### What was the problem?

This PR resolves #5305 

### How was it solved?

Add browser version of Buffer which have bigint implementation temporally 

### How was it tested?

Open index.html in `elements/lisk-client/index.html` after build, and check function that uses bigint works in browser
```
lisk.cryptography.getAddressFromPassphrase('123')
```
