### PR TITLE
Remove caching for max height prevoted - Closes #5506

### DIFF
--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -16,11 +16,7 @@ import { codec } from '@liskhq/lisk-codec';
 import * as assert from 'assert';
 import { EventEmitter } from 'events';
 
-import {
-	EVENT_BFT_FINALIZED_HEIGHT_CHANGED,
-	FinalityManager,
-	CONSENSUS_STATE_DELEGATE_LEDGER_KEY,
-} from './finality_manager';
+import { EVENT_BFT_FINALIZED_HEIGHT_CHANGED, FinalityManager } from './finality_manager';
 import * as forkChoiceRule from './fork_choice_rule';
 import { BFTPersistedValues, BlockHeader, Chain, DPoS, ForkStatus, StateStore } from './types';
 
@@ -178,10 +174,7 @@ export class BFT extends EventEmitter {
 	}
 
 	public async getMaxHeightPrevoted(): Promise<number> {
-		const bftState = await this._chain.dataAccess.getConsensusState(
-			CONSENSUS_STATE_DELEGATE_LEDGER_KEY,
-		);
-		return this.finalityManager.getMaxHeightPrevoted(bftState);
+		return this.finalityManager.getMaxHeightPrevoted();
 	}
 
 	public get finalizedHeight(): number {
@@ -205,6 +198,7 @@ export class BFT extends EventEmitter {
 
 		// Initialize consensus manager
 		const finalityManager = new FinalityManager({
+			chain: this._chain,
 			dpos: this._dpos,
 			finalizedHeight,
 			activeDelegates: this.constants.activeDelegates,

--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -129,8 +129,6 @@ export class FinalityManager extends EventEmitter {
 	public readonly maxHeaders: number;
 
 	public finalizedHeight: number;
-	public chainMaxHeightPrevoted: number;
-
 	private readonly _dpos: DPoS;
 
 	public constructor({
@@ -164,9 +162,6 @@ export class FinalityManager extends EventEmitter {
 
 		// Height up to which blocks are finalized
 		this.finalizedHeight = finalizedHeight;
-
-		// Height up to which blocks have pre-voted
-		this.chainMaxHeightPrevoted = 0;
 	}
 
 	public async addBlockHeader(
@@ -178,17 +173,16 @@ export class FinalityManager extends EventEmitter {
 		const { lastBlockHeaders } = stateStore.consensus;
 
 		// Verify the integrity of the header with chain
-		this.verifyBlockHeaders(blockHeader, lastBlockHeaders);
+		await this.verifyBlockHeaders(blockHeader, stateStore);
 
 		// Update the pre-votes and pre-commits
 		await this.updatePreVotesPreCommits(blockHeader, stateStore, lastBlockHeaders);
 
 		// Update the pre-voted confirmed and finalized height
-		await this.updatePreVotedAndFinalizedHeight(stateStore);
+		await this.updateFinalizedHeight(stateStore);
 
 		debug('after adding block header', {
 			finalizedHeight: this.finalizedHeight,
-			chainMaxHeightPrevoted: this.chainMaxHeightPrevoted,
 		});
 
 		return this;
@@ -327,18 +321,10 @@ export class FinalityManager extends EventEmitter {
 		return true;
 	}
 
-	public async updatePreVotedAndFinalizedHeight(stateStore: StateStore): Promise<boolean> {
+	public async updateFinalizedHeight(stateStore: StateStore): Promise<boolean> {
 		debug('updatePreVotedAndFinalizedHeight invoked');
 
 		const { ledger } = await this._getVotingLedger(stateStore);
-
-		const highestHeightPreVoted = Object.keys(ledger)
-			.reverse()
-			.find(key => ledger[key].preVotes >= this.preVoteThreshold);
-
-		this.chainMaxHeightPrevoted = highestHeightPreVoted
-			? parseInt(highestHeightPreVoted, 10)
-			: this.chainMaxHeightPrevoted;
 
 		const highestHeightPreCommitted = Object.keys(ledger)
 			.reverse()
@@ -358,25 +344,24 @@ export class FinalityManager extends EventEmitter {
 		return true;
 	}
 
-	public reset(): void {
-		this.chainMaxHeightPrevoted = 0;
-	}
-
-	public verifyBlockHeaders(
+	public async verifyBlockHeaders(
 		blockHeader: BlockHeader,
-		bftBlockHeaders: ReadonlyArray<BlockHeader>,
-	): boolean {
+		stateStore: StateStore,
+	): Promise<boolean> {
 		debug('verifyBlockHeaders invoked');
 		debug(blockHeader);
 
+		const bftBlockHeaders = stateStore.consensus.lastBlockHeaders;
+		const { ledger } = await this._getVotingLedger(stateStore);
+		const { preVoted: chainMaxHeightPrevoted } = this._getChainMaxHeightStatus(ledger);
 		// We need minimum processingThreshold to decide
 		// If maxHeightPrevoted is correct
 		if (
 			bftBlockHeaders.length >= this.processingThreshold &&
-			blockHeader.asset.maxHeightPrevoted !== this.chainMaxHeightPrevoted
+			blockHeader.asset.maxHeightPrevoted !== chainMaxHeightPrevoted
 		) {
 			throw new BFTInvalidAttributeError(
-				`Wrong maxHeightPrevoted in blockHeader. maxHeightPrevoted: ${blockHeader.asset.maxHeightPrevoted}, : ${this.chainMaxHeightPrevoted}`,
+				`Wrong maxHeightPrevoted in blockHeader. maxHeightPrevoted: ${blockHeader.asset.maxHeightPrevoted}, : ${chainMaxHeightPrevoted}`,
 			);
 		}
 
@@ -428,6 +413,31 @@ export class FinalityManager extends EventEmitter {
 		}
 
 		return true;
+	}
+
+	public getMaxHeightPrevoted(bftVotingLedgerBuffer: Buffer | undefined): number {
+		const { ledger } = this._decodeVotingLedger(bftVotingLedgerBuffer);
+		const { preVoted } = this._getChainMaxHeightStatus(ledger);
+
+		return preVoted;
+	}
+
+	private _getChainMaxHeightStatus(ledger: LedgerMap): { preVoted: number; preComitted: number } {
+		debug('updatePreVotedAndFinalizedHeight invoked');
+
+		const highestHeightPreVoted = Object.keys(ledger)
+			.reverse()
+			.find(key => ledger[key].preVotes >= this.preVoteThreshold);
+
+		const preVoted = highestHeightPreVoted ? parseInt(highestHeightPreVoted, 10) : 0;
+
+		const highestHeightPreComitted = Object.keys(ledger)
+			.reverse()
+			.find(key => ledger[key].preCommits >= this.preCommitThreshold);
+
+		const preComitted = highestHeightPreComitted ? parseInt(highestHeightPreComitted, 10) : 0;
+
+		return { preVoted, preComitted };
 	}
 
 	/**
@@ -486,17 +496,18 @@ export class FinalityManager extends EventEmitter {
 	// eslint-disable-next-line class-methods-use-this
 	private async _getVotingLedger(stateStore: StateStore): Promise<VotingLedgerMap> {
 		const votingLedgerBuffer = await stateStore.consensus.get(CONSENSUS_STATE_DELEGATE_LEDGER_KEY);
+		return this._decodeVotingLedger(votingLedgerBuffer);
+	}
 
+	// eslint-disable-next-line class-methods-use-this
+	private _decodeVotingLedger(bftVotingLedgerBuffer: Buffer | undefined): VotingLedgerMap {
 		const votingLedger =
-			votingLedgerBuffer === undefined
+			bftVotingLedgerBuffer === undefined
 				? {
 						ledger: [],
 						delegates: [],
 				  }
-				: codec.decode<VotingLedger>(
-						BFTVotingLedgerSchema,
-						(votingLedgerBuffer as unknown) as Buffer,
-				  );
+				: codec.decode<VotingLedger>(BFTVotingLedgerSchema, bftVotingLedgerBuffer);
 
 		const ledger = votingLedger.ledger.reduce((prev: LedgerMap, curr) => {
 			// eslint-disable-next-line no-param-reassign

--- a/elements/lisk-bft/src/types.ts
+++ b/elements/lisk-bft/src/types.ts
@@ -100,6 +100,9 @@ export interface Chain {
 		readonly isWithinTimeslot: (slotNumber: number, receivedAt: number | undefined) => boolean;
 		readonly timeSinceGenesis: (time?: number) => number;
 	};
+	readonly dataAccess: {
+		getConsensusState(key: string): Promise<Buffer | undefined>;
+	};
 }
 
 export enum ForkStatus {

--- a/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
@@ -146,7 +146,10 @@ describe('FinalityManager', () => {
 
 						expect(finalityManager.finalizedHeight).toEqual(testCase.output.finalizedHeight);
 
-						expect(finalityManager.chainMaxHeightPrevoted).toEqual(
+						const updatedBftLedgers = await stateStore.consensus.get(
+							CONSENSUS_STATE_DELEGATE_LEDGER_KEY,
+						);
+						expect(finalityManager.getMaxHeightPrevoted(updatedBftLedgers)).toEqual(
 							testCase.output.preVotedConfirmedHeight,
 						);
 					});

--- a/elements/lisk-bft/test/protocol_specs/bft_fork_choice_rules_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_fork_choice_rules_protocol_specs.spec.ts
@@ -32,6 +32,9 @@ describe('bft', () => {
 
 		let chainStub: {
 			slots: Slots;
+			dataAccess: {
+				getConsensusState: jest.Mock;
+			};
 		};
 		let dposStub: {
 			getMinActiveHeight: jest.Mock;
@@ -46,6 +49,9 @@ describe('bft', () => {
 			});
 			chainStub = {
 				slots,
+				dataAccess: {
+					getConsensusState: jest.fn(),
+				},
 			};
 			dposStub = {
 				getMinActiveHeight: jest.fn(),

--- a/elements/lisk-bft/test/protocol_specs/bft_invalid_block_headers_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_invalid_block_headers_protocol_specs.spec.ts
@@ -27,12 +27,32 @@ describe('FinalityManager', () => {
 			isBootstrapPeriod: jest.Mock;
 		};
 		let stateStore: StateStoreMock;
+		let chainStub: {
+			slots: {
+				getSlotNumber: jest.Mock;
+				isWithinTimeslot: jest.Mock;
+				timeSinceGenesis: jest.Mock;
+			};
+			dataAccess: {
+				getConsensusState: jest.Mock;
+			};
+		};
 
 		beforeEach(() => {
 			dposStub = {
 				getMinActiveHeight: jest.fn(),
 				isStandbyDelegate: jest.fn(),
 				isBootstrapPeriod: jest.fn().mockReturnValue(false),
+			};
+			chainStub = {
+				slots: {
+					getSlotNumber: jest.fn(),
+					isWithinTimeslot: jest.fn(),
+					timeSinceGenesis: jest.fn(),
+				},
+				dataAccess: {
+					getConsensusState: jest.fn(),
+				},
 			};
 			stateStore = new StateStoreMock();
 		});
@@ -45,6 +65,7 @@ describe('FinalityManager', () => {
 				);
 
 				const finalityManager = new FinalityManager({
+					chain: chainStub,
 					dpos: dposStub,
 					finalizedHeight: invalidBlockHeaderSpec.config.finalizedHeight,
 					activeDelegates: invalidBlockHeaderSpec.config.activeDelegates,

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -55,6 +55,16 @@ describe('finality_manager', () => {
 			isStandbyDelegate: jest.Mock;
 			isBootstrapPeriod: jest.Mock;
 		};
+		let chainStub: {
+			slots: {
+				getSlotNumber: jest.Mock;
+				isWithinTimeslot: jest.Mock;
+				timeSinceGenesis: jest.Mock;
+			};
+			dataAccess: {
+				getConsensusState: jest.Mock;
+			};
+		};
 
 		beforeEach(() => {
 			dposStub = {
@@ -62,8 +72,19 @@ describe('finality_manager', () => {
 				isStandbyDelegate: jest.fn(),
 				isBootstrapPeriod: jest.fn().mockReturnValue(false),
 			};
+			chainStub = {
+				slots: {
+					getSlotNumber: jest.fn(),
+					isWithinTimeslot: jest.fn(),
+					timeSinceGenesis: jest.fn(),
+				},
+				dataAccess: {
+					getConsensusState: jest.fn(),
+				},
+			};
 
 			finalityManager = new FinalityManager({
+				chain: chainStub,
 				dpos: dposStub,
 				finalizedHeight,
 				activeDelegates,
@@ -84,6 +105,7 @@ describe('finality_manager', () => {
 				expect(
 					() =>
 						new FinalityManager({
+							chain: chainStub,
 							dpos: dposStub,
 							finalizedHeight,
 							activeDelegates: 0,

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -13,7 +13,7 @@
  */
 
 import { codec } from '@liskhq/lisk-codec';
-import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { getRandomBytes, getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import {
 	FinalityManager,
 	CONSENSUS_STATE_DELEGATE_LEDGER_KEY,
@@ -93,9 +93,13 @@ describe('finality_manager', () => {
 		});
 
 		describe('verifyBlockHeaders', () => {
-			it('should throw error if maxHeightPrevoted is not accurate', () => {
+			let stateStore: StateStoreMock;
+
+			it('should throw error if maxHeightPrevoted is not accurate', async () => {
 				// Add the header directly to list so verifyBlockHeaders can be validated against it
 				const bftHeaders = generateValidHeaders(finalityManager.processingThreshold + 1);
+
+				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: bftHeaders });
 
 				const header = createFakeBlockHeader({
 					asset: { maxHeightPrevoted: 10 },
@@ -103,31 +107,57 @@ describe('finality_manager', () => {
 
 				expect.assertions(1);
 				try {
-					finalityManager.verifyBlockHeaders(header, bftHeaders);
+					await finalityManager.verifyBlockHeaders(header, stateStore);
 				} catch (error) {
 					// eslint-disable-next-line jest/no-try-expect
 					expect(error.message).toContain('Wrong maxHeightPrevoted in blockHeader.');
 				}
 			});
 
-			it('should not throw error if maxHeightPrevoted is accurate', () => {
+			it('should not throw error if maxHeightPrevoted is accurate', async () => {
 				// Add the header directly to list so verifyBlockHeaders can be validated against it
 				const bftHeaders = generateValidHeaders(finalityManager.processingThreshold + 1);
 				const header = createFakeBlockHeader({
 					asset: { maxHeightPrevoted: 10 },
 				});
-				finalityManager.chainMaxHeightPrevoted = 10;
+				const delegateLedger = {
+					delegates: [
+						{
+							address: getAddressFromPublicKey(header.generatorPublicKey),
+							maxPreVoteHeight: 1,
+							maxPreCommitHeight: 0,
+						},
+					],
+					ledger: [
+						{
+							height: 10,
+							preVotes: 69,
+							preCommits: 0,
+						},
+					],
+				};
+				stateStore = new StateStoreMock(
+					[],
+					{
+						[CONSENSUS_STATE_DELEGATE_LEDGER_KEY]: codec.encode(
+							BFTVotingLedgerSchema,
+							delegateLedger,
+						),
+					},
+					{ lastBlockHeaders: bftHeaders },
+				);
 
-				expect(() => finalityManager.verifyBlockHeaders(header, bftHeaders)).not.toThrow();
+				await expect(finalityManager.verifyBlockHeaders(header, stateStore)).resolves.toBeTrue();
 			});
 
-			it("should return true if delegate didn't forge any block previously", () => {
+			it("should return true if delegate didn't forge any block previously", async () => {
 				const header = createFakeBlockHeader();
+				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [] });
 
-				expect(finalityManager.verifyBlockHeaders(header, [])).toBeTruthy();
+				await expect(finalityManager.verifyBlockHeaders(header, stateStore)).resolves.toBeTruthy();
 			});
 
-			it('should throw error if same delegate forged block on different height', () => {
+			it('should throw error if same delegate forged block on different height', async () => {
 				const maxHeightPrevoted = 10;
 				const generatorPublicKey = getRandomBytes(32);
 				const lastBlock = createFakeBlockHeader({
@@ -147,12 +177,14 @@ describe('finality_manager', () => {
 					height: 9,
 				});
 
-				expect(() => finalityManager.verifyBlockHeaders(currentBlock, [lastBlock])).toThrow(
+				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+
+				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTForkChoiceRuleError,
 				);
 			});
 
-			it('should throw error if delegate forged block on same height', () => {
+			it('should throw error if delegate forged block on same height', async () => {
 				const maxHeightPreviouslyForged = 10;
 				const generatorPublicKey = getRandomBytes(32);
 				const lastBlock = createFakeBlockHeader({
@@ -169,13 +201,14 @@ describe('finality_manager', () => {
 					},
 					height: 10,
 				});
+				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
 
-				expect(() => finalityManager.verifyBlockHeaders(currentBlock, [lastBlock])).toThrow(
+				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTForkChoiceRuleError,
 				);
 			});
 
-			it('should throw error if maxHeightPreviouslyForged has wrong value', () => {
+			it('should throw error if maxHeightPreviouslyForged has wrong value', async () => {
 				const generatorPublicKey = getRandomBytes(32);
 				const lastBlock = createFakeBlockHeader({
 					generatorPublicKey,
@@ -188,12 +221,14 @@ describe('finality_manager', () => {
 					},
 				});
 
-				expect(() => finalityManager.verifyBlockHeaders(currentBlock, [lastBlock])).toThrow(
+				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+
+				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTChainDisjointError,
 				);
 			});
 
-			it('should throw error if maxHeightPrevoted has wrong value', () => {
+			it('should throw error if maxHeightPrevoted has wrong value', async () => {
 				const generatorPublicKey = getRandomBytes(32);
 				const lastBlock = createFakeBlockHeader({
 					generatorPublicKey,
@@ -211,15 +246,20 @@ describe('finality_manager', () => {
 					},
 				});
 
-				expect(() => finalityManager.verifyBlockHeaders(currentBlock, [lastBlock])).toThrow(
+				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+
+				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTLowerChainBranchError,
 				);
 			});
 
-			it('should return true if headers are valid', () => {
+			it('should return true if headers are valid', async () => {
 				const [lastBlock, currentBlock] = generateValidHeaders(2);
+				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
 
-				expect(finalityManager.verifyBlockHeaders(currentBlock, [lastBlock])).toBeTruthy();
+				await expect(
+					finalityManager.verifyBlockHeaders(currentBlock, stateStore),
+				).resolves.toBeTruthy();
 			});
 		});
 
@@ -259,7 +299,7 @@ describe('finality_manager', () => {
 				await finalityManager.addBlockHeader(header1, stateStore);
 
 				expect(finalityManager.verifyBlockHeaders).toHaveBeenCalledTimes(1);
-				expect(finalityManager.verifyBlockHeaders).toHaveBeenCalledWith(header1, bftHeaders);
+				expect(finalityManager.verifyBlockHeaders).toHaveBeenCalledWith(header1, stateStore);
 			});
 
 			it('should call updatePreVotesPreCommits with the provided header', async () => {

--- a/framework/src/application/node/block_processor_v2.ts
+++ b/framework/src/application/node/block_processor_v2.ts
@@ -175,12 +175,13 @@ export class BlockProcessorV2 extends BaseBlockProcessor {
 				const previousBlockID = data.previousBlock.header.id;
 				const forgerInfo = previouslyForgedMap.get(delegateAddress);
 				const maxHeightPreviouslyForged = forgerInfo?.height ?? 0;
+				const maxHeightPrevoted = await this.bftModule.getMaxHeightPrevoted();
 				const block = await this._create({
 					...data,
 					height,
 					previousBlockID,
 					maxHeightPreviouslyForged,
-					maxHeightPrevoted: this.bftModule.maxHeightPrevoted,
+					maxHeightPrevoted,
 					stateStore,
 				});
 

--- a/framework/test/unit/specs/application/node/block_processor_v2.spec.ts
+++ b/framework/test/unit/specs/application/node/block_processor_v2.spec.ts
@@ -66,7 +66,7 @@ describe('block processor v2', () => {
 			init: jest.fn(),
 			deleteBlocks: jest.fn(),
 			validateBlock: jest.fn(),
-			maxHeightPrevoted: 0,
+			getMaxHeightPrevoted: jest.fn().mockResolvedValue(0),
 			isBFTProtocolCompliant: jest.fn().mockReturnValue(true),
 		};
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5506 

### How was it solved?

- Remove memory cache for the maxHeightPrevoted, and calculate on demand

### How was it tested?

- Update all the tests
- Prepare 2 nodes, and make syncing node fail manually by mutating the code
- It should revert blocks and resync again. It should not fail to resync.
