### PR TITLE
Add http-api for GET api/node/transactions?limit=xxx&offset=yyy - Closes #5253

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
@@ -34,8 +34,9 @@ export const getTransactions = (channel: BaseChannel, codec: PluginCodec) => asy
 	next: NextFunction,
 ): Promise<void> => {
 	const { limit, offset } = req.query;
-	let limitNumber = 0;
+	let limitNumber = 10;
 	let offsetNumber = 0;
+
 	if (limit) {
 		if (!isNumberString(limit)) {
 			res.status(400).send({
@@ -70,19 +71,12 @@ export const getTransactions = (channel: BaseChannel, codec: PluginCodec) => asy
 		decodedTransactions.push(codec.decodeTransaction(transaction));
 	}
 
-	let data = decodedTransactions;
-
-	if (offset) {
-		data = decodedTransactions.slice(offsetNumber, decodedTransactions.length);
-	}
-
-	if (limit) {
-		data = data.slice(0, limitNumber);
-	}
-
 	// 200 - Response
 	res.status(200).json({
-		data,
+		data: decodedTransactions.slice(
+			offsetNumber || 0,
+			Math.min(limitNumber + offsetNumber, decodedTransactions.length),
+		),
 		meta: { limit: limitNumber, offset: offsetNumber, total: decodedTransactions.length },
 	});
 };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/node.ts
@@ -12,7 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { Request, Response, NextFunction } from 'express';
-import { BaseChannel } from 'lisk-framework';
+import { BaseChannel, PluginCodec } from 'lisk-framework';
+import { isNumberString } from '@liskhq/lisk-validator';
 
 export const getNodeInfo = (channel: BaseChannel) => async (
 	_req: Request,
@@ -25,4 +26,63 @@ export const getNodeInfo = (channel: BaseChannel) => async (
 	} catch (err) {
 		next(err);
 	}
+};
+
+export const getTransactions = (channel: BaseChannel, codec: PluginCodec) => async (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	const { limit, offset } = req.query;
+	let limitNumber = 0;
+	let offsetNumber = 0;
+	if (limit) {
+		if (!isNumberString(limit)) {
+			res.status(400).send({
+				errors: [{ message: 'The limit query parameter should be a number.' }],
+			});
+			return;
+		}
+		limitNumber = Number(limit);
+	}
+
+	if (offset) {
+		if (!isNumberString(offset)) {
+			res.status(400).send({
+				errors: [{ message: 'The offset query parameter should be a number.' }],
+			});
+			return;
+		}
+		offsetNumber = Number(offset);
+	}
+
+	let transactionsInPool;
+
+	try {
+		transactionsInPool = await channel.invoke<string>('app:getTransactionsFromPool');
+	} catch (err) {
+		next(err);
+		return;
+	}
+
+	const decodedTransactions = [];
+	for (const transaction of transactionsInPool) {
+		decodedTransactions.push(codec.decodeTransaction(transaction));
+	}
+
+	let data = decodedTransactions;
+
+	if (offset) {
+		data = decodedTransactions.slice(offsetNumber, decodedTransactions.length);
+	}
+
+	if (limit) {
+		data = data.slice(0, limitNumber);
+	}
+
+	// 200 - Response
+	res.status(200).json({
+		data,
+		meta: { limit: limitNumber, offset: offsetNumber, total: decodedTransactions.length },
+	});
 };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -117,5 +117,9 @@ export class HTTPAPIPlugin extends BasePlugin {
 			controllers.accounts.getAccount(this._channel, this.codec),
 		);
 		this._app.get('/api/node/info', controllers.node.getNodeInfo(this._channel));
+		this._app.get(
+			'/api/node/transactions',
+			controllers.node.getTransactions(this._channel, this.codec),
+		);
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -175,6 +175,18 @@ describe('Node Info endpoint', () => {
 					errors: [{ message: 'The limit query parameter should be a number.' }],
 				});
 			});
+
+			it('should fail if offset is not a number', async () => {
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/node/transactions/?offset=a')),
+				);
+
+				expect(status).toEqual(400);
+				expect(response).toEqual({
+					errors: [{ message: 'The offset query parameter should be a number.' }],
+				});
+			});
 		});
 	});
 });

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -100,6 +100,37 @@ describe('Node Info endpoint', () => {
 				expect(status).toEqual(200);
 				expect(response).toEqual({ data: [transaction], meta: { limit: 0, offset: 0, total: 1 } });
 			});
+
+			it('should be ok with limit', async () => {
+				const transaction = createTransferTransaction({
+					amount: '2',
+					recipientAddress: account.address,
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+				const { id: txID, ...input1 } = transaction;
+				await axios.post(getURL('/api/transactions'), input1);
+				const transaction2 = createTransferTransaction({
+					amount: '2',
+					recipientAddress: account.address,
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+
+				const { id, ...input2 } = transaction2;
+				await axios.post(getURL('/api/transactions'), input2);
+
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/node/transactions/?limit=1')),
+				);
+
+				// Assert
+				expect(status).toEqual(200);
+				expect(response).toEqual({ data: [transaction], meta: { limit: 1, offset: 0, total: 2 } });
+			});
 		});
 	});
 });

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -79,7 +79,7 @@ describe('Node Info endpoint', () => {
 
 				// Assert
 				expect(status).toEqual(200);
-				expect(response).toEqual({ data: [], meta: { limit: 0, offset: 0, total: 0 } });
+				expect(response).toEqual({ data: [], meta: { limit: 10, offset: 0, total: 0 } });
 			});
 
 			it('should be ok with transactions in pool', async () => {
@@ -98,7 +98,7 @@ describe('Node Info endpoint', () => {
 
 				// Assert
 				expect(status).toEqual(200);
-				expect(response).toEqual({ data: [transaction], meta: { limit: 0, offset: 0, total: 1 } });
+				expect(response).toEqual({ data: [transaction], meta: { limit: 10, offset: 0, total: 1 } });
 			});
 
 			it('should be ok with limit', async () => {
@@ -159,7 +159,10 @@ describe('Node Info endpoint', () => {
 
 				// Assert
 				expect(status).toEqual(200);
-				expect(response).toEqual({ data: [transaction2], meta: { limit: 0, offset: 1, total: 2 } });
+				expect(response).toEqual({
+					data: [transaction2],
+					meta: { limit: 10, offset: 1, total: 2 },
+				});
 			});
 		});
 

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -13,7 +13,8 @@
  */
 import { Application } from 'lisk-framework';
 import axios from 'axios';
-import { createApplication, closeApplication, getURL } from './utils/application';
+import { createApplication, closeApplication, getURL, waitNBlocks } from './utils/application';
+import { getRandomAccount } from './utils/accounts';
 
 describe('Node Info endpoint', () => {
 	let app: Application;
@@ -49,6 +50,29 @@ describe('Node Info endpoint', () => {
 
 			expect(result.data).toEqual({ data: nodeStatusAndConstantFixture });
 			expect(result.status).toBe(200);
+		});
+	});
+
+	describe('GET /api/node/transactions/', () => {
+		describe('200 - Success', () => {
+			let account: any;
+
+			beforeEach(() => {
+				account = getRandomAccount();
+			});
+
+			afterEach(async () => {
+				await waitNBlocks(app, 2);
+			});
+
+			it('should be ok with no transactions in pool', async () => {
+				// Act
+				const { response, status } = await callNetwork(axios.get(getURL('/api/node/transactions')));
+
+				// Assert
+				expect(status).toEqual(200);
+				expect(response).toEqual({ data: [], meta: { limit: 0, offset: 0, total: 0 } });
+			});
 		});
 	});
 });

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -131,6 +131,36 @@ describe('Node Info endpoint', () => {
 				expect(status).toEqual(200);
 				expect(response).toEqual({ data: [transaction], meta: { limit: 1, offset: 0, total: 2 } });
 			});
+
+			it('should be ok with offset', async () => {
+				const transaction = createTransferTransaction({
+					amount: '2',
+					recipientAddress: account.address,
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+				const { id: txID, ...input1 } = transaction;
+				await axios.post(getURL('/api/transactions'), input1);
+				const transaction2 = createTransferTransaction({
+					amount: '2',
+					recipientAddress: account.address,
+					fee: '0.3',
+					nonce: 5,
+				});
+
+				const { id, ...input2 } = transaction2;
+				await axios.post(getURL('/api/transactions'), input2);
+
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/node/transactions/?offset=1')),
+				);
+
+				// Assert
+				expect(status).toEqual(200);
+				expect(response).toEqual({ data: [transaction2], meta: { limit: 0, offset: 1, total: 2 } });
+			});
 		});
 	});
 });

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -162,5 +162,19 @@ describe('Node Info endpoint', () => {
 				expect(response).toEqual({ data: [transaction2], meta: { limit: 0, offset: 1, total: 2 } });
 			});
 		});
+
+		describe('400 - Malformed query or parameters', () => {
+			it('should fail if limit is not a number', async () => {
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/node/transactions/?limit=a')),
+				);
+
+				expect(status).toEqual(400);
+				expect(response).toEqual({
+					errors: [{ message: 'The limit query parameter should be a number.' }],
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

Endpoint to retrieve transactions in pool from node was needed.

This PR resolves #5253 

### How was it solved?

-  Add GET api/node/transactions URL and Controller
-  Add functional test

### How was it tested?

Run `npm run test:functional node.spec` under `framework-plugins/lisk-framework-http-api-plugin/`
