### PR TITLE
Update balance in beforeTransactionApply - Closes #5704

### DIFF
--- a/framework/src/modules/token/token_module.ts
+++ b/framework/src/modules/token/token_module.ts
@@ -101,8 +101,11 @@ export class TokenModule extends BaseModule {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
-	public async beforeTransactionApply({ transaction }: TransactionApplyContext): Promise<void> {
-		// Throw error if fee is lower than minimum fee (minFeePerBytes + baseFee)
+	public async beforeTransactionApply({
+		transaction,
+		stateStore,
+	}: TransactionApplyContext): Promise<void> {
+		// Check if transaction fee is lower than the minimum required fee (minFeePerBytes + baseFee)
 		const minFee = BigInt(this.config.minFeePerByte) * BigInt(transaction.getBytes().length);
 		const baseFee =
 			this.config.baseFees.find(
@@ -114,6 +117,12 @@ export class TokenModule extends BaseModule {
 				`Insufficient transaction fee. Minimum required fee is: ${minimumRequiredFee.toString()}`,
 			);
 		}
+
+		// Deduct transaction fee from sender balance
+		const senderAddress = transaction.senderID;
+		const sender = await stateStore.account.getOrDefault<TokenAccount>(senderAddress);
+		sender.token.balance -= transaction.fee;
+		stateStore.account.set(senderAddress, sender);
 	}
 
 	public async afterTransactionApply({

--- a/framework/src/modules/token/token_module.ts
+++ b/framework/src/modules/token/token_module.ts
@@ -120,7 +120,7 @@ export class TokenModule extends BaseModule {
 
 		// Deduct transaction fee from sender balance
 		const senderAddress = transaction.senderID;
-		const sender = await stateStore.account.getOrDefault<TokenAccount>(senderAddress);
+		const sender = await stateStore.account.get<TokenAccount>(senderAddress);
 		sender.token.balance -= transaction.fee;
 		stateStore.account.set(senderAddress, sender);
 	}

--- a/framework/test/unit/modules/token/token_module.spec.ts
+++ b/framework/test/unit/modules/token/token_module.spec.ts
@@ -238,6 +238,27 @@ describe('token module', () => {
 				),
 			);
 		});
+
+		it('should deduct transaction fee from sender account', async () => {
+			const expectedSenderAccount = {
+				...senderAccount,
+				token: {
+					...senderAccount.token,
+					balance: senderAccount.token.balance - validTransaction.fee,
+				},
+			};
+
+			await tokenModule.beforeTransactionApply({
+				stateStore,
+				transaction: validTransaction,
+				reducerHandler,
+			});
+
+			expect(stateStore.account.set).toHaveBeenCalledWith(
+				senderAccount.address,
+				expectedSenderAccount,
+			);
+		});
 	});
 
 	describe('#afterTransactionApply', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5704 

### How was it solved?

Deduct fee from sender in `beforeTransactionApply` stage. Added unit test.

### How was it tested?

Unit test in token module.
