### PR TITLE
Fix npm package setting and export codec and utils - Closes #5501 

### DIFF
--- a/framework/.npmignore
+++ b/framework/.npmignore
@@ -1,5 +1,1 @@
-*
-
-!src/**/*
-!docs/**/*
-!README.md
+../templates/.npmignore.tmpl

--- a/sdk/.npmignore
+++ b/sdk/.npmignore
@@ -1,5 +1,1 @@
-*
-
-!src/**/*
-!docs/**/*
-!README.md
+../templates/.npmignore.tmpl

--- a/sdk/.npmrc
+++ b/sdk/.npmrc
@@ -1,2 +1,1 @@
-message = ":arrow_up: Version %s"
-save-exact = true
+../templates/.npmrc.tmpl

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -28,9 +28,11 @@
 		"build": "tsc"
 	},
 	"dependencies": {
+		"@liskhq/lisk-codec": "0.1.0",
 		"@liskhq/lisk-cryptography": "2.5.0-alpha.0",
 		"@liskhq/lisk-framework-http-api-plugin": "0.1.0",
 		"@liskhq/lisk-transactions": "4.0.0-alpha.0",
+		"@liskhq/lisk-utils": "0.1.0",
 		"@liskhq/lisk-validator": "0.4.0-alpha.0",
 		"lisk-framework": "0.6.0-alpha.0"
 	},

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -15,6 +15,8 @@
 export * as cryptography from '@liskhq/lisk-cryptography';
 export * as transactions from '@liskhq/lisk-transactions';
 export * as validator from '@liskhq/lisk-validator';
+export * as utils from '@liskhq/lisk-utils';
+export { codec } from '@liskhq/lisk-codec';
 export * from '@liskhq/lisk-framework-http-api-plugin';
 export * from 'lisk-framework';
 

--- a/templates/.npmignore.tmpl
+++ b/templates/.npmignore.tmpl
@@ -1,19 +1,24 @@
 .babelrc
 .eslintignore
 .eslintrc.json
+.eslintrc.js
 .gitignore
 .lintstagedrc.json
 .nycrc
 .prettierrc.json
+.prettierignore
 cypress.json
 index.html
 Jenkinsfile*
+*.log
 
 .nyc_output/
 coverage/
+.coverage/
 cypress/
 fixtures/
 tmp/
+logs/
 src/
 test/
 browsertest/


### PR DESCRIPTION
### What was the problem?

This PR resolves #5501 

### How was it solved?

- Update npmignore to use the same file as other packages
- Export utils and codec from SDK

### How was it tested?

- npm pack --dry-run in sdk and framework, check if the dist-node is packed
- check the built file to see if utils and codec is exposed
