### PR TITLE
Expose common schemas - Closes #5665

### DIFF
--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -12,7 +12,17 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export { Transaction } from '@liskhq/lisk-chain';
+export {
+	Transaction,
+	transactionSchema,
+	readGenesisBlockJSON,
+	blockHeaderSchema,
+	blockSchema,
+	signingBlockHeaderSchema,
+	getAccountSchemaWithDefault,
+	getGenesisBlockHeaderAssetSchema,
+	blockHeaderAssetSchema,
+} from '@liskhq/lisk-chain';
 export {
 	BaseModule,
 	BaseAsset,


### PR DESCRIPTION
### What was the problem?

This PR resolves #5665 

### How was it solved?

- Expose common schema and utils from lisk-framework

### How was it tested?

- All build should pass
- Check lisk-sdk can use the exposed schemas and utils