### PR TITLE
Add GET /api/node/info endpoint - Closes #5252

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
@@ -11,7 +11,18 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import { Request, Response, NextFunction } from 'express';
+import { BaseChannel } from 'lisk-framework';
 
-export * from './hello';
-export * as accounts from './account';
-export * as node from './node';
+export const getNodeStatusAndConstants = (channel: BaseChannel) => async (
+	_req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	try {
+		const nodeStatusAndInfo: Buffer = await channel.invoke('app:getNodeStatusAndConstants');
+		res.status(200).send(nodeStatusAndInfo);
+	} catch (err) {
+		next(err);
+	}
+};

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
@@ -14,13 +14,13 @@
 import { Request, Response, NextFunction } from 'express';
 import { BaseChannel } from 'lisk-framework';
 
-export const getNodeStatusAndConstants = (channel: BaseChannel) => async (
+export const getNodeInfo = (channel: BaseChannel) => async (
 	_req: Request,
 	res: Response,
 	next: NextFunction,
 ): Promise<void> => {
 	try {
-		const nodeStatusAndInfo: Buffer = await channel.invoke('app:getNodeStatusAndConstants');
+		const nodeStatusAndInfo = await channel.invoke('app:getNodeInfo');
 		res.status(200).send(nodeStatusAndInfo);
 	} catch (err) {
 		next(err);

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -105,6 +105,6 @@ export class HTTPAPIPlugin extends BasePlugin {
 	private _registerControllers(): void {
 		this._app.get('/v1/hello', helloController(this._channel));
 		this._app.get('/api/accounts/:address', accounts.getAccount(this._channel, this.codec));
-		this._app.get('/api/node/info', node.getNodeStatusAndConstants(this._channel));
+		this._app.get('/api/node/info', node.getNodeInfo(this._channel));
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -19,7 +19,7 @@ import * as express from 'express';
 import type { Express } from 'express';
 import * as cors from 'cors';
 import * as rateLimit from 'express-rate-limit';
-import { accounts, helloController } from './controllers';
+import { accounts, helloController, node } from './controllers';
 import * as middlewares from './middlewares';
 import * as config from './defaults';
 import { Options } from './types';
@@ -105,5 +105,6 @@ export class HTTPAPIPlugin extends BasePlugin {
 	private _registerControllers(): void {
 		this._app.get('/v1/hello', helloController(this._channel));
 		this._app.get('/api/accounts/:address', accounts.getAccount(this._channel, this.codec));
+		this._app.get('/api/node/info', node.getNodeStatusAndConstants(this._channel));
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
+++ b/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
@@ -876,3 +876,11 @@ definitions:
                 type: integer
                 description: Distance in height between each milestone.
                 example: 3000000
+          communityIdentifier:
+            type: string
+            description: Community identifier the node is part of.
+            example: Lisk
+          totalAmount:
+            type: string
+            description: Initial token senderPublicKey
+            example: 10000000000000000

--- a/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
+++ b/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
@@ -878,9 +878,9 @@ definitions:
                 example: 3000000
           communityIdentifier:
             type: string
-            description: Community identifier the node is part of.
+            description: The unique name of the relevant community as a string encoded in UTF-8 format.
             example: Lisk
           totalAmount:
             type: string
-            description: Initial token senderPublicKey
+            description: Total amount of LSK available in network before rewards milestone started
             example: 10000000000000000

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Application } from 'lisk-framework';
+import axios from 'axios';
+import { createApplication, closeApplication, getURL } from './utils/application';
+
+describe('Node Info endpoint', () => {
+	let app: Application;
+
+	beforeAll(async () => {
+		app = await createApplication('hello');
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('api/node/info', () => {
+		it('should respond node info', async () => {
+			const appInstance = app as any;
+			const nodeStatusAndConstantFixture = {
+				version: appInstance._node._options.version,
+				protocolVersion: appInstance._node._options.protocolVersion,
+				networkID: appInstance._node._options.networkId,
+				lastBlockID: appInstance._node._chain.lastBlock.header.id.toString('base64'),
+				height: appInstance._node._chain.lastBlock.header.height,
+				finalizedHeight: appInstance._node._bft.finalityManager.finalizedHeight,
+				syncing: appInstance._node._synchronizer.isActive,
+				unconfirmedTransactions: appInstance._node._transactionPool.getAll().length,
+				genesisConfig: {
+					...appInstance._node._options.genesisConfig,
+					...appInstance._node._options.constants,
+					totalAmount: appInstance._node._options.constants.totalAmount.toString(),
+				},
+			};
+
+			const result = await axios.get(getURL('/api/node/info'));
+
+			expect(result.data).toEqual(nodeStatusAndConstantFixture);
+			expect(result.status).toBe(200);
+		});
+	});
+});

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -414,9 +414,6 @@ export class Application {
 					handler: async (action: ActionInfoObject) =>
 						this._node.actions.postTransaction(action.params as EventPostTransactionData),
 				},
-				getNodeStatus: {
-					handler: (_action: ActionInfoObject) => this._node.actions.getNodeStatus(),
-				},
 				getLastBlock: {
 					handler: async (_action: ActionInfoObject) => this._node.actions.getLastBlock(),
 					isPublic: true,
@@ -470,8 +467,8 @@ export class Application {
 				getSchema: {
 					handler: () => this._node.actions.getSchema(),
 				},
-				getNodeStatusAndConstants: {
-					handler: () => this._node.actions.getNodeStatusAndConstants(),
+				getNodeInfo: {
+					handler: () => this._node.actions.getNodeInfo(),
 				},
 			},
 			{ skipInternalEvents: true },

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -470,6 +470,9 @@ export class Application {
 				getSchema: {
 					handler: () => this._node.actions.getSchema(),
 				},
+				getNodeStatusAndConstants: {
+					handler: () => this._node.actions.getNodeStatusAndConstants(),
+				},
 			},
 			{ skipInternalEvents: true },
 		);

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -446,6 +446,7 @@ export class Node {
 				genesisConfig: {
 					...this._options.genesisConfig,
 					...this._options.constants,
+					totalAmount: this._options.constants.totalAmount.toString(),
 				},
 			}),
 		};

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -99,14 +99,6 @@ interface NodeConstructor {
 	readonly networkModule: Network;
 }
 
-interface NodeStatus {
-	readonly syncing: boolean;
-	readonly unconfirmedTransactions: number;
-	readonly secondsSinceEpoch: number;
-	readonly lastBlock: string;
-	readonly chainMaxHeightFinalized: number;
-}
-
 interface RegisteredSchemas {
 	[key: string]: Schema;
 }
@@ -407,13 +399,6 @@ export class Node {
 				this._chain.slots.getSlotNumber(params.timeStamp),
 			calcSlotRound: (params: { height: number }): number =>
 				this._dpos.rounds.calcRound(params.height),
-			getNodeStatus: (): NodeStatus => ({
-				syncing: this._synchronizer.isActive,
-				unconfirmedTransactions: this._transactionPool.getAll().length,
-				secondsSinceEpoch: this._chain.slots.timeSinceGenesis(),
-				lastBlock: this._chain.dataAccess.encode(this._chain.lastBlock).toString('base64'),
-				chainMaxHeightFinalized: this._bft.finalityManager.finalizedHeight,
-			}),
 			// eslint-disable-next-line @typescript-eslint/require-await
 			getLastBlock: async (): Promise<string> =>
 				this._chain.dataAccess.encode(this._chain.lastBlock).toString('base64'),
@@ -434,7 +419,7 @@ export class Node {
 				baseTransaction: BaseTransaction.BASE_SCHEMA,
 				transactionsAssets: this._getRegisteredTransactionSchemas(),
 			}),
-			getNodeStatusAndConstants: () => ({
+			getNodeInfo: () => ({
 				version: this._options.version,
 				protocolVersion: this._options.protocolVersion,
 				networkID: this._options.networkId,

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -69,6 +69,9 @@ export interface NodeConstants {
 }
 
 export interface Options {
+	readonly version: string;
+	readonly protocolVersion: string;
+	readonly networkId: string;
 	readonly label: string;
 	readonly rootPath: string;
 	readonly communityIdentifier: string;
@@ -83,6 +86,7 @@ export interface Options {
 		readonly [key: number]: typeof BaseTransaction;
 	};
 	genesisBlock: GenesisBlock<AccountAsset>;
+	readonly genesisConfig: object;
 }
 
 interface NodeConstructor {
@@ -429,6 +433,20 @@ export class Node {
 				},
 				baseTransaction: BaseTransaction.BASE_SCHEMA,
 				transactionsAssets: this._getRegisteredTransactionSchemas(),
+			}),
+			getNodeStatusAndConstants: () => ({
+				version: this._options.version,
+				protocolVersion: this._options.protocolVersion,
+				networkID: this._options.networkId,
+				lastBlockID: this._chain.lastBlock.header.id.toString('base64'),
+				height: this._chain.lastBlock.header.height,
+				finalizedHeight: this._bft.finalityManager.finalizedHeight,
+				syncing: this._synchronizer.isActive,
+				unconfirmedTransactions: this._transactionPool.getAll().length,
+				genesisConfig: {
+					...this._options.genesisConfig,
+					...this._options.constants,
+				},
 			}),
 		};
 	}

--- a/framework/test/functional/specs/actions/application.spec.ts
+++ b/framework/test/functional/specs/actions/application.spec.ts
@@ -78,4 +78,29 @@ describe('Application related actions', () => {
 			expect(frameworkSchemas).toEqual(expectedFrameworkSchemas);
 		});
 	});
+
+	describe('getNodeStatusAndConstants', () => {
+		it('should return node status and constants', async () => {
+			const appInstance = app as any;
+
+			const expectedStatusAndConstants = {
+				version: appInstance._node._options.version,
+				protocolVersion: appInstance._node._options.protocolVersion,
+				networkID: appInstance._node._options.networkId,
+				lastBlockID: appInstance._node._chain.lastBlock.header.id.toString('base64'),
+				height: appInstance._node._chain.lastBlock.header.height,
+				finalizedHeight: appInstance._node._bft.finalityManager.finalizedHeight,
+				syncing: appInstance._node._synchronizer.isActive,
+				unconfirmedTransactions: appInstance._node._transactionPool.getAll().length,
+				genesisConfig: {
+					...appInstance._node._options.genesisConfig,
+					...appInstance._node._options.constants,
+					totalAmount: appInstance._node._options.constants.totalAmount.toString(),
+				},
+			};
+
+			const nodeStatusAndConstants = await app['_channel'].invoke('app:getNodeStatusAndConstants');
+			expect(nodeStatusAndConstants).toEqual(expectedStatusAndConstants);
+		});
+	});
 });

--- a/framework/test/functional/specs/actions/application.spec.ts
+++ b/framework/test/functional/specs/actions/application.spec.ts
@@ -79,7 +79,7 @@ describe('Application related actions', () => {
 		});
 	});
 
-	describe('getNodeStatusAndConstants', () => {
+	describe('getNodeInfo', () => {
 		it('should return node status and constants', async () => {
 			const appInstance = app as any;
 
@@ -99,7 +99,7 @@ describe('Application related actions', () => {
 				},
 			};
 
-			const nodeStatusAndConstants = await app['_channel'].invoke('app:getNodeStatusAndConstants');
+			const nodeStatusAndConstants = await app['_channel'].invoke('app:getNodeInfo');
 			expect(nodeStatusAndConstants).toEqual(expectedStatusAndConstants);
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5252

### How was it solved?

- By adding new action `getNodeStatusAndConstants`
- By adding new controller for route /api/node/info

### How was it tested?

- build and run `node test/test_app/index.js`
- `curl http://localhost:4000/api/node/info | jq` (or use Postman/Browser with that URL)
- functional tests for new action and route
