### PR TITLE
Fix cleanup socket files after application stop - Closes #5185

### DIFF
--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -327,7 +327,7 @@ export class Application {
 			await this._blockchainDB.close();
 			await this._forgerDB.close();
 			await this._nodeDB.close();
-			await this.emptyDirectory();
+			await this._emptySocketsDirectory();
 		} catch (error) {
 			this.logger.fatal({ err: error as Error }, 'failed to shutdown');
 		}
@@ -599,7 +599,7 @@ export class Application {
 		);
 	}
 
-	private async emptyDirectory(): Promise<void> {
+	private async _emptySocketsDirectory(): Promise<void> {
 		const { sockets } = systemDirs(this.config.label, this.config.rootPath);
 		const socketFiles = fs.readdirSync(sockets);
 

--- a/framework/test/unit/specs/application/application.spec.ts
+++ b/framework/test/unit/specs/application/application.spec.ts
@@ -15,6 +15,8 @@
 
 import * as fs from 'fs-extra';
 import * as os from 'os';
+import { join } from 'path';
+
 import {
 	BaseTransaction as Base,
 	TransferTransaction,
@@ -412,6 +414,40 @@ describe('Application', () => {
 				`${dirs.pids}/controller.pid`,
 				expect.toBeNumber(),
 			);
+		});
+	});
+
+	describe('#_emptySocketsDirectory', () => {
+		let app: Application;
+		const fakeSocketFiles = ['1.sock' as any, '2.sock' as any];
+
+		beforeEach(async () => {
+			app = new Application(genesisBlock as GenesisBlockJSON, config);
+			try {
+				await app.run();
+			} catch (error) {
+				// Expected error
+			}
+			jest.spyOn(fs, 'readdirSync').mockReturnValue(fakeSocketFiles);
+		});
+
+		it('should delete all files in ~/.lisk/tmp/sockets', () => {
+			const { sockets: socketsPath } = systemDirs(
+				app.config.label,
+				app.config.rootPath,
+			);
+
+			// Arrange
+			const spy = jest.spyOn(fs, 'unlink').mockReturnValue(Promise.resolve());
+			(app as any)._emptySocketsDirectory();
+
+			// Assert
+			for (const aSocketFile of fakeSocketFiles) {
+				expect(spy).toHaveBeenCalledWith(
+					join(socketsPath, aSocketFile),
+					expect.anything(),
+				);
+			}
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5185

### How was it solved?

By adding a function to delete all files in the sockets directory for the app instance being shut down

### How was it tested?

Added unit test
