### PR TITLE
Add banning for the missedBlock, and forged height diff conditions - Closes #4942

### DIFF
--- a/elements/lisk-dpos/test/unit/apply.spec.ts
+++ b/elements/lisk-dpos/test/unit/apply.spec.ts
@@ -459,6 +459,234 @@ describe('dpos.apply()', () => {
 					expect(forger.asset.delegate.lastForgedHeight).toEqual(block.height);
 				});
 			});
+
+			describe('when forger missed a block has 50 consecutive missed block, but forged within 260k blocks', () => {
+				it('should not ban the missed forger', async () => {
+					const forgedDelegate = forgedDelegates[forgedDelegates.length - 1];
+					// Arrange
+					const lastBlock = {
+						generatorPublicKey: forgedDelegate.publicKey,
+						height: 920006,
+						timestamp: 10000270,
+					} as BlockHeader;
+					block = {
+						height: 920007,
+						timestamp: 10000290,
+						generatorPublicKey: forgedDelegate.publicKey,
+					} as BlockHeader;
+					const forgerIndex = forgersList.forgersList[0].delegates.findIndex(
+						forger => forger.equals(forgedDelegate.address),
+					);
+					const missedDelegate = forgedDelegates[forgerIndex - 1];
+					forgersList = {
+						forgersList: [
+							{
+								round: 8933,
+								delegates: [...forgedDelegates.map(d => d.address)],
+								standby: [],
+							},
+						],
+					};
+					delegateVoteWeights = {
+						voteWeights: [
+							{
+								round: 10,
+								delegates: forgedDelegates.map(d => ({
+									address: d.address,
+									voteWeight: d.asset.delegate.totalVotesReceived,
+								})),
+							},
+						],
+					};
+					stateStore = new StateStoreMock(
+						[
+							...forgedDelegates.map(forger => {
+								if (forger.address.equals(missedDelegate.address)) {
+									// eslint-disable-next-line no-param-reassign
+									forger.asset.delegate.lastForgedHeight =
+										block.height - 260000 + 5000;
+									// eslint-disable-next-line no-param-reassign
+									forger.asset.delegate.consecutiveMissedBlocks = 50;
+								}
+								return forger;
+							}),
+						],
+						{
+							[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: codec.encode(
+								forgerListSchema,
+								forgersList,
+							),
+							[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: codec.encode(
+								voteWeightsSchema,
+								delegateVoteWeights,
+							),
+						},
+						{ lastBlockHeaders: [lastBlock] },
+					);
+					// Act
+					await dpos.apply(block, stateStore);
+
+					const updatedMissedForger = await stateStore.account.get(
+						missedDelegate.address,
+					);
+					expect(updatedMissedForger.asset.delegate.isBanned).toBeFalse();
+					expect(
+						updatedMissedForger.asset.delegate.consecutiveMissedBlocks,
+					).toEqual(51);
+				});
+			});
+
+			describe('when forger missed a block has not forged within 260k blocks, but does not have 50 consecutive missed block', () => {
+				it('should not ban the missed forger', async () => {
+					const forgedDelegate = forgedDelegates[forgedDelegates.length - 1];
+					// Arrange
+					const lastBlock = {
+						generatorPublicKey: forgedDelegate.publicKey,
+						height: 920006,
+						timestamp: 10000270,
+					} as BlockHeader;
+					block = {
+						height: 920007,
+						timestamp: 10000290,
+						generatorPublicKey: forgedDelegate.publicKey,
+					} as BlockHeader;
+					const forgerIndex = forgersList.forgersList[0].delegates.findIndex(
+						forger => forger.equals(forgedDelegate.address),
+					);
+					const missedDelegate = forgedDelegates[forgerIndex - 1];
+					forgersList = {
+						forgersList: [
+							{
+								round: 8933,
+								delegates: [...forgedDelegates.map(d => d.address)],
+								standby: [],
+							},
+						],
+					};
+					delegateVoteWeights = {
+						voteWeights: [
+							{
+								round: 10,
+								delegates: forgedDelegates.map(d => ({
+									address: d.address,
+									voteWeight: d.asset.delegate.totalVotesReceived,
+								})),
+							},
+						],
+					};
+					stateStore = new StateStoreMock(
+						[
+							...forgedDelegates.map(forger => {
+								if (forger.address.equals(missedDelegate.address)) {
+									// eslint-disable-next-line no-param-reassign
+									forger.asset.delegate.lastForgedHeight =
+										block.height - 260000 - 1;
+									// eslint-disable-next-line no-param-reassign
+									forger.asset.delegate.consecutiveMissedBlocks = 40;
+								}
+								return forger;
+							}),
+						],
+						{
+							[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: codec.encode(
+								forgerListSchema,
+								forgersList,
+							),
+							[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: codec.encode(
+								voteWeightsSchema,
+								delegateVoteWeights,
+							),
+						},
+						{ lastBlockHeaders: [lastBlock] },
+					);
+					// Act
+					await dpos.apply(block, stateStore);
+
+					const updatedMissedForger = await stateStore.account.get(
+						missedDelegate.address,
+					);
+					expect(updatedMissedForger.asset.delegate.isBanned).toBeFalse();
+					expect(
+						updatedMissedForger.asset.delegate.consecutiveMissedBlocks,
+					).toEqual(41);
+				});
+			});
+
+			describe('when forger missed a block has 50 consecutive missed block, and not forged within 260k blocks', () => {
+				it('should ban the missed forger', async () => {
+					const forgedDelegate = forgedDelegates[forgedDelegates.length - 1];
+					// Arrange
+					const lastBlock = {
+						generatorPublicKey: forgedDelegate.publicKey,
+						height: 920006,
+						timestamp: 10000270,
+					} as BlockHeader;
+					block = {
+						height: 920007,
+						timestamp: 10000290,
+						generatorPublicKey: forgedDelegate.publicKey,
+					} as BlockHeader;
+					const forgerIndex = forgersList.forgersList[0].delegates.findIndex(
+						forger => forger.equals(forgedDelegate.address),
+					);
+					const missedDelegate = forgedDelegates[forgerIndex - 1];
+					forgersList = {
+						forgersList: [
+							{
+								round: 8933,
+								delegates: [...forgedDelegates.map(d => d.address)],
+								standby: [],
+							},
+						],
+					};
+					delegateVoteWeights = {
+						voteWeights: [
+							{
+								round: 10,
+								delegates: forgedDelegates.map(d => ({
+									address: d.address,
+									voteWeight: d.asset.delegate.totalVotesReceived,
+								})),
+							},
+						],
+					};
+					stateStore = new StateStoreMock(
+						[
+							...forgedDelegates.map(forger => {
+								if (forger.address.equals(missedDelegate.address)) {
+									// eslint-disable-next-line no-param-reassign
+									forger.asset.delegate.lastForgedHeight =
+										block.height - 260000 - 1;
+									// eslint-disable-next-line no-param-reassign
+									forger.asset.delegate.consecutiveMissedBlocks = 50;
+								}
+								return forger;
+							}),
+						],
+						{
+							[CONSENSUS_STATE_DELEGATE_FORGERS_LIST]: codec.encode(
+								forgerListSchema,
+								forgersList,
+							),
+							[CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS]: codec.encode(
+								voteWeightsSchema,
+								delegateVoteWeights,
+							),
+						},
+						{ lastBlockHeaders: [lastBlock] },
+					);
+					// Act
+					await dpos.apply(block, stateStore);
+
+					const updatedMissedForger = await stateStore.account.get(
+						missedDelegate.address,
+					);
+					expect(updatedMissedForger.asset.delegate.isBanned).toBeTrue();
+					expect(
+						updatedMissedForger.asset.delegate.consecutiveMissedBlocks,
+					).toEqual(51);
+				});
+			});
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4942 

### How was it solved?

Add condition to ban the delegate based on the consecutiveMissedBlock and last forged height

### How was it tested?

Added tests for all condition
- only pass the consecutive missed block condition
- only pass the forged height diff condition
- pass both consecutive missed block and forged height diff conditions
