### PR TITLE
Fix multisig sorting for the buffer - Closes #5400

### DIFF
--- a/elements/lisk-transactions/src/12_multisignature_transaction.ts
+++ b/elements/lisk-transactions/src/12_multisignature_transaction.ts
@@ -341,12 +341,14 @@ export class MultisignatureTransaction extends BaseTransaction {
 		}
 
 		// Check keys are sorted lexicographically
-		// eslint-disable-next-line @typescript-eslint/require-array-sort-compare
-		const sortedMandatoryKeys = [...mandatoryKeys].sort();
-		// eslint-disable-next-line @typescript-eslint/require-array-sort-compare
-		const sortedOptionalKeys = [...optionalKeys].sort();
+		const sortedMandatoryKeys = [...mandatoryKeys].sort((a, b) =>
+			a.compare(b as Buffer),
+		);
+		const sortedOptionalKeys = [...optionalKeys].sort((a, b) =>
+			a.compare(b as Buffer),
+		);
 		for (let i = 0; i < sortedMandatoryKeys.length; i += 1) {
-			if (mandatoryKeys[i] !== sortedMandatoryKeys[i]) {
+			if (!mandatoryKeys[i].equals(sortedMandatoryKeys[i] as Buffer)) {
 				errors.push(
 					new TransactionError(
 						'Mandatory keys should be sorted lexicographically',
@@ -360,7 +362,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 		}
 
 		for (let i = 0; i < sortedOptionalKeys.length; i += 1) {
-			if (optionalKeys[i] !== sortedOptionalKeys[i]) {
+			if (!optionalKeys[i].equals(sortedOptionalKeys[i] as Buffer)) {
 				errors.push(
 					new TransactionError(
 						'Optional keys should be sorted lexicographically',


### PR DESCRIPTION
### What was the problem?

This PR resolves #5400 

### How was it solved?

Fix the sorting function for sorting the Buffer

### How was it tested?
Run `framework/test/integration/specs/application/node/processor/transaction_order.spec.ts` 30 times, and will not fail

