### PR TITLE
Get delegates api - Closes #5255 & #5554 & #5556

### DIFF
--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -15,7 +15,7 @@ import { hash } from '@liskhq/lisk-cryptography';
 import { codec } from '@liskhq/lisk-codec';
 import * as Debug from 'debug';
 import { EventEmitter } from 'events';
-import { voteWeightsSchema } from './schemas';
+import { voteWeightsSchema, delegatesUserNamesSchema } from './schemas';
 
 import {
 	CONSENSUS_STATE_DELEGATE_VOTE_WEIGHTS,
@@ -24,6 +24,7 @@ import {
 	DEFAULT_STANDBY_DELEGATE,
 	DEFAULT_STANDBY_THRESHOLD,
 	DEFAULT_VOTE_WEIGHT_CAP_RATE,
+	CHAIN_STATE_DELEGATE_USERNAMES,
 } from './constants';
 import { DelegatesInfo } from './delegates_info';
 import {
@@ -40,6 +41,7 @@ import {
 	ForgersList,
 	StateStore,
 	DecodedVoteWeights,
+	DecodedUsernames,
 } from './types';
 
 interface DposConstructor {
@@ -271,6 +273,21 @@ export class Dpos {
 		});
 
 		return false;
+	}
+
+	public async getAllDelegates(): Promise<DecodedUsernames | undefined> {
+		const usernamesBuffer = await this.chain.dataAccess.getChainState(
+			CHAIN_STATE_DELEGATE_USERNAMES,
+		);
+		if (usernamesBuffer) {
+			const parsedUsernames = codec.decode<DecodedUsernames>(
+				delegatesUserNamesSchema,
+				usernamesBuffer,
+			);
+			return parsedUsernames;
+		}
+
+		return undefined;
 	}
 
 	/**

--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -275,10 +275,11 @@ export class Dpos {
 		return false;
 	}
 
-	public async getAllUsernames(): Promise<DecodedUsernames | undefined> {
+	public async getAllUsernames(): Promise<DecodedUsernames | []> {
 		const usernamesBuffer = await this.chain.dataAccess.getChainState(
 			CHAIN_STATE_DELEGATE_USERNAMES,
 		);
+
 		if (usernamesBuffer) {
 			const parsedUsernames = codec.decode<DecodedUsernames>(
 				delegatesUserNamesSchema,
@@ -287,7 +288,7 @@ export class Dpos {
 			return parsedUsernames;
 		}
 
-		return undefined;
+		return [];
 	}
 
 	/**

--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -275,7 +275,7 @@ export class Dpos {
 		return false;
 	}
 
-	public async getAllDelegates(): Promise<DecodedUsernames | undefined> {
+	public async getAllUsernames(): Promise<DecodedUsernames | undefined> {
 		const usernamesBuffer = await this.chain.dataAccess.getChainState(
 			CHAIN_STATE_DELEGATE_USERNAMES,
 		);

--- a/elements/lisk-dpos/src/dpos.ts
+++ b/elements/lisk-dpos/src/dpos.ts
@@ -42,6 +42,7 @@ import {
 	StateStore,
 	DecodedVoteWeights,
 	DecodedUsernames,
+	RegisteredDelegate,
 } from './types';
 
 interface DposConstructor {
@@ -275,7 +276,7 @@ export class Dpos {
 		return false;
 	}
 
-	public async getAllUsernames(): Promise<DecodedUsernames | []> {
+	public async getAllUsernames(): Promise<RegisteredDelegate[]> {
 		const usernamesBuffer = await this.chain.dataAccess.getChainState(
 			CHAIN_STATE_DELEGATE_USERNAMES,
 		);
@@ -285,7 +286,7 @@ export class Dpos {
 				delegatesUserNamesSchema,
 				usernamesBuffer,
 			);
-			return parsedUsernames;
+			return parsedUsernames.registeredDelegates;
 		}
 
 		return [];

--- a/elements/lisk-dpos/src/types.ts
+++ b/elements/lisk-dpos/src/types.ts
@@ -141,11 +141,11 @@ export interface DecodedVoteWeights {
 	voteWeights: VoteWeights;
 }
 
+export interface RegisteredDelegate {
+	readonly username: string;
+	readonly address: Buffer;
+}
+
 export interface DecodedUsernames {
-	registeredDelegates: [
-		{
-			username: string;
-			address: Buffer;
-		},
-	];
+	registeredDelegates: [RegisteredDelegate];
 }

--- a/elements/lisk-dpos/src/types.ts
+++ b/elements/lisk-dpos/src/types.ts
@@ -147,5 +147,5 @@ export interface RegisteredDelegate {
 }
 
 export interface DecodedUsernames {
-	registeredDelegates: [RegisteredDelegate];
+	registeredDelegates: RegisteredDelegate[];
 }

--- a/elements/lisk-dpos/src/types.ts
+++ b/elements/lisk-dpos/src/types.ts
@@ -88,6 +88,7 @@ export interface Chain {
 	};
 	readonly dataAccess: {
 		getConsensusState(key: string): Promise<Buffer | undefined>;
+		getChainState(key: string): Promise<Buffer | undefined>;
 		getBlockHeadersByHeightBetween(fromHeight: number, toHeight: number): Promise<BlockHeader[]>;
 	};
 }

--- a/elements/lisk-validator/src/formats.ts
+++ b/elements/lisk-validator/src/formats.ts
@@ -33,9 +33,9 @@ export const int64 = (data: string): boolean => isNumberString(data) && isSInt64
 
 export const uint64 = (data: string): boolean => isNumberString(data) && isUInt64(BigInt(data));
 
-export const uint32 = (data: string): boolean => isNumberString(data) && isUInt32(BigInt(data));
+export const uint32 = (data: string): boolean => isNumberString(data) && isUInt32(Number(data));
 
-export const int32 = (data: string): boolean => isNumberString(data) && isSInt32(BigInt(data));
+export const int32 = (data: string): boolean => isNumberString(data) && isSInt32(Number(data));
 
 const camelCaseRegex = /^[a-z]+((\d)|([A-Z0-9][a-zA-Z0-9]+))*([a-z0-9A-Z])?$/;
 

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
@@ -30,10 +30,6 @@ const getDelegatesQuerySchema = {
 			description: 'Offset to get delegates after a specific length in a delegates list',
 		},
 	},
-	default: {
-		limit: 100,
-		offset: 0,
-	},
 };
 
 export const getDelegates = (channel: BaseChannel, codec: PluginCodec) => async (
@@ -51,12 +47,16 @@ export const getDelegates = (channel: BaseChannel, codec: PluginCodec) => async 
 	}
 
 	const { limit = 100, offset = 0 } = req.query;
-
 	try {
 		const encodedDelegates: string[] = await channel.invoke('app:getAllDelegates');
 		const decodedDelegates = encodedDelegates.map(delegate => codec.decodeAccount(delegate));
 
-		res.status(200).send({ data: paginateList(decodedDelegates, +limit, +offset) });
+		res
+			.status(200)
+			.send({
+				meta: { count: decodedDelegates.length, limit: +limit, offset: +offset },
+				data: paginateList(decodedDelegates, +limit, +offset),
+			});
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
@@ -21,13 +21,13 @@ const getDelegatesQuerySchema = {
 	properties: {
 		limit: {
 			type: 'string',
-			format: 'uint64',
+			format: 'uint32',
 			description: 'Number of delegates to be returned',
 		},
 		offset: {
 			type: 'string',
-			format: 'uint64',
-			description: 'Offset to get delegates after a specific length in a peer list',
+			format: 'uint32',
+			description: 'Offset to get delegates after a specific length in a delegates list',
 		},
 	},
 	default: {
@@ -54,9 +54,7 @@ export const getDelegates = (channel: BaseChannel, codec: PluginCodec) => async 
 
 	try {
 		const encodedDelegates: string[] = await channel.invoke('app:getAllDelegates');
-		const decodedDelegates = encodedDelegates
-			.map(account => codec.decodeAccount(account))
-			.filter(account => account.asset.delegate.username);
+		const decodedDelegates = encodedDelegates.map(delegate => codec.decodeAccount(delegate));
 
 		res.status(200).send({ data: paginateList(decodedDelegates, +limit, +offset) });
 	} catch (err) {

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
@@ -51,12 +51,10 @@ export const getDelegates = (channel: BaseChannel, codec: PluginCodec) => async 
 		const encodedDelegates: string[] = await channel.invoke('app:getAllDelegates');
 		const decodedDelegates = encodedDelegates.map(delegate => codec.decodeAccount(delegate));
 
-		res
-			.status(200)
-			.send({
-				meta: { count: decodedDelegates.length, limit: +limit, offset: +offset },
-				data: paginateList(decodedDelegates, +limit, +offset),
-			});
+		res.status(200).send({
+			meta: { count: decodedDelegates.length, limit: +limit, offset: +offset },
+			data: paginateList(decodedDelegates, +limit, +offset),
+		});
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
@@ -51,7 +51,7 @@ export const getDelegates = (channel: BaseChannel, codec: PluginCodec) => async 
 		const encodedDelegates: string[] = await channel.invoke('app:getAllDelegates');
 		const decodedDelegates = encodedDelegates.map(delegate => codec.decodeAccount(delegate));
 
-		res.status(200).send({
+		res.status(200).json({
 			meta: { count: decodedDelegates.length, limit: +limit, offset: +offset },
 			data: paginateList(decodedDelegates, +limit, +offset),
 		});

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/delegates.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Request, Response, NextFunction } from 'express';
+import { validator, LiskValidationError } from '@liskhq/lisk-validator';
+import { BaseChannel, PluginCodec } from 'lisk-framework';
+import { paginateList } from '../utils';
+
+const getDelegatesQuerySchema = {
+	type: 'object',
+	properties: {
+		limit: {
+			type: 'string',
+			format: 'uint64',
+			description: 'Number of delegates to be returned',
+		},
+		offset: {
+			type: 'string',
+			format: 'uint64',
+			description: 'Offset to get delegates after a specific length in a peer list',
+		},
+	},
+	default: {
+		limit: 100,
+		offset: 0,
+	},
+};
+
+export const getDelegates = (channel: BaseChannel, codec: PluginCodec) => async (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	const errors = validator.validate(getDelegatesQuerySchema, req.query);
+	// 400 - Malformed query or parameters
+	if (errors.length) {
+		res.status(400).send({
+			errors: [{ message: new LiskValidationError([...errors]).message }],
+		});
+		return;
+	}
+
+	const { limit = 100, offset = 0 } = req.query;
+
+	try {
+		const encodedDelegates: string[] = await channel.invoke('app:getAllDelegates');
+		const decodedDelegates = encodedDelegates
+			.map(account => codec.decodeAccount(account))
+			.filter(account => account.asset.delegate.username);
+
+		res.status(200).send({ data: paginateList(decodedDelegates, +limit, +offset) });
+	} catch (err) {
+		next(err);
+	}
+};

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/index.ts
@@ -17,6 +17,7 @@ import * as accounts from './accounts';
 import * as node from './node';
 import * as blocks from './blocks';
 import * as peers from './peers';
+import * as delegates from './delegates';
 
 export * from './hello';
-export { accounts, blocks, node, transactions, peers };
+export { accounts, blocks, node, transactions, peers, delegates };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
@@ -74,7 +74,7 @@ export const getPeers = (channel: BaseChannel) => async (
 			peers = await channel.invoke<ReadonlyArray<PeerInfo>>('app:getConnectedPeers');
 		}
 
-		res.status(200).send({
+		res.status(200).json({
 			meta: { count: peers.length, limit: +limit, offset: +offset },
 			data: paginateList(peers, +limit, +offset),
 		});

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
@@ -74,12 +74,10 @@ export const getPeers = (channel: BaseChannel) => async (
 			peers = await channel.invoke<ReadonlyArray<PeerInfo>>('app:getConnectedPeers');
 		}
 
-		res
-			.status(200)
-			.send({
-				meta: { count: peers.length, limit: +limit, offset: +offset },
-				data: paginateList(peers, +limit, +offset),
-			});
+		res.status(200).send({
+			meta: { count: peers.length, limit: +limit, offset: +offset },
+			data: paginateList(peers, +limit, +offset),
+		});
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
@@ -21,12 +21,12 @@ const getPeerSchema = {
 	properties: {
 		limit: {
 			type: 'string',
-			format: 'uint64',
+			format: 'uint32',
 			description: 'Number of peers to be returned',
 		},
 		offset: {
 			type: 'string',
-			format: 'uint64',
+			format: 'uint32',
 			description: 'Offset to get peers after a specific point in a peer list',
 		},
 		state: {

--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
@@ -34,11 +34,6 @@ const getPeerSchema = {
 			enum: ['connected', 'disconnected'],
 		},
 	},
-	default: {
-		limit: 100,
-		offset: 0,
-		state: 'connected',
-	},
 };
 
 enum PeerState {
@@ -79,9 +74,12 @@ export const getPeers = (channel: BaseChannel) => async (
 			peers = await channel.invoke<ReadonlyArray<PeerInfo>>('app:getConnectedPeers');
 		}
 
-		peers = paginateList(peers, +limit, +offset);
-
-		res.status(200).send(peers);
+		res
+			.status(200)
+			.send({
+				meta: { count: peers.length, limit: +limit, offset: +offset },
+				data: paginateList(peers, +limit, +offset),
+			});
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -124,5 +124,6 @@ export class HTTPAPIPlugin extends BasePlugin {
 			controllers.node.getTransactions(this._channel, this.codec),
 		);
 		this._app.get('/api/peers', controllers.peers.getPeers(this._channel));
+		this._app.get('/api/delegates', controllers.delegates.getDelegates(this._channel, this.codec));
 	}
 }

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
@@ -86,7 +86,7 @@ describe('Delegates endpoint', () => {
 				errors: [
 					{
 						message:
-							'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint64"',
+							'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint32"',
 					},
 				],
 			});
@@ -102,7 +102,7 @@ describe('Delegates endpoint', () => {
 				errors: [
 					{
 						message:
-							'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint64"',
+							'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint32"',
 					},
 				],
 			});

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
@@ -13,7 +13,6 @@
  */
 import { Application } from 'lisk-framework';
 import axios from 'axios';
-import { when } from 'jest-when';
 import { callNetwork, createApplication, closeApplication, getURL } from './utils/application';
 
 describe('Delegates endpoint', () => {
@@ -52,35 +51,54 @@ describe('Delegates endpoint', () => {
 
 	describe('/api/delegates', () => {
 		it('should respond with all the delegates', async () => {
+			// Act
 			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=100')));
+			// Assert
 			expect(response.data).toHaveLength(100);
 			expect(response.data[0]).toEqual(firstDelegateAccount);
+			expect(response.meta).toEqual({
+				count: 103,
+				limit: 100,
+				offset: 0,
+			});
 			expect(status).toBe(200);
 		});
 
 		it('should respond with all the delegates after first 100 delegates', async () => {
+			// Act
 			const { response, status } = await callNetwork(
 				axios.get(getURL('/api/delegates?limit=100&offset=100')),
 			);
+			// Assert
 			expect(response.data).toHaveLength(3);
+			expect(response.meta).toEqual({
+				count: 103,
+				limit: 100,
+				offset: 100,
+			});
 			expect(status).toBe(200);
 		});
 
 		it('should respond with blank array when no delegates are found', async () => {
-			app['_channel'].invoke = jest.fn();
-			when(app['_channel'].invoke)
-				.calledWith('app:getAllDelegates')
-				.mockResolvedValue([] as never);
-
-			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=100')));
+			// Act
+			const { response, status } = await callNetwork(
+				axios.get(getURL('/api/delegates?limit=100&offset=103')),
+			);
+			// Assert
 			expect(response.data).toHaveLength(0);
 			expect(response.data).toEqual([]);
+			expect(response.meta).toEqual({
+				count: 103,
+				limit: 100,
+				offset: 103,
+			});
 			expect(status).toBe(200);
 		});
 
 		it('should respond with 400 and error message when limit value is invalid', async () => {
+			// Act
 			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=xxx')));
-
+			// Assert
 			expect(status).toBe(400);
 			expect(response).toEqual({
 				errors: [
@@ -93,10 +111,11 @@ describe('Delegates endpoint', () => {
 		});
 
 		it('should respond with 400 and error message when offset value is invalid', async () => {
+			// Act
 			const { response, status } = await callNetwork(
 				axios.get(getURL('/api/delegates?offset=xxx')),
 			);
-
+			// Assert
 			expect(status).toBe(400);
 			expect(response).toEqual({
 				errors: [

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Application } from 'lisk-framework';
+import axios from 'axios';
+import { when } from 'jest-when';
+import { callNetwork, createApplication, closeApplication, getURL } from './utils/application';
+
+describe('Delegates endpoint', () => {
+	let app: Application;
+	const firstDelegateAccount = {
+		address: 'A/bZC329BJfcOlLRwn4ju4x1iX8=',
+		balance: '0',
+		nonce: '0',
+		keys: { numberOfSignatures: 0, mandatoryKeys: [], optionalKeys: [] },
+		asset: {
+			delegate: {
+				username: 'genesis_34',
+				pomHeights: [],
+				consecutiveMissedBlocks: 0,
+				lastForgedHeight: 0,
+				isBanned: false,
+				totalVotesReceived: '1000000000000',
+			},
+			sentVotes: [
+				{
+					delegateAddress: 'A/bZC329BJfcOlLRwn4ju4x1iX8=',
+					amount: '1000000000000',
+				},
+			],
+			unlocking: [],
+		},
+	};
+
+	beforeAll(async () => {
+		app = await createApplication('delegates_http_functional');
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('/api/delegates', () => {
+		it('should respond with all the delegates', async () => {
+			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=100')));
+			expect(response.data).toHaveLength(100);
+			expect(response.data[0]).toEqual(firstDelegateAccount);
+			expect(status).toBe(200);
+		});
+
+		it('should respond with all the delegates after first 100 delegates', async () => {
+			const { response, status } = await callNetwork(
+				axios.get(getURL('/api/delegates?limit=100&offset=100')),
+			);
+			expect(response.data).toHaveLength(3);
+			expect(status).toBe(200);
+		});
+
+		it('should respond with blank array when no delegates are found', async () => {
+			app['_channel'].invoke = jest.fn();
+			when(app['_channel'].invoke)
+				.calledWith('app:getAllDelegates')
+				.mockResolvedValue([] as never);
+
+			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=100')));
+			expect(response.data).toHaveLength(0);
+			expect(response.data).toEqual([]);
+			expect(status).toBe(200);
+		});
+
+		it('should respond with 400 and error message when limit value is invalid', async () => {
+			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=xxx')));
+
+			expect(status).toBe(400);
+			expect(response).toEqual({
+				errors: [
+					{
+						message:
+							'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint64"',
+					},
+				],
+			});
+		});
+
+		it('should respond with 400 and error message when offset value is invalid', async () => {
+			const { response, status } = await callNetwork(
+				axios.get(getURL('/api/delegates?offset=xxx')),
+			);
+
+			expect(status).toBe(400);
+			expect(response).toEqual({
+				errors: [
+					{
+						message:
+							'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint64"',
+					},
+				],
+			});
+		});
+	});
+});

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/delegates.spec.ts
@@ -50,80 +50,88 @@ describe('Delegates endpoint', () => {
 	});
 
 	describe('/api/delegates', () => {
-		it('should respond with all the delegates', async () => {
-			// Act
-			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=100')));
-			// Assert
-			expect(response.data).toHaveLength(100);
-			expect(response.data[0]).toEqual(firstDelegateAccount);
-			expect(response.meta).toEqual({
-				count: 103,
-				limit: 100,
-				offset: 0,
+		describe('200 - Success', () => {
+			it('should respond with all the delegates', async () => {
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/delegates?limit=100')),
+				);
+				// Assert
+				expect(response.data).toHaveLength(100);
+				expect(response.data[0]).toEqual(firstDelegateAccount);
+				expect(response.meta).toEqual({
+					count: 103,
+					limit: 100,
+					offset: 0,
+				});
+				expect(status).toBe(200);
 			});
-			expect(status).toBe(200);
-		});
 
-		it('should respond with all the delegates after first 100 delegates', async () => {
-			// Act
-			const { response, status } = await callNetwork(
-				axios.get(getURL('/api/delegates?limit=100&offset=100')),
-			);
-			// Assert
-			expect(response.data).toHaveLength(3);
-			expect(response.meta).toEqual({
-				count: 103,
-				limit: 100,
-				offset: 100,
+			it('should respond with all the delegates after first 100 delegates', async () => {
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/delegates?limit=100&offset=100')),
+				);
+				// Assert
+				expect(response.data).toHaveLength(3);
+				expect(response.meta).toEqual({
+					count: 103,
+					limit: 100,
+					offset: 100,
+				});
+				expect(status).toBe(200);
 			});
-			expect(status).toBe(200);
-		});
 
-		it('should respond with blank array when no delegates are found', async () => {
-			// Act
-			const { response, status } = await callNetwork(
-				axios.get(getURL('/api/delegates?limit=100&offset=103')),
-			);
-			// Assert
-			expect(response.data).toHaveLength(0);
-			expect(response.data).toEqual([]);
-			expect(response.meta).toEqual({
-				count: 103,
-				limit: 100,
-				offset: 103,
-			});
-			expect(status).toBe(200);
-		});
-
-		it('should respond with 400 and error message when limit value is invalid', async () => {
-			// Act
-			const { response, status } = await callNetwork(axios.get(getURL('/api/delegates?limit=xxx')));
-			// Assert
-			expect(status).toBe(400);
-			expect(response).toEqual({
-				errors: [
-					{
-						message:
-							'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint32"',
-					},
-				],
+			it('should respond with blank array when no delegates are found', async () => {
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/delegates?limit=100&offset=103')),
+				);
+				// Assert
+				expect(response.data).toHaveLength(0);
+				expect(response.data).toEqual([]);
+				expect(response.meta).toEqual({
+					count: 103,
+					limit: 100,
+					offset: 103,
+				});
+				expect(status).toBe(200);
 			});
 		});
 
-		it('should respond with 400 and error message when offset value is invalid', async () => {
-			// Act
-			const { response, status } = await callNetwork(
-				axios.get(getURL('/api/delegates?offset=xxx')),
-			);
-			// Assert
-			expect(status).toBe(400);
-			expect(response).toEqual({
-				errors: [
-					{
-						message:
-							'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint32"',
-					},
-				],
+		describe('400 - Invalid query values', () => {
+			it('should respond with 400 and error message when limit value is invalid', async () => {
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/delegates?limit=xxx')),
+				);
+				// Assert
+				expect(status).toBe(400);
+				expect(response).toEqual({
+					errors: [
+						{
+							message:
+								'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint32"',
+						},
+					],
+				});
+			});
+
+			it('should respond with 400 and error message when offset value is invalid', async () => {
+				// Act
+				const { response, status } = await callNetwork(
+					axios.get(getURL('/api/delegates?offset=xxx')),
+				);
+				// Assert
+				expect(status).toBe(400);
+				expect(response).toEqual({
+					errors: [
+						{
+							message:
+								'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint32"',
+						},
+					],
+				});
 			});
 		});
 	});

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -105,7 +105,7 @@ describe('Peers endpoint', () => {
 				errors: [
 					{
 						message:
-							'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint64"',
+							'Lisk validator found 1 error[s]:\nProperty \'.limit\' should match format "uint32"',
 					},
 				],
 			});
@@ -120,7 +120,7 @@ describe('Peers endpoint', () => {
 				errors: [
 					{
 						message:
-							'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint64"',
+							'Lisk validator found 1 error[s]:\nProperty \'.offset\' should match format "uint32"',
 					},
 				],
 			});

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -42,7 +42,8 @@ describe('Peers endpoint', () => {
 			const { response, status } = await callNetwork(axios.get(getURL('/api/peers')));
 
 			// Assert
-			expect(response).toEqual(peers.slice(0, 100));
+			expect(response.data).toEqual(peers.slice(0, 100));
+			expect(response.meta).toEqual({ count: peers.length, limit: 100, offset: 0 });
 			expect(status).toBe(200);
 		});
 
@@ -60,7 +61,8 @@ describe('Peers endpoint', () => {
 			);
 
 			// Assert
-			expect(response).toEqual(peers.slice(2, 102));
+			expect(response.data).toEqual(peers.slice(2, 102));
+			expect(response.meta).toEqual({ count: peers.length, limit: 100, offset: 2 });
 			expect(status).toBe(200);
 		});
 

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -420,6 +420,9 @@ export class Application {
 					handler: async (action: ActionInfoObject) =>
 						this._node.actions.getAccounts(action.params as { address: readonly string[] }),
 				},
+				getAllDelegates: {
+					handler: async () => this._node.actions.getAllDelegates(),
+				},
 				getBlockByID: {
 					handler: async (action: ActionInfoObject) =>
 						this._node.actions.getBlockByID(action.params as { id: string }),

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -286,9 +286,9 @@ export class Node {
 			},
 			getAllDelegates: async (): Promise<readonly string[]> => {
 				const delegatesUsernames = await this._dpos.getAllUsernames();
-				if (delegatesUsernames) {
+				if (delegatesUsernames.length > 0) {
 					const delegates = await Promise.all(
-						delegatesUsernames.registeredDelegates.map(async delegate =>
+						delegatesUsernames.map(async delegate =>
 							this._chain.dataAccess.getAccountByAddress(delegate.address),
 						),
 					);

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -284,6 +284,20 @@ export class Node {
 				const forgersAddress = await this._dpos.getForgerAddressesForRound(params.round);
 				return forgersAddress.map(a => a.toString('base64'));
 			},
+			getAllDelegates: async (): Promise<readonly string[]> => {
+				const delegatesUsernames = await this._dpos.getAllDelegates();
+				if (delegatesUsernames) {
+					const delegates = await Promise.all(
+						delegatesUsernames.registeredDelegates.map(async delegate =>
+							this._chain.dataAccess.getAccountByAddress(delegate.address),
+						),
+					);
+
+					return delegates.map(d => this._chain.dataAccess.encodeAccount(d).toString('base64'));
+				}
+
+				return [];
+			},
 			updateForgingStatus: async (params: {
 				address: string;
 				password: string;

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -285,7 +285,7 @@ export class Node {
 				return forgersAddress.map(a => a.toString('base64'));
 			},
 			getAllDelegates: async (): Promise<readonly string[]> => {
-				const delegatesUsernames = await this._dpos.getAllDelegates();
+				const delegatesUsernames = await this._dpos.getAllUsernames();
 				if (delegatesUsernames) {
 					const delegates = await Promise.all(
 						delegatesUsernames.registeredDelegates.map(async delegate =>


### PR DESCRIPTION
### What was the problem?

This PR resolves #5255, #5554 & #5556

### How was it solved?

- Exposed `getAllDelegates` from dpos #5556
- Exposed `getAllDelegates` from action in node and Application #5556
- Added handler `api/delegates?limit=xx&offset=xx` endpoint to controller #5255
- Added unit tests #5255
- Fixed bug related `uint32` and `sint32` format in `lisk-validator` #5554

### How was it tested?

Run `npm run test:functional delegates` under `framework-plugins/lisk-framework-http-api-plugin`
