### PR TITLE
Call BFT apply function to update BFT properties - Close #5688

### DIFF
--- a/framework/src/application/node/processor/processor.ts
+++ b/framework/src/application/node/processor/processor.ts
@@ -371,7 +371,6 @@ export class Processor {
 		const stateStore = await this._chain.newStateStore();
 		const reducerHandler = this._createReducerHandler(stateStore);
 		await this._chain.verifyBlockHeader(block, stateStore);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 		await this._bft.verifyBlockHeader(block.header, stateStore);
 
 		if (!skipBroadcast) {
@@ -386,6 +385,8 @@ export class Processor {
 			stateStore,
 			reducerHandler,
 		});
+
+		await this._bft.applyBlockHeader(block.header, stateStore);
 
 		if (block.payload.length) {
 			for (const transaction of block.payload) {

--- a/framework/test/unit/specs/application/node/processor/processor.spec.ts
+++ b/framework/test/unit/specs/application/node/processor/processor.spec.ts
@@ -75,6 +75,7 @@ describe('processor', () => {
 			init: jest.fn(),
 			forkChoice: jest.fn(),
 			verifyBlockHeader: jest.fn(),
+			applyBlockHeader: jest.fn(),
 			finalizedHeight: 5,
 		} as unknown) as BFT;
 
@@ -304,6 +305,7 @@ describe('processor', () => {
 			});
 
 			it('should apply the block', () => {
+				expect(bftModuleStub.applyBlockHeader).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.afterBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeTransactionApply).toHaveBeenCalledTimes(1);
@@ -370,6 +372,7 @@ describe('processor', () => {
 			});
 
 			it('should apply the last block', () => {
+				expect(bftModuleStub.applyBlockHeader).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.afterBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeTransactionApply).toHaveBeenCalledTimes(0);
@@ -483,6 +486,7 @@ describe('processor', () => {
 			});
 
 			it('should apply the block', () => {
+				expect(bftModuleStub.applyBlockHeader).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.afterBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeTransactionApply).toHaveBeenCalledTimes(1);
@@ -634,6 +638,7 @@ describe('processor', () => {
 			});
 
 			it('should not apply the block', () => {
+				expect(bftModuleStub.applyBlockHeader).not.toHaveBeenCalled();
 				expect(customModule0.beforeBlockApply).not.toHaveBeenCalled();
 				expect(customModule0.afterBlockApply).not.toHaveBeenCalled();
 				expect(customModule0.beforeTransactionApply).not.toHaveBeenCalled();
@@ -700,6 +705,7 @@ describe('processor', () => {
 			});
 
 			it('should apply the block', () => {
+				expect(bftModuleStub.applyBlockHeader).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.afterBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeTransactionApply).toHaveBeenCalledTimes(1);
@@ -748,6 +754,7 @@ describe('processor', () => {
 			});
 
 			it('should apply the block', () => {
+				expect(bftModuleStub.applyBlockHeader).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.afterBlockApply).toHaveBeenCalledTimes(1);
 				expect(customModule0.beforeTransactionApply).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5688 

### How was it solved?

- Call the BFT applyBlockHeader after `beforeBlockApply` step

### How was it tested?

- Added unit test
- Run a node and check finality and maxHeightPrevoted change
