### PR TITLE
Expose legacy address from cryptography - Closes #5625

### DIFF
--- a/elements/lisk-cryptography/src/index.ts
+++ b/elements/lisk-cryptography/src/index.ts
@@ -19,6 +19,7 @@ export * from './convert';
 export * from './encrypt';
 export * from './hash';
 export * from './keys';
+export * from './legacy_address';
 export * from './sign';
 export * from './hash_onion';
 export { getRandomBytes } from './nacl';


### PR DESCRIPTION
### What was the problem?

This PR resolves #5625 

### How was it solved?

- Exposed legacy address functions

### How was it tested?

- Require `lisk-sdk` and cryptography should expose `getLegacyAddressFromPublicKey`