### PR TITLE
Fix network to return peers in JSON format - Closes #5583

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -89,6 +89,7 @@ import {
 	PeerLists,
 	ProtocolPeerInfo,
 	RPCSchemas,
+	PeerInfo,
 } from './types';
 import {
 	assignInternalInfo,
@@ -531,7 +532,7 @@ export class P2P extends EventEmitter {
 	}
 
 	// Make sure you always share shared peer state to a user
-	public getConnectedPeers(): ReadonlyArray<ProtocolPeerInfo> {
+	public getConnectedPeers(): ReadonlyArray<PeerInfo> {
 		// Only share the shared state to the user
 		return this._peerPool
 			.getAllConnectedPeerInfos()
@@ -545,7 +546,7 @@ export class P2P extends EventEmitter {
 	}
 
 	// Make sure you always share shared peer state to a user
-	public getDisconnectedPeers(): ReadonlyArray<ProtocolPeerInfo> {
+	public getDisconnectedPeers(): ReadonlyArray<PeerInfo> {
 		const { allPeers } = this._peerBook;
 		const connectedPeers = this.getConnectedPeers();
 		const disconnectedPeers = allPeers.filter(peer => {

--- a/elements/lisk-p2p/src/types.ts
+++ b/elements/lisk-p2p/src/types.ts
@@ -50,6 +50,8 @@ export interface UnknownKVPair {
 	[key: string]: unknown;
 }
 
+export type PeerInfo = ProtocolPeerInfo & Partial<P2PSharedState>;
+
 export interface P2PSharedState {
 	readonly networkId: string;
 	readonly networkVersion: string;

--- a/framework/src/application/network/network.ts
+++ b/framework/src/application/network/network.ts
@@ -15,6 +15,7 @@
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import { KVStore, NotFoundError } from '@liskhq/lisk-db';
 import * as liskP2P from '@liskhq/lisk-p2p';
+import { codec } from '@liskhq/lisk-codec';
 import { lookupPeersIPs } from './utils';
 import { Logger } from '../logger';
 import { InMemoryChannel } from '../../controller/channels';
@@ -441,12 +442,32 @@ export class Network {
 		});
 	}
 
-	public getConnectedPeers(): ReadonlyArray<liskP2P.p2pTypes.ProtocolPeerInfo> {
-		return this._p2p.getConnectedPeers();
+	public getConnectedPeers(): ReadonlyArray<liskP2P.p2pTypes.PeerInfo> {
+		const peers = this._p2p.getConnectedPeers();
+		return peers.map(peer => {
+			const parsedPeer = {
+				...peer,
+			};
+			if (parsedPeer.options) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				parsedPeer.options = codec.toJSON(customNodeInfoSchema, parsedPeer.options);
+			}
+			return parsedPeer;
+		});
 	}
 
-	public getDisconnectedPeers(): ReadonlyArray<liskP2P.p2pTypes.ProtocolPeerInfo> {
-		return this._p2p.getDisconnectedPeers();
+	public getDisconnectedPeers(): ReadonlyArray<liskP2P.p2pTypes.PeerInfo> {
+		const peers = this._p2p.getDisconnectedPeers();
+		return peers.map(peer => {
+			const parsedPeer = {
+				...peer,
+			};
+			if (parsedPeer.options) {
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+				parsedPeer.options = codec.toJSON(customNodeInfoSchema, parsedPeer.options);
+			}
+			return parsedPeer;
+		});
 	}
 
 	public applyPenaltyOnPeer(penaltyPacket: liskP2P.p2pTypes.P2PPenalty): void {

--- a/framework/test/unit/specs/application/network/network.spec.ts
+++ b/framework/test/unit/specs/application/network/network.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { KVStore } from '@liskhq/lisk-db';
+import { P2P } from '@liskhq/lisk-p2p';
+import { Network } from '../../../../../src/application/network';
+import { Logger } from '../../../../../src/application/logger';
+import { InMemoryChannel } from '../../../../../src/controller';
+
+jest.mock('@liskhq/lisk-p2p');
+jest.mock('@liskhq/lisk-db');
+
+describe('network', () => {
+	let network: Network;
+
+	beforeEach(() => {
+		const db = new KVStore('~/.lisk/stubed');
+		network = new Network({
+			nodeDB: db,
+			networkId: 'networkID',
+			networkVersion: '2.0',
+			logger: ({
+				info: jest.fn(),
+				error: jest.fn(),
+				warn: jest.fn(),
+				level: jest.fn(),
+				debug: jest.fn(),
+				trace: jest.fn(),
+			} as unknown) as Logger,
+			channel: ({} as unknown) as InMemoryChannel,
+			options: {
+				port: 3000,
+				seedPeers: [],
+			},
+		});
+	});
+
+	describe('getConnectedPeers', () => {
+		describe('when peer does not have options', () => {
+			it('should return peer info without options', () => {
+				const expected = [
+					{
+						ipAddress: '1.1.1.1',
+						port: 1000,
+						networkId: 'networkId',
+						networVersion: '1.1',
+						nonce: 'nonce1',
+					},
+				];
+				network['_p2p'] = ({
+					getConnectedPeers: jest.fn().mockReturnValue(expected),
+				} as unknown) as P2P;
+
+				const peers = network.getConnectedPeers();
+
+				expect(peers).toEqual(expected);
+			});
+		});
+
+		describe('when peer does have options', () => {
+			it('should return decoded peer info in JSON format', () => {
+				const id = 'GhAypT2vepaauMk/TN+rbZ+YziLGnm7hUeobRuobLOQ=';
+				const expected = [
+					{
+						ipAddress: '1.1.1.1',
+						port: 1000,
+						networkId: 'networkId',
+						networVersion: '1.1',
+						nonce: 'nonce1',
+						options: {
+							height: 32,
+							maxHeightPrevoted: 3,
+							blockVersion: 1,
+							lastBlockID: Buffer.from(id, 'base64'),
+						},
+					},
+				];
+				network['_p2p'] = ({
+					getConnectedPeers: jest.fn().mockReturnValue(expected),
+				} as unknown) as P2P;
+
+				const peers = network.getConnectedPeers();
+
+				expect(peers).toEqual(
+					expected.map(e => ({
+						...e,
+						options: {
+							...e.options,
+							lastBlockID: e.options.lastBlockID.toString('base64'),
+						},
+					})),
+				);
+			});
+		});
+	});
+
+	describe('getDisconnectedPeers', () => {
+		describe('when peer does not have options', () => {
+			it('should return peer info without options', () => {
+				const expected = [
+					{
+						ipAddress: '1.1.1.1',
+						port: 1000,
+						networkId: 'networkId',
+						networVersion: '1.1',
+						nonce: 'nonce1',
+					},
+				];
+				network['_p2p'] = ({
+					getDisconnectedPeers: jest.fn().mockReturnValue(expected),
+				} as unknown) as P2P;
+
+				const peers = network.getDisconnectedPeers();
+
+				expect(peers).toEqual(expected);
+			});
+		});
+
+		describe('when peer does have options', () => {
+			it('should return decoded peer info in JSON format', () => {
+				const id = 'GhAypT2vepaauMk/TN+rbZ+YziLGnm7hUeobRuobLOQ=';
+				const expected = [
+					{
+						ipAddress: '1.1.1.1',
+						port: 1000,
+						networkId: 'networkId',
+						networVersion: '1.1',
+						nonce: 'nonce1',
+						options: {
+							height: 32,
+							maxHeightPrevoted: 3,
+							blockVersion: 1,
+							lastBlockID: Buffer.from(id, 'base64'),
+						},
+					},
+				];
+				network['_p2p'] = ({
+					getDisconnectedPeers: jest.fn().mockReturnValue(expected),
+				} as unknown) as P2P;
+
+				const peers = network.getDisconnectedPeers();
+
+				expect(peers).toEqual(
+					expected.map(e => ({
+						...e,
+						options: {
+							...e.options,
+							lastBlockID: e.options.lastBlockID.toString('base64'),
+						},
+					})),
+				);
+			});
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5583 

### How was it solved?

Decode the `options` field on network to the JSON format if exists

### How was it tested?

- Added unit test
- Connect to core and call /api/peers endpoint and see lastBlockID is in base64 string
