### PR TITLE
Update framework build to include d.ts files - Closes #5551

### DIFF
--- a/framework/package.json
+++ b/framework/package.json
@@ -32,7 +32,7 @@
 		"format": "prettier --write '**/*'",
 		"test": "jest --config=./test/unit/jest.config.js",
 		"test:coverage": "jest --config=./test/unit/jest.config.js --coverage=true --coverage-reporters=text",
-		"copy-static-files": "copyfiles -u 1 src/**/*.{yml} ./dist-node",
+		"copy-static-files": "copyfiles -u 1 src/**/*.d.ts ./dist-node",
 		"build": "tsc && npm run copy-static-files",
 		"test:unit": "jest --config=./test/unit/jest.config.js --coverage=true --coverage-reporters=json --verbose",
 		"test:integration": "jest --config=./test/integration/jest.config.js",


### PR DESCRIPTION
### What was the problem?

This PR resolves #5551 

### How was it solved?

Make copyfiles on the build process to copy d.ts

### How was it tested?

`npm pack --dry-run` and check
```
npm notice 607B   dist-node/external_types/pm2-axon-rpc/index.d.ts
npm notice 3.6kB  dist-node/external_types/pm2-axon/index.d.ts
```
these are included
