### PR TITLE
Update child process IPC communication integration test - Closes #5512

### DIFF
--- a/framework/test/integration/specs/controller/ipc/ipc_client.spec.ts
+++ b/framework/test/integration/specs/controller/ipc/ipc_client.spec.ts
@@ -12,18 +12,21 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { mkdirSync, rmdirSync } from 'fs';
 import { resolve as pathResolve } from 'path';
 import { homedir } from 'os';
 import { IPCServer } from '../../../../../src/controller/ipc/ipc_server';
 import { IPCClient } from '../../../../../src/controller/ipc/ipc_client';
 
-const socketsDir = pathResolve(`${homedir()}/.lisk/devnet/tmp/sockets`);
-/* eslint-disable jest/no-disabled-tests */
-describe.skip('IPCClient', () => {
+const socketsDir = pathResolve(`${homedir()}/.lisk/functional/ipc_client/sockets`);
+
+describe('IPCClient', () => {
 	let server: IPCServer;
 	let client: IPCClient;
 
 	beforeEach(async () => {
+		mkdirSync(socketsDir, { recursive: true });
+
 		server = new IPCServer({
 			socketsDir,
 			name: 'bus',
@@ -45,6 +48,7 @@ describe.skip('IPCClient', () => {
 	afterEach(() => {
 		client.stop();
 		server.stop();
+		rmdirSync(socketsDir);
 	});
 
 	describe('start', () => {

--- a/framework/test/integration/specs/controller/ipc/ipc_server.spec.ts
+++ b/framework/test/integration/specs/controller/ipc/ipc_server.spec.ts
@@ -12,16 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { mkdirSync, rmdirSync } from 'fs';
 import { resolve as pathResolve } from 'path';
 import { homedir } from 'os';
 import { IPCServer } from '../../../../../src/controller/ipc/ipc_server';
 
-const socketsDir = pathResolve(`${homedir()}/.lisk/devnet/tmp/sockets`);
-/* eslint-disable jest/no-disabled-tests */
-describe.skip('IPCServer', () => {
+const socketsDir = pathResolve(`${homedir()}/.lisk/functional/ipc_server/sockets`);
+
+describe('IPCServer', () => {
 	let server: IPCServer;
 
 	beforeEach(() => {
+		mkdirSync(socketsDir, { recursive: true });
+
 		server = new IPCServer({
 			socketsDir,
 			name: 'bus',
@@ -30,6 +33,7 @@ describe.skip('IPCServer', () => {
 
 	afterEach(() => {
 		server.stop();
+		rmdirSync(socketsDir);
 	});
 
 	describe('start', () => {

--- a/framework/test/integration/specs/controller/ipc_channel.spec.ts
+++ b/framework/test/integration/specs/controller/ipc_channel.spec.ts
@@ -13,7 +13,7 @@
  */
 
 import { homedir } from 'os';
-
+import { mkdirSync, rmdirSync } from 'fs';
 import { resolve as pathResolve } from 'path';
 import { IPCChannel, InMemoryChannel } from '../../../../src/controller/channels';
 import { Bus } from '../../../../src/controller/bus';
@@ -23,7 +23,7 @@ const logger: any = {
 	info: jest.fn(),
 };
 
-const socketsDir = pathResolve(`${homedir()}/.lisk/devnet/tmp/sockets`);
+const socketsDir = pathResolve(`${homedir()}/.lisk/functional/ipc_channel/sockets`);
 
 const config: any = {
 	ipc: {
@@ -63,14 +63,16 @@ const beta = {
 		},
 	},
 };
-/* eslint-disable jest/no-disabled-tests */
-describe.skip('IPCChannel', () => {
+
+describe('IPCChannel', () => {
 	describe('after registering itself to the bus', () => {
 		let alphaChannel: IPCChannel;
 		let betaChannel: IPCChannel;
 		let bus: Bus;
 
 		beforeAll(async () => {
+			mkdirSync(socketsDir, { recursive: true });
+
 			// Arrange
 			bus = new Bus(logger, config);
 
@@ -87,6 +89,8 @@ describe.skip('IPCChannel', () => {
 			alphaChannel.cleanup();
 			betaChannel.cleanup();
 			await bus.cleanup();
+
+			rmdirSync(socketsDir);
 		});
 
 		describe('#subscribe', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5512

### How was it solved?

Configured each test to run with its own sockets directory. 

### How was it tested?

Run integration tests. 
