### PR TITLE
Improve performance of Lisk-codec - Partially Solves #5353

### DIFF
--- a/elements/lisk-codec/src/bytes.ts
+++ b/elements/lisk-codec/src/bytes.ts
@@ -11,10 +11,9 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { writeUInt32, readUInt32 } from './varint';
+import { readUInt32 } from './varint';
 
-export const writeBytes = (bytes: Buffer): Buffer =>
-	Buffer.concat([writeUInt32(bytes.length), bytes]);
+export const writeBytes = (bytes: Buffer): Buffer => bytes;
 
 export const readBytes = (buffer: Buffer, offset: number): [Buffer, number] => {
 	const [byteLength, keySize] = readUInt32(buffer, offset);

--- a/elements/lisk-codec/src/string.ts
+++ b/elements/lisk-codec/src/string.ts
@@ -11,12 +11,12 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { readBytes, writeBytes } from './bytes';
+import { readBytes } from './bytes';
 
 export const writeString = (value: string): Buffer => {
 	const stringBuffer = Buffer.from(value, 'utf8');
 
-	return writeBytes(stringBuffer);
+	return stringBuffer;
 };
 
 export const readString = (buffer: Buffer, offset: number): [string, number] => {


### PR DESCRIPTION
### What was the problem?

This PR partially resolves #5353

### How was it solved?

- By removing buffer.concat from bytes/string writers and replacing with regular push to array

Benchmark before change
```
node benchmark/encode
encode x 130,545 ops/sec ±0.74% (91 runs sampled)
```
Benchmark after change
```
node benchmark/encode
encode x 162,285 ops/sec ±0.45% (90 runs sampled)
```
So this change would yield about 32K more encodings per second

### How was it tested?

- Need to update tests 
- Need to check real impact in string/bytes readers
