### PR TITLE
Fix afterGenesisBlockApply type

### DIFF
--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 /* eslint-disable class-methods-use-this */
-import { AccountDefaultProps } from '@liskhq/lisk-chain';
 import {
 	GenesisConfig,
 	AccountSchema,
@@ -42,9 +41,7 @@ export abstract class BaseModule {
 
 	public async beforeTransactionApply?(input: TransactionApplyInput): Promise<void>;
 	public async afterTransactionApply?(input: TransactionApplyInput): Promise<void>;
-	public async afterGenesisBlockApply?<T = AccountDefaultProps>(
-		input: AfterGenesisBlockApplyInput<T>,
-	): Promise<void>;
+	public async afterGenesisBlockApply?(input: AfterGenesisBlockApplyInput): Promise<void>;
 	public async beforeBlockApply?(input: BeforeBlockApplyInput): Promise<void>;
 	public async afterBlockApply?(input: AfterBlockApplyInput): Promise<void>;
 }

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -19,7 +19,6 @@ import {
 	StateStore as ChainStateStore,
 	GenesisBlock,
 	Block,
-	AccountDefaultProps,
 } from '@liskhq/lisk-chain';
 
 export interface StringKeyVal {
@@ -194,7 +193,7 @@ export interface TransactionApplyInput {
 	reducerHandler: ReducerHandler;
 }
 
-export interface AfterGenesisBlockApplyInput<T = AccountDefaultProps> {
+export interface AfterGenesisBlockApplyInput<T = unknown> {
 	genesisBlock: GenesisBlock<T>;
 	stateStore: StateStore;
 	reducerHandler: ReducerHandler;


### PR DESCRIPTION
### What was the problem?

afterGenesisBlockApply interface was incompatible with implementation

### How was it solved?

- Update type to allow more generic typeing.

### How was it tested?

Framework should build
