### PR TITLE
transport.ts handleEventPostTransaction returns on error instead of throwing - Closes #5596

### DIFF
--- a/framework/src/application/node/transport/transport.ts
+++ b/framework/src/application/node/transport/transport.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { validator } from '@liskhq/lisk-validator';
+import { validator, LiskValidationError } from '@liskhq/lisk-validator';
 import { Chain, Block } from '@liskhq/lisk-chain';
 import { p2pTypes } from '@liskhq/lisk-p2p';
 import { TransactionPool } from '@liskhq/lisk-transaction-pool';
@@ -328,13 +328,21 @@ export class Transport {
 	public async handleEventPostTransaction(
 		data: EventPostTransactionData,
 	): Promise<handlePostTransactionReturn> {
-		const tx = this._chainModule.dataAccess.decodeTransaction(
-			Buffer.from(data.transaction, 'base64'),
-		);
-		const id = await this._receiveTransaction(tx);
-		return {
-			transactionId: id.toString('base64'),
-		};
+		try {
+			const tx = this._chainModule.dataAccess.decodeTransaction(
+				Buffer.from(data.transaction, 'base64'),
+			);
+			const id = await this._receiveTransaction(tx);
+			return {
+				transactionId: id.toString('base64'),
+			};
+		} catch (err) {
+			if (Array.isArray(err)) {
+				throw new LiskValidationError(err);
+			} else {
+				throw err;
+			}
+		}
 	}
 
 	/**

--- a/framework/src/application/node/transport/transport.ts
+++ b/framework/src/application/node/transport/transport.ts
@@ -328,21 +328,13 @@ export class Transport {
 	public async handleEventPostTransaction(
 		data: EventPostTransactionData,
 	): Promise<handlePostTransactionReturn> {
-		try {
-			const tx = this._chainModule.dataAccess.decodeTransaction(
-				Buffer.from(data.transaction, 'base64'),
-			);
-			const id = await this._receiveTransaction(tx);
-			return {
-				transactionId: id.toString('base64'),
-			};
-		} catch (err) {
-			return {
-				message: 'Transaction was rejected with errors',
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-				errors: err.errors || err,
-			};
-		}
+		const tx = this._chainModule.dataAccess.decodeTransaction(
+			Buffer.from(data.transaction, 'base64'),
+		);
+		const id = await this._receiveTransaction(tx);
+		return {
+			transactionId: id.toString('base64'),
+		};
 	}
 
 	/**

--- a/framework/test/integration/specs/application/node/matcher.spec.ts
+++ b/framework/test/integration/specs/application/node/matcher.spec.ts
@@ -132,11 +132,7 @@ describe('Matcher', () => {
 					node['_transport'].handleEventPostTransaction({
 						transaction: tx.getBytes().toString('base64'),
 					}),
-				).resolves.toEqual(
-					expect.objectContaining({
-						message: expect.stringContaining('Transaction was rejected'),
-					}),
-				);
+				).rejects.toEqual(new Error('Transaction type not found.'));
 			});
 		});
 	});

--- a/framework/test/unit/specs/application/node/transport/transport_private.spec.ts
+++ b/framework/test/unit/specs/application/node/transport/transport_private.spec.ts
@@ -659,34 +659,32 @@ describe('transport', () => {
 					describe('when transportModule._receiveTransaction fails', () => {
 						const receiveTransactionError = new Error('Invalid transaction body ...');
 
-						beforeEach(async () => {
+						beforeEach(() => {
 							transportModule._receiveTransaction = jest
 								.fn()
 								.mockResolvedValue(Promise.reject(receiveTransactionError));
-
-							result = await transportModule.handleEventPostTransaction(query);
 						});
 
-						it('should resolve with object { message: err }', () => {
-							expect(result).toHaveProperty('errors');
-							expect(result.errors).toEqual(receiveTransactionError);
+						it('should throw when transaction is invalid', async () => {
+							return expect(transportModule.handleEventPostTransaction(query)).rejects.toThrow(
+								receiveTransactionError,
+							);
 						});
 					});
 
 					describe('when transportModule._receiveTransaction fails with "Transaction pool is full"', () => {
 						const receiveTransactionError = new Error('Transaction pool is full');
 
-						beforeEach(async () => {
+						beforeEach(() => {
 							transportModule._receiveTransaction = jest
 								.fn()
 								.mockResolvedValue(Promise.reject(receiveTransactionError));
-
-							result = await transportModule.handleEventPostTransaction(query);
 						});
 
-						it('should resolve with object { message: err }', () => {
-							expect(result).toHaveProperty('errors');
-							expect(result.errors).toEqual(receiveTransactionError);
+						it('should throw when transaction pool is full', async () => {
+							return expect(transportModule.handleEventPostTransaction(query)).rejects.toThrow(
+								receiveTransactionError,
+							);
 						});
 					});
 				});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5596

### How was it solved?

By letting `handleEventPostTransaction` reject if errors occur

### How was it tested?

- Unit tests updated
- you can also use https://github.com/LiskHQ/lisk-core/pull/313 for testing this manually and see the new behaviour
