### PR TITLE
Create and export toJSON and toObject from lisk-codec - Closes #5473

### DIFF
--- a/elements/lisk-codec/src/codec.ts
+++ b/elements/lisk-codec/src/codec.ts
@@ -130,7 +130,7 @@ export class Codec {
 
 	// For performance applications use encode() instead!
 	public encodeJSON(schema: Schema, message: object): Buffer {
-		const objectFromJson = this.toObject(schema, message);
+		const objectFromJson = this.fromJSON(schema, message);
 		return this.encode(schema, objectFromJson);
 	}
 
@@ -149,7 +149,7 @@ export class Codec {
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	public toObject<T = object>(schema: Schema, message: object): T {
+	public fromJSON<T = object>(schema: Schema, message: object): T {
 		const messageCopy = objectUtils.cloneDeep(message);
 		(messageCopy as IteratableGenericObject)[Symbol.iterator] = iterator;
 

--- a/elements/lisk-codec/test/fromJSON.spec.ts
+++ b/elements/lisk-codec/test/fromJSON.spec.ts
@@ -92,7 +92,7 @@ describe('toJSON', () => {
 			},
 		};
 
-		const res = codec.toObject(schema, jsonLikeObject);
+		const res = codec.fromJSON(schema, jsonLikeObject);
 		expect(res).toEqual(jsObject);
 	});
 });

--- a/elements/lisk-codec/test/toJSON.spec.ts
+++ b/elements/lisk-codec/test/toJSON.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { codec } from '../src/codec';
+import * as accountEncoding from '../fixtures/account_encodings.json';
+
+describe('toJSON', () => {
+	it('should return JSON like object from JS object', () => {
+		const { schema, object } = accountEncoding.testCases[0].input;
+
+		const jsObject = {
+			...object,
+			address: Buffer.from(object.address.data),
+			balance: BigInt(object.balance),
+			publicKey: Buffer.from(object.publicKey.data),
+			nonce: BigInt(object.nonce),
+			keys: {
+				...object.keys,
+				mandatoryKeys: object.keys.mandatoryKeys.map(mKey =>
+					Buffer.from(mKey.data),
+				),
+				optionalKeys: object.keys.optionalKeys.map((oKey: any) =>
+					Buffer.from(oKey.data),
+				),
+			},
+			asset: {
+				...object.asset,
+				delegate: {
+					...object.asset.delegate,
+					totalVotesReceived: BigInt(object.asset.delegate.totalVotesReceived),
+				},
+				sentVotes: object.asset.sentVotes.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data),
+					amount: BigInt(v.amount),
+				})),
+				unlocking: object.asset.unlocking.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data),
+					amount: BigInt(v.amount.toString()),
+				})),
+			},
+		};
+
+		const jsonLikeObject = {
+			...object,
+			address: Buffer.from(object.address.data).toString('base64'),
+			balance: BigInt(object.balance).toString(),
+			publicKey: Buffer.from(object.publicKey.data).toString('base64'),
+			nonce: BigInt(object.nonce).toString(),
+			keys: {
+				...object.keys,
+				mandatoryKeys: object.keys.mandatoryKeys.map(mKey =>
+					Buffer.from(mKey.data).toString('base64'),
+				),
+				optionalKeys: object.keys.optionalKeys.map((oKey: any) =>
+					Buffer.from(oKey.data).toString('base64'),
+				),
+			},
+			asset: {
+				...object.asset,
+				delegate: {
+					...object.asset.delegate,
+					totalVotesReceived: BigInt(
+						object.asset.delegate.totalVotesReceived,
+					).toString(),
+				},
+				sentVotes: object.asset.sentVotes.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data).toString(
+						'base64',
+					),
+					amount: BigInt(v.amount).toString(),
+				})),
+				unlocking: object.asset.unlocking.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data).toString(
+						'base64',
+					),
+					amount: BigInt(v.amount.toString()).toString(),
+				})),
+			},
+		};
+
+		const res = codec.toJSON(schema, jsObject);
+		expect(res).toEqual(jsonLikeObject);
+	});
+});

--- a/elements/lisk-codec/test/toObject.spec.ts
+++ b/elements/lisk-codec/test/toObject.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { codec } from '../src/codec';
+import * as accountEncoding from '../fixtures/account_encodings.json';
+
+describe('toJSON', () => {
+	it('should return JSON like object from JS object', () => {
+		const { schema, object } = accountEncoding.testCases[0].input;
+
+		const jsObject = {
+			...object,
+			address: Buffer.from(object.address.data),
+			balance: BigInt(object.balance),
+			publicKey: Buffer.from(object.publicKey.data),
+			nonce: BigInt(object.nonce),
+			keys: {
+				...object.keys,
+				mandatoryKeys: object.keys.mandatoryKeys.map(mKey =>
+					Buffer.from(mKey.data),
+				),
+				optionalKeys: object.keys.optionalKeys.map((oKey: any) =>
+					Buffer.from(oKey.data),
+				),
+			},
+			asset: {
+				...object.asset,
+				delegate: {
+					...object.asset.delegate,
+					totalVotesReceived: BigInt(object.asset.delegate.totalVotesReceived),
+				},
+				sentVotes: object.asset.sentVotes.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data),
+					amount: BigInt(v.amount),
+				})),
+				unlocking: object.asset.unlocking.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data),
+					amount: BigInt(v.amount.toString()),
+				})),
+			},
+		};
+
+		const jsonLikeObject = {
+			...object,
+			address: Buffer.from(object.address.data).toString('base64'),
+			balance: BigInt(object.balance).toString(),
+			publicKey: Buffer.from(object.publicKey.data).toString('base64'),
+			nonce: BigInt(object.nonce).toString(),
+			keys: {
+				...object.keys,
+				mandatoryKeys: object.keys.mandatoryKeys.map(mKey =>
+					Buffer.from(mKey.data).toString('base64'),
+				),
+				optionalKeys: object.keys.optionalKeys.map((oKey: any) =>
+					Buffer.from(oKey.data).toString('base64'),
+				),
+			},
+			asset: {
+				...object.asset,
+				delegate: {
+					...object.asset.delegate,
+					totalVotesReceived: BigInt(
+						object.asset.delegate.totalVotesReceived,
+					).toString(),
+				},
+				sentVotes: object.asset.sentVotes.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data).toString(
+						'base64',
+					),
+					amount: BigInt(v.amount).toString(),
+				})),
+				unlocking: object.asset.unlocking.map(v => ({
+					...v,
+					delegateAddress: Buffer.from(v.delegateAddress.data).toString(
+						'base64',
+					),
+					amount: BigInt(v.amount.toString()).toString(),
+				})),
+			},
+		};
+
+		const res = codec.toObject(schema, jsonLikeObject);
+		expect(res).toEqual(jsObject);
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5473

### How was it solved?

By refactoring `decodeJSON` and `encodeJSON` to use the newly exported methods `toJSON` and `toObject`

### How was it tested?

Unit Tests
