### PR TITLE
Wrong calculation for votesReceived forging info - Closes #5574

### DIFF
--- a/framework-plugins/lisk-framework-forger-plugin/src/controllers/forging.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/controllers/forging.ts
@@ -78,7 +78,6 @@ export const updateForging = (channel: BaseChannel, db: KVStore) => async (
 			totalReceivedRewards,
 			votesReceived,
 			totalProducedBlocks,
-			totalMissedBlocks,
 		} = await getForgerInfo(db, address);
 
 		res.status(200).json({
@@ -88,7 +87,6 @@ export const updateForging = (channel: BaseChannel, db: KVStore) => async (
 				forging: result.forging,
 				totalProducedBlocks,
 				votesReceived,
-				totalMissedBlocks,
 				totalReceivedFees: totalReceivedFees.toString(),
 				totalReceivedRewards: totalReceivedRewards.toString(),
 			},

--- a/framework-plugins/lisk-framework-forger-plugin/src/controllers/voters.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/controllers/voters.ts
@@ -43,7 +43,7 @@ export const getVoters = (channel: BaseChannel, codec: PluginCodec, db: KVStore)
 				username: account.asset.delegate.username,
 				totalVotesReceived: account.asset.delegate.totalVotesReceived,
 				voters: forgerInfo.votesReceived.map(vote => ({
-					address: vote.address,
+					address: vote.address.toString('base64'),
 					amount: vote.amount.toString(),
 				})),
 			});

--- a/framework-plugins/lisk-framework-forger-plugin/src/db.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/db.ts
@@ -70,7 +70,6 @@ export const getForgerInfo = async (db: KVStore, forgerAddress: string): Promise
 		debug(`Forger info does not exists for delegate: ${forgerAddress}`);
 		return {
 			totalProducedBlocks: 0,
-			totalMissedBlocks: 0,
 			totalReceivedFees: BigInt(0),
 			totalReceivedRewards: BigInt(0),
 			votesReceived: [],

--- a/framework-plugins/lisk-framework-forger-plugin/src/db.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/db.ts
@@ -13,7 +13,7 @@
  */
 
 import * as Debug from 'debug';
-import { KVStore } from '@liskhq/lisk-db';
+import { KVStore, BatchChain } from '@liskhq/lisk-db';
 import { codec } from '@liskhq/lisk-codec';
 import * as os from 'os';
 import { join } from 'path';
@@ -54,7 +54,7 @@ export const setForgerSyncInfo = async (db: KVStore, blockHeight: number): Promi
 };
 
 export const setForgerInfo = async (
-	db: KVStore,
+	db: KVStore | BatchChain,
 	forgerAddress: string,
 	forgerInfo: ForgerInfo,
 ): Promise<void> => {

--- a/framework-plugins/lisk-framework-forger-plugin/src/db.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/db.ts
@@ -13,7 +13,7 @@
  */
 
 import * as Debug from 'debug';
-import { KVStore, BatchChain } from '@liskhq/lisk-db';
+import { KVStore } from '@liskhq/lisk-db';
 import { codec } from '@liskhq/lisk-codec';
 import * as os from 'os';
 import { join } from 'path';
@@ -54,7 +54,7 @@ export const setForgerSyncInfo = async (db: KVStore, blockHeight: number): Promi
 };
 
 export const setForgerInfo = async (
-	db: KVStore | BatchChain,
+	db: KVStore,
 	forgerAddress: string,
 	forgerInfo: ForgerInfo,
 ): Promise<void> => {

--- a/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
@@ -131,7 +131,7 @@ export class ForgerPlugin extends BasePlugin {
 			{
 				'User-Agent': `lisk-framework-forger-plugin/0.1.0 (${os.platform()} ${os.release()}; ${os.arch()} ${locale}.${
 					process.env.LC_CTYPE ?? ''
-					}) lisk-framework/${options.version}`,
+				}) lisk-framework/${options.version}`,
 			},
 			options.webhook,
 		);
@@ -442,15 +442,11 @@ export class ForgerPlugin extends BasePlugin {
 				const rawIndex = (forgerIndex - 1 - index) % forgersRoundLength;
 				const forgerRoundIndex = rawIndex >= 0 ? rawIndex : rawIndex + forgersRoundLength;
 				const missedForgerInfo = forgersInfoForRound[forgerRoundIndex];
-				const missedForger = await getForgerInfo(this._forgerPluginDB, missedForgerInfo.address);
-				missedForger.totalMissedBlocks += 1;
 
 				missedBlocksByAddress[missedForgerInfo.address] =
 					missedBlocksByAddress[missedForgerInfo.address] === undefined
 						? 1
 						: (missedBlocksByAddress[missedForgerInfo.address] += 1);
-
-				await setForgerInfo(this._forgerPluginDB, missedForgerInfo.address, missedForger);
 			}
 
 			// Only emit event if block missed and the plugin is not syncing with the forging node

--- a/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/forger_plugin.ts
@@ -27,7 +27,7 @@ import {
 	BlockHeaderJSON,
 } from 'lisk-framework';
 import { VoteTransaction } from '@liskhq/lisk-transactions';
-import { objects } from '@liskhq/lisk-utils';
+import { objects, dataStructures as ds } from '@liskhq/lisk-utils';
 import type { Express } from 'express';
 import { initApi } from './api';
 import {
@@ -57,6 +57,7 @@ interface Vote {
 
 interface ForgerPayloadInfo {
 	forgerAddress: string;
+	forgerAddressBuffer: Buffer;
 	forgerAddressBinary: string;
 	header: BlockHeaderJSON;
 	payload: readonly TransactionJSON[];
@@ -80,13 +81,14 @@ interface ForgerReceivedVotes {
 const packageJSON = require('../package.json');
 const getBinaryAddress = (base64AddressStr: string) =>
 	Buffer.from(base64AddressStr, 'base64').toString('binary');
+const getAddressBuffer = (base64AddressStr: string) => Buffer.from(base64AddressStr, 'base64');
 
 export class ForgerPlugin extends BasePlugin {
 	private _forgerPluginDB!: KVStore;
 	private _server!: Server;
 	private _app!: Express;
 	private _channel!: BaseChannel;
-	private _forgersList!: ReadonlyArray<Forger>;
+	private _forgersList!: ds.BufferMap<boolean>;
 	private _transactionFees!: TransactionFees;
 	private _webhooks!: Webhooks;
 	private _syncingWithNode!: boolean;
@@ -198,6 +200,35 @@ export class ForgerPlugin extends BasePlugin {
 		await this._forgerPluginDB.close();
 	}
 
+	private async _setForgersList(): Promise<void> {
+		this._forgersList = new ds.BufferMap<boolean>();
+		const forgersList = await this._channel.invoke<Forger[]>('app:getForgingStatusOfAllDelegates');
+		for (const { address, forging } of forgersList) {
+			this._forgersList.set(Buffer.from(address, 'base64'), forging);
+		}
+	}
+
+	private async _setTransactionFees(): Promise<void> {
+		this._transactionFees = await this._channel.invoke<TransactionFees>('app:getTransactionsFees');
+	}
+
+	private _getForgerHeaderAndPayloadInfo(block: string): ForgerPayloadInfo {
+		const { header, payload } = this.codec.decodeBlock(block);
+		const forgerAddress = getAddressFromPublicKey(
+			Buffer.from(header.generatorPublicKey, 'base64'),
+		).toString('base64');
+		const forgerAddressBuffer = getAddressBuffer(forgerAddress);
+		const forgerAddressBinary = getBinaryAddress(forgerAddress);
+
+		return {
+			forgerAddress,
+			forgerAddressBuffer,
+			forgerAddressBinary,
+			header,
+			payload,
+		};
+	}
+
 	private async _syncForgerInfo(): Promise<void> {
 		const {
 			header: { height: lastBlockHeight },
@@ -234,7 +265,8 @@ export class ForgerPlugin extends BasePlugin {
 
 			// Reverse the blocks to get blocks from lower height to highest
 			for (const block of blocks.reverse()) {
-				await this._addForgerInfo(block);
+				const forgerPayloadInfo = this._getForgerHeaderAndPayloadInfo(block);
+				await this._addForgerInfo(block, forgerPayloadInfo);
 			}
 
 			needleHeight = toHeight + 1;
@@ -250,59 +282,42 @@ export class ForgerPlugin extends BasePlugin {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		this._channel.subscribe('app:block:new', async (eventInfo: EventInfoObject) => {
 			const { block } = eventInfo.data as Data;
+			const forgerPayloadInfo = this._getForgerHeaderAndPayloadInfo(block);
 			const {
 				header: { height },
-			} = this._getForgerHeaderAndPayloadInfo(block);
+			} = forgerPayloadInfo;
 
-			await this._addForgerInfo(block);
+			await this._addForgerInfo(block, forgerPayloadInfo);
 			await setForgerSyncInfo(this._forgerPluginDB, height);
 		});
 
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		this._channel.subscribe('app:block:delete', async (eventInfo: EventInfoObject) => {
 			const { block } = eventInfo.data as Data;
+			const forgerPayloadInfo = this._getForgerHeaderAndPayloadInfo(block);
 			const {
 				header: { height },
-			} = this._getForgerHeaderAndPayloadInfo(block);
+			} = forgerPayloadInfo;
 
-			await this._revertForgerInfo(block);
+			await this._revertForgerInfo(block, forgerPayloadInfo);
 			await setForgerSyncInfo(this._forgerPluginDB, height);
 		});
 	}
 
-	private async _setForgersList(): Promise<void> {
-		this._forgersList = await this._channel.invoke<Forger[]>('app:getForgingStatusOfAllDelegates');
-	}
-
-	private async _setTransactionFees(): Promise<void> {
-		this._transactionFees = await this._channel.invoke<TransactionFees>('app:getTransactionsFees');
-	}
-
-	private _getForgerHeaderAndPayloadInfo(block: string): ForgerPayloadInfo {
-		const { header, payload } = this.codec.decodeBlock(block);
-		const forgerAddress = getAddressFromPublicKey(
-			Buffer.from(header.generatorPublicKey, 'base64'),
-		).toString('base64');
-		const forgerAddressBinary = getBinaryAddress(forgerAddress);
-
-		return {
-			forgerAddress,
-			forgerAddressBinary,
-			header,
-			payload,
-		};
-	}
-
-	private async _addForgerInfo(encodedBlock: string): Promise<void> {
+	private async _addForgerInfo(
+		encodedBlock: string,
+		forgerPayloadInfo: ForgerPayloadInfo,
+	): Promise<void> {
 		const {
 			forgerAddress,
+			forgerAddressBuffer,
 			forgerAddressBinary,
 			header: { reward, height },
 			payload,
-		} = this._getForgerHeaderAndPayloadInfo(encodedBlock);
+		} = forgerPayloadInfo;
 		const forgerInfo = await getForgerInfo(this._forgerPluginDB, forgerAddressBinary);
 
-		if (this._forgersList.find(forger => forger.address === forgerAddress)) {
+		if (this._forgersList.has(forgerAddressBuffer)) {
 			forgerInfo.totalProducedBlocks += 1;
 			forgerInfo.totalReceivedRewards += BigInt(reward);
 			forgerInfo.totalReceivedFees += this._getFee(payload, encodedBlock);
@@ -319,16 +334,19 @@ export class ForgerPlugin extends BasePlugin {
 		await this._updateMissedBlock(encodedBlock);
 	}
 
-	private async _revertForgerInfo(encodedBlock: string): Promise<void> {
+	private async _revertForgerInfo(
+		encodedBlock: string,
+		forgerPayloadInfo: ForgerPayloadInfo,
+	): Promise<void> {
 		const {
-			forgerAddress,
+			forgerAddressBuffer,
 			forgerAddressBinary,
 			header: { reward },
 			payload,
-		} = this._getForgerHeaderAndPayloadInfo(encodedBlock);
+		} = forgerPayloadInfo;
 		const forgerInfo = await getForgerInfo(this._forgerPluginDB, forgerAddressBinary);
 
-		if (this._forgersList.find(forger => forger.address === forgerAddress)) {
+		if (this._forgersList.has(forgerAddressBuffer)) {
 			forgerInfo.totalProducedBlocks -= 1;
 			forgerInfo.totalReceivedRewards -= BigInt(reward);
 			forgerInfo.totalReceivedFees -= this._getFee(payload, encodedBlock);
@@ -345,13 +363,15 @@ export class ForgerPlugin extends BasePlugin {
 			if (trx.type === VoteTransaction.TYPE) {
 				const senderAddress = getAddressFromPublicKey(Buffer.from(trx.senderPublicKey, 'base64'));
 				(trx.asset as Asset).votes.reduce((acc: ForgerReceivedVotes, curr) => {
-					const registeredDelegateIndex = this._forgersList.findIndex(
-						forger => forger.address === curr.delegateAddress,
-					);
-					if (registeredDelegateIndex !== -1) {
+					if (
+						this._forgersList.has(getAddressBuffer(curr.delegateAddress)) &&
+						acc[curr.delegateAddress]
+					) {
+						acc[curr.delegateAddress].amount += BigInt(curr.amount);
+					} else {
 						acc[curr.delegateAddress] = {
 							address: senderAddress,
-							amount: BigInt(acc[curr.delegateAddress] || 0) + BigInt(curr.amount),
+							amount: BigInt(curr.amount),
 						};
 					}
 					return acc;

--- a/framework-plugins/lisk-framework-forger-plugin/src/schema.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/schema.ts
@@ -20,21 +20,17 @@ export const forgerInfoSchema = {
 			dataType: 'uint32',
 			fieldNumber: 1,
 		},
-		totalMissedBlocks: {
-			dataType: 'uint32',
-			fieldNumber: 2,
-		},
 		totalReceivedFees: {
 			dataType: 'uint64',
-			fieldNumber: 3,
+			fieldNumber: 2,
 		},
 		totalReceivedRewards: {
 			dataType: 'uint64',
-			fieldNumber: 4,
+			fieldNumber: 3,
 		},
 		votesReceived: {
 			type: 'array',
-			fieldNumber: 5,
+			fieldNumber: 4,
 			items: {
 				type: 'object',
 				properties: {
@@ -51,13 +47,7 @@ export const forgerInfoSchema = {
 			required: ['address', 'amount'],
 		},
 	},
-	required: [
-		'totalProducedBlocks',
-		'totalMissedBlocks',
-		'totalReceivedFees',
-		'totalReceivedRewards',
-		'votesReceived',
-	],
+	required: ['totalProducedBlocks', 'totalReceivedFees', 'totalReceivedRewards', 'votesReceived'],
 };
 
 export const forgerSyncSchema = {

--- a/framework-plugins/lisk-framework-forger-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/src/types.ts
@@ -44,7 +44,6 @@ export interface Forger {
 
 export interface ForgerInfo {
 	totalProducedBlocks: number;
-	totalMissedBlocks: number;
 	totalReceivedFees: bigint;
 	totalReceivedRewards: bigint;
 	votesReceived: Voters[];

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/event_track.spec.ts.snap
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/event_track.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`Forger Info Delete Block should update forger info after delete block 1`] = `
 Object {
-  "totalMissedBlocks": 0,
   "totalProducedBlocks": 0,
   "totalReceivedFees": 0n,
   "totalReceivedRewards": 0n,
@@ -10,19 +9,8 @@ Object {
 }
 `;
 
-exports[`Forger Info Missed Block should save missed block info 1`] = `
-Object {
-  "totalMissedBlocks": 0,
-  "totalProducedBlocks": 1,
-  "totalReceivedFees": 140000n,
-  "totalReceivedRewards": 0n,
-  "votesReceived": Array [],
-}
-`;
-
 exports[`Forger Info New Block should save forger info after new block 1`] = `
 Object {
-  "totalMissedBlocks": 0,
   "totalProducedBlocks": 0,
   "totalReceivedFees": 0n,
   "totalReceivedRewards": 0n,
@@ -32,7 +20,6 @@ Object {
 
 exports[`Forger Info New Block should save forger info with received fees if payload included in new block 1`] = `
 Object {
-  "totalMissedBlocks": 0,
   "totalProducedBlocks": 0,
   "totalReceivedFees": 0n,
   "totalReceivedRewards": 0n,
@@ -42,7 +29,6 @@ Object {
 
 exports[`Forger Info New Block should save forger info with votes received in new block 1`] = `
 Object {
-  "totalMissedBlocks": 0,
   "totalProducedBlocks": 0,
   "totalReceivedFees": 0n,
   "totalReceivedRewards": 0n,

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/event_track.spec.ts.snap
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/event_track.spec.ts.snap
@@ -123,45 +123,16 @@ Object {
 }
 `;
 
-exports[`Forger Info New Block Vote transactions should update forger info with voters info in new block 1`] = `
+exports[`Forger Info New Block Vote transactions should update forger info with voters info and remove when amount becomes zero 1`] = `
 Object {
   "totalProducedBlocks": 0,
   "totalReceivedFees": 0n,
   "totalReceivedRewards": 0n,
-  "votesReceived": Array [
-    Object {
-      "address": Object {
-        "data": Array [
-          208,
-          70,
-          153,
-          229,
-          124,
-          74,
-          56,
-          70,
-          201,
-          136,
-          243,
-          193,
-          83,
-          6,
-          121,
-          111,
-          142,
-          174,
-          92,
-          28,
-        ],
-        "type": "Buffer",
-      },
-      "amount": 5000000000n,
-    },
-  ],
+  "votesReceived": Array [],
 }
 `;
 
-exports[`Forger Info New Block Vote transactions should update forger info with voters info in new block 2`] = `
+exports[`Forger Info New Block Vote transactions should update forger info with voters info and remove when amount becomes zero 2`] = `
 Object {
   "totalProducedBlocks": 0,
   "totalReceivedFees": 0n,

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/event_track.spec.ts.snap
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/event_track.spec.ts.snap
@@ -9,6 +9,196 @@ Object {
 }
 `;
 
+exports[`Forger Info New Block Vote transactions should save forger info with votes received in new block 1`] = `
+Object {
+  "totalProducedBlocks": 0,
+  "totalReceivedFees": 0n,
+  "totalReceivedRewards": 0n,
+  "votesReceived": Array [
+    Object {
+      "address": Object {
+        "data": Array [
+          208,
+          70,
+          153,
+          229,
+          124,
+          74,
+          56,
+          70,
+          201,
+          136,
+          243,
+          193,
+          83,
+          6,
+          121,
+          111,
+          142,
+          174,
+          92,
+          28,
+        ],
+        "type": "Buffer",
+      },
+      "amount": 1000000000n,
+    },
+  ],
+}
+`;
+
+exports[`Forger Info New Block Vote transactions should update forger info with multiple votes received for same delegate in new block 1`] = `
+Object {
+  "totalProducedBlocks": 0,
+  "totalReceivedFees": 0n,
+  "totalReceivedRewards": 0n,
+  "votesReceived": Array [
+    Object {
+      "address": Object {
+        "data": Array [
+          208,
+          70,
+          153,
+          229,
+          124,
+          74,
+          56,
+          70,
+          201,
+          136,
+          243,
+          193,
+          83,
+          6,
+          121,
+          111,
+          142,
+          174,
+          92,
+          28,
+        ],
+        "type": "Buffer",
+      },
+      "amount": 7000000000n,
+    },
+  ],
+}
+`;
+
+exports[`Forger Info New Block Vote transactions should update forger info with upvote and downvote for same delegate in new block 1`] = `
+Object {
+  "totalProducedBlocks": 0,
+  "totalReceivedFees": 0n,
+  "totalReceivedRewards": 0n,
+  "votesReceived": Array [
+    Object {
+      "address": Object {
+        "data": Array [
+          208,
+          70,
+          153,
+          229,
+          124,
+          74,
+          56,
+          70,
+          201,
+          136,
+          243,
+          193,
+          83,
+          6,
+          121,
+          111,
+          142,
+          174,
+          92,
+          28,
+        ],
+        "type": "Buffer",
+      },
+      "amount": 3000000000n,
+    },
+  ],
+}
+`;
+
+exports[`Forger Info New Block Vote transactions should update forger info with voters info in new block 1`] = `
+Object {
+  "totalProducedBlocks": 0,
+  "totalReceivedFees": 0n,
+  "totalReceivedRewards": 0n,
+  "votesReceived": Array [
+    Object {
+      "address": Object {
+        "data": Array [
+          208,
+          70,
+          153,
+          229,
+          124,
+          74,
+          56,
+          70,
+          201,
+          136,
+          243,
+          193,
+          83,
+          6,
+          121,
+          111,
+          142,
+          174,
+          92,
+          28,
+        ],
+        "type": "Buffer",
+      },
+      "amount": 5000000000n,
+    },
+  ],
+}
+`;
+
+exports[`Forger Info New Block Vote transactions should update forger info with voters info in new block 2`] = `
+Object {
+  "totalProducedBlocks": 0,
+  "totalReceivedFees": 0n,
+  "totalReceivedRewards": 0n,
+  "votesReceived": Array [
+    Object {
+      "address": Object {
+        "data": Array [
+          208,
+          70,
+          153,
+          229,
+          124,
+          74,
+          56,
+          70,
+          201,
+          136,
+          243,
+          193,
+          83,
+          6,
+          121,
+          111,
+          142,
+          174,
+          92,
+          28,
+        ],
+        "type": "Buffer",
+      },
+      "amount": 2000000000n,
+    },
+  ],
+}
+`;
+
 exports[`Forger Info New Block should save forger info after new block 1`] = `
 Object {
   "totalProducedBlocks": 0,
@@ -19,15 +209,6 @@ Object {
 `;
 
 exports[`Forger Info New Block should save forger info with received fees if payload included in new block 1`] = `
-Object {
-  "totalProducedBlocks": 0,
-  "totalReceivedFees": 0n,
-  "totalReceivedRewards": 0n,
-  "votesReceived": Array [],
-}
-`;
-
-exports[`Forger Info New Block should save forger info with votes received in new block 1`] = `
 Object {
   "totalProducedBlocks": 0,
   "totalReceivedFees": 0n,

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/forger_info_sync.spec.ts.snap
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/__snapshots__/forger_info_sync.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`Forger Info Sync should sync information from scratch on startup 1`] = `
 Object {
-  "totalMissedBlocks": 0,
   "totalProducedBlocks": 1,
   "totalReceivedFees": 140000n,
   "totalReceivedRewards": 0n,

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
@@ -17,7 +17,8 @@ import { Application } from 'lisk-framework';
 import {
 	closeApplication,
 	createApplication,
-	getForgerInfo,
+	getForgerInfoByAddress,
+	getForgerInfoByPublicKey,
 	waitNBlocks,
 	waitTill,
 } from '../../utils/application';
@@ -44,7 +45,7 @@ describe('Forger Info', () => {
 
 			// Act
 			const { generatorPublicKey } = app['_node']['_chain'].lastBlock.header;
-			const forgerInfo = await getForgerInfo(forgerPluginInstance, generatorPublicKey);
+			const forgerInfo = await getForgerInfoByPublicKey(forgerPluginInstance, generatorPublicKey);
 
 			// Assert
 			expect(forgerInfo).toMatchSnapshot();
@@ -70,36 +71,157 @@ describe('Forger Info', () => {
 			const {
 				header: { generatorPublicKey },
 			} = app['_node']['_chain'].lastBlock;
-			const forgerInfo = await getForgerInfo(forgerPluginInstance, generatorPublicKey);
+			const forgerInfo = await getForgerInfoByPublicKey(forgerPluginInstance, generatorPublicKey);
 
 			// Assert
 			expect(forgerInfo).toMatchSnapshot();
 		});
 
-		it('should save forger info with votes received in new block', async () => {
-			// Arrange
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
-			const forgingDelegateAddress = forgerPluginInstance['_forgersList'][0].address;
-			const transaction = createVoteTransaction({
-				amount: '10',
-				recipientAddress: forgingDelegateAddress,
-				fee: '0.3',
-				nonce: accountNonce,
+		describe('Vote transactions', () => {
+			it('should save forger info with votes received in new block', async () => {
+				// Arrange
+				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const [forgingDelegateAddress] = forgerPluginInstance['_forgersList'].entries()[0];
+				const transaction1 = createVoteTransaction({
+					amount: '10',
+					recipientAddress: forgingDelegateAddress.toString('base64'),
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+
+				await app['_channel'].invoke('app:postTransaction', {
+					transaction: transaction1.getBytes().toString('base64'),
+				});
+				await waitNBlocks(app, 1);
+				await waitTill(200);
+
+				const forgerInfo = await getForgerInfoByAddress(
+					forgerPluginInstance,
+					forgingDelegateAddress.toString('binary'),
+				);
+				// Assert
+				expect(forgerInfo).toMatchSnapshot();
+				expect(forgerInfo.votesReceived[0].amount).toEqual(BigInt(1000000000));
 			});
-			accountNonce += 1;
 
-			await app['_channel'].invoke('app:postTransaction', {
-				transaction: transaction.getBytes().toString('base64'),
+			it('should update forger info with multiple votes received for same delegate in new block', async () => {
+				// Arrange
+				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const [forgingDelegateAddress] = forgerPluginInstance['_forgersList'].entries()[0];
+				const transaction1 = createVoteTransaction({
+					amount: '10',
+					recipientAddress: forgingDelegateAddress.toString('base64'),
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+				const transaction2 = createVoteTransaction({
+					amount: '50',
+					recipientAddress: forgingDelegateAddress.toString('base64'),
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+
+				await app['_channel'].invoke('app:postTransaction', {
+					transaction: transaction1.getBytes().toString('base64'),
+				});
+				await app['_channel'].invoke('app:postTransaction', {
+					transaction: transaction2.getBytes().toString('base64'),
+				});
+				await waitNBlocks(app, 1);
+				await waitTill(200);
+
+				const forgerInfo = await getForgerInfoByAddress(
+					forgerPluginInstance,
+					forgingDelegateAddress.toString('binary'),
+				);
+				// Assert
+				expect(forgerInfo).toMatchSnapshot();
+				expect(forgerInfo.votesReceived[0].amount).toEqual(BigInt(7000000000));
 			});
-			await waitNBlocks(app, 1);
 
-			const {
-				header: { generatorPublicKey },
-			} = app['_node']['_chain'].lastBlock;
-			const forgerInfo = await getForgerInfo(forgerPluginInstance, generatorPublicKey);
+			it('should update forger info with upvote and downvote for same delegate in new block', async () => {
+				// Arrange
+				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const [forgingDelegateAddress] = forgerPluginInstance['_forgersList'].entries()[0];
+				const transaction1 = createVoteTransaction({
+					amount: '-50',
+					recipientAddress: forgingDelegateAddress.toString('base64'),
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+				const transaction2 = createVoteTransaction({
+					amount: '+10',
+					recipientAddress: forgingDelegateAddress.toString('base64'),
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
 
-			// Assert
-			expect(forgerInfo).toMatchSnapshot();
+				await app['_channel'].invoke('app:postTransaction', {
+					transaction: transaction1.getBytes().toString('base64'),
+				});
+				await app['_channel'].invoke('app:postTransaction', {
+					transaction: transaction2.getBytes().toString('base64'),
+				});
+				await waitNBlocks(app, 1);
+				await waitTill(200);
+
+				const forgerInfo = await getForgerInfoByAddress(
+					forgerPluginInstance,
+					forgingDelegateAddress.toString('binary'),
+				);
+				// Assert
+				expect(forgerInfo).toMatchSnapshot();
+				expect(forgerInfo.votesReceived[0].amount).toEqual(BigInt(3000000000));
+			});
+
+			it('should update forger info with voters info in new block', async () => {
+				// Arrange
+				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const [forgingDelegateAddress1] = forgerPluginInstance['_forgersList'].entries()[0];
+				const [forgingDelegateAddress2] = forgerPluginInstance['_forgersList'].entries()[1];
+				const transaction1 = createVoteTransaction({
+					amount: '20',
+					recipientAddress: forgingDelegateAddress1.toString('base64'),
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+				const transaction2 = createVoteTransaction({
+					amount: '20',
+					recipientAddress: forgingDelegateAddress2.toString('base64'),
+					fee: '0.3',
+					nonce: accountNonce,
+				});
+				accountNonce += 1;
+
+				await app['_channel'].invoke('app:postTransaction', {
+					transaction: transaction1.getBytes().toString('base64'),
+				});
+				await app['_channel'].invoke('app:postTransaction', {
+					transaction: transaction2.getBytes().toString('base64'),
+				});
+				await waitNBlocks(app, 1);
+				await waitTill(200);
+
+				const forgerInfo1 = await getForgerInfoByAddress(
+					forgerPluginInstance,
+					forgingDelegateAddress1.toString('binary'),
+				);
+				const forgerInfo2 = await getForgerInfoByAddress(
+					forgerPluginInstance,
+					forgingDelegateAddress2.toString('binary'),
+				);
+				// Assert
+				expect(forgerInfo1).toMatchSnapshot();
+				expect(forgerInfo1.votesReceived[0].amount).toEqual(BigInt(5000000000));
+				expect(forgerInfo2).toMatchSnapshot();
+				expect(forgerInfo2.votesReceived[0].amount).toEqual(BigInt(2000000000));
+			});
 		});
 	});
 
@@ -112,7 +234,7 @@ describe('Forger Info', () => {
 
 			// Act
 			await waitTill(50);
-			const forgerInfo = await getForgerInfo(forgerPluginInstance, generatorPublicKey);
+			const forgerInfo = await getForgerInfoByPublicKey(forgerPluginInstance, generatorPublicKey);
 
 			// Asserts
 			expect(forgerInfo).toMatchSnapshot();

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
@@ -179,13 +179,13 @@ describe('Forger Info', () => {
 				expect(forgerInfo.votesReceived[0].amount).toEqual(BigInt(3000000000));
 			});
 
-			it('should update forger info with voters info in new block', async () => {
+			it('should update forger info with voters info and remove when amount becomes zero', async () => {
 				// Arrange
 				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
 				const [forgingDelegateAddress1] = forgerPluginInstance['_forgersList'].entries()[0];
 				const [forgingDelegateAddress2] = forgerPluginInstance['_forgersList'].entries()[1];
 				const transaction1 = createVoteTransaction({
-					amount: '20',
+					amount: '-30',
 					recipientAddress: forgingDelegateAddress1.toString('base64'),
 					fee: '0.3',
 					nonce: accountNonce,
@@ -218,7 +218,7 @@ describe('Forger Info', () => {
 				);
 				// Assert
 				expect(forgerInfo1).toMatchSnapshot();
-				expect(forgerInfo1.votesReceived[0].amount).toEqual(BigInt(5000000000));
+				expect(forgerInfo1.votesReceived).toBeEmpty();
 				expect(forgerInfo2).toMatchSnapshot();
 				expect(forgerInfo2.votesReceived[0].amount).toEqual(BigInt(2000000000));
 			});

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/forger_info_sync.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/forger_info_sync.spec.ts
@@ -13,11 +13,11 @@
  */
 
 import { Application } from 'lisk-framework';
-import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 
 import {
 	closeApplication,
 	createApplication,
+	getForgerInfoByPublicKey,
 	startApplication,
 	waitNBlocks,
 	waitTill,
@@ -25,20 +25,6 @@ import {
 import { ForgerPlugin } from '../../../src';
 import { getRandomAccount } from '../../utils/accounts';
 import { createTransferTransaction } from '../../utils/transactions';
-import { getForgerInfo as getForgerInfoFromDB } from '../../../src/db';
-
-const getForgerInfo = async (forgerPluginInstance: ForgerPlugin, generatorPublicKey: string) => {
-	const forgerAddress = getAddressFromPublicKey(Buffer.from(generatorPublicKey, 'base64')).toString(
-		'binary',
-	);
-
-	const forgerInfo = await getForgerInfoFromDB(
-		forgerPluginInstance['_forgerPluginDB'],
-		forgerAddress,
-	);
-
-	return forgerInfo;
-};
 
 describe('Forger Info Sync', () => {
 	let app: Application;
@@ -69,7 +55,7 @@ describe('Forger Info Sync', () => {
 		await waitNBlocks(app, 1);
 		await waitTill(2000);
 		const { generatorPublicKey } = app['_node']['_chain'].lastBlock.header;
-		const forgerInfo = await getForgerInfo(forgerPluginInstance, generatorPublicKey);
+		const forgerInfo = await getForgerInfoByPublicKey(forgerPluginInstance, generatorPublicKey);
 		// Make sure forger info is not changed
 		expect(forgerInfo).toMatchSnapshot();
 
@@ -86,7 +72,10 @@ describe('Forger Info Sync', () => {
 
 		await waitTill(2000);
 		// Get forger info
-		const forgerInfoAfterRestart = await getForgerInfo(forgerPluginInstance, generatorPublicKey);
+		const forgerInfoAfterRestart = await getForgerInfoByPublicKey(
+			forgerPluginInstance,
+			generatorPublicKey,
+		);
 
 		// Assert
 		expect(forgerInfo).toEqual(forgerInfoAfterRestart);

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forging.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forging.spec.ts
@@ -27,7 +27,6 @@ describe('api/forging', () => {
 		forging: true,
 		totalProducedBlocks: 0,
 		votesReceived: [],
-		totalMissedBlocks: 1,
 		totalReceivedFees: '0',
 		totalReceivedRewards: '0',
 	};

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forging_info.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forging_info.spec.ts
@@ -18,11 +18,10 @@ import { ForgerPlugin } from '../../src';
 import {
 	createApplication,
 	closeApplication,
-	getForgerInfo,
+	getForgerInfoByAddress,
 	waitNBlocks,
 	getURL,
 } from '../utils/application';
-import { Forger } from '../../src/types';
 
 describe('Forger endpoint', () => {
 	let app: Application;
@@ -40,9 +39,13 @@ describe('Forger endpoint', () => {
 		it('should return list of all forgers info', async () => {
 			// Arrange
 			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
-			const forgersList = forgerPluginInstance['_forgersList'] as ReadonlyArray<Forger>;
+			const forgersList = forgerPluginInstance['_forgersList'].entries() as ReadonlyArray<
+				[Buffer, boolean]
+			>;
 			const forgersInfo = await Promise.all(
-				forgersList.map(async forger => getForgerInfo(forgerPluginInstance, forger.address)),
+				forgersList.map(async ([forgerAddress, _]) =>
+					getForgerInfoByAddress(forgerPluginInstance, forgerAddress.toString('binary')),
+				),
 			);
 			const { data: resultData } = await axios.get(getURL('/api/forging/info'));
 

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/voters.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/voters.spec.ts
@@ -66,9 +66,7 @@ describe('Voters endpoint', () => {
 				);
 			});
 
-			// TODO: Enable after fixing https://github.com/LiskHQ/lisk-sdk/issues/5574
-			// eslint-disable-next-line jest/no-disabled-tests
-			it.skip('should return valid voters', async () => {
+			it('should return valid voters', async () => {
 				// Arrange
 				const { response: delegateResponse } = await callNetwork(axios.get(getURL('/api/voters')));
 				const forgingDelegateAddress = delegateResponse.data[0].address;
@@ -82,7 +80,7 @@ describe('Voters endpoint', () => {
 				await app['_channel'].invoke('app:postTransaction', {
 					transaction: transaction.getBytes().toString('base64'),
 				});
-				await waitNBlocks(app, 103);
+				await waitNBlocks(app, 1);
 				// Wait a bit to give plugin a time to calculate forger info
 				await waitTill(2000);
 
@@ -96,8 +94,8 @@ describe('Voters endpoint', () => {
 				expect(status).toEqual(200);
 				expect(forgerInfo.voters[0]).toMatchObject(
 					expect.objectContaining({
-						address: forgingDelegateAddress,
-						amount: '10',
+						address: transaction.senderId.toString('base64'),
+						amount: '1000000000',
 					}),
 				);
 			});

--- a/framework-plugins/lisk-framework-forger-plugin/test/utils/application.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/utils/application.ts
@@ -146,7 +146,7 @@ export const callNetwork = async (
 	return { status, response };
 };
 
-export const getForgerInfo = async (
+export const getForgerInfoByPublicKey = async (
 	forgerPluginInstance: ForgerPlugin,
 	generatorPublicKey: string,
 ): Promise<ForgerInfo> => {
@@ -154,6 +154,18 @@ export const getForgerInfo = async (
 		'binary',
 	);
 
+	const forgerInfo = await getForgerInfoFromDB(
+		forgerPluginInstance['_forgerPluginDB'],
+		forgerAddress,
+	);
+
+	return forgerInfo;
+};
+
+export const getForgerInfoByAddress = async (
+	forgerPluginInstance: ForgerPlugin,
+	forgerAddress: string,
+): Promise<ForgerInfo> => {
 	const forgerInfo = await getForgerInfoFromDB(
 		forgerPluginInstance['_forgerPluginDB'],
 		forgerAddress,


### PR DESCRIPTION
### What was the problem?

This PR resolves #5574 

### How was it solved?

- If delegate a receives votes from b and c then forgers info should save voters(b,c) address and amount, also separated add and revert voter logic
- We have consecutiveMissedBlocks details available for a given forging account removed associated missed block test and updated schema

### How was it tested?

- Unskipped voters test
-  Updated other functional tests
