### PR TITLE
Add http-api for GET api/peers?limit=xxx&offset=yyy&state=zzz endpoint - Closes #5254

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
@@ -16,6 +16,7 @@ import * as transactions from './transactions';
 import * as accounts from './accounts';
 import * as node from './node';
 import * as blocks from './blocks';
+import * as peers from './peers';
 
 export * from './hello';
-export { accounts, blocks, node, transactions };
+export { accounts, blocks, node, transactions, peers };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Request, Response, NextFunction } from 'express';
+import { isUInt32, isString } from '@liskhq/lisk-validator';
+import { BaseChannel } from 'lisk-framework';
+
+export enum PeerState {
+	connected = 'connected',
+	disconnected = 'disconnected',
+}
+
+interface PeerInfo {
+	readonly ipAddress: string;
+	readonly port: number;
+	readonly networkId: string;
+	readonly networkVersion: string;
+	readonly nonce: string;
+	readonly options: { [key: string]: unknown };
+}
+
+const filterPeers = (
+	peers: ReadonlyArray<PeerInfo>,
+	limit: number,
+	offset: number,
+): ReadonlyArray<PeerInfo> => {
+	if (offset === 0) {
+		return peers.slice(0, Math.min(limit, peers.length));
+	}
+
+	return peers.slice(offset, Math.min(limit + offset, peers.length));
+};
+
+export const getPeers = (channel: BaseChannel) => async (
+	req: Request,
+	res: Response,
+	_next: NextFunction,
+): Promise<void> => {
+	const { limit = 100, offset = 0, state = PeerState.connected } = req.query;
+
+	if (
+		!isUInt32(Number(limit)) ||
+		!isUInt32(Number(offset)) ||
+		!isString(state) ||
+		!(state === PeerState.connected || state === PeerState.disconnected)
+	) {
+		res.status(400).send({
+			errors: [
+				{
+					message:
+						'Invalid param value(s), limit and offset should be a valid number and state can be either "connected" or "disconnected"',
+				},
+			],
+		});
+		return;
+	}
+
+	try {
+		let peers;
+		if (state === PeerState.disconnected) {
+			peers = await channel.invoke<ReadonlyArray<PeerInfo>>('app:getDisconnectedPeers');
+		} else {
+			peers = await channel.invoke<ReadonlyArray<PeerInfo>>('app:getConnectedPeers');
+		}
+
+		peers = filterPeers(peers, +limit, +offset);
+
+		res.status(200).send(peers);
+	} catch (err) {
+		res.status(500).send({
+			errors: [
+				{ message: `Something went wrong while fetching peers list: ${(err as Error).message}` },
+			],
+		});
+	}
+};

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
@@ -83,6 +83,6 @@ export const getPeers = (channel: BaseChannel) => async (
 
 		res.status(200).send(peers);
 	} catch (err) {
-		next();
+		next(err);
 	}
 };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -123,5 +123,6 @@ export class HTTPAPIPlugin extends BasePlugin {
 			'/api/node/transactions',
 			controllers.node.getTransactions(this._channel, this.codec),
 		);
+		this._app.get('/api/peers', controllers.peers.getPeers(this._channel));
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/src/utils.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/utils.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export const paginateList = <T>(
+	list: ReadonlyArray<T>,
+	limit: number,
+	offset: number,
+): ReadonlyArray<T> => {
+	if (offset === 0) {
+		return list.slice(0, Math.min(limit, list.length));
+	}
+
+	return list.slice(offset, Math.min(limit + offset, list.length));
+};

--- a/framework-plugins/lisk-framework-http-api-plugin/src/utils.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/utils.ts
@@ -14,8 +14,8 @@
 
 export const paginateList = <T>(
 	list: ReadonlyArray<T>,
-	limit: number,
-	offset: number,
+	limit = 100,
+	offset = 0,
 ): ReadonlyArray<T> => {
 	if (offset === 0) {
 		return list.slice(0, Math.min(limit, list.length));

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -15,33 +15,11 @@ import { Application } from 'lisk-framework';
 import axios from 'axios';
 import { when } from 'jest-when';
 import { createApplication, closeApplication, getURL, callNetwork } from './utils/application';
-
-const peers = [
-	{
-		ipAddress: '1.1.1.1',
-		port: 1001,
-		networkId: 'networkId',
-		networVersion: '1.1',
-		nonce: 'nonce1',
-	},
-	{
-		ipAddress: '1.1.1.2',
-		port: 1002,
-		networkId: 'networkId',
-		networVersion: '1.1',
-		nonce: 'nonce2',
-	},
-	{
-		ipAddress: '1.1.1.3',
-		port: 1003,
-		networkId: 'networkId',
-		networVersion: '1.1',
-		nonce: 'nonce3',
-	},
-];
+import { generatePeers } from './utils/peers';
 
 describe('Peers endpoint', () => {
 	let app: Application;
+	const peers = generatePeers();
 
 	beforeAll(async () => {
 		app = await createApplication('peers');
@@ -52,7 +30,7 @@ describe('Peers endpoint', () => {
 	});
 
 	describe('/api/peers', () => {
-		it('should respond with all connected peers', async () => {
+		it('should respond with 100 connected peers as limit has 100 default value', async () => {
 			// Arrange
 			app['_channel'].invoke = jest.fn();
 			// Mock channel invoke only when app:getConnectedPeers is called
@@ -64,7 +42,7 @@ describe('Peers endpoint', () => {
 			const { response, status } = await callNetwork(axios.get(getURL('/api/peers')));
 
 			// Assert
-			expect(response).toEqual(peers);
+			expect(response).toEqual(peers.slice(0, 100));
 			expect(status).toBe(200);
 		});
 
@@ -82,7 +60,7 @@ describe('Peers endpoint', () => {
 			);
 
 			// Assert
-			expect(response).toEqual(peers.slice(2, peers.length));
+			expect(response).toEqual(peers.slice(2, 102));
 			expect(status).toBe(200);
 		});
 

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -14,7 +14,7 @@
 import { Application } from 'lisk-framework';
 import axios from 'axios';
 import { when } from 'jest-when';
-import { createApplication, closeApplication, getURL } from './utils/application';
+import { createApplication, closeApplication, getURL, callNetwork } from './utils/application';
 
 const peers = [
 	{
@@ -61,11 +61,11 @@ describe('Peers endpoint', () => {
 				.mockResolvedValue(peers as never);
 
 			// Act
-			const result = await axios.get(getURL('/api/peers'));
+			const { response, status } = await callNetwork(axios.get(getURL('/api/peers')));
 
 			// Assert
-			expect(result.data).toEqual(peers);
-			expect(result.status).toBe(200);
+			expect(response).toEqual(peers);
+			expect(status).toBe(200);
 		});
 
 		it('should respond with all disconnected peers when all query parameters are passed', async () => {
@@ -77,11 +77,13 @@ describe('Peers endpoint', () => {
 				.mockResolvedValue(peers as never);
 
 			// Act
-			const result = await axios.get(getURL('/api/peers?state=disconnected&limit=100&offset=2'));
+			const { response, status } = await callNetwork(
+				axios.get(getURL('/api/peers?state=disconnected&limit=100&offset=2')),
+			);
 
 			// Assert
-			expect(result.data).toEqual(peers.slice(2, peers.length));
-			expect(result.status).toBe(200);
+			expect(response).toEqual(peers.slice(2, peers.length));
+			expect(status).toBe(200);
 		});
 
 		it('should respond with 400 and error message when channel.invoke throws error', async () => {

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -86,93 +86,47 @@ describe('Peers endpoint', () => {
 			expect(status).toBe(200);
 		});
 
-		it('should respond with 400 and error message when channel.invoke throws error', async () => {
-			expect.assertions(2);
-			try {
-				// Arrange
-				app['_channel'].invoke = jest.fn();
-				// Mock channel invoke only when app:getConnectedPeers is called
-				when(app['_channel'].invoke)
-					.calledWith('app:getConnectedPeers')
-					.mockRejectedValue(new Error('Error occured') as never);
-				// Act
-				await axios.get(getURL('/api/peers'));
-			} catch (err) {
-				// Assert
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.status).toBe(500);
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.data).toEqual({
-					errors: [
-						{
-							message: 'Something went wrong while fetching peers list: Error occured',
-						},
-					],
-				});
-			}
-		});
-
 		it('should respond with 400 and error message when passed incorrect state value', async () => {
-			expect.assertions(2);
-			try {
-				// Act
-				await axios.get(getURL('/api/peers?state=xxx'));
-			} catch (err) {
-				// Assert
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.status).toBe(400);
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.data).toEqual({
-					errors: [
-						{
-							message:
-								'Invalid param value(s), limit and offset should be a valid number and state can be either "connected" or "disconnected"',
-						},
-					],
-				});
-			}
+			const { response, status } = await callNetwork(axios.get(getURL('/api/peers?state=xxx')));
+			// Assert
+			expect(status).toBe(400);
+			expect(response).toEqual({
+				errors: [
+					{
+						message:
+							'Lisk validator found 1 error[s]:\nshould be equal to one of the allowed values',
+					},
+				],
+			});
 		});
 
 		it('should respond with 400 and error message when passed incorrect limit value', async () => {
-			expect.assertions(2);
-			try {
-				// Act
-				await axios.get(getURL('/api/peers?limit=123xy'));
-			} catch (err) {
-				// Assert
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.status).toBe(400);
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.data).toEqual({
-					errors: [
-						{
-							message:
-								'Invalid param value(s), limit and offset should be a valid number and state can be either "connected" or "disconnected"',
-						},
-					],
-				});
-			}
+			const { response, status } = await callNetwork(axios.get(getURL('/api/peers?limit=123xy')));
+			// Assert
+			expect(status).toBe(400);
+			expect(response).toEqual({
+				errors: [
+					{
+						message:
+							'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint64"',
+					},
+				],
+			});
 		});
 
 		it('should respond with 400 and error message when passed incorrect offset value', async () => {
-			expect.assertions(2);
-			try {
-				// Act
-				await axios.get(getURL('/api/peers?offset=123xy'));
-			} catch (err) {
-				// Assert
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.status).toBe(400);
-				// eslint-disable-next-line jest/no-try-expect
-				expect(err.response.data).toEqual({
-					errors: [
-						{
-							message:
-								'Invalid param value(s), limit and offset should be a valid number and state can be either "connected" or "disconnected"',
-						},
-					],
-				});
-			}
+			// Act
+			const { response, status } = await callNetwork(axios.get(getURL('/api/peers?offset=123xy')));
+			// Assert
+			expect(status).toBe(400);
+			expect(response).toEqual({
+				errors: [
+					{
+						message:
+							'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint64"',
+					},
+				],
+			});
 		});
 	});
 });

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -64,6 +64,25 @@ describe('Peers endpoint', () => {
 			expect(status).toBe(200);
 		});
 
+		it('should throw 500 error when channel.invoke fails', async () => {
+			// Arrange
+			app['_channel'].invoke = jest.fn();
+			// Mock channel invoke only when app:getConnectedPeers is called
+			when(app['_channel'].invoke)
+				.calledWith('app:getConnectedPeers')
+				.mockRejectedValue(new Error('test') as never);
+			const { response, status } = await callNetwork(axios.get(getURL('/api/peers')));
+			// Assert
+			expect(status).toBe(500);
+			expect(response).toEqual({
+				errors: [
+					{
+						message: 'test',
+					},
+				],
+			});
+		});
+
 		it('should respond with 400 and error message when passed incorrect state value', async () => {
 			const { response, status } = await callNetwork(axios.get(getURL('/api/peers?state=xxx')));
 			// Assert

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Application } from 'lisk-framework';
+import axios from 'axios';
+import { when } from 'jest-when';
+import { createApplication, closeApplication, getURL } from './utils/application';
+
+const peers = [
+	{
+		ipAddress: '1.1.1.1',
+		port: 1001,
+		networkId: 'networkId',
+		networVersion: '1.1',
+		nonce: 'nonce1',
+	},
+	{
+		ipAddress: '1.1.1.2',
+		port: 1002,
+		networkId: 'networkId',
+		networVersion: '1.1',
+		nonce: 'nonce2',
+	},
+	{
+		ipAddress: '1.1.1.3',
+		port: 1003,
+		networkId: 'networkId',
+		networVersion: '1.1',
+		nonce: 'nonce3',
+	},
+];
+
+describe('Peers endpoint', () => {
+	let app: Application;
+
+	beforeAll(async () => {
+		app = await createApplication('peers');
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('/api/peers', () => {
+		it('should respond with all connected peers', async () => {
+			// Arrange
+			app['_channel'].invoke = jest.fn();
+			// Mock channel invoke only when app:getConnectedPeers is called
+			when(app['_channel'].invoke)
+				.calledWith('app:getConnectedPeers')
+				.mockResolvedValue(peers as never);
+
+			// Act
+			const result = await axios.get(getURL('/api/peers'));
+
+			// Assert
+			expect(result.data).toEqual(peers);
+			expect(result.status).toBe(200);
+		});
+
+		it('should respond with all disconnected peers when all query parameters are passed', async () => {
+			// Arrange
+			app['_channel'].invoke = jest.fn();
+			// Mock channel invoke only when app:getDisconnectedPeers is called
+			when(app['_channel'].invoke)
+				.calledWith('app:getDisconnectedPeers')
+				.mockResolvedValue(peers as never);
+
+			// Act
+			const result = await axios.get(getURL('/api/peers?state=disconnected&limit=100&offset=2'));
+
+			// Assert
+			expect(result.data).toEqual(peers.slice(2, peers.length));
+			expect(result.status).toBe(200);
+		});
+
+		it('should respond with 400 and error message when channel.invoke throws error', async () => {
+			expect.assertions(2);
+			try {
+				// Arrange
+				app['_channel'].invoke = jest.fn();
+				// Mock channel invoke only when app:getConnectedPeers is called
+				when(app['_channel'].invoke)
+					.calledWith('app:getConnectedPeers')
+					.mockRejectedValue(new Error('Error occured') as never);
+				// Act
+				await axios.get(getURL('/api/peers'));
+			} catch (err) {
+				// Assert
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.status).toBe(500);
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.data).toEqual({
+					errors: [
+						{
+							message: 'Something went wrong while fetching peers list: Error occured',
+						},
+					],
+				});
+			}
+		});
+
+		it('should respond with 400 and error message when passed incorrect state value', async () => {
+			expect.assertions(2);
+			try {
+				// Act
+				await axios.get(getURL('/api/peers?state=xxx'));
+			} catch (err) {
+				// Assert
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.status).toBe(400);
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.data).toEqual({
+					errors: [
+						{
+							message:
+								'Invalid param value(s), limit and offset should be a valid number and state can be either "connected" or "disconnected"',
+						},
+					],
+				});
+			}
+		});
+
+		it('should respond with 400 and error message when passed incorrect limit value', async () => {
+			expect.assertions(2);
+			try {
+				// Act
+				await axios.get(getURL('/api/peers?limit=123xy'));
+			} catch (err) {
+				// Assert
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.status).toBe(400);
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.data).toEqual({
+					errors: [
+						{
+							message:
+								'Invalid param value(s), limit and offset should be a valid number and state can be either "connected" or "disconnected"',
+						},
+					],
+				});
+			}
+		});
+
+		it('should respond with 400 and error message when passed incorrect offset value', async () => {
+			expect.assertions(2);
+			try {
+				// Act
+				await axios.get(getURL('/api/peers?offset=123xy'));
+			} catch (err) {
+				// Assert
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.status).toBe(400);
+				// eslint-disable-next-line jest/no-try-expect
+				expect(err.response.data).toEqual({
+					errors: [
+						{
+							message:
+								'Invalid param value(s), limit and offset should be a valid number and state can be either "connected" or "disconnected"',
+						},
+					],
+				});
+			}
+		});
+	});
+});

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/utils/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/utils/peers.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export const generatePeers = (numOfPeers = 200) => {
+	const peers = [];
+	for (let i = 0; i < numOfPeers; i += 1) {
+		peers.push({
+			ipAddress: `1.1.1.${i}`,
+			port: 1000 + i,
+			networkId: 'networkId',
+			networVersion: '1.1',
+			nonce: `nonce${i}`,
+		});
+	}
+
+	return peers;
+};

--- a/framework-plugins/lisk-framework-http-api-plugin/test/unit/utils.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/unit/utils.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { paginateList } from '../../src/utils';
+
+describe('paginateList', () => {
+	const exampleArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+	const exampleArrayLength = exampleArray.length;
+
+	it('should return all elements when limit and offset are not provided', () => {
+		expect(paginateList(exampleArray)).toEqual(exampleArray);
+	});
+
+	it('should return only first 5 elements when limit is 5', () => {
+		expect(paginateList(exampleArray, 5)).toEqual(exampleArray.slice(0, 5));
+	});
+
+	it('should return elements after 5th element when offset and limit are 5', () => {
+		expect(paginateList(exampleArray, 5, 5)).toEqual(exampleArray.slice(5, exampleArrayLength));
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5254

### How was it solved?

- Add GET `api/peers` URL and Controller
- Add functional test

### How was it tested?

Run `npm run test:functional peers.spec.ts` under `framework-plugins/lisk-framework-http-api-plugin/`
