### PR TITLE
Fix types for genesis block - Closes #5649

### DIFF
--- a/elements/lisk-chain/src/types.ts
+++ b/elements/lisk-chain/src/types.ts
@@ -45,8 +45,8 @@ export interface RawBlock {
 	payload: ReadonlyArray<Buffer>;
 }
 
-export interface GenesisBlockHeaderAsset<T = Account> {
-	readonly accounts: ReadonlyArray<T>;
+export interface GenesisBlockHeaderAsset<T = AccountDefaultProps> {
+	readonly accounts: ReadonlyArray<Account<T>>;
 	readonly initDelegates: ReadonlyArray<Buffer>;
 	readonly initRounds: number;
 }
@@ -59,7 +59,7 @@ export interface BlockHeaderAsset {
 
 export type BlockHeader<T = BlockHeaderAsset> = BaseBlockHeader & { asset: T };
 
-export type GenesisBlockHeader<T = Account> = BaseBlockHeader & {
+export type GenesisBlockHeader<T = AccountDefaultProps> = BaseBlockHeader & {
 	asset: GenesisBlockHeaderAsset<T>;
 };
 
@@ -68,7 +68,7 @@ export interface Block<T = BlockHeaderAsset> {
 	payload: ReadonlyArray<Transaction>;
 }
 
-export interface GenesisBlock<T = Account> {
+export interface GenesisBlock<T = AccountDefaultProps> {
 	header: GenesisBlockHeader<T>;
 	payload: ReadonlyArray<Transaction>;
 }

--- a/elements/lisk-chain/src/utils/genesis_block.ts
+++ b/elements/lisk-chain/src/utils/genesis_block.ts
@@ -15,7 +15,7 @@
 import { Schema, codec } from '@liskhq/lisk-codec';
 import { objects } from '@liskhq/lisk-utils';
 import { hash } from '@liskhq/lisk-cryptography';
-import { GenesisBlock, AccountSchema } from '../types';
+import { GenesisBlock, AccountSchema, AccountDefaultProps } from '../types';
 import {
 	baseAccountSchema,
 	getGenesisBlockHeaderAssetSchema,
@@ -23,10 +23,10 @@ import {
 	blockHeaderSchema,
 } from '../schema';
 
-export const readGenesisBlockJSON = (
+export const readGenesisBlockJSON = <T = AccountDefaultProps>(
 	genesisBlockJSON: Record<string, unknown>,
 	accounts: { [name: string]: AccountSchema },
-): GenesisBlock => {
+): GenesisBlock<T> => {
 	const accountSchema = {
 		...baseAccountSchema,
 	} as Schema;
@@ -61,7 +61,7 @@ export const readGenesisBlockJSON = (
 		// eslint-disable-next-line no-param-reassign
 		delete (cloned as { header: { id: unknown } }).header.id;
 	}
-	const genesisBlock = codec.fromJSON<GenesisBlock>(genesisBlockSchema, cloned);
+	const genesisBlock = codec.fromJSON<GenesisBlock<T>>(genesisBlockSchema, cloned);
 	const genesisAssetBuffer = codec.encode(assetSchema, genesisBlock.header.asset);
 	const id = hash(
 		codec.encode(blockHeaderSchema, {

--- a/elements/lisk-genesis/test/fixtures/index.ts
+++ b/elements/lisk-genesis/test/fixtures/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { Account, getAccountSchemaAndDefault } from '@liskhq/lisk-chain';
+import { Account, getAccountSchemaWithDefault } from '@liskhq/lisk-chain';
 import { GenesisBlockParams } from '../../src';
 
 const delegates = [
@@ -200,7 +200,11 @@ export const defaultAccountModules = {
 	},
 };
 
-export const { schema: defaultAccountSchema } = getAccountSchemaAndDefault(defaultAccountModules);
+const { default: defaultAccount, ...defaultAccountSchema } = getAccountSchemaWithDefault(
+	defaultAccountModules,
+);
+
+export { defaultAccountSchema };
 
 export const validGenesisBlockParams = {
 	initRounds: 5,

--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 /* eslint-disable class-methods-use-this */
+import { AccountDefaultProps } from '@liskhq/lisk-chain';
 import {
 	GenesisConfig,
 	AccountSchema,
@@ -41,7 +42,7 @@ export abstract class BaseModule {
 
 	public async beforeTransactionApply?(input: TransactionApplyInput): Promise<void>;
 	public async afterTransactionApply?(input: TransactionApplyInput): Promise<void>;
-	public async afterGenesisBlockApply?<T = Account>(
+	public async afterGenesisBlockApply?<T = AccountDefaultProps>(
 		input: AfterGenesisBlockApplyInput<T>,
 	): Promise<void>;
 	public async beforeBlockApply?(input: BeforeBlockApplyInput): Promise<void>;

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -14,12 +14,12 @@
 import { p2pTypes } from '@liskhq/lisk-p2p';
 import {
 	Validator,
-	Account,
 	AccountSchema as ChainAccountSchema,
 	Transaction,
 	StateStore as ChainStateStore,
 	GenesisBlock,
 	Block,
+	AccountDefaultProps,
 } from '@liskhq/lisk-chain';
 
 export interface StringKeyVal {
@@ -194,7 +194,7 @@ export interface TransactionApplyInput {
 	reducerHandler: ReducerHandler;
 }
 
-export interface AfterGenesisBlockApplyInput<T = Account> {
+export interface AfterGenesisBlockApplyInput<T = AccountDefaultProps> {
 	genesisBlock: GenesisBlock<T>;
 	stateStore: StateStore;
 	reducerHandler: ReducerHandler;

--- a/framework/test/fixtures/blocks.ts
+++ b/framework/test/fixtures/blocks.ts
@@ -27,6 +27,7 @@ import {
 	Chain,
 	Transaction,
 	readGenesisBlockJSON,
+	Account,
 } from '@liskhq/lisk-chain';
 import * as genesisBlockJSON from './config/devnet/genesis_block.json';
 import { defaultAccountSchema } from './accounts';
@@ -36,8 +37,8 @@ export const defaultNetworkIdentifier = Buffer.from(
 	'hex',
 );
 
-export const genesisBlock = (): GenesisBlock =>
-	readGenesisBlockJSON(genesisBlockJSON, defaultAccountSchema);
+export const genesisBlock = <T>(): GenesisBlock<Account<T>> =>
+	readGenesisBlockJSON<Account<T>>(genesisBlockJSON, defaultAccountSchema);
 
 const getKeyPair = (): { publicKey: Buffer; privateKey: Buffer } => {
 	const passphrase = Mnemonic.generateMnemonic();


### PR DESCRIPTION
### What was the problem?

This PR resolves #5649 

### How was it solved?

- GenesisBlock generics now accepts AccountDefaultProps consistently
- Creating genesis block has consistent generic exposure

### How was it tested?

- It should build the typescript
