### PR TITLE
Remove unnecessary validation from lisk-chain - Closes #5690

### DIFF
--- a/elements/lisk-chain/src/validate.ts
+++ b/elements/lisk-chain/src/validate.ts
@@ -17,7 +17,7 @@
 
 import { verifyData } from '@liskhq/lisk-cryptography';
 import { MerkleTree } from '@liskhq/lisk-tree';
-import { dataStructures, objects } from '@liskhq/lisk-utils';
+import { objects } from '@liskhq/lisk-utils';
 import { validator, LiskValidationError } from '@liskhq/lisk-validator';
 import { Schema } from '@liskhq/lisk-codec';
 import { Slots } from './slots';
@@ -46,18 +46,6 @@ export const validateSignature = (
 	}
 };
 
-export const validatePreviousBlockProperty = (block: Block, genesisBlock: GenesisBlock): void => {
-	const isGenesisBlock =
-		block.header.id.equals(genesisBlock.header.id) &&
-		block.header.version === genesisBlock.header.version;
-	const propertyIsValid =
-		isGenesisBlock || (block.header.previousBlockID.length > 0 && block.header.version !== 0);
-
-	if (!propertyIsValid) {
-		throw new Error('Invalid previous block');
-	}
-};
-
 export const validateReward = (block: Block, maxReward: bigint): void => {
 	if (block.header.reward > maxReward) {
 		throw new Error(
@@ -82,17 +70,11 @@ export const validateBlockProperties = (
 	}
 
 	const transactionIds: Buffer[] = [];
-	const appliedTransactions = new dataStructures.BufferSet();
 	for (const transaction of block.payload) {
-		if (appliedTransactions.has(transaction.id)) {
-			throw new Error(`Encountered duplicate transaction: ${transaction.id.toString('base64')}`);
-		}
 		transactionIds.push(transaction.id);
-		appliedTransactions.add(transaction.id);
 	}
 
 	const transactionRoot = getTransactionRoot(transactionIds);
-
 	if (!transactionRoot.equals(block.header.transactionRoot)) {
 		throw new Error('Invalid transaction root');
 	}

--- a/elements/lisk-chain/src/verify.ts
+++ b/elements/lisk-chain/src/verify.ts
@@ -31,20 +31,12 @@ export const verifyBlockNotExists = async (dataAccess: DataAccess, block: Block)
 	}
 };
 
-export const verifyPreviousBlockId = (
-	block: Block,
-	lastBlock: Block,
-	genesisBlock: GenesisBlock,
-): void => {
-	const isGenesisBlock =
-		block.header.id.equals(genesisBlock.header.id) &&
-		block.header.version === genesisBlock.header.version;
-
+export const verifyPreviousBlockId = (block: Block, lastBlock: Block): void => {
 	const isConsecutiveBlock =
 		lastBlock.header.height + 1 === block.header.height &&
 		block.header.previousBlockID.equals(lastBlock.header.id);
 
-	if (!isGenesisBlock && !isConsecutiveBlock) {
+	if (!isConsecutiveBlock) {
 		throw new Error('Invalid previous block');
 	}
 };

--- a/elements/lisk-chain/test/unit/process.spec.ts
+++ b/elements/lisk-chain/test/unit/process.spec.ts
@@ -75,17 +75,6 @@ describe('chain/process block', () => {
 	});
 
 	describe('#validateBlockHeader', () => {
-		describe('when previous block property is invalid', () => {
-			it('should throw error', () => {
-				// Arrange
-				block = createValidDefaultBlock({
-					header: { previousBlockID: Buffer.alloc(0), height: 3 },
-				} as any);
-				// Act & assert
-				expect(() => chainInstance.validateBlockHeader(block)).toThrow('Invalid previous block');
-			});
-		});
-
 		describe('when signature is invalid', () => {
 			it('should throw error', () => {
 				// Arrange


### PR DESCRIPTION
### What was the problem?

This PR resolves #5690 

### How was it solved?

- Remove redundant previousID property check which will be checked in verify step
- Remove genesis block check from verifyPreviousID since genesis block will not pass to this function
- Remove redundant transactioin id check since this should fail on the nonce check
- Update to throw all errors in case of validation fails with LiskValidatorError

### How was it tested?

- Updated unit tests
