### PR TITLE
Fix to allow signature of transaction to be empty string - Closes #5713

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/transactions.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/transactions.ts
@@ -50,7 +50,7 @@ const transactionInputSchema = {
 			type: 'array',
 			items: {
 				type: 'string',
-				format: 'hex',
+				anyOf: [{ const: '' }, { format: 'hex' }],
 				description: 'Hex encoded value of the signature for the transaction.',
 			},
 			minItems: 1,


### PR DESCRIPTION
### What was the problem?

This PR resolves #5713 

### How was it solved?

- Updated the schema to allow empty string

### How was it tested?

- Send transaction from multi-signature account where it has at least one optional space
- Add functional test
