### PR TITLE
Endpoints accounts/ and node/info/ do not exactly follow swagger schema - Closes #5535

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/account.ts
@@ -33,7 +33,7 @@ export const getAccount = (channel: BaseChannel, codec: PluginCodec) => async (
 		const account: Buffer = await channel.invoke('app:getAccount', {
 			address: accountAddres,
 		});
-		res.status(200).send(codec.decodeAccount(account));
+		res.status(200).send({ data: codec.decodeAccount(account) });
 	} catch (err) {
 		if (/^Specified key accounts:address:(.*)does not exist/.test((err as Error).message)) {
 			res.status(404).send({

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
@@ -21,7 +21,7 @@ export const getNodeInfo = (channel: BaseChannel) => async (
 ): Promise<void> => {
 	try {
 		const nodeStatusAndInfo = await channel.invoke('app:getNodeInfo');
-		res.status(200).send(nodeStatusAndInfo);
+		res.status(200).send({ data: nodeStatusAndInfo });
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/account.spec.ts
@@ -46,7 +46,7 @@ describe('Account endpoint', () => {
 	};
 
 	beforeAll(async () => {
-		app = await createApplication('hello');
+		app = await createApplication('account_http_functional');
 	});
 
 	afterAll(async () => {
@@ -56,7 +56,7 @@ describe('Account endpoint', () => {
 	describe('/api/accounts', () => {
 		it('should respond with account when account found in db', async () => {
 			const result = await axios.get(getURL('/api/accounts/nQFJsJYtRL%2FAip9k1a%2FOtigdf7U%3D'));
-			expect(result.data).toEqual(accountFixture);
+			expect(result.data).toEqual({ data: accountFixture });
 			expect(result.status).toBe(200);
 		});
 

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -19,7 +19,7 @@ describe('Node Info endpoint', () => {
 	let app: Application;
 
 	beforeAll(async () => {
-		app = await createApplication('hello');
+		app = await createApplication('node_http_functional');
 	});
 
 	afterAll(async () => {
@@ -47,7 +47,7 @@ describe('Node Info endpoint', () => {
 
 			const result = await axios.get(getURL('/api/node/info'));
 
-			expect(result.data).toEqual(nodeStatusAndConstantFixture);
+			expect(result.data).toEqual({ data: nodeStatusAndConstantFixture });
 			expect(result.status).toBe(200);
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5535

### How was it solved?

By wrapping the responses in a `data` property

### How was it tested?

Functional tests updated
