### PR TITLE
Add last block forged parameter to account - Closes #4935

### DIFF
--- a/elements/lisk-dpos/src/delegates_info.ts
+++ b/elements/lisk-dpos/src/delegates_info.ts
@@ -112,7 +112,7 @@ export class DelegatesInfo {
 
 		const round = this.rounds.calcRound(block.height);
 		// Safety measure is calculated every block
-		await this._updateSafetyMeasure(block, stateStore);
+		await this._updateProductivity(block, stateStore);
 
 		// Below event should only happen at the end of the round
 		if (!this._isLastBlockOfTheRound(block)) {
@@ -160,7 +160,7 @@ export class DelegatesInfo {
 		return true;
 	}
 
-	private async _updateSafetyMeasure(
+	private async _updateProductivity(
 		blockHeader: BlockHeader,
 		stateStore: StateStore,
 	): Promise<void> {

--- a/elements/lisk-dpos/src/delegates_info.ts
+++ b/elements/lisk-dpos/src/delegates_info.ts
@@ -111,8 +111,8 @@ export class DelegatesInfo {
 		}
 
 		const round = this.rounds.calcRound(block.height);
-		// ConsecutiveMissedBlock is calculated every block
-		await this._updateMissedBlocks(block, stateStore);
+		// Safety measure is calculated every block
+		await this._updateSafetyMeasure(block, stateStore);
 
 		// Below event should only happen at the end of the round
 		if (!this._isLastBlockOfTheRound(block)) {
@@ -160,7 +160,7 @@ export class DelegatesInfo {
 		return true;
 	}
 
-	private async _updateMissedBlocks(
+	private async _updateSafetyMeasure(
 		blockHeader: BlockHeader,
 		stateStore: StateStore,
 	): Promise<void> {
@@ -197,6 +197,7 @@ export class DelegatesInfo {
 		// Reset consecutive missed block
 		const forger = await stateStore.account.get(forgerAddress);
 		forger.asset.delegate.consecutiveMissedBlocks = 0;
+		forger.asset.delegate.lastForgedHeight = blockHeader.height;
 		stateStore.account.set(forgerAddress, forger);
 	}
 

--- a/elements/lisk-dpos/test/unit/apply.spec.ts
+++ b/elements/lisk-dpos/test/unit/apply.spec.ts
@@ -205,7 +205,7 @@ describe('dpos.apply()', () => {
 			);
 		});
 
-		describe('consecutiveMissedBlock', () => {
+		describe('safety measure', () => {
 			let forgedDelegates: Account[];
 			let forgersList: DecodedForgersList;
 			let delegateVoteWeights: DecodedVoteWeights;
@@ -266,7 +266,7 @@ describe('dpos.apply()', () => {
 					// Act
 					await dpos.apply(block, stateStore);
 
-					expect.assertions(forgedDelegates.length);
+					expect.assertions(forgedDelegates.length + 1);
 					for (const delegate of forgedDelegates) {
 						const updatedAccount = await stateStore.account.get(
 							delegate.address,
@@ -281,6 +281,8 @@ describe('dpos.apply()', () => {
 							).toEqual(1);
 						}
 					}
+					const forger = await stateStore.account.get(forgedDelegate.address);
+					expect(forger.asset.delegate.lastForgedHeight).toEqual(block.height);
 				});
 			});
 
@@ -442,7 +444,7 @@ describe('dpos.apply()', () => {
 
 					// Act
 					await dpos.apply(block, stateStore);
-					expect.assertions(forgedDelegates.length);
+					expect.assertions(forgedDelegates.length + 1);
 					for (const delegate of forgedDelegates) {
 						const updatedAccount = await stateStore.account.get(
 							delegate.address,
@@ -451,6 +453,10 @@ describe('dpos.apply()', () => {
 							updatedAccount.asset.delegate.consecutiveMissedBlocks,
 						).toEqual(0);
 					}
+					const forger = await stateStore.account.get(
+						forgedDelegates[forgedDelegates.length - 1].address,
+					);
+					expect(forger.asset.delegate.lastForgedHeight).toEqual(block.height);
 				});
 			});
 		});

--- a/elements/lisk-dpos/test/unit/apply.spec.ts
+++ b/elements/lisk-dpos/test/unit/apply.spec.ts
@@ -205,7 +205,7 @@ describe('dpos.apply()', () => {
 			);
 		});
 
-		describe('safety measure', () => {
+		describe('productivity of forgers', () => {
 			let forgedDelegates: Account[];
 			let forgersList: DecodedForgersList;
 			let delegateVoteWeights: DecodedVoteWeights;

--- a/elements/lisk-transactions/src/10_delegate_transaction.ts
+++ b/elements/lisk-transactions/src/10_delegate_transaction.ts
@@ -173,6 +173,8 @@ export class DelegateTransaction extends BaseTransaction {
 			);
 		}
 		sender.asset.delegate.username = this.asset.username;
+		sender.asset.delegate.lastForgedHeight =
+			store.chain.lastBlockHeader.height + 1;
 		store.account.set(sender.address, sender);
 
 		return errors;

--- a/elements/lisk-transactions/src/10_delegate_transaction.ts
+++ b/elements/lisk-transactions/src/10_delegate_transaction.ts
@@ -173,8 +173,11 @@ export class DelegateTransaction extends BaseTransaction {
 			);
 		}
 		sender.asset.delegate.username = this.asset.username;
-		sender.asset.delegate.lastForgedHeight =
-			store.chain.lastBlockHeader.height + 1;
+		// Genesis block does not have last block header. Remove with #5200
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		sender.asset.delegate.lastForgedHeight = store.chain.lastBlockHeader
+			? store.chain.lastBlockHeader.height + 1
+			: 1;
 		store.account.set(sender.address, sender);
 
 		return errors;


### PR DESCRIPTION
### What was the problem?

This PR resolves #4935 

### How was it solved?

- Initialize last forged height from delegate registration tx to the last block height + 1
- Set last forged height to the block header height in dpos every block

### How was it tested?

- Add unit test to check if those values are set
