### PR TITLE
Update GET /api/accounts/:address endpoint - Closes #5250

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
@@ -20,7 +20,9 @@ export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 	res: Response,
 	next: NextFunction,
 ): Promise<void> => {
-	if (!isBase64String(req.params.address)) {
+	const accountAddres = req.params.address;
+
+	if (!isBase64String(accountAddres)) {
 		res.status(400).send({
 			errors: [{ message: 'The Address parameter should be a base64 string.' }],
 		});
@@ -28,7 +30,7 @@ export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 
 	try {
 		const account: Buffer = await channel.invoke('app:getAccount', {
-			address: req.params.address,
+			address: accountAddres,
 		});
 		res.status(200).send(codec.decodeAccount(account));
 	} catch (err) {
@@ -37,11 +39,9 @@ export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 				(err as Error).message,
 			)
 		) {
-			res
-				.status(404)
-				.send({
-					message: `Account with address '${req.params.address}' was not found`,
-				});
+			res.status(404).send({
+				message: `Account with address '${accountAddres}' was not found`,
+			});
 		} else {
 			next(err);
 		}

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
@@ -41,7 +41,9 @@ export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 			)
 		) {
 			res.status(404).send({
-				message: `Account with address '${accountAddres}' was not found`,
+				errors: [
+					{ message: `Account with address '${accountAddres}' was not found` },
+				],
 			});
 		} else {
 			next(err);

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
@@ -13,9 +13,9 @@
  */
 import { Request, Response, NextFunction } from 'express';
 import { isBase64String } from '@liskhq/lisk-validator';
-import { BaseChannel } from 'lisk-framework';
+import { BaseChannel, PluginCodec } from 'lisk-framework';
 
-export const accountController = (channel: BaseChannel) => async (
+export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 	req: Request,
 	res: Response,
 	next: NextFunction,
@@ -27,10 +27,10 @@ export const accountController = (channel: BaseChannel) => async (
 	}
 
 	try {
-		const account = await channel.invoke('app:getAccount', {
+		const account: Buffer = await channel.invoke('app:getAccount', {
 			address: req.params.address,
 		});
-		res.status(200).send(account);
+		res.status(200).send(codec.decodeAccount(account));
 	} catch (err) {
 		if (
 			/^Specified key accounts:address:(.*)does not exist/.test(

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
@@ -39,7 +39,9 @@ export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 		) {
 			res
 				.status(404)
-				.send(`Account with address '${req.params.address}' was not found`);
+				.send({
+					message: `Account with address '${req.params.address}' was not found`,
+				});
 		} else {
 			next(err);
 		}

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
@@ -26,6 +26,7 @@ export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 		res.status(400).send({
 			errors: [{ message: 'The Address parameter should be a base64 string.' }],
 		});
+		return;
 	}
 
 	try {

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
@@ -12,5 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import * as accounts from './account';
+
 export * from './hello';
-export * from './account';
+export { accounts };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import * as accounts from './account';
-
 export * from './hello';
-export { accounts };
+
+export * as accounts from './account';

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
@@ -13,3 +13,4 @@
  */
 
 export * from './hello';
+export * from './account';

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -114,7 +114,7 @@ export class HTTPAPIPlugin extends BasePlugin {
 		this._app.get('/v1/hello', controllers.helloController(this._channel));
 		this._app.get(
 			'/api/accounts/:address',
-			controllers.accountController(this._channel),
+			controllers.accounts.getAccount(this._channel, this.codec),
 		);
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -112,5 +112,9 @@ export class HTTPAPIPlugin extends BasePlugin {
 
 	private _registerControllers(): void {
 		this._app.get('/v1/hello', controllers.helloController(this._channel));
+		this._app.get(
+			'/api/accounts/:address',
+			controllers.accountController(this._channel),
+		);
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -23,7 +23,7 @@ import * as express from 'express';
 import type { Express } from 'express';
 import * as cors from 'cors';
 import * as rateLimit from 'express-rate-limit';
-import * as controllers from './controllers';
+import { accounts, helloController } from './controllers';
 import * as middlewares from './middlewares';
 import * as config from './defaults';
 import { Options } from './types';
@@ -111,10 +111,10 @@ export class HTTPAPIPlugin extends BasePlugin {
 	}
 
 	private _registerControllers(): void {
-		this._app.get('/v1/hello', controllers.helloController(this._channel));
+		this._app.get('/v1/hello', helloController(this._channel));
 		this._app.get(
 			'/api/accounts/:address',
-			controllers.accounts.getAccount(this._channel, this.codec),
+			accounts.getAccount(this._channel, this.codec),
 		);
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Application } from 'lisk-framework';
+import axios from 'axios';
+import {
+	createApplication,
+	closeApplication,
+	getURL,
+} from './utils/application';
+
+describe('Hello endpoint', () => {
+	let app: Application;
+	const accountFixture = {
+		address: 'nQFJsJYtRL/Aip9k1a/Otigdf7U=',
+		balance: '0',
+		nonce: '0',
+		keys: {
+			numberOfSignatures: 0,
+			mandatoryKeys: [],
+			optionalKeys: [],
+		},
+		asset: {
+			delegate: {
+				username: 'genesis_5',
+				pomHeights: [],
+				consecutiveMissedBlocks: 0,
+				lastForgedHeight: 0,
+				isBanned: false,
+				totalVotesReceived: '1000000000000',
+			},
+			sentVotes: [
+				{
+					delegateAddress: 'nQFJsJYtRL/Aip9k1a/Otigdf7U=',
+					amount: '1000000000000',
+				},
+			],
+			unlocking: [],
+		},
+	};
+
+	beforeAll(async () => {
+		app = await createApplication('hello');
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('/api/accounts', () => {
+		it('should respond with account when account found in db', async () => {
+			const result = await axios.get(
+				getURL('/api/accounts/nQFJsJYtRL%2FAip9k1a%2FOtigdf7U%3D'),
+			);
+			expect(result.data).toEqual(accountFixture);
+			expect(result.status).toBe(200);
+		});
+
+		it('should respond with 404 and error message when account not found in db', async () => {
+			expect.assertions(2);
+			try {
+				await axios.get(
+					getURL('/api/accounts/nQFJsJYtRL%2FAip0k1a%2FOtigdf7U%3D'),
+				);
+			} catch (err) {
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.status).toBe(404);
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.data).toEqual({
+					message:
+						"Account with address 'nQFJsJYtRL/Aip0k1a/Otigdf7U=' was not found",
+				});
+			}
+		});
+
+		it('should respond with 400 and error message when address param is not base64', async () => {
+			expect.assertions(2);
+			try {
+				await axios.get(getURL('/api/accounts/-nein-no'));
+			} catch (err) {
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.status).toBe(400);
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.data).toEqual({
+					errors: [
+						{ message: 'The Address parameter should be a base64 string.' },
+					],
+				});
+			}
+		});
+	});
+});

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
@@ -77,8 +77,12 @@ describe('Account endpoint', () => {
 				expect(err.response.status).toBe(404);
 				// eslint-disable-next-line jest/no-try-expect
 				expect(err.response.data).toEqual({
-					message:
-						"Account with address 'nQFJsJYtRL/Aip0k1a/Otigdf7U=' was not found",
+					errors: [
+						{
+							message:
+								"Account with address 'nQFJsJYtRL/Aip0k1a/Otigdf7U=' was not found",
+						},
+					],
 				});
 			}
 		});

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
@@ -19,7 +19,7 @@ import {
 	getURL,
 } from './utils/application';
 
-describe('Hello endpoint', () => {
+describe('Account endpoint', () => {
 	let app: Application;
 	const accountFixture = {
 		address: 'nQFJsJYtRL/Aip9k1a/Otigdf7U=',

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -15,7 +15,7 @@
 export { Application } from './application';
 export { version } from './version';
 export { systemDirs } from './application/system_dirs';
-export { BasePlugin, PluginInfo } from './plugins/base_plugin';
+export { BasePlugin, PluginInfo, PluginCodec } from './plugins/base_plugin';
 export { IPCChannel } from './controller/channels';
 export type { BaseChannel } from './controller/channels';
 export type { EventsArray } from './controller/event';

--- a/framework/src/plugins/base_plugin.ts
+++ b/framework/src/plugins/base_plugin.ts
@@ -124,6 +124,11 @@ const decodeAccountToJSON = (
 	};
 };
 
+export interface PluginCodec {
+	decodeTransaction: (data: Buffer | string) => TransactionJSON;
+	decodeAccount: (data: Buffer | string) => AccountJSON;
+}
+
 export abstract class BasePlugin {
 	public readonly options: object;
 	public schemas!: {
@@ -138,10 +143,7 @@ export abstract class BasePlugin {
 		};
 	};
 
-	public codec: {
-		decodeTransaction: (data: Buffer | string) => TransactionJSON;
-		decodeAccount: (data: Buffer | string) => AccountJSON;
-	};
+	public codec: PluginCodec;
 
 	protected constructor(options: object) {
 		this.options = options;


### PR DESCRIPTION
### What was the problem?

This PR resolves #5250

### How was it solved?

- By adding controller for accounts
- By adding decoding to JSON in base plugin

### How was it tested?

- run `node test/test_app/index.js`
- send request: `http://localhost:4000/api/accounts/nQFJsJYtRL%2FAip9k1a%2FOtigdf7U%3D` should return account
- send request: `http://localhost:4000/api/accounts/nQFJsJYtRL%2FAip8k1a%2FOtigdf7U%3D` and should return 404 with message
- send request: `http://localhost:4000/api/accounts/-invalid` should fail with 400 and message
- Functional tests also added
