### PR TITLE
Add forger plugin api for GET api/forgers - Closes #525, #5570, #5559

### DIFF
--- a/framework-plugins/lisk-framework-forger-plugin/src/api.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/api.ts
@@ -21,7 +21,7 @@ import * as middlewares from './middlewares';
 import * as controllers from './controllers';
 import { Options } from './types';
 
-export const initApi = (options: Options, channel: BaseChannel, _codec: PluginCodec): Express => {
+export const initApi = (options: Options, channel: BaseChannel, codec: PluginCodec): Express => {
 	const app: Express = express();
 
 	// Register before middleware
@@ -32,6 +32,7 @@ export const initApi = (options: Options, channel: BaseChannel, _codec: PluginCo
 
 	// Register controllers
 	app.get('/v1/hello', controllers.helloController(channel));
+	app.get('/api/forgers', controllers.forgers.getForgers(channel, codec));
 
 	// Register after middleware
 	app.use(middlewares.errorMiddleware());

--- a/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
@@ -19,16 +19,16 @@ export const getForgers = (channel: BaseChannel, codec: PluginCodec) => async (
 	res: Response,
 	next: NextFunction,
 ): Promise<void> => {
-	let forgersInfo: ReadonlyArray<{ address: string; forging: boolean }>;
+	let forgersFrameworkInfo: ReadonlyArray<{ address: string; forging: boolean }>;
 	try {
-		forgersInfo = await channel.invoke('app:getForgersInfoForActiveRound');
+		forgersFrameworkInfo = await channel.invoke('app:getForgersInfoForActiveRound');
 	} catch (err) {
 		next(err);
 		return;
 	}
 	try {
-		const forgerAccounts = await channel.invoke<Buffer[]>('app:getAccounts', {
-			address: forgersInfo.map(forgerInfo => forgerInfo.address),
+		const forgerAccounts = await channel.invoke<string[]>('app:getAccounts', {
+			address: forgersFrameworkInfo.map(info => info.address),
 		});
 
 		const data = [];
@@ -38,11 +38,11 @@ export const getForgers = (channel: BaseChannel, codec: PluginCodec) => async (
 			data.push({
 				username: account.asset.delegate.username,
 				totalVotesReceived: account.asset.delegate.totalVotesReceived,
-				...forgersInfo[i],
+				...forgersFrameworkInfo[i],
 			});
 		}
 
-		res.status(200).send(data);
+		res.status(200).json({ data, meta: {} });
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
@@ -21,7 +21,7 @@ export const getForgers = (channel: BaseChannel, codec: PluginCodec) => async (
 ): Promise<void> => {
 	let forgersInfo: ReadonlyArray<{ address: string; forging: boolean }>;
 	try {
-		forgersInfo = await channel.invoke('app:getForgerAddressesForRound');
+		forgersInfo = await channel.invoke('app:getForgersInfoForRound');
 	} catch (err) {
 		next(err);
 		return;

--- a/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Request, Response, NextFunction } from 'express';
+import { BaseChannel, PluginCodec } from 'lisk-framework';
+
+export const getForgers = (channel: BaseChannel, codec: PluginCodec) => async (
+	_req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	let forgersInfo: ReadonlyArray<{ address: string; forging: boolean }>;
+	try {
+		forgersInfo = await channel.invoke('app:getForgerAddressesForRound');
+	} catch (err) {
+		next(err);
+		return;
+	}
+	try {
+		const forgerAccounts = await channel.invoke<Buffer[]>('app:getAccounts', {
+			address: forgersInfo.map(forgerInfo => forgerInfo.address),
+		});
+
+		const data = [];
+		for (let i = 0; i < forgerAccounts.length; i += 1) {
+			const account = codec.decodeAccount(forgerAccounts[i]);
+
+			data.push({
+				username: account.asset.delegate.username,
+				totalVotesReceived: account.asset.delegate.totalVotesReceived,
+				...forgersInfo[i],
+			});
+		}
+
+		res.status(200).send(data);
+	} catch (err) {
+		next(err);
+	}
+};

--- a/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/controllers/forger.ts
@@ -21,7 +21,7 @@ export const getForgers = (channel: BaseChannel, codec: PluginCodec) => async (
 ): Promise<void> => {
 	let forgersInfo: ReadonlyArray<{ address: string; forging: boolean }>;
 	try {
-		forgersInfo = await channel.invoke('app:getForgersInfoForRound');
+		forgersInfo = await channel.invoke('app:getForgersInfoForActiveRound');
 	} catch (err) {
 		next(err);
 		return;

--- a/framework-plugins/lisk-framework-forger-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/controllers/index.ts
@@ -11,5 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import * as forgers from './forger';
 
 export * from './hello';
+export { forgers };

--- a/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
@@ -367,21 +367,19 @@ export class ForgerPlugin extends BasePlugin {
 		const missedBlocks = Math.ceil((timestamp - previousBlock.timestamp) / blockTime) - 1;
 
 		if (missedBlocks > 0) {
-			const round = await this._channel.invoke('app:getSlotRound', { height });
-			const forgerAddressForRound = await this._channel.invoke<readonly string[]>(
-				'app:getForgerAddressesForRound',
-				{ round },
-			);
-			const forgersRoundLength = forgerAddressForRound.length;
-			const forgerIndex = forgerAddressForRound.findIndex(address => address === forgerAddress);
+			const forgersInfoForRound = await this._channel.invoke<
+				readonly { address: string; nextForgingTime: number }[]
+			>('app:getForgersInfoForRound');
+			const forgersRoundLength = forgersInfoForRound.length;
+			const forgerIndex = forgersInfoForRound.findIndex(f => f.address === forgerAddress);
 
 			for (let index = 0; index < missedBlocks; index += 1) {
 				const rawIndex = (forgerIndex - 1 - index) % forgersRoundLength;
 				const forgerRoundIndex = rawIndex >= 0 ? rawIndex : rawIndex + forgersRoundLength;
-				const missedForgerAddress = forgerAddressForRound[forgerRoundIndex];
-				const missedForger = await getForgerInfo(this._forgerPluginDB, missedForgerAddress);
+				const missedForgerInfo = forgersInfoForRound[forgerRoundIndex];
+				const missedForger = await this._getForgerInfo(missedForgerInfo.address);
 				missedForger.totalMissedBlocks += 1;
-				await setForgerInfo(this._forgerPluginDB, missedForgerAddress, missedForger);
+				await this._setForgerInfo(missedForgerInfo.address, missedForger);
 			}
 		}
 	}

--- a/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
@@ -369,7 +369,7 @@ export class ForgerPlugin extends BasePlugin {
 		if (missedBlocks > 0) {
 			const forgersInfoForRound = await this._channel.invoke<
 				readonly { address: string; nextForgingTime: number }[]
-			>('app:getForgersInfoForRound');
+			>('app:getForgersInfoForActiveRound');
 			const forgersRoundLength = forgersInfoForRound.length;
 			const forgerIndex = forgersInfoForRound.findIndex(f => f.address === forgerAddress);
 
@@ -377,9 +377,9 @@ export class ForgerPlugin extends BasePlugin {
 				const rawIndex = (forgerIndex - 1 - index) % forgersRoundLength;
 				const forgerRoundIndex = rawIndex >= 0 ? rawIndex : rawIndex + forgersRoundLength;
 				const missedForgerInfo = forgersInfoForRound[forgerRoundIndex];
-				const missedForger = await this._getForgerInfo(missedForgerInfo.address);
+				const missedForger = await getForgerInfo(this._forgerPluginDB, missedForgerInfo.address);
 				missedForger.totalMissedBlocks += 1;
-				await this._setForgerInfo(missedForgerInfo.address, missedForger);
+				await setForgerInfo(this._forgerPluginDB, missedForgerInfo.address, missedForger);
 			}
 		}
 	}

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
@@ -49,5 +49,9 @@ describe('Forger endpoint', () => {
 		it('should return forger address', () => {
 			expect(typeof result.data[0].address).toBe('string');
 		});
+
+		it('should return forger nextForgingTime', () => {
+			expect(typeof result.data[0].nextForgingTime).toBe('number');
+		});
 	});
 });

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
@@ -37,5 +37,9 @@ describe('Forger endpoint', () => {
 		it('should return list of 103 forgers', () => {
 			expect(result.data).toHaveLength(103);
 		});
+
+		it('should return forger username', () => {
+			expect(typeof result.data[0].username).toBe('string');
+		});
 	});
 });

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
@@ -41,5 +41,9 @@ describe('Forger endpoint', () => {
 		it('should return forger username', () => {
 			expect(typeof result.data[0].username).toBe('string');
 		});
+
+		it('should return forger totalVotesReceived', () => {
+			expect(typeof result.data[0].totalVotesReceived).toBe('string');
+		});
 	});
 });

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
@@ -45,5 +45,9 @@ describe('Forger endpoint', () => {
 		it('should return forger totalVotesReceived', () => {
 			expect(typeof result.data[0].totalVotesReceived).toBe('string');
 		});
+
+		it('should return forger address', () => {
+			expect(typeof result.data[0].address).toBe('string');
+		});
 	});
 });

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
@@ -35,23 +35,23 @@ describe('Forger endpoint', () => {
 		});
 
 		it('should return list of 103 forgers', () => {
-			expect(result.data).toHaveLength(103);
+			expect(result.data.data).toHaveLength(103);
 		});
 
 		it('should return forger username', () => {
-			expect(typeof result.data[0].username).toBe('string');
+			expect(typeof result.data.data[0].username).toBe('string');
 		});
 
 		it('should return forger totalVotesReceived', () => {
-			expect(typeof result.data[0].totalVotesReceived).toBe('string');
+			expect(typeof result.data.data[0].totalVotesReceived).toBe('string');
 		});
 
 		it('should return forger address', () => {
-			expect(typeof result.data[0].address).toBe('string');
+			expect(typeof result.data.data[0].address).toBe('string');
 		});
 
 		it('should return forger nextForgingTime', () => {
-			expect(typeof result.data[0].nextForgingTime).toBe('number');
+			expect(typeof result.data.data[0].nextForgingTime).toBe('number');
 		});
 	});
 });

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Application } from 'lisk-framework';
+import axios from 'axios';
+import { createApplication, closeApplication, waitNBlocks, getURL } from '../utils/application';
+
+describe('Forger endpoint', () => {
+	let app: Application;
+
+	beforeAll(async () => {
+		app = await createApplication('forger_functional');
+		await waitNBlocks(app, 1);
+	});
+
+	afterAll(async () => {
+		await closeApplication(app);
+	});
+
+	describe('GET /api/forgers/', () => {
+		let result: any;
+
+		beforeEach(async () => {
+			result = await axios.get(getURL('/api/forgers'));
+		});
+	});
+});

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger.spec.ts
@@ -33,5 +33,9 @@ describe('Forger endpoint', () => {
 		beforeEach(async () => {
 			result = await axios.get(getURL('/api/forgers'));
 		});
+
+		it('should return list of 103 forgers', () => {
+			expect(result.data).toHaveLength(103);
+		});
 	});
 });

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
@@ -136,16 +136,15 @@ describe('Forger Info', () => {
 	describe('Missed Block', () => {
 		let disableForgerAddresses: string[];
 		beforeEach(async () => {
-			const { height, generatorPublicKey } = app['_node']['_chain'].lastBlock.header;
-			const round = await app['_channel'].invoke('app:getSlotRound', { height });
-			const forgerAddressForRound: string[] = await app[
+			const { generatorPublicKey } = app['_node']['_chain'].lastBlock.header;
+			const forgersInfoForRound: Array<{ address: string; nextForgingTime: number }> = await app[
 				'_channel'
-			].invoke('app:getForgerAddressesForRound', { round });
+			].invoke('app:getForgersInfoForRound');
 			const lastForgerAddress = getAddressFromPublicKey(
 				Buffer.from(generatorPublicKey, 'base64'),
 			).toString('base64');
-			const lastForgerIndex = forgerAddressForRound.findIndex(f => f === lastForgerAddress);
-			disableForgerAddresses = forgerAddressForRound.splice(lastForgerIndex, 1);
+			const lastForgerIndex = forgersInfoForRound.findIndex(f => f.address === lastForgerAddress);
+			disableForgerAddresses = forgersInfoForRound.map(f => f.address).splice(lastForgerIndex, 1);
 
 			await Promise.all(
 				disableForgerAddresses.map(async disableForgerAddress => {

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
@@ -139,7 +139,7 @@ describe('Forger Info', () => {
 			const { generatorPublicKey } = app['_node']['_chain'].lastBlock.header;
 			const forgersInfoForRound: Array<{ address: string; nextForgingTime: number }> = await app[
 				'_channel'
-			].invoke('app:getForgersInfoForRound');
+			].invoke('app:getForgersInfoForActiveRound');
 			const lastForgerAddress = getAddressFromPublicKey(
 				Buffer.from(generatorPublicKey, 'base64'),
 			).toString('base64');

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -369,8 +369,9 @@ export class Application {
 				getDisconnectedPeers: {
 					handler: (_action: ActionInfoObject) => this._network.getDisconnectedPeers(),
 				},
-				getForgersInfoForRound: {
-					handler: async (_action: ActionInfoObject) => this._node.actions.getForgersInfoForRound(),
+				getForgersInfoForActiveRound: {
+					handler: async (_action: ActionInfoObject) =>
+						this._node.actions.getForgersInfoForActiveRound(),
 				},
 				updateForgingStatus: {
 					handler: async (action: ActionInfoObject) =>

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -369,7 +369,7 @@ export class Application {
 				getDisconnectedPeers: {
 					handler: (_action: ActionInfoObject) => this._network.getDisconnectedPeers(),
 				},
-				getForgerAddressesForRound: {
+				getForgersInfoForRound: {
 					handler: async (_action: ActionInfoObject) => this._node.actions.getForgersInfoForRound(),
 				},
 				updateForgingStatus: {

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -370,8 +370,7 @@ export class Application {
 					handler: (_action: ActionInfoObject) => this._network.getDisconnectedPeers(),
 				},
 				getForgerAddressesForRound: {
-					handler: async (action: ActionInfoObject) =>
-						this._node.actions.getForgerAddressesForRound(action.params as { round: number }),
+					handler: async (_action: ActionInfoObject) => this._node.actions.getForgersInfoForRound(),
 				},
 				updateForgingStatus: {
 					handler: async (action: ActionInfoObject) =>

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -289,10 +289,10 @@ export class Node {
 				const startTime = this._chain.slots.getSlotTime(slot);
 
 				let nextForgingTime = startTime;
-				const slotInRound = slot % 103;
+				const slotInRound = slot % this._dpos.delegatesPerRound;
 				const blockTime = this._chain.slots.blockTime();
 				const forgersInfo = [];
-				for (let i = slotInRound; i < slotInRound + 103; i += 1) {
+				for (let i = slotInRound; i < slotInRound + this._dpos.delegatesPerRound; i += 1) {
 					forgersInfo.push({
 						address: forgerAddresses[i % forgerAddresses.length].toString('base64'),
 						nextForgingTime,

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -280,7 +280,7 @@ export class Node {
 				this._chain.blockReward.calculateMilestone(params.height),
 			calculateReward: (params: { height: number }): bigint =>
 				this._chain.blockReward.calculateReward(params.height),
-			getForgersInfoForRound: async (): Promise<
+			getForgersInfoForActiveRound: async (): Promise<
 				ReadonlyArray<{ address: string; nextForgingTime: number }>
 			> => {
 				const currentRound = this._dpos.rounds.calcRound(this._chain.lastBlock.header.height);

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -280,9 +280,27 @@ export class Node {
 				this._chain.blockReward.calculateMilestone(params.height),
 			calculateReward: (params: { height: number }): bigint =>
 				this._chain.blockReward.calculateReward(params.height),
-			getForgerAddressesForRound: async (params: { round: number }): Promise<readonly string[]> => {
-				const forgersAddress = await this._dpos.getForgerAddressesForRound(params.round);
-				return forgersAddress.map(a => a.toString('base64'));
+			getForgersInfoForRound: async (): Promise<
+				ReadonlyArray<{ address: string; nextForgingTime: number }>
+			> => {
+				const currentRound = this._dpos.rounds.calcRound(this._chain.lastBlock.header.height);
+				const forgerAddresses = await this._dpos.getForgerAddressesForRound(currentRound);
+				const slot = this._chain.slots.getSlotNumber(Date.now());
+				const startTime = this._chain.slots.getSlotTime(slot);
+
+				let nextForgingTime = startTime;
+				const slotInRound = slot % 103;
+				const blockTime = this._chain.slots.blockTime();
+				const forgersInfo = [];
+				for (let i = slotInRound; i < slotInRound + 103; i += 1) {
+					forgersInfo.push({
+						address: forgerAddresses[i % forgerAddresses.length].toString('base64'),
+						nextForgingTime,
+					});
+					nextForgingTime += blockTime;
+				}
+
+				return forgersInfo;
 			},
 			getAllDelegates: async (): Promise<readonly string[]> => {
 				const delegatesUsernames = await this._dpos.getAllUsernames();


### PR DESCRIPTION
### What was the problem?

Endpoint to retrieve forgers list with username, address, totalVotesReceived and nextForgingTime was needed.

This PR resolves #5256, #5570, #5559 

### How was it solved?

- Create new action to calculate nextForgingTime for each delegate based on current slot and round 
- Add GET api/forgers URL and Controller
- Add functional tests

### How was it tested?

Run npm run test:functional forger.spec under framework-plugins/lisk-framework-forger-plugin/
