### PR TITLE
Getting multiple data using data access should not throw - Closes #5425

### DIFF
--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -331,8 +331,15 @@ export class Storage {
 	): Promise<Buffer[]> {
 		const accounts = [];
 		for (const address of arrayOfAddresses) {
-			const account = await this.getAccountByAddress(address);
-			accounts.push(account);
+			try {
+				const account = await this.getAccountByAddress(address);
+				accounts.push(account);
+			} catch (dbError) {
+				if (dbError instanceof NotFoundError) {
+					continue;
+				}
+				throw dbError;
+			}
 		}
 
 		return accounts;

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -11,7 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-// TODO: Remove this after using lisk-codec
+/* eslint-disable no-continue */
 
 import {
 	KVStore,
@@ -56,8 +56,17 @@ export class Storage {
 	): Promise<Buffer[]> {
 		const blocks = [];
 		for (const id of arrayOfBlockIds) {
-			const block = await this._db.get(`${DB_KEY_BLOCKS_ID}:${keyString(id)}`);
-			blocks.push(block);
+			try {
+				const block = await this._db.get(
+					`${DB_KEY_BLOCKS_ID}:${keyString(id)}`,
+				);
+				blocks.push(block);
+			} catch (dbError) {
+				if (dbError instanceof NotFoundError) {
+					continue;
+				}
+				throw dbError;
+			}
 		}
 		return blocks;
 	}
@@ -99,8 +108,15 @@ export class Storage {
 	): Promise<Buffer[]> {
 		const blocks = [];
 		for (const height of heightList) {
-			const block = await this.getBlockHeaderByHeight(height);
-			blocks.push(block);
+			try {
+				const block = await this.getBlockHeaderByHeight(height);
+				blocks.push(block);
+			} catch (dbError) {
+				if (dbError instanceof NotFoundError) {
+					continue;
+				}
+				throw dbError;
+			}
 		}
 		return blocks;
 	}
@@ -147,9 +163,17 @@ export class Storage {
 		arrayOfBlockIds: ReadonlyArray<Buffer>,
 	): Promise<RawBlock[]> {
 		const blocks = [];
+
 		for (const id of arrayOfBlockIds) {
-			const block = await this.getBlockByID(id);
-			blocks.push(block);
+			try {
+				const block = await this.getBlockByID(id);
+				blocks.push(block);
+			} catch (dbError) {
+				if (dbError instanceof NotFoundError) {
+					continue;
+				}
+				throw dbError;
+			}
 		}
 
 		return blocks;

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -361,8 +361,15 @@ export class Storage {
 	): Promise<Buffer[]> {
 		const transactions = [];
 		for (const id of arrayOfTransactionIds) {
-			const transaction = await this.getTransactionByID(id);
-			transactions.push(transaction);
+			try {
+				const transaction = await this.getTransactionByID(id);
+				transactions.push(transaction);
+			} catch (dbError) {
+				if (dbError instanceof NotFoundError) {
+					continue;
+				}
+				throw dbError;
+			}
 		}
 
 		return transactions;

--- a/elements/lisk-chain/test/integration/data_access/accounts.spec.ts
+++ b/elements/lisk-chain/test/integration/data_access/accounts.spec.ts
@@ -111,17 +111,23 @@ describe('dataAccess.transactions', () => {
 	});
 
 	describe('getAccountsByPublicKey', () => {
-		it('should throw not found error if non existent public key is specified', async () => {
-			expect.assertions(1);
-			try {
-				await dataAccess.getAccountsByPublicKey([
+		it('should not throw "not found" error if non existent public key is specified', async () => {
+			await expect(
+				dataAccess.getAccountsByPublicKey([
 					getRandomBytes(32),
 					accounts[0].publicKey,
-				]);
-			} catch (error) {
-				// eslint-disable-next-line jest/no-try-expect
-				expect(error).toBeInstanceOf(NotFoundError);
-			}
+				]),
+			).resolves.toEqual([accounts[0]]);
+		});
+
+		it('should return existing accounts by public keys if one invalid public specified', async () => {
+			await expect(
+				dataAccess.getAccountsByPublicKey([
+					accounts[1].publicKey,
+					getRandomBytes(32),
+					accounts[0].publicKey,
+				]),
+			).resolves.toEqual([accounts[1], accounts[0]]);
 		});
 
 		it('should return account by public keys', async () => {
@@ -135,17 +141,23 @@ describe('dataAccess.transactions', () => {
 	});
 
 	describe('getAccountsByAddress', () => {
-		it('should throw not found error if non existent address is specified', async () => {
-			expect.assertions(1);
-			try {
-				await dataAccess.getAccountsByAddress([
+		it('should not throw "not found" error if non existent address is specified', async () => {
+			await expect(
+				dataAccess.getAccountsByAddress([
 					getRandomBytes(20),
 					accounts[0].address,
-				]);
-			} catch (error) {
-				// eslint-disable-next-line jest/no-try-expect
-				expect(error).toBeInstanceOf(NotFoundError);
-			}
+				]),
+			).resolves.toEqual([accounts[0]]);
+		});
+
+		it('should return existing accounts by address if one invalid address specified', async () => {
+			await expect(
+				dataAccess.getAccountsByAddress([
+					accounts[1].address,
+					getRandomBytes(20),
+					accounts[0].address,
+				]),
+			).resolves.toEqual([accounts[1], accounts[0]]);
 		});
 
 		it('should return account by address', async () => {

--- a/elements/lisk-chain/test/integration/data_access/transactions.spec.ts
+++ b/elements/lisk-chain/test/integration/data_access/transactions.spec.ts
@@ -77,17 +77,23 @@ describe('dataAccess.transactions', () => {
 	});
 
 	describe('getTransactionsByIDs', () => {
-		it('should throw not found error if one of ID specified does not exist', async () => {
-			expect.assertions(1);
-			try {
-				await dataAccess.getTransactionsByIDs([
+		it('should not throw "not found" error if one of ID specified does not exist', async () => {
+			await expect(
+				dataAccess.getTransactionsByIDs([
 					Buffer.from('randomId'),
 					transactions[0].id,
-				]);
-			} catch (error) {
-				// eslint-disable-next-line jest/no-try-expect
-				expect(error).toBeInstanceOf(NotFoundError);
-			}
+				]),
+			).resolves.toEqual([transactions[0]]);
+		});
+
+		it('should return existent transaction by ID when some of the IDs do not exist', async () => {
+			await expect(
+				dataAccess.getTransactionsByIDs([
+					transactions[1].id,
+					Buffer.from('randomId'),
+					transactions[0].id,
+				]),
+			).resolves.toEqual([transactions[1], transactions[0]]);
 		});
 
 		it('should return transaction by ID', async () => {

--- a/framework/src/application/node/transport/transport.ts
+++ b/framework/src/application/node/transport/transport.ts
@@ -343,17 +343,9 @@ export class Transport {
 
 		if (idsNotInPool.length) {
 			// Check if any transaction that was not in the queues, is in the database instead.
-			const transactionsFromDatabase: BaseTransaction[] = [];
-			for (const id of idsNotInPool) {
-				try {
-					const tx = await this._chainModule.dataAccess.getTransactionByID(id);
-					transactionsFromDatabase.push(tx);
-				} catch (error) {
-					if (!(error instanceof NotFoundError)) {
-						throw error;
-					}
-				}
-			}
+			const transactionsFromDatabase: BaseTransaction[] = await this._chainModule.dataAccess.getTransactionsByIDs(
+				idsNotInPool,
+			);
 
 			return {
 				transactions: transactionsFromQueues.concat(

--- a/framework/src/application/node/transport/transport.ts
+++ b/framework/src/application/node/transport/transport.ts
@@ -17,7 +17,6 @@ import { Chain, Block } from '@liskhq/lisk-chain';
 import { p2pTypes } from '@liskhq/lisk-p2p';
 import { TransactionPool } from '@liskhq/lisk-transaction-pool';
 import { BaseTransaction, TransactionJSON } from '@liskhq/lisk-transactions';
-import { NotFoundError } from '@liskhq/lisk-db';
 import { convertErrorsToString } from '../utils/error_handlers';
 import { InvalidTransactionError } from './errors';
 import { schemas } from './schemas';
@@ -459,17 +458,9 @@ export class Transport {
 
 		if (unknownTransactionsIDs.length) {
 			// Check if any transaction exists in the database.
-			const existingTransactions: BaseTransaction[] = [];
-			for (const id of unknownTransactionsIDs) {
-				try {
-					const tx = await this._chainModule.dataAccess.getTransactionByID(id);
-					existingTransactions.push(tx);
-				} catch (error) {
-					if (!(error instanceof NotFoundError)) {
-						throw error;
-					}
-				}
-			}
+			const existingTransactions: BaseTransaction[] = await this._chainModule.dataAccess.getTransactionsByIDs(
+				unknownTransactionsIDs,
+			);
 
 			return unknownTransactionsIDs.filter(
 				id =>

--- a/framework/test/unit/specs/application/node/transport/transport.spec.ts
+++ b/framework/test/unit/specs/application/node/transport/transport.spec.ts
@@ -16,7 +16,6 @@ import { when } from 'jest-when';
 import { TransferTransaction } from '@liskhq/lisk-transactions';
 import { getAddressAndPublicKeyFromPassphrase } from '@liskhq/lisk-cryptography';
 import { BufferMap } from '@liskhq/lisk-transaction-pool';
-import { NotFoundError } from '@liskhq/lisk-db';
 import { Transport } from '../../../../../../src/application/node/transport';
 import { genesis } from '../../../../../fixtures';
 import { devnetNetworkIdentifier as networkIdentifier } from '../../../../../utils/network_identifier';
@@ -787,9 +786,7 @@ describe('Transport', () => {
 		describe('when none of the transactions ids are known', () => {
 			beforeEach(() => {
 				transactionPoolStub.contains.mockReturnValue(false);
-				chainStub.dataAccess.getTransactionByID.mockRejectedValue(
-					new NotFoundError('not found'),
-				);
+				chainStub.dataAccess.getTransactionsByIDs.mockResolvedValue([]);
 				chainStub.dataAccess.decodeTransaction
 					.mockReturnValueOnce(txInstance)
 					.mockReturnValueOnce(tx2Instance);
@@ -873,9 +870,7 @@ describe('Transport', () => {
 						data: { transactions: [tx2] },
 						peerId: defaultPeerId,
 					} as never);
-				chainStub.dataAccess.getTransactionByID.mockRejectedValue(
-					new NotFoundError('not found'),
-				);
+				chainStub.dataAccess.getTransactionsByIDs.mockResolvedValue([]);
 				chainStub.dataAccess.decodeTransaction.mockReturnValue(tx2Instance);
 			});
 

--- a/framework/test/unit/specs/application/node/transport/transport.spec.ts
+++ b/framework/test/unit/specs/application/node/transport/transport.spec.ts
@@ -64,6 +64,7 @@ describe('Transport', () => {
 				.mockReturnValue([{ status: 1, errors: [] }]),
 			dataAccess: {
 				getTransactionByID: jest.fn(),
+				getTransactionsByIDs: jest.fn(),
 				getHighestCommonBlockHeader: jest.fn(),
 				decodeTransaction: jest.fn(),
 				encodeBlockHeader: jest.fn().mockReturnValue(encodedBlock),
@@ -627,7 +628,9 @@ describe('Transport', () => {
 				);
 				txDatabase = txDatabaseInstance;
 				when(transactionPoolStub.get).calledWith(tx.id).mockReturnValue(tx);
-				chainStub.dataAccess.getTransactionByID.mockResolvedValue(txDatabase);
+				chainStub.dataAccess.getTransactionsByIDs.mockResolvedValue([
+					txDatabase,
+				]);
 			});
 
 			it('should call find get with the id', async () => {
@@ -645,7 +648,9 @@ describe('Transport', () => {
 			});
 
 			it('should return transaction in the pool', async () => {
-				chainStub.dataAccess.getTransactionByID.mockResolvedValue(txDatabase);
+				chainStub.dataAccess.getTransactionsByIDs.mockResolvedValue([
+					txDatabase,
+				]);
 				const result = await transport.handleRPCGetTransactions(
 					{
 						transactionIds: [

--- a/framework/test/unit/specs/application/node/transport/transport_private.spec.ts
+++ b/framework/test/unit/specs/application/node/transport/transport_private.spec.ts
@@ -19,7 +19,6 @@ import {
 } from '@liskhq/lisk-transactions';
 import { validator } from '@liskhq/lisk-validator';
 import { getAddressAndPublicKeyFromPassphrase } from '@liskhq/lisk-cryptography';
-import { NotFoundError } from '@liskhq/lisk-db';
 import { Logger } from '../../../../../../src/application/logger';
 import { Transport } from '../../../../../../src/application/node/transport';
 
@@ -166,6 +165,7 @@ describe('transport', () => {
 						{ height: 37, version: 1, timestamp: 1 },
 					]),
 					getTransactionByID: jest.fn(),
+					getTransactionsByIDs: jest.fn(),
 					decodeTransaction: jest.fn().mockReturnValue(transaction),
 					encode: jest.fn().mockReturnValue(encodedBlock),
 					decode: jest.fn().mockReturnValue(getGenesisBlock()),
@@ -208,9 +208,7 @@ describe('transport', () => {
 					].contains = jest.fn().mockReturnValue(false);
 					transportModule[
 						'_chainModule'
-					].dataAccess.getTransactionByID = jest
-						.fn()
-						.mockRejectedValue(new NotFoundError('not found'));
+					].dataAccess.getTransactionsByIDs = jest.fn().mockReturnValue([]);
 					resultTransactionsIDsCheck = await transportModule._obtainUnknownTransactionIDs(
 						query.ids,
 					);
@@ -225,12 +223,9 @@ describe('transport', () => {
 				});
 
 				it('should call transportModule._chainModule.dataAccess.getTransactionByID with query.transaction.ids as arguments', () => {
-					expect.assertions(transactionsList.length);
-					for (const tx of transactionsList) {
-						expect(
-							transportModule['_chainModule'].dataAccess.getTransactionByID,
-						).toHaveBeenCalledWith(tx.id);
-					}
+					expect(
+						transportModule['_chainModule'].dataAccess.getTransactionsByIDs,
+					).toHaveBeenCalledWith(transactionsList.map(tx => tx.id));
 				});
 
 				it('should return array of transactions ids', () =>
@@ -282,10 +277,9 @@ describe('transport', () => {
 					].contains = jest.fn().mockReturnValue(false);
 					transportModule[
 						'_chainModule'
-					].dataAccess.getTransactionByID = jest
+					].dataAccess.getTransactionsByIDs = jest
 						.fn()
-						.mockResolvedValueOnce(transactionsList[0])
-						.mockResolvedValueOnce(transactionsList[1]);
+						.mockResolvedValue(transactionsList);
 					resultTransactionsIDsCheck = await transportModule._obtainUnknownTransactionIDs(
 						query.ids,
 					);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5425

### How was it solved?

- By catching instances of `NotFoundError` thrown by the db module and not letting them bubble up.
- By removing transport temp fix for this issue and replacing with correct data access method

### How was it tested?

- added integration tests
- added missing integration tests for some methods that were missing