### PR TITLE
Fix PoM not to deduct amount more than minimum remaining balance - Closes #5758

### DIFF
--- a/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
@@ -230,10 +230,19 @@ export class PomTransactionAsset extends BaseAsset<PomTransactionAssetContext> {
 		const delegateAccountBalance = await reducerHandler.invoke<bigint>('token:getBalance', {
 			address: delegateAccount.address,
 		});
+		const minRemainingBalance = await reducerHandler.invoke<bigint>(
+			'token:getMinRemainingBalance',
+			{},
+		);
+
+		const delegateSubtractableBalance =
+			delegateAccountBalance - minRemainingBalance > BigInt(0)
+				? delegateAccountBalance - minRemainingBalance
+				: BigInt(0);
 
 		const reward =
-			store.chain.lastBlockReward > delegateAccountBalance
-				? delegateAccountBalance
+			store.chain.lastBlockReward > delegateSubtractableBalance
+				? delegateSubtractableBalance
 				: store.chain.lastBlockReward;
 
 		await reducerHandler.invoke('token:credit', { address: senderAddress, amount: reward });

--- a/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
@@ -230,10 +230,7 @@ export class PomTransactionAsset extends BaseAsset<PomTransactionAssetContext> {
 		const delegateAccountBalance = await reducerHandler.invoke<bigint>('token:getBalance', {
 			address: delegateAccount.address,
 		});
-		const minRemainingBalance = await reducerHandler.invoke<bigint>(
-			'token:getMinRemainingBalance',
-			{},
-		);
+		const minRemainingBalance = await reducerHandler.invoke<bigint>('token:getMinRemainingBalance');
 
 		const delegateSubtractableBalance =
 			delegateAccountBalance - minRemainingBalance > BigInt(0)

--- a/framework/src/modules/token/token_module.ts
+++ b/framework/src/modules/token/token_module.ts
@@ -86,6 +86,8 @@ export class TokenModule extends BaseModule {
 			const account = await stateStore.account.getOrDefault<TokenAccount>(address);
 			return account.token.balance;
 		},
+		// eslint-disable-next-line @typescript-eslint/require-await
+		getMinRemainingBalance: async (): Promise<bigint> => this._minRemainingBalance,
 	};
 
 	private readonly _minRemainingBalance: bigint;

--- a/framework/src/node/processor/processor.ts
+++ b/framework/src/node/processor/processor.ts
@@ -494,7 +494,7 @@ export class Processor {
 
 	private _createReducerHandler(stateStore: StateStore): ReducerHandler {
 		return {
-			invoke: async <T = unknown>(name: string, params: Record<string, unknown>): Promise<T> => {
+			invoke: async <T = unknown>(name: string, params?: Record<string, unknown>): Promise<T> => {
 				const requestNames = name.split(':');
 				if (requestNames.length !== 2) {
 					throw new Error('Invalid format to call reducer');
@@ -505,7 +505,7 @@ export class Processor {
 				if (!fn) {
 					throw new Error(`${funcName} does not exist in module ${moduleName}`);
 				}
-				return fn(params, this._createScopedStateStore(stateStore, moduleName)) as Promise<T>;
+				return fn(params ?? {}, this._createScopedStateStore(stateStore, moduleName)) as Promise<T>;
 			},
 		};
 	}

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -194,7 +194,7 @@ export interface StateStore {
 }
 
 export interface ReducerHandler {
-	invoke: <T = unknown>(name: string, params: Record<string, unknown>) => Promise<T>;
+	invoke: <T = unknown>(name: string, params?: Record<string, unknown>) => Promise<T>;
 }
 
 export interface Reducers {

--- a/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
@@ -301,7 +301,7 @@ describe('PomTransactionAsset', () => {
 				.calledWith('token:getBalance', { address: misBehavingDelegate.address })
 				.mockResolvedValue(remainingBalance as never);
 			when(applyContext.reducerHandler.invoke as any)
-				.calledWith('token:getMinRemainingBalance', {})
+				.calledWith('token:getMinRemainingBalance')
 				.mockResolvedValue(minRemainingBalance as never);
 
 			await transactionAsset.apply(applyContext);
@@ -320,7 +320,7 @@ describe('PomTransactionAsset', () => {
 				.calledWith('token:getBalance', { address: misBehavingDelegate.address })
 				.mockResolvedValue(remainingBalance as never);
 			when(applyContext.reducerHandler.invoke as any)
-				.calledWith('token:getMinRemainingBalance', {})
+				.calledWith('token:getMinRemainingBalance')
 				.mockResolvedValue(minRemainingBalance as never);
 
 			await transactionAsset.apply(applyContext);
@@ -339,7 +339,7 @@ describe('PomTransactionAsset', () => {
 				.calledWith('token:getBalance', { address: misBehavingDelegate.address })
 				.mockResolvedValue(remainingBalance as never);
 			when(applyContext.reducerHandler.invoke as any)
-				.calledWith('token:getMinRemainingBalance', {})
+				.calledWith('token:getMinRemainingBalance')
 				.mockResolvedValue(minRemainingBalance as never);
 
 			await transactionAsset.apply(applyContext);

--- a/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
@@ -293,7 +293,7 @@ describe('PomTransactionAsset', () => {
 			);
 		});
 
-		it('should reward the sender with last block reward if delegate have emough balance', async () => {
+		it('should reward the sender with last block reward if delegate have enough balance', async () => {
 			const remainingBalance = lastBlockReward + BigInt('10000000000');
 			const minRemainingBalance = BigInt('5000000');
 

--- a/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/pom_transaction_asset.spec.ts
@@ -293,18 +293,60 @@ describe('PomTransactionAsset', () => {
 			);
 		});
 
-		it('should add remaining balance of delegate to balance of the sender if delegate balance is less than last block reward', async () => {
-			const remainingBalance = lastBlockReward - BigInt(1);
+		it('should reward the sender with last block reward if delegate have emough balance', async () => {
+			const remainingBalance = lastBlockReward + BigInt('10000000000');
+			const minRemainingBalance = BigInt('5000000');
 
 			when(applyContext.reducerHandler.invoke as any)
 				.calledWith('token:getBalance', { address: misBehavingDelegate.address })
 				.mockResolvedValue(remainingBalance as never);
+			when(applyContext.reducerHandler.invoke as any)
+				.calledWith('token:getMinRemainingBalance', {})
+				.mockResolvedValue(minRemainingBalance as never);
 
 			await transactionAsset.apply(applyContext);
 
 			expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
 				address: applyContext.senderAddress,
-				amount: remainingBalance,
+				amount: lastBlockReward,
+			});
+		});
+
+		it('should not reward the sender if delegate does not have emough minimum remaining balance', async () => {
+			const remainingBalance = BigInt(100);
+			const minRemainingBalance = BigInt('5000000');
+
+			when(applyContext.reducerHandler.invoke as any)
+				.calledWith('token:getBalance', { address: misBehavingDelegate.address })
+				.mockResolvedValue(remainingBalance as never);
+			when(applyContext.reducerHandler.invoke as any)
+				.calledWith('token:getMinRemainingBalance', {})
+				.mockResolvedValue(minRemainingBalance as never);
+
+			await transactionAsset.apply(applyContext);
+
+			expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+				address: applyContext.senderAddress,
+				amount: BigInt(0),
+			});
+		});
+
+		it('should add (remaining balance - min remaining balance) of delegate to balance of the sender if delegate balance is less than last block reward', async () => {
+			const remainingBalance = lastBlockReward - BigInt(1);
+			const minRemainingBalance = BigInt('5000000');
+
+			when(applyContext.reducerHandler.invoke as any)
+				.calledWith('token:getBalance', { address: misBehavingDelegate.address })
+				.mockResolvedValue(remainingBalance as never);
+			when(applyContext.reducerHandler.invoke as any)
+				.calledWith('token:getMinRemainingBalance', {})
+				.mockResolvedValue(minRemainingBalance as never);
+
+			await transactionAsset.apply(applyContext);
+
+			expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+				address: applyContext.senderAddress,
+				amount: remainingBalance - minRemainingBalance,
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5758 

### How was it solved?

- Add `getMinRemainingBalance` to the token module
- Use the `getMinRemainingBalance` to calculate subtractable balance from punishing delegate

### How was it tested?

- Add unit test case
