### PR TITLE
Remove validation of delegate username - Closes #5717

### DIFF
--- a/framework/src/modules/dpos/utils.ts
+++ b/framework/src/modules/dpos/utils.ts
@@ -84,10 +84,6 @@ export const isUsername = (username: string): boolean => {
 		return false;
 	}
 
-	if (/^[0-9]{1,21}[L|l]$/g.test(username)) {
-		return false;
-	}
-
 	return /^[a-z0-9!@$&_.]+$/g.test(username);
 };
 

--- a/framework/test/unit/modules/dpos/transaction_assets/register_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/register_transaction_asset.spec.ts
@@ -85,18 +85,6 @@ describe('RegisterTransactionAsset', () => {
 			expect(() => transactionAsset.validate({ asset } as any)).toThrow(error);
 		});
 
-		it('should throw error when username is like address', () => {
-			// Arrange
-			const asset: RegisterTransactionAssetContext = { username: '17670127987160191762l' };
-			const error = new ValidationError(
-				'The username is in unsupported format',
-				'17670127987160191762l',
-			);
-
-			// Act & Assert
-			expect(() => transactionAsset.validate({ asset } as any)).toThrow(error);
-		});
-
 		it('should throw error when username includes forbidden character', () => {
 			// Arrange
 			const asset: RegisterTransactionAssetContext = { username: 'obe^lis' };


### PR DESCRIPTION
### What was the problem?

This PR resolves #5715 

### How was it solved?

- Remove delegate username validation to allow old legacy address format

### How was it tested?

- Remove test for the old legacy address
- Register username "123L"
