### PR TITLE
Add basic functional tests - Closes #4894

### DIFF
--- a/Jenkinsfile.sdk
+++ b/Jenkinsfile.sdk
@@ -194,7 +194,14 @@ pipeline {
 				stage('Lisk Framework Functional') {
 					agent { node { label 'lisk-framework' }}
 					steps {
-						setup(true)
+						// jest ITs seem to need special treatment
+						nvm(getNodejsVersion()) {
+							sh '''
+							npm install --global yarn
+							yarn
+							yarn build
+							'''
+						}
 						run_jest('functional')
 					}
 					post {

--- a/framework/package.json
+++ b/framework/package.json
@@ -35,7 +35,7 @@
 		"build": "tsc && npm run copy-static-files",
 		"test:unit": "jest --config=./test/unit/jest.config.js",
 		"test:integration": "jest --config=./test/integration/jest.config.js",
-		"test:functional": "jest --config=./test/functional/jest.config.js --passWithNoTests"
+		"test:functional": "jest --config=./test/functional/jest.config.js --runInBand"
 	},
 	"dependencies": {
 		"@liskhq/lisk-bft": "0.1.0-alpha.0",

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -317,8 +317,6 @@ export class Application {
 		} catch (error) {
 			this.logger.fatal({ err: error as Error }, 'failed to shutdown');
 		}
-
-		process.exit(errorCode);
 	}
 
 	// --------------------------------------

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -317,6 +317,8 @@ export class Application {
 		} catch (error) {
 			this.logger.fatal({ err: error as Error }, 'failed to shutdown');
 		}
+
+		process.exit(errorCode);
 	}
 
 	// --------------------------------------

--- a/framework/src/application/network/network.ts
+++ b/framework/src/application/network/network.ts
@@ -384,7 +384,7 @@ export class Network {
 				},
 				'Failed to initialize network',
 			);
-			process.exit(0);
+			throw error;
 		}
 	}
 

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -377,7 +377,7 @@ export class Node {
 				},
 				'Failed to initialization node',
 			);
-			process.exit(0);
+			throw error;
 		}
 	}
 

--- a/framework/src/application/node/transport/transport.ts
+++ b/framework/src/application/node/transport/transport.ts
@@ -343,9 +343,17 @@ export class Transport {
 
 		if (idsNotInPool.length) {
 			// Check if any transaction that was not in the queues, is in the database instead.
-			const transactionsFromDatabase = await this._chainModule.dataAccess.getTransactionsByIDs(
-				idsNotInPool,
-			);
+			const transactionsFromDatabase: BaseTransaction[] = [];
+			for (const id of idsNotInPool) {
+				try {
+					const tx = await this._chainModule.dataAccess.getTransactionByID(id);
+					transactionsFromDatabase.push(tx);
+				} catch (error) {
+					if (!(error instanceof NotFoundError)) {
+						throw error;
+					}
+				}
+			}
 
 			return {
 				transactions: transactionsFromQueues.concat(

--- a/framework/test/functional/setup.js
+++ b/framework/test/functional/setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2020 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/framework/test/functional/setup.js
+++ b/framework/test/functional/setup.js
@@ -11,14 +11,6 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+require('../config/setup');
 
-'use strict';
-
-const base = require('../config/jest.config.base');
-
-module.exports = {
-	...base,
-	collectCoverage: false,
-	setupFilesAfterEnv: ['<rootDir>/test/functional/setup.js'],
-	testMatch: ['<rootDir>/test/functional/specs/**/*.(spec|test).ts'],
-};
+jest.setTimeout(30000);

--- a/framework/test/functional/specs/actions/accounts.spec.ts
+++ b/framework/test/functional/specs/actions/accounts.spec.ts
@@ -42,11 +42,12 @@ describe('Account related actions', () => {
 
 	describe('getAccounts', () => {
 		it('should return valid encoded account', async () => {
-			const encodedAccounts: string[] = await app[
-				'_channel'
-			].invoke('app:getAccounts', {
-				address: [genesis.address.toString('base64')],
-			});
+			const encodedAccounts: string[] = await app['_channel'].invoke(
+				'app:getAccounts',
+				{
+					address: [genesis.address.toString('base64')],
+				},
+			);
 			expect(encodedAccounts).toHaveLength(1);
 			const account = app['_node']['_chain'].dataAccess.decodeAccount(
 				Buffer.from(encodedAccounts[0], 'base64'),

--- a/framework/test/functional/specs/actions/accounts.spec.ts
+++ b/framework/test/functional/specs/actions/accounts.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { createApplication, closeApplication } from '../../utils/application';
+import { Application } from '../../../../src';
+import { genesis } from '../../../fixtures';
+
+describe('Account related actions', () => {
+	let app: Application;
+
+	beforeAll(async () => {
+		app = await createApplication('actions-account');
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('getAccount', () => {
+		it('should return valid encoded account', async () => {
+			const encodedAccount = await app['_channel'].invoke('app:getAccount', {
+				address: genesis.address.toString('base64'),
+			});
+			expect(encodedAccount).toBeString();
+			const account = app['_node']['_chain'].dataAccess.decodeAccount(
+				Buffer.from(encodedAccount as string, 'base64'),
+			);
+			expect(account.address).toEqual(genesis.address);
+		});
+	});
+
+	describe('getAccounts', () => {
+		it('should return valid encoded account', async () => {
+			const encodedAccounts: string[] = await app[
+				'_channel'
+			].invoke('app:getAccounts', {
+				address: [genesis.address.toString('base64')],
+			});
+			expect(encodedAccounts).toHaveLength(1);
+			const account = app['_node']['_chain'].dataAccess.decodeAccount(
+				Buffer.from(encodedAccounts[0], 'base64'),
+			);
+			expect(account.address).toEqual(genesis.address);
+		});
+	});
+});

--- a/framework/test/functional/specs/actions/blocks.spec.ts
+++ b/framework/test/functional/specs/actions/blocks.spec.ts
@@ -12,23 +12,14 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { TransferTransaction } from '@liskhq/lisk-transactions';
-import {
-	createApplication,
-	closeApplication,
-	sendTransaction,
-	waitNBlocks,
-} from '../../utils/application';
+import { createApplication, closeApplication } from '../../utils/application';
 import { Application } from '../../../../src';
 
 describe('Block related actions', () => {
 	let app: Application;
-	let sentTx: TransferTransaction;
 
 	beforeAll(async () => {
 		app = await createApplication('actions-blocks');
-		sentTx = await sendTransaction(app);
-		await waitNBlocks(app, 1);
 	});
 
 	afterAll(async () => {
@@ -50,14 +41,15 @@ describe('Block related actions', () => {
 
 	describe('getBlocksByIDs', () => {
 		it('should return valid encoded blocks', async () => {
-			const encodedBlocks: string[] = await app[
-				'_channel'
-			].invoke('app:getBlocksByIDs', {
-				ids: [
-					app['_node']['_chain'].genesisBlock.header.id.toString('base64'),
-					app['_node']['_chain'].lastBlock.header.id.toString('base64'),
-				],
-			});
+			const encodedBlocks: string[] = await app['_channel'].invoke(
+				'app:getBlocksByIDs',
+				{
+					ids: [
+						app['_node']['_chain'].genesisBlock.header.id.toString('base64'),
+						app['_node']['_chain'].lastBlock.header.id.toString('base64'),
+					],
+				},
+			);
 			expect(encodedBlocks).toHaveLength(2);
 			const block = app['_node']['_chain'].dataAccess.decode(
 				Buffer.from(encodedBlocks[0], 'base64'),
@@ -90,34 +82,6 @@ describe('Block related actions', () => {
 				Buffer.from(encodedBlocks[0], 'base64'),
 			);
 			expect(block.header.height).toEqual(2);
-		});
-	});
-
-	describe('getTransactionByID', () => {
-		it('should return valid encoded transaction', async () => {
-			const encodedTx = await app['_channel'].invoke('app:getTransactionByID', {
-				id: sentTx.id.toString('base64'),
-			});
-			expect(encodedTx).toBeString();
-			const tx = app['_node']['_chain'].dataAccess.decodeTransaction(
-				Buffer.from(encodedTx as string, 'base64'),
-			);
-			expect(tx.senderPublicKey).toEqual(sentTx.senderPublicKey);
-		});
-	});
-
-	describe('getTransactionsByIDs', () => {
-		it('should return valid encoded transactions', async () => {
-			const encodedTxs: string[] = await app[
-				'_channel'
-			].invoke('app:getTransactionsByIDs', {
-				ids: [sentTx.id.toString('base64')],
-			});
-			expect(encodedTxs).toHaveLength(1);
-			const tx = app['_node']['_chain'].dataAccess.decodeTransaction(
-				Buffer.from(encodedTxs[0], 'base64'),
-			);
-			expect(tx.senderPublicKey).toEqual(sentTx.senderPublicKey);
 		});
 	});
 });

--- a/framework/test/functional/specs/actions/blocks.spec.ts
+++ b/framework/test/functional/specs/actions/blocks.spec.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { TransferTransaction } from '@liskhq/lisk-transactions';
+import {
+	createApplication,
+	closeApplication,
+	sendTransaction,
+	waitNBlocks,
+} from '../../utils/application';
+import { Application } from '../../../../src';
+
+describe('Block related actions', () => {
+	let app: Application;
+	let sentTx: TransferTransaction;
+
+	beforeAll(async () => {
+		app = await createApplication('actions-blocks');
+		sentTx = await sendTransaction(app);
+		await waitNBlocks(app, 1);
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('getBlockByID', () => {
+		it('should return valid encoded block', async () => {
+			const encodedBlock = await app['_channel'].invoke('app:getBlockByID', {
+				id: app['_node']['_chain'].genesisBlock.header.id.toString('base64'),
+			});
+			expect(encodedBlock).toBeString();
+			const block = app['_node']['_chain'].dataAccess.decode(
+				Buffer.from(encodedBlock as string, 'base64'),
+			);
+			expect(block.header.height).toEqual(1);
+		});
+	});
+
+	describe('getBlocksByIDs', () => {
+		it('should return valid encoded blocks', async () => {
+			const encodedBlocks: string[] = await app[
+				'_channel'
+			].invoke('app:getBlocksByIDs', {
+				ids: [
+					app['_node']['_chain'].genesisBlock.header.id.toString('base64'),
+					app['_node']['_chain'].lastBlock.header.id.toString('base64'),
+				],
+			});
+			expect(encodedBlocks).toHaveLength(2);
+			const block = app['_node']['_chain'].dataAccess.decode(
+				Buffer.from(encodedBlocks[0], 'base64'),
+			);
+			expect(block.header.height).toEqual(1);
+		});
+	});
+
+	describe('getBlockByHeight', () => {
+		it('should return valid encoded block', async () => {
+			const encodedBlock = await app['_channel'].invoke(
+				'app:getBlockByHeight',
+				{ height: 2 },
+			);
+			expect(encodedBlock).toBeString();
+			const block = app['_node']['_chain'].dataAccess.decode(
+				Buffer.from(encodedBlock as string, 'base64'),
+			);
+			expect(block.header.height).toEqual(2);
+		});
+	});
+
+	describe('getBlocksByHeightBetween', () => {
+		it('should return valid encoded blocks', async () => {
+			const encodedBlocks: string[] = await app[
+				'_channel'
+			].invoke('app:getBlocksByHeightBetween', { from: 1, to: 2 });
+			expect(encodedBlocks).toHaveLength(2);
+			const block = app['_node']['_chain'].dataAccess.decode(
+				Buffer.from(encodedBlocks[0], 'base64'),
+			);
+			expect(block.header.height).toEqual(2);
+		});
+	});
+
+	describe('getTransactionByID', () => {
+		it('should return valid encoded transaction', async () => {
+			const encodedTx = await app['_channel'].invoke('app:getTransactionByID', {
+				id: sentTx.id.toString('base64'),
+			});
+			expect(encodedTx).toBeString();
+			const tx = app['_node']['_chain'].dataAccess.decodeTransaction(
+				Buffer.from(encodedTx as string, 'base64'),
+			);
+			expect(tx.senderPublicKey).toEqual(sentTx.senderPublicKey);
+		});
+	});
+
+	describe('getTransactionsByIDs', () => {
+		it('should return valid encoded transactions', async () => {
+			const encodedTxs: string[] = await app[
+				'_channel'
+			].invoke('app:getTransactionsByIDs', {
+				ids: [sentTx.id.toString('base64')],
+			});
+			expect(encodedTxs).toHaveLength(1);
+			const tx = app['_node']['_chain'].dataAccess.decodeTransaction(
+				Buffer.from(encodedTxs[0], 'base64'),
+			);
+			expect(tx.senderPublicKey).toEqual(sentTx.senderPublicKey);
+		});
+	});
+});

--- a/framework/test/functional/specs/actions/transactions.spec.ts
+++ b/framework/test/functional/specs/actions/transactions.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { TransferTransaction } from '@liskhq/lisk-transactions';
+import {
+	createApplication,
+	closeApplication,
+	sendTransaction,
+	waitNBlocks,
+} from '../../utils/application';
+import { Application } from '../../../../src';
+import { genesis } from '../../../fixtures';
+import { nodeUtils } from '../../../utils';
+
+describe('Transaction related actions', () => {
+	let app: Application;
+	let sentTx: TransferTransaction;
+
+	beforeAll(async () => {
+		app = await createApplication('actions-transactions');
+		sentTx = await sendTransaction(app);
+		await waitNBlocks(app, 1);
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('getTransactionsFromPool', () => {
+		it('should return valid encoded encodedTransactions', async () => {
+			const encodedTransactions = await app['_channel'].invoke(
+				'app:getTransactionsFromPool',
+			);
+			expect(encodedTransactions).toHaveLength(0);
+		});
+	});
+
+	describe('postTransaction', () => {
+		it('should successfully post valid transaction', async () => {
+			const genesisAccount = await app['_node'][
+				'_chain'
+			].dataAccess.getAccountByAddress(genesis.address);
+			const accountWithoutBalance = nodeUtils.createAccount();
+			const fundingTx = new TransferTransaction({
+				nonce: genesisAccount.nonce,
+				senderPublicKey: genesis.publicKey,
+				fee: BigInt('200000'),
+				asset: {
+					recipientAddress: accountWithoutBalance.address,
+					amount: BigInt('10000000000'),
+					data: '',
+				},
+			});
+			fundingTx.sign(app['_node']['_networkIdentifier'], genesis.passphrase);
+
+			await expect(
+				app['_channel'].invoke('app:postTransaction', {
+					transaction: fundingTx.getBytes().toString('base64'),
+				}),
+			).resolves.toEqual({ transactionId: fundingTx.id.toString('base64') });
+		});
+	});
+
+	describe('getTransactionByID', () => {
+		it('should return valid encoded transaction', async () => {
+			const encodedTx = await app['_channel'].invoke('app:getTransactionByID', {
+				id: sentTx.id.toString('base64'),
+			});
+			expect(encodedTx).toBeString();
+			const tx = app['_node']['_chain'].dataAccess.decodeTransaction(
+				Buffer.from(encodedTx as string, 'base64'),
+			);
+			expect(tx.senderPublicKey).toEqual(sentTx.senderPublicKey);
+		});
+	});
+
+	describe('getTransactionsByIDs', () => {
+		it('should return valid encoded transactions', async () => {
+			const encodedTxs: string[] = await app['_channel'].invoke(
+				'app:getTransactionsByIDs',
+				{
+					ids: [sentTx.id.toString('base64')],
+				},
+			);
+			expect(encodedTxs).toHaveLength(1);
+			const tx = app['_node']['_chain'].dataAccess.decodeTransaction(
+				Buffer.from(encodedTxs[0], 'base64'),
+			);
+			expect(tx.senderPublicKey).toEqual(sentTx.senderPublicKey);
+		});
+	});
+});

--- a/framework/test/functional/specs/network/blocks.spec.ts
+++ b/framework/test/functional/specs/network/blocks.spec.ts
@@ -18,6 +18,7 @@ import {
 	createApplication,
 	closeApplication,
 	getPeerID,
+	waitNBlocks,
 } from '../../utils/application';
 import { createProbe } from '../../utils/probe';
 
@@ -118,6 +119,26 @@ describe('Public block related P2P endpoints', () => {
 				getPeerID(app),
 			);
 			expect(data).toBeUndefined();
+		});
+	});
+
+	describe('postBlock', () => {
+		it('should not fail if valid block is sent', async () => {
+			const { lastBlock } = app['_node']['_chain'];
+			const encodedBlock = app['_node']['_chain'].dataAccess.encode(lastBlock);
+			p2p.sendToPeer(
+				{
+					event: 'postBlock',
+					data: { block: encodedBlock.toString('base64') },
+				},
+				getPeerID(app),
+			);
+
+			await waitNBlocks(app, 1);
+			// Expect next block to be forged properly
+			expect(app['_node']['_chain'].lastBlock.header.id).not.toEqual(
+				lastBlock.header.id,
+			);
 		});
 	});
 });

--- a/framework/test/functional/specs/network/blocks.spec.ts
+++ b/framework/test/functional/specs/network/blocks.spec.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { P2P } from '@liskhq/lisk-p2p';
+import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { Application } from '../../../../src';
+import {
+	createApplication,
+	closeApplication,
+	getPeerID,
+} from '../../utils/application';
+import { createProbe } from '../../utils/probe';
+
+describe('Public block related P2P endpoints', () => {
+	let app: Application;
+	let p2p: P2P;
+
+	beforeAll(async () => {
+		app = await createApplication('network-blocks');
+		p2p = await createProbe(app.config);
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('getLastBlock', () => {
+		it('should return decodable block', async () => {
+			const { data } = await p2p.requestFromPeer(
+				{
+					procedure: 'getLastBlock',
+				},
+				getPeerID(app),
+			);
+			const decodedBlock = app['_node']['_chain'].dataAccess.decode(
+				Buffer.from(data as string, 'base64'),
+			);
+			expect(decodedBlock.header.height).toBeGreaterThan(1);
+		});
+	});
+
+	describe('getBlocksFromId', () => {
+		it('should return decodable block', async () => {
+			const { data } = (await p2p.requestFromPeer(
+				{
+					procedure: 'getBlocksFromId',
+					data: {
+						blockId: app['_node']['_chain'].genesisBlock.header.id.toString(
+							'base64',
+						),
+					},
+				},
+				getPeerID(app),
+			)) as { data: string[] };
+			expect.assertions(data.length + 1);
+			expect(data.length).toBeGreaterThan(0);
+			for (const id of data) {
+				const decodedBlock = app['_node']['_chain'].dataAccess.decode(
+					Buffer.from(id, 'base64'),
+				);
+				expect(decodedBlock.header.height).toBeGreaterThan(1);
+			}
+		});
+
+		it('should be rejected if blockId does not exist', async () => {
+			await expect(
+				p2p.requestFromPeer(
+					{
+						procedure: 'getBlocksFromId',
+						data: {
+							blockId: getRandomBytes(32).toString('base64'),
+						},
+					},
+					getPeerID(app),
+				),
+			).rejects.toThrow('does not exist');
+		});
+	});
+
+	describe('getHighestCommonBlock', () => {
+		it('should return decodable block', async () => {
+			const { data } = await p2p.requestFromPeer(
+				{
+					procedure: 'getHighestCommonBlock',
+					data: {
+						ids: [
+							app['_node']['_chain'].genesisBlock.header.id.toString('base64'),
+							getRandomBytes(32).toString('base64'),
+						],
+					},
+				},
+				getPeerID(app),
+			);
+			const decodedBlock = app['_node']['_chain'].dataAccess.decodeBlockHeader(
+				Buffer.from(data as string, 'base64'),
+			);
+			expect(decodedBlock.height).toEqual(1);
+		});
+
+		it('should return undefined', async () => {
+			const { data } = await p2p.requestFromPeer(
+				{
+					procedure: 'getHighestCommonBlock',
+					data: {
+						ids: [getRandomBytes(32).toString('base64')],
+					},
+				},
+				getPeerID(app),
+			);
+			expect(data).toBeUndefined();
+		});
+	});
+});

--- a/framework/test/functional/specs/network/transactions.spec.ts
+++ b/framework/test/functional/specs/network/transactions.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { P2P } from '@liskhq/lisk-p2p';
+import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { Application } from '../../../../src';
+import {
+	createApplication,
+	closeApplication,
+	getPeerID,
+	waitNBlocks,
+	sendTransaction,
+} from '../../utils/application';
+import { createProbe } from '../../utils/probe';
+
+describe('Public transaction related P2P endpoints', () => {
+	let app: Application;
+	let p2p: P2P;
+
+	beforeAll(async () => {
+		app = await createApplication('network-transactions');
+		p2p = await createProbe(app.config);
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('getTransactions', () => {
+		it('should be rejected if unknown transaction is queried', async () => {
+			await expect(
+				p2p.requestFromPeer(
+					{
+						procedure: 'getTransactions',
+						data: {
+							transactionIds: [getRandomBytes(32).toString('base64')],
+						},
+					},
+					getPeerID(app),
+				),
+			).rejects.toThrow('does not exist');
+		});
+
+		it('should return transaction if known transaction id is queried', async () => {
+			const sendTx = await sendTransaction(app);
+			await waitNBlocks(app, 1);
+			const { data } = (await p2p.requestFromPeer(
+				{
+					procedure: 'getTransactions',
+					data: {
+						transactionIds: [sendTx.id.toString('base64')],
+					},
+				},
+				getPeerID(app),
+			)) as { data: { transactions: string[] } };
+			expect(data.transactions).toHaveLength(1);
+		});
+	});
+});

--- a/framework/test/functional/specs/network/transactions.spec.ts
+++ b/framework/test/functional/specs/network/transactions.spec.ts
@@ -11,8 +11,9 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { P2P } from '@liskhq/lisk-p2p';
+import { P2P, events, p2pTypes } from '@liskhq/lisk-p2p';
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { TransferTransaction } from '@liskhq/lisk-transactions';
 import { Application } from '../../../../src';
 import {
 	createApplication,
@@ -22,6 +23,8 @@ import {
 	sendTransaction,
 } from '../../utils/application';
 import { createProbe } from '../../utils/probe';
+import { genesis } from '../../../fixtures';
+import { nodeUtils } from '../../../utils';
 
 describe('Public transaction related P2P endpoints', () => {
 	let app: Application;
@@ -64,6 +67,44 @@ describe('Public transaction related P2P endpoints', () => {
 				getPeerID(app),
 			)) as { data: { transactions: string[] } };
 			expect(data.transactions).toHaveLength(1);
+		});
+	});
+
+	describe('postTransactionsAnnouncement', () => {
+		it('should request announced transaction', async () => {
+			const genesisAccount = await app['_node'][
+				'_chain'
+			].dataAccess.getAccountByAddress(genesis.address);
+			const accountWithoutBalance = nodeUtils.createAccount();
+			const tx = new TransferTransaction({
+				nonce: genesisAccount.nonce,
+				senderPublicKey: genesis.publicKey,
+				fee: BigInt('200000'),
+				asset: {
+					recipientAddress: accountWithoutBalance.address,
+					amount: BigInt('10000000000'),
+					data: '',
+				},
+			});
+			tx.sign(app['_node']['_networkIdentifier'], genesis.passphrase);
+			p2p.sendToPeer(
+				{
+					event: 'postTransactionsAnnouncement',
+					data: { transactionIds: [tx.id.toString('base64')] },
+				},
+				getPeerID(app),
+			);
+
+			const request = await new Promise<p2pTypes.P2PRequestPacket>(resolve => {
+				p2p.on(events.EVENT_REQUEST_RECEIVED, (req: any) => {
+					req.end({ transaction: tx.getBytes().toString('base64') });
+					resolve(req);
+				});
+			});
+			expect(request.procedure).toEqual('getTransactions');
+			expect((request as any).data.transactionIds[0]).toEqual(
+				tx.id.toString('base64'),
+			);
 		});
 	});
 });

--- a/framework/test/functional/specs/network/transactions.spec.ts
+++ b/framework/test/functional/specs/network/transactions.spec.ts
@@ -40,18 +40,17 @@ describe('Public transaction related P2P endpoints', () => {
 	});
 
 	describe('getTransactions', () => {
-		it('should be rejected if unknown transaction is queried', async () => {
-			await expect(
-				p2p.requestFromPeer(
-					{
-						procedure: 'getTransactions',
-						data: {
-							transactionIds: [getRandomBytes(32).toString('base64')],
-						},
+		it('should return empty array if unknown transaction is queried', async () => {
+			const { data } = (await p2p.requestFromPeer(
+				{
+					procedure: 'getTransactions',
+					data: {
+						transactionIds: [getRandomBytes(32).toString('base64')],
 					},
-					getPeerID(app),
-				),
-			).rejects.toThrow('does not exist');
+				},
+				getPeerID(app),
+			)) as { data: { transactions: string[] } };
+			expect(data.transactions).toHaveLength(0);
 		});
 
 		it('should return transaction if known transaction id is queried', async () => {

--- a/framework/test/functional/utils/application.ts
+++ b/framework/test/functional/utils/application.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { TransferTransaction } from '@liskhq/lisk-transactions';
+import * as genesisBlockJSON from '../../fixtures/config/devnet/genesis_block.json';
+import * as configJSON from '../../fixtures/config/devnet/config.json';
+import { Application, ApplicationConfig } from '../../../src';
+import { GenesisBlockJSON } from '../../../src/application/node/node';
+import { genesis } from '../../fixtures';
+import { nodeUtils } from '../../utils';
+
+export const createApplication = async (
+	label: string,
+	consoleLogLevel?: string,
+): Promise<Application> => {
+	const config = {
+		...configJSON,
+		rootPath: '~/.lisk/functional',
+		label,
+		logger: {
+			consoleLogLevel: consoleLogLevel ?? 'fatal',
+			fileLogLevel: 'fatal',
+		},
+	} as Partial<ApplicationConfig>;
+	genesisBlockJSON.header.timestamp = 128113100;
+	const app = new Application(genesisBlockJSON as GenesisBlockJSON, config);
+
+	// eslint-disable-next-line @typescript-eslint/no-floating-promises
+	await Promise.race([
+		app.run(),
+		new Promise(resolve => setTimeout(resolve, 3000)),
+	]);
+	let blockHeight = 0;
+	await new Promise(resolve => {
+		app['_channel'].subscribe('app:block:new', () => {
+			blockHeight += 1;
+			if (blockHeight === 2) {
+				resolve();
+			}
+		});
+	});
+	return app;
+};
+
+export const closeApplication = async (app: Application): Promise<void> => {
+	await app['_forgerDB'].clear();
+	await app['_blockchainDB'].clear();
+	await app.shutdown();
+};
+
+export const getPeerID = (app: Application): string =>
+	`127.0.0.1:${app.config.network.wsPort}`;
+
+export const waitNBlocks = async (app: Application, n = 1): Promise<void> => {
+	const height = app['_node']['_chain'].lastBlock.header.height + n;
+	return new Promise(resolve => {
+		app['_channel'].subscribe('app:block:new', () => {
+			if (app['_node']['_chain'].lastBlock.header.height >= height) {
+				resolve();
+			}
+		});
+	});
+};
+
+export const sendTransaction = async (
+	app: Application,
+): Promise<TransferTransaction> => {
+	const genesisAccount = await app['_node'][
+		'_chain'
+	].dataAccess.getAccountByAddress(genesis.address);
+	const accountWithoutBalance = nodeUtils.createAccount();
+	const fundingTx = new TransferTransaction({
+		nonce: genesisAccount.nonce,
+		senderPublicKey: genesis.publicKey,
+		fee: BigInt('200000'),
+		asset: {
+			recipientAddress: accountWithoutBalance.address,
+			amount: BigInt('10000000000'),
+			data: '',
+		},
+	});
+	fundingTx.sign(app['_node']['_networkIdentifier'], genesis.passphrase);
+
+	await app['_channel'].invoke('app:postTransaction', {
+		transaction: fundingTx.getBytes().toString('base64'),
+	});
+	return fundingTx;
+};

--- a/framework/test/functional/utils/application.ts
+++ b/framework/test/functional/utils/application.ts
@@ -53,6 +53,8 @@ export const createApplication = async (
 };
 
 export const closeApplication = async (app: Application): Promise<void> => {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
 	await app['_forgerDB'].clear();
 	await app['_blockchainDB'].clear();
 	await app.shutdown();

--- a/framework/test/functional/utils/probe.ts
+++ b/framework/test/functional/utils/probe.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { P2P, events } from '@liskhq/lisk-p2p';
+import { ApplicationConfig } from '../../../src';
+
+export const createProbe = async (config: ApplicationConfig): Promise<P2P> => {
+	const p2p = new P2P({
+		nodeInfo: {
+			protocolVersion: config.protocolVersion,
+			advertiseAddress: true,
+			wsPort: 1111,
+			networkId: config.networkId,
+			height: 3,
+			nonce: 'O2wTkjqplHII',
+			os: 'test-os',
+			version: config.version,
+		},
+		seedPeers: [
+			{
+				ipAddress: '127.0.0.1',
+				wsPort: config.network.wsPort,
+			},
+		],
+		populatorInterval: 50,
+		maxInboundConnections: 0,
+	});
+	const networkReady = new Promise(resolve => {
+		p2p.on(events.EVENT_NETWORK_READY, resolve);
+	});
+	await p2p.start();
+	await networkReady;
+
+	return p2p;
+};


### PR DESCRIPTION
### What was the problem?

This PR resolves #4894 

### How was it solved?

- Add functional tests for actions, events and open p2p endpoints

### How was it tested?

- Run in framework, `npm run test:functional`
