### PR TITLE
Update handling of unload behaviour for child process plugins - Closes #5562, #3632

### DIFF
--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/event_track.spec.ts
@@ -19,10 +19,10 @@ import {
 	createApplication,
 	getForgerInfoByAddress,
 	getForgerInfoByPublicKey,
+	getForgerPlugin,
 	waitNBlocks,
 	waitTill,
 } from '../../utils/application';
-import { ForgerPlugin } from '../../../src';
 import { getRandomAccount } from '../../utils/accounts';
 import { createTransferTransaction, createVoteTransaction } from '../../utils/transactions';
 
@@ -41,7 +41,7 @@ describe('Forger Info', () => {
 	describe('New Block', () => {
 		it('should save forger info after new block', async () => {
 			// Arrange
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+			const forgerPluginInstance = getForgerPlugin(app);
 
 			// Act
 			const { generatorPublicKey } = app['_node']['_chain'].lastBlock.header;
@@ -53,7 +53,7 @@ describe('Forger Info', () => {
 
 		it('should save forger info with received fees if payload included in new block', async () => {
 			// Arrange
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+			const forgerPluginInstance = getForgerPlugin(app);
 			const account = getRandomAccount();
 			const transaction = createTransferTransaction({
 				amount: '2',
@@ -80,7 +80,7 @@ describe('Forger Info', () => {
 		describe('Vote transactions', () => {
 			it('should save forger info with votes received in new block', async () => {
 				// Arrange
-				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const forgerPluginInstance = getForgerPlugin(app);
 				const [forgingDelegateAddress] = forgerPluginInstance['_forgersList'].entries()[0];
 				const transaction1 = createVoteTransaction({
 					amount: '10',
@@ -107,7 +107,7 @@ describe('Forger Info', () => {
 
 			it('should update forger info with multiple votes received for same delegate in new block', async () => {
 				// Arrange
-				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const forgerPluginInstance = getForgerPlugin(app);
 				const [forgingDelegateAddress] = forgerPluginInstance['_forgersList'].entries()[0];
 				const transaction1 = createVoteTransaction({
 					amount: '10',
@@ -144,7 +144,7 @@ describe('Forger Info', () => {
 
 			it('should update forger info with upvote and downvote for same delegate in new block', async () => {
 				// Arrange
-				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const forgerPluginInstance = getForgerPlugin(app);
 				const [forgingDelegateAddress] = forgerPluginInstance['_forgersList'].entries()[0];
 				const transaction1 = createVoteTransaction({
 					amount: '-50',
@@ -181,7 +181,7 @@ describe('Forger Info', () => {
 
 			it('should update forger info with voters info and remove when amount becomes zero', async () => {
 				// Arrange
-				const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+				const forgerPluginInstance = getForgerPlugin(app);
 				const [forgingDelegateAddress1] = forgerPluginInstance['_forgersList'].entries()[0];
 				const [forgingDelegateAddress2] = forgerPluginInstance['_forgersList'].entries()[1];
 				const transaction1 = createVoteTransaction({
@@ -229,7 +229,7 @@ describe('Forger Info', () => {
 		it('should update forger info after delete block', async () => {
 			// Arrange
 			const { generatorPublicKey } = app['_node']['_chain'].lastBlock.header;
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+			const forgerPluginInstance = getForgerPlugin(app);
 			await app['_node']['_processor'].deleteLastBlock();
 
 			// Act

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/forger_info_sync.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forger_info/forger_info_sync.spec.ts
@@ -18,11 +18,11 @@ import {
 	closeApplication,
 	createApplication,
 	getForgerInfoByPublicKey,
+	getForgerPlugin,
 	startApplication,
 	waitNBlocks,
 	waitTill,
 } from '../../utils/application';
-import { ForgerPlugin } from '../../../src';
 import { getRandomAccount } from '../../utils/accounts';
 import { createTransferTransaction } from '../../utils/transactions';
 
@@ -40,7 +40,7 @@ describe('Forger Info Sync', () => {
 
 	it('should sync information from scratch on startup', async () => {
 		// Arrange
-		let forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+		let forgerPluginInstance = getForgerPlugin(app);
 		const account = getRandomAccount();
 		const transaction = createTransferTransaction({
 			amount: '2',
@@ -68,7 +68,7 @@ describe('Forger Info Sync', () => {
 
 		// Start the application again
 		await startApplication(app);
-		forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+		forgerPluginInstance = getForgerPlugin(app);
 
 		await waitTill(2000);
 		// Get forger info

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forging_info.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forging_info.spec.ts
@@ -14,13 +14,13 @@
 
 import { Application } from 'lisk-framework';
 import axios from 'axios';
-import { ForgerPlugin } from '../../src';
 import {
 	createApplication,
 	closeApplication,
 	getForgerInfoByAddress,
 	waitNBlocks,
 	getURL,
+	getForgerPlugin,
 } from '../utils/application';
 
 describe('Forger endpoint', () => {
@@ -38,7 +38,7 @@ describe('Forger endpoint', () => {
 	describe('GET /api/forging/info', () => {
 		it('should return list of all forgers info', async () => {
 			// Arrange
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+			const forgerPluginInstance = getForgerPlugin(app);
 			const forgersList = forgerPluginInstance['_forgersList'].entries() as ReadonlyArray<
 				[Buffer, boolean]
 			>;

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/webhook_events.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/webhook_events.spec.ts
@@ -15,8 +15,12 @@ import axios from 'axios';
 
 import { Application } from 'lisk-framework';
 
-import { closeApplication, createApplication, waitNBlocks } from '../utils/application';
-import { ForgerPlugin } from '../../src';
+import {
+	closeApplication,
+	createApplication,
+	getForgerPlugin,
+	waitNBlocks,
+} from '../utils/application';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -63,7 +67,7 @@ describe('Forger Plugin webhooks', () => {
 	describe('App start', () => {
 		it('should call webhook forger:node:start', () => {
 			// Arrange
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+			const forgerPluginInstance = getForgerPlugin(app) as any;
 			forgerPluginInstance._webhooks.headers['User-Agent'] = 'LISK/TEST/UA';
 			const expectedCallArgs = [
 				'http://fake.host',
@@ -84,7 +88,7 @@ describe('Forger Plugin webhooks', () => {
 	describe('New Block', () => {
 		it('should call webhook forger:block:created', async () => {
 			// Arrange
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+			const forgerPluginInstance = getForgerPlugin(app) as any;
 			forgerPluginInstance._webhooks.headers['User-Agent'] = 'LISK/TEST/UA';
 			const expectedCallArgs = [
 				'http://fake.host',
@@ -110,7 +114,7 @@ describe('Forger Plugin webhooks', () => {
 	describe('Missed Block', () => {
 		it('should call webhook forger:block:missed', () => {
 			// Arrange
-			const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+			const forgerPluginInstance = getForgerPlugin(app) as any;
 			forgerPluginInstance._webhooks.headers['User-Agent'] = 'LISK/TEST/UA';
 			const expectedCallArgs = [
 				'http://fake.host',

--- a/framework-plugins/lisk-framework-forger-plugin/test/utils/application.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/utils/application.ts
@@ -25,6 +25,10 @@ import { ForgerInfo } from '../../src/types';
 
 const forgerApiPort = 5001;
 
+export const getForgerPlugin = (app: Application): ForgerPlugin => {
+	return app['_controller']['_inMemoryPlugins'][ForgerPlugin.alias]['plugin'];
+};
+
 export const startApplication = async (app: Application): Promise<void> => {
 	// TODO: Need to figure out why below error appears but its only in tests
 	//  Trace: Error: schema with key or id "/block/header"
@@ -99,7 +103,7 @@ export const closeApplication = async (
 	if (options.clearDB) {
 		await app['_forgerDB'].clear();
 		await app['_blockchainDB'].clear();
-		const forgerPluginInstance = app['_controller'].plugins[ForgerPlugin.alias];
+		const forgerPluginInstance = getForgerPlugin(app);
 		await forgerPluginInstance['_forgerPluginDB'].clear();
 	}
 

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -77,7 +77,7 @@ const registerProcessHooks = (app: Application): void => {
 			'System error: uncaughtException',
 		);
 
-		handleShutdown(1, err.message).catch(error => app.logger.error({}, error));
+		handleShutdown(1, err.message).catch((error: Error) => app.logger.error({ error }));
 	});
 
 	process.on('unhandledRejection', err => {
@@ -89,19 +89,19 @@ const registerProcessHooks = (app: Application): void => {
 			'System error: unhandledRejection',
 		);
 
-		handleShutdown(1, (err as Error).message).catch(error => app.logger.error({}, error));
+		handleShutdown(1, (err as Error).message).catch((error: Error) => app.logger.error({ error }));
 	});
 
 	process.once('SIGTERM', () => {
-		handleShutdown(0, 'SIGTERM').catch(error => app.logger.error({}, error));
+		handleShutdown(0, 'SIGTERM').catch((error: Error) => app.logger.error({ error }));
 	});
 
 	process.once('SIGINT', () => {
-		handleShutdown(0, 'SIGINT').catch(error => app.logger.error({}, error));
+		handleShutdown(0, 'SIGINT').catch((error: Error) => app.logger.error({ error }));
 	});
 
 	process.once('exit' as any, (code: number) => {
-		handleShutdown(code, 'process.exit').catch(error => app.logger.error({}, error));
+		handleShutdown(code, 'process.exit').catch((error: Error) => app.logger.error({ error }));
 	});
 };
 

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -62,6 +62,10 @@ const isPidRunning = async (pid: number): Promise<boolean> =>
 	psList().then(list => list.some(x => x.pid === pid));
 
 const registerProcessHooks = (app: Application): void => {
+	const handleShutdown = async (code: number, message: string) => {
+		await app.shutdown(code, message);
+	};
+
 	process.title = `${app.config.label}(${app.config.version})`;
 
 	process.on('uncaughtException', err => {
@@ -72,8 +76,8 @@ const registerProcessHooks = (app: Application): void => {
 			},
 			'System error: uncaughtException',
 		);
-		// eslint-disable-next-line @typescript-eslint/no-floating-promises
-		app.shutdown(1, err.message);
+
+		handleShutdown(1, err.message).catch(error => app.logger.error({}, error));
 	});
 
 	process.on('unhandledRejection', err => {
@@ -84,18 +88,21 @@ const registerProcessHooks = (app: Application): void => {
 			},
 			'System error: unhandledRejection',
 		);
-		// eslint-disable-next-line @typescript-eslint/no-floating-promises
-		app.shutdown(1, (err as Error).message);
+
+		handleShutdown(1, (err as Error).message).catch(error => app.logger.error({}, error));
 	});
 
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	process.once('SIGTERM', async () => app.shutdown(1));
+	process.once('SIGTERM', () => {
+		handleShutdown(0, 'SIGTERM').catch(error => app.logger.error({}, error));
+	});
 
-	// eslint-disable-next-line @typescript-eslint/no-misused-promises
-	process.once('SIGINT', async () => app.shutdown(1));
+	process.once('SIGINT', () => {
+		handleShutdown(0, 'SIGINT').catch(error => app.logger.error({}, error));
+	});
 
-	// eslint-disable-next-line
-	process.once('exit' as any, (code: number) => app.shutdown(code));
+	process.once('exit' as any, (code: number) => {
+		handleShutdown(code, 'process.exit').catch(error => app.logger.error({}, error));
+	});
 };
 
 export class Application {
@@ -275,7 +282,10 @@ export class Application {
 		this._network = this._initNetwork();
 		this._node = this._initNode();
 
-		await this._controller.load(this.getPlugins(), this.config.plugins);
+		await this._controller.load();
+		await this._controller.loadPlugins(this.getPlugins(), this.config.plugins);
+		this.logger.debug(this._controller.bus.getEvents(), 'Application listening to events');
+		this.logger.debug(this._controller.bus.getActions(), 'Application ready for actions');
 
 		await this._network.bootstrap();
 		await this._node.bootstrap();
@@ -284,13 +294,12 @@ export class Application {
 	}
 
 	public async shutdown(errorCode = 0, message = ''): Promise<void> {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		this.logger.info({ errorCode, message }, 'Application shutdown started');
+
 		if (this._controller) {
 			this._channel.publish('app:shutdown');
 			await this._controller.cleanup(errorCode, message);
 		}
-
-		this.logger.info({ errorCode, message }, 'Shutting down application');
 
 		try {
 			await this._node.cleanup();
@@ -299,14 +308,17 @@ export class Application {
 			await this._forgerDB.close();
 			await this._nodeDB.close();
 			await this._emptySocketsDirectory();
+			this.logger.info({ errorCode, message }, 'Application shutdown completed');
 		} catch (error) {
-			this.logger.fatal({ err: error as Error }, 'failed to shutdown');
+			this.logger.fatal({ err: error as Error }, 'Application shutdown failed');
+		} finally {
+			// Unfreeze the configuration
+			this.config = mergeDeep({}, this.config) as ApplicationConfig;
+
+			// To avoid redundant shutdown call
+			process.removeAllListeners('exit');
+			process.exit(errorCode);
 		}
-
-		// Unfreeze the configuration
-		this.config = mergeDeep({}, this.config) as ApplicationConfig;
-
-		process.exit(errorCode);
 	}
 
 	// --------------------------------------

--- a/framework/src/application/application.ts
+++ b/framework/src/application/application.ts
@@ -283,12 +283,13 @@ export class Application {
 		this._node = this._initNode();
 
 		await this._controller.load();
-		await this._controller.loadPlugins(this.getPlugins(), this.config.plugins);
-		this.logger.debug(this._controller.bus.getEvents(), 'Application listening to events');
-		this.logger.debug(this._controller.bus.getActions(), 'Application ready for actions');
 
 		await this._network.bootstrap();
 		await this._node.bootstrap();
+
+		await this._controller.loadPlugins(this.getPlugins(), this.config.plugins);
+		this.logger.debug(this._controller.bus.getEvents(), 'Application listening to events');
+		this.logger.debug(this._controller.bus.getActions(), 'Application ready for actions');
 
 		this._channel.publish('app:ready');
 	}

--- a/framework/src/application/logger/logger.ts
+++ b/framework/src/application/logger/logger.ts
@@ -102,7 +102,7 @@ class ConsoleLog {
 			}
 			process.stdout.write(log);
 		} catch (err) {
-			console.error('Failed on logging', rec.err);
+			console.error('Failed on logging', err);
 		}
 	}
 }

--- a/framework/src/application/network/network.ts
+++ b/framework/src/application/network/network.ts
@@ -493,8 +493,8 @@ export class Network {
 	}
 
 	public async cleanup(): Promise<void> {
-		this._logger.info({}, 'Cleaning network...');
-
+		this._logger.info('Network cleanup started');
 		await this._p2p.stop();
+		this._logger.info('Network cleanup completed');
 	}
 }

--- a/framework/src/application/node/node.ts
+++ b/framework/src/application/node/node.ts
@@ -459,6 +459,7 @@ export class Node {
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async cleanup(): Promise<void> {
+		this._logger.info('Node cleanup started');
 		this._transactionPool.stop();
 		this._unsubscribeToEvents();
 		if (this._forgingJob) {
@@ -466,7 +467,7 @@ export class Node {
 		}
 		await this._synchronizer.stop();
 		await this._processor.stop();
-		this._logger.info('Cleaned up successfully');
+		this._logger.info('Node cleanup completed');
 	}
 
 	private _initModules(): void {

--- a/framework/src/application/node/transport/transport.ts
+++ b/framework/src/application/node/transport/transport.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { validator } from '@liskhq/lisk-validator';
+import { validator, LiskValidationError } from '@liskhq/lisk-validator';
 import { Chain, Block } from '@liskhq/lisk-chain';
 import { p2pTypes } from '@liskhq/lisk-p2p';
 import { TransactionPool } from '@liskhq/lisk-transaction-pool';
@@ -328,13 +328,21 @@ export class Transport {
 	public async handleEventPostTransaction(
 		data: EventPostTransactionData,
 	): Promise<handlePostTransactionReturn> {
-		const tx = this._chainModule.dataAccess.decodeTransaction(
-			Buffer.from(data.transaction, 'base64'),
-		);
-		const id = await this._receiveTransaction(tx);
-		return {
-			transactionId: id.toString('base64'),
-		};
+		try {
+			const tx = this._chainModule.dataAccess.decodeTransaction(
+				Buffer.from(data.transaction, 'base64'),
+			);
+			const id = await this._receiveTransaction(tx);
+			return {
+				transactionId: id.toString('base64'),
+			};
+		} catch (err) {
+			if (Array.isArray(err)) {
+				throw new LiskValidationError(err);
+			} else {
+				throw err;
+			}
+		}
 	}
 
 	/**

--- a/framework/src/application/node/transport/transport.ts
+++ b/framework/src/application/node/transport/transport.ts
@@ -328,21 +328,13 @@ export class Transport {
 	public async handleEventPostTransaction(
 		data: EventPostTransactionData,
 	): Promise<handlePostTransactionReturn> {
-		try {
-			const tx = this._chainModule.dataAccess.decodeTransaction(
-				Buffer.from(data.transaction, 'base64'),
-			);
-			const id = await this._receiveTransaction(tx);
-			return {
-				transactionId: id.toString('base64'),
-			};
-		} catch (err) {
-			return {
-				message: 'Transaction was rejected with errors',
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-member-access
-				errors: err.errors || err,
-			};
-		}
+		const tx = this._chainModule.dataAccess.decodeTransaction(
+			Buffer.from(data.transaction, 'base64'),
+		);
+		const id = await this._receiveTransaction(tx);
+		return {
+			transactionId: id.toString('base64'),
+		};
 	}
 
 	/**

--- a/framework/src/controller/channels/ipc_channel.ts
+++ b/framework/src/controller/channels/ipc_channel.ts
@@ -27,12 +27,6 @@ import { SocketPaths } from '../types';
 import { IPCClient } from '../ipc/ipc_client';
 import { ActionInfoForBus } from '../../types';
 
-export const setupProcessHandlers = (channel: IPCChannel): void => {
-	process.once('SIGTERM', () => channel.cleanup(1));
-	process.once('SIGINT', () => channel.cleanup(1));
-	process.once('exit', code => channel.cleanup(code));
-};
-
 type NodeCallback = (error: Error | null, result?: unknown) => void;
 
 interface ChildProcessOptions extends BaseChannelOptions {
@@ -62,8 +56,6 @@ export class IPCChannel extends BaseChannel {
 			delimiter: ':',
 			maxListeners: 1000,
 		});
-
-		setupProcessHandlers(this);
 	}
 
 	public async startAndListen(): Promise<void> {
@@ -167,9 +159,6 @@ export class IPCChannel extends BaseChannel {
 
 	public cleanup(_status?: number, _message?: string): void {
 		this._ipcClient.stop();
-		process.removeAllListeners('SIGTERM');
-		process.removeAllListeners('SIGINT');
-		process.removeAllListeners('exit');
 	}
 
 	private get _rpcServer(): RPCServer {

--- a/framework/src/controller/constants.ts
+++ b/framework/src/controller/constants.ts
@@ -16,6 +16,9 @@ export const INTERNAL_EVENTS = Object.freeze([
 	'registeredToBus',
 	'loading:started',
 	'loading:finished',
+	'unloading:started',
+	'unloading:finished',
+	'unloading:error',
 ]);
 
 export const eventWithModuleNameReg = /^([^\d][\w]+)((?::[^\d][\w]+)+)$/;

--- a/framework/src/controller/controller.ts
+++ b/framework/src/controller/controller.ts
@@ -58,7 +58,7 @@ interface PluginsObject {
 	readonly [key: string]: InstantiablePlugin<BasePlugin>;
 }
 
-const validatePluginSpec = (pluginSpec: Partial<BasePlugin>): void => {
+export const validatePluginSpec = (pluginSpec: Partial<BasePlugin>): void => {
 	assert((pluginSpec.constructor as typeof BasePlugin).alias, 'Plugin alias is required.');
 	assert((pluginSpec.constructor as typeof BasePlugin).info.name, 'Plugin name is required.');
 	assert((pluginSpec.constructor as typeof BasePlugin).info.author, 'Plugin author is required.');
@@ -213,7 +213,7 @@ export class Controller {
 		const plugin: BasePlugin = new Klass(options);
 		validatePluginSpec(plugin);
 
-		this.logger.info({ name, version, pluginAlias }, 'Loading in-memory plugin');
+		this.logger.info({ name, version, alias: pluginAlias }, 'Loading in-memory plugin');
 
 		const channel = new InMemoryChannel(pluginAlias, plugin.events, plugin.actions);
 
@@ -229,7 +229,7 @@ export class Controller {
 
 		this._inMemoryPlugins[pluginAlias] = { plugin, channel };
 
-		this.logger.info({ name, version, pluginAlias }, 'Loaded in-memory plugin');
+		this.logger.info({ name, version, alias: pluginAlias }, 'Loaded in-memory plugin');
 	}
 
 	private async _loadChildProcessPlugin(
@@ -243,7 +243,7 @@ export class Controller {
 		const plugin: BasePlugin = new Klass(options);
 		validatePluginSpec(plugin);
 
-		this.logger.info({ name, version, pluginAlias }, 'Loading plugin as child process');
+		this.logger.info({ name, version, alias: pluginAlias }, 'Loading child-process plugin');
 
 		const program = path.resolve(__dirname, 'child_process_loader.js');
 
@@ -289,7 +289,7 @@ export class Controller {
 		await Promise.race([
 			new Promise(resolve => {
 				this.channel.once(`${pluginAlias}:loading:finished`, () => {
-					this.logger.info({ name, version, pluginAlias }, 'Child process plugin ready');
+					this.logger.info({ name, version, alias: pluginAlias }, 'Loaded child-process plugin');
 					resolve();
 				});
 			}),

--- a/framework/src/controller/controller.ts
+++ b/framework/src/controller/controller.ts
@@ -273,7 +273,7 @@ export class Controller {
 
 		child.on('exit', (code, signal) => {
 			// If child process exited with error
-			if (code && code !== 0) {
+			if (code !== null && code !== undefined && code !== 0) {
 				this.logger.error(
 					{ name, version, pluginAlias, code, signal: signal ?? '' },
 					'Child process plugin exited',

--- a/framework/test/integration/specs/application/node/matcher.spec.ts
+++ b/framework/test/integration/specs/application/node/matcher.spec.ts
@@ -132,11 +132,7 @@ describe('Matcher', () => {
 					node['_transport'].handleEventPostTransaction({
 						transaction: tx.getBytes().toString('base64'),
 					}),
-				).resolves.toEqual(
-					expect.objectContaining({
-						message: expect.stringContaining('Transaction was rejected'),
-					}),
-				);
+				).rejects.toEqual(new Error('Transaction type not found.'));
 			});
 		});
 	});

--- a/framework/test/unit/specs/application/node/transport/transport_private.spec.ts
+++ b/framework/test/unit/specs/application/node/transport/transport_private.spec.ts
@@ -659,34 +659,32 @@ describe('transport', () => {
 					describe('when transportModule._receiveTransaction fails', () => {
 						const receiveTransactionError = new Error('Invalid transaction body ...');
 
-						beforeEach(async () => {
+						beforeEach(() => {
 							transportModule._receiveTransaction = jest
 								.fn()
 								.mockResolvedValue(Promise.reject(receiveTransactionError));
-
-							result = await transportModule.handleEventPostTransaction(query);
 						});
 
-						it('should resolve with object { message: err }', () => {
-							expect(result).toHaveProperty('errors');
-							expect(result.errors).toEqual(receiveTransactionError);
+						it('should throw when transaction is invalid', async () => {
+							return expect(transportModule.handleEventPostTransaction(query)).rejects.toThrow(
+								receiveTransactionError,
+							);
 						});
 					});
 
 					describe('when transportModule._receiveTransaction fails with "Transaction pool is full"', () => {
 						const receiveTransactionError = new Error('Transaction pool is full');
 
-						beforeEach(async () => {
+						beforeEach(() => {
 							transportModule._receiveTransaction = jest
 								.fn()
 								.mockResolvedValue(Promise.reject(receiveTransactionError));
-
-							result = await transportModule.handleEventPostTransaction(query);
 						});
 
-						it('should resolve with object { message: err }', () => {
-							expect(result).toHaveProperty('errors');
-							expect(result.errors).toEqual(receiveTransactionError);
+						it('should throw when transaction pool is full', async () => {
+							return expect(transportModule.handleEventPostTransaction(query)).rejects.toThrow(
+								receiveTransactionError,
+							);
 						});
 					});
 				});

--- a/framework/test/unit/specs/controller/channels/base/__snapshots__/constants.spec.ts.snap
+++ b/framework/test/unit/specs/controller/channels/base/__snapshots__/constants.spec.ts.snap
@@ -5,5 +5,8 @@ Array [
   "registeredToBus",
   "loading:started",
   "loading:finished",
+  "unloading:started",
+  "unloading:finished",
+  "unloading:error",
 ]
 `;

--- a/framework/test/unit/specs/controller/channels/ipc_channel.spec.ts
+++ b/framework/test/unit/specs/controller/channels/ipc_channel.spec.ts
@@ -166,7 +166,15 @@ describe('IPCChannel Channel', () => {
 			expect(ipcClientMock.rpcClient.call).toHaveBeenCalledWith(
 				'registerChannel',
 				params.moduleAlias,
-				[...params.events, 'registeredToBus', 'loading:started', 'loading:finished'],
+				[
+					...params.events,
+					'registeredToBus',
+					'loading:started',
+					'loading:finished',
+					'unloading:started',
+					'unloading:finished',
+					'unloading:error',
+				],
 				actionsInfo,
 				{
 					rpcSocketPath: undefined,
@@ -291,21 +299,6 @@ describe('IPCChannel Channel', () => {
 
 			// Assert
 			expect(ipcClientMock.stop).toHaveBeenCalled();
-		});
-
-		it('should clear process events', async () => {
-			// Arrange
-			jest.spyOn(process, 'removeAllListeners');
-			await ipcChannel.registerToBus();
-
-			// Act
-			ipcChannel.cleanup();
-
-			// Assert
-			expect(ipcClientMock.stop).toHaveBeenCalled();
-			expect(process.removeAllListeners).toHaveBeenCalledWith('SIGTERM');
-			expect(process.removeAllListeners).toHaveBeenCalledWith('SIGINT');
-			expect(process.removeAllListeners).toHaveBeenCalledWith('exit');
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves ##5562, and #3632

### How was it solved?

- Added the different logic unload plugins in the child process
- Send message to child process using Node IPC to unload 
- Child process unload the plugin and send confirmation over Lisk Socket using events
- Child process clears all and exit itself 
- Main process listen to confirmation event and proceed
- Main process listen is child process exit with some non-standard code. 
- Child process handles the `SIGINT` and `SIGTERM` and discard so main process can do cleanup. 

### How was it tested?

- Run the unit tests 
- Link SDK with Core and try this command. 

```
./bin/run start --network devnet --enable-forger --enable-http-api --console-log=debug --enable-ipc
```
- Then try to exit with `Ctrl+C`

