### PR TITLE
Rename senderID to senderAddress - Closes #5738

### DIFF
--- a/elements/lisk-chain/src/transaction.ts
+++ b/elements/lisk-chain/src/transaction.ts
@@ -88,7 +88,7 @@ export class Transaction {
 	public readonly senderPublicKey: Buffer;
 	public readonly signatures: ReadonlyArray<Buffer>;
 	private _id?: Buffer;
-	private _senderID?: Buffer;
+	private _senderAddress?: Buffer;
 
 	public constructor(transaction: TransactionInput) {
 		this.moduleID = transaction.moduleID;
@@ -112,11 +112,11 @@ export class Transaction {
 		return this._id;
 	}
 
-	public get senderID(): Buffer {
-		if (!this._senderID) {
-			this._senderID = getAddressFromPublicKey(this.senderPublicKey);
+	public get senderAddress(): Buffer {
+		if (!this._senderAddress) {
+			this._senderAddress = getAddressFromPublicKey(this.senderPublicKey);
 		}
-		return this._senderID;
+		return this._senderAddress;
 	}
 
 	public getBytes(): Buffer {

--- a/elements/lisk-chain/test/unit/transactions.spec.ts
+++ b/elements/lisk-chain/test/unit/transactions.spec.ts
@@ -14,7 +14,7 @@
 describe('blocks/transactions', () => {
 	describe('transaction', () => {
 		it.todo('should have id');
-		it.todo('should have senderID');
+		it.todo('should have senderAddress');
 		it.todo('should throw when moduleID is below 2');
 		it.todo('should throw when moduleID is invalid');
 		it.todo('should throw when assetID is invalid');

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/voters.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/voters.spec.ts
@@ -99,7 +99,7 @@ describe('Voters endpoint', () => {
 				expect(status).toEqual(200);
 				expect(forgerInfo.voters[0]).toMatchObject(
 					expect.objectContaining({
-						address: transaction.senderID.toString('hex'),
+						address: transaction.senderAddress.toString('hex'),
 						amount: '1000000000',
 					}),
 				);

--- a/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
@@ -144,7 +144,7 @@ export class PomTransactionAsset extends BaseAsset<PomTransactionAssetContext> {
 	// eslint-disable-next-line class-methods-use-this
 	public async apply({
 		asset,
-		senderID,
+		senderAddress,
 		stateStore: store,
 		reducerHandler,
 	}: ApplyAssetContext<PomTransactionAssetContext>): Promise<void> {
@@ -236,7 +236,7 @@ export class PomTransactionAsset extends BaseAsset<PomTransactionAssetContext> {
 				? delegateAccountBalance
 				: store.chain.lastBlockReward;
 
-		await reducerHandler.invoke('token:credit', { address: senderID, amount: reward });
+		await reducerHandler.invoke('token:credit', { address: senderAddress, amount: reward });
 
 		/*
 			Update delegate account

--- a/framework/src/modules/dpos/transaction_assets/register_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/register_transaction_asset.ts
@@ -48,10 +48,10 @@ export class RegisterTransactionAsset extends BaseAsset<RegisterTransactionAsset
 	// eslint-disable-next-line class-methods-use-this
 	public async apply({
 		asset,
-		senderID,
+		senderAddress,
 		stateStore,
 	}: ApplyAssetContext<RegisterTransactionAssetContext>): Promise<void> {
-		const sender = await stateStore.account.get<DPOSAccountProps>(senderID);
+		const sender = await stateStore.account.get<DPOSAccountProps>(senderAddress);
 
 		if (sender.dpos.delegate.username) {
 			throw new Error('Account is already a delegate');
@@ -65,7 +65,7 @@ export class RegisterTransactionAsset extends BaseAsset<RegisterTransactionAsset
 		if (!usernameExists) {
 			usernames.registeredDelegates.push({
 				username: asset.username,
-				address: senderID,
+				address: senderAddress,
 			});
 
 			setRegisteredDelegates(stateStore, usernames);

--- a/framework/src/modules/dpos/transaction_assets/unlock_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/unlock_transaction_asset.ts
@@ -78,12 +78,12 @@ export class UnlockTransactionAsset extends BaseAsset<UnlockTransactionAssetCont
 	// eslint-disable-next-line class-methods-use-this
 	public async apply({
 		asset,
-		senderID,
+		senderAddress,
 		stateStore: store,
 		reducerHandler,
 	}: ApplyAssetContext<UnlockTransactionAssetContext>): Promise<void> {
 		for (const unlock of asset.unlockObjects) {
-			const sender = await store.account.get<DPOSAccountProps>(senderID);
+			const sender = await store.account.get<DPOSAccountProps>(senderAddress);
 			const delegate = await store.account.get<DPOSAccountProps>(unlock.delegateAddress);
 
 			if (delegate.dpos.delegate.username === '') {
@@ -123,7 +123,7 @@ export class UnlockTransactionAsset extends BaseAsset<UnlockTransactionAssetCont
 			sender.dpos.unlocking.splice(unlockIndex, 1);
 
 			await reducerHandler.invoke('token:credit', {
-				address: senderID,
+				address: senderAddress,
 				amount: unlock.amount,
 			});
 

--- a/framework/src/modules/dpos/transaction_assets/vote_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/vote_transaction_asset.ts
@@ -95,7 +95,7 @@ export class VoteTransactionAsset extends BaseAsset<VoteTransactionAssetContext>
 	// eslint-disable-next-line class-methods-use-this
 	public async apply({
 		asset,
-		senderID,
+		senderAddress,
 		stateStore: store,
 		reducerHandler,
 	}: ApplyAssetContext<VoteTransactionAssetContext>): Promise<void> {
@@ -116,7 +116,7 @@ export class VoteTransactionAsset extends BaseAsset<VoteTransactionAssetContext>
 		});
 
 		for (const vote of assetCopy) {
-			const sender = await store.account.get<DPOSAccountProps>(senderID);
+			const sender = await store.account.get<DPOSAccountProps>(senderAddress);
 			const votedDelegate = await store.account.get<DPOSAccountProps>(vote.delegateAddress);
 
 			if (votedDelegate.dpos.delegate.username === '') {
@@ -183,7 +183,7 @@ export class VoteTransactionAsset extends BaseAsset<VoteTransactionAssetContext>
 
 				// Balance is checked in the token module
 				await reducerHandler.invoke('token:debit', {
-					address: senderID,
+					address: senderAddress,
 					amount: vote.amount,
 				});
 

--- a/framework/src/modules/keys/keys_module.ts
+++ b/framework/src/modules/keys/keys_module.ts
@@ -60,7 +60,7 @@ export class KeysModule extends BaseModule {
 		stateStore,
 		transaction,
 	}: TransactionApplyContext): Promise<void> {
-		const sender = await stateStore.account.get<AccountKeys>(transaction.senderID);
+		const sender = await stateStore.account.get<AccountKeys>(transaction.senderAddress);
 		const { networkIdentifier } = stateStore.chain;
 		const transactionBytes = transaction.getSigningBytes();
 

--- a/framework/src/modules/keys/register_asset.ts
+++ b/framework/src/modules/keys/register_asset.ts
@@ -111,8 +111,12 @@ export class RegisterAsset extends BaseAsset {
 		}
 	}
 
-	public async apply({ asset, stateStore, senderID }: ApplyAssetContext<Asset>): Promise<void> {
-		const sender = await stateStore.account.get<AccountKeys>(senderID);
+	public async apply({
+		asset,
+		stateStore,
+		senderAddress,
+	}: ApplyAssetContext<Asset>): Promise<void> {
+		const sender = await stateStore.account.get<AccountKeys>(senderAddress);
 
 		// Check if multisignatures already exists on account
 		if (sender.keys.numberOfSignatures > 0) {

--- a/framework/src/modules/token/token_module.ts
+++ b/framework/src/modules/token/token_module.ts
@@ -106,10 +106,9 @@ export class TokenModule extends BaseModule {
 		stateStore,
 	}: TransactionApplyContext): Promise<void> {
 		// Deduct transaction fee from sender balance
-		const senderAddress = transaction.senderID;
-		const sender = await stateStore.account.get<TokenAccount>(senderAddress);
+		const sender = await stateStore.account.get<TokenAccount>(transaction.senderAddress);
 		sender.token.balance -= transaction.fee;
-		stateStore.account.set(senderAddress, sender);
+		stateStore.account.set(transaction.senderAddress, sender);
 	}
 
 	public async afterTransactionApply({
@@ -117,8 +116,7 @@ export class TokenModule extends BaseModule {
 		stateStore,
 	}: TransactionApplyContext): Promise<void> {
 		// Verify sender has minimum remaining balance
-		const senderAddress = transaction.senderID;
-		const sender = await stateStore.account.getOrDefault<TokenAccount>(senderAddress);
+		const sender = await stateStore.account.getOrDefault<TokenAccount>(transaction.senderAddress);
 		if (sender.token.balance < this._minRemainingBalance) {
 			throw new Error(
 				`Account does not have enough minimum remaining balance: ${sender.address.toString(

--- a/framework/src/modules/token/transfer_asset.ts
+++ b/framework/src/modules/token/transfer_asset.ts
@@ -51,10 +51,14 @@ export class TransferAsset extends BaseAsset {
 		this._minRemainingBalance = minRemainingBalance;
 	}
 
-	public async apply({ asset, senderID, stateStore }: ApplyAssetContext<Asset>): Promise<void> {
-		const sender = await stateStore.account.get<TokenAccount>(senderID);
+	public async apply({
+		asset,
+		senderAddress,
+		stateStore,
+	}: ApplyAssetContext<Asset>): Promise<void> {
+		const sender = await stateStore.account.get<TokenAccount>(senderAddress);
 		if (!sender) {
-			throw new Error(`Account does not exist for senderID: ${senderID.toString('hex')}`);
+			throw new Error(`Account does not exist for senderAddress: ${senderAddress.toString('hex')}`);
 		}
 		sender.token.balance -= asset.amount;
 		stateStore.account.set(sender.address, sender);

--- a/framework/src/node/processor/processor.ts
+++ b/framework/src/node/processor/processor.ts
@@ -341,7 +341,7 @@ export class Processor {
 				await customAsset.apply({
 					asset: decodedAsset,
 					reducerHandler: this._createReducerHandler(stateStore),
-					senderID: transaction.senderID,
+					senderAddress: transaction.senderAddress,
 					stateStore,
 					transaction,
 				});
@@ -402,7 +402,7 @@ export class Processor {
 				await customAsset.apply({
 					asset: decodedAsset,
 					reducerHandler,
-					senderID: transaction.senderID,
+					senderAddress: transaction.senderAddress,
 					stateStore,
 					transaction,
 				});

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -207,7 +207,7 @@ export interface AfterBlockApplyContext extends BeforeBlockApplyContext {
 }
 
 export interface ApplyAssetContext<T> {
-	senderID: Buffer;
+	senderAddress: Buffer;
 	asset: T;
 	stateStore: StateStore;
 	reducerHandler: ReducerHandler;

--- a/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
@@ -70,7 +70,7 @@ describe('PomTransactionAsset', () => {
 		);
 		transactionAsset = new PomTransactionAsset();
 		applyContext = ({
-			senderID: sender.address,
+			senderAddress: sender.address,
 			asset: {
 				header1: {},
 				header2: {},
@@ -307,7 +307,7 @@ describe('PomTransactionAsset', () => {
 			await transactionAsset.apply(applyContext);
 
 			expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
-				address: applyContext.senderID,
+				address: applyContext.senderAddress,
 				amount: remainingBalance,
 			});
 		});
@@ -344,7 +344,7 @@ describe('PomTransactionAsset', () => {
 		});
 
 		it('should not return balance if sender and delegate account are same', async () => {
-			applyContext.senderID = misBehavingDelegate.address;
+			applyContext.senderAddress = misBehavingDelegate.address;
 
 			await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
 		});

--- a/framework/test/unit/modules/dpos/transaction_assets/register_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/register_transaction_asset.spec.ts
@@ -35,7 +35,7 @@ describe('RegisterTransactionAsset', () => {
 		});
 		transactionAsset = new RegisterTransactionAsset();
 		context = {
-			senderID: sender.address,
+			senderAddress: sender.address,
 			asset: {
 				username: 'delegate',
 			},
@@ -109,7 +109,7 @@ describe('RegisterTransactionAsset', () => {
 			await transactionAsset.apply(context);
 
 			// Assert
-			expect(stateStoreMock.account.get).toHaveBeenCalledWith(context.senderID);
+			expect(stateStoreMock.account.get).toHaveBeenCalledWith(context.senderAddress);
 			expect(stateStoreMock.account.set).toHaveBeenCalledWith(sender.address, {
 				...sender,
 				dpos: {

--- a/framework/test/unit/modules/dpos/transaction_assets/unlock_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/unlock_transaction_asset.spec.ts
@@ -102,7 +102,7 @@ describe('UnlockTransactionAsset', () => {
 		);
 		transactionAsset = new UnlockTransactionAsset();
 		applyContext = {
-			senderID: sender.address,
+			senderAddress: sender.address,
 			asset: {
 				unlockObjects: [],
 			},

--- a/framework/test/unit/modules/dpos/transaction_assets/vote_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/vote_transaction_asset.spec.ts
@@ -42,7 +42,7 @@ describe('VoteTransactionAsset', () => {
 		);
 		transactionAsset = new VoteTransactionAsset();
 		applyContext = {
-			senderID: sender.address,
+			senderAddress: sender.address,
 			asset: {
 				votes: [],
 			},
@@ -291,11 +291,11 @@ describe('VoteTransactionAsset', () => {
 
 				expect(applyContext.reducerHandler.invoke).toHaveBeenCalledTimes(2);
 				expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:debit', {
-					address: applyContext.senderID,
+					address: applyContext.senderAddress,
 					amount: delegate1VoteAmount,
 				});
 				expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:debit', {
-					address: applyContext.senderID,
+					address: applyContext.senderAddress,
 					amount: delegate2VoteAmount,
 				});
 			});
@@ -503,7 +503,7 @@ describe('VoteTransactionAsset', () => {
 
 				expect(applyContext.reducerHandler.invoke).toHaveBeenCalledTimes(1);
 				expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:debit', {
-					address: applyContext.senderID,
+					address: applyContext.senderAddress,
 					amount: positiveVoteDelegate1,
 				});
 			});

--- a/framework/test/unit/modules/keys/register_asset.spec.ts
+++ b/framework/test/unit/modules/keys/register_asset.spec.ts
@@ -399,18 +399,18 @@ describe('register asset', () => {
 				registerAsset.apply({
 					stateStore,
 					asset: validTestTransaction.asset,
-					senderID: validTestTransaction.address,
+					senderAddress: validTestTransaction.address,
 					reducerHandler,
 					transaction: validTestTransaction,
 				}),
 			).not.toThrow();
 		});
 
-		it('should call state store get() with senderID and set() with adress and updated account', async () => {
+		it('should call state store get() with senderAddress and set() with adress and updated account', async () => {
 			await registerAsset.apply({
 				stateStore,
 				asset: validTestTransaction.asset,
-				senderID: validTestTransaction.address,
+				senderAddress: validTestTransaction.address,
 				reducerHandler,
 				transaction: validTestTransaction,
 			});
@@ -430,7 +430,7 @@ describe('register asset', () => {
 				registerAsset.apply({
 					stateStore,
 					asset: validTestTransaction.asset,
-					senderID: validTestTransaction.address,
+					senderAddress: validTestTransaction.address,
 					reducerHandler,
 					transaction: validTestTransaction,
 				}),

--- a/framework/test/unit/modules/token/transfer_asset.spec.ts
+++ b/framework/test/unit/modules/token/transfer_asset.spec.ts
@@ -68,7 +68,7 @@ describe('Transfer asset', () => {
 			expect(async () =>
 				transferAsset.apply({
 					asset: validTransaction.asset,
-					senderID: validTransaction.address,
+					senderAddress: validTransaction.address,
 					stateStore,
 					reducerHandler,
 					transaction: validTransaction,
@@ -79,7 +79,7 @@ describe('Transfer asset', () => {
 		it('should call state store with a valid transfer asset', async () => {
 			await transferAsset.apply({
 				asset: validTransaction.asset,
-				senderID: validTransaction.address,
+				senderAddress: validTransaction.address,
 				stateStore,
 				reducerHandler,
 				transaction: validTransaction,
@@ -113,7 +113,7 @@ describe('Transfer asset', () => {
 			return expect(async () =>
 				transferAsset.apply({
 					asset: validTransaction.asset,
-					senderID: validTransaction.address,
+					senderAddress: validTransaction.address,
 					stateStore,
 					reducerHandler,
 					transaction: validTransaction,
@@ -136,7 +136,7 @@ describe('Transfer asset', () => {
 			return expect(async () =>
 				transferAsset.apply({
 					asset: { ...validTransaction.asset, amount: BigInt(0) },
-					senderID: validTransaction.address,
+					senderAddress: validTransaction.address,
 					stateStore,
 					reducerHandler,
 					transaction: validTransaction,


### PR DESCRIPTION
### What was the problem?

This PR resolves #5738 

### How was it solved?

- Rename all the usage of `senderID` to `senderAddress`

### How was it tested?

- all build and test should pass
