### PR TITLE
Add test for scenarios related to previousPeers, banning and whitelist  - Closes #5759

### DIFF
--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -405,8 +405,8 @@ export class Peer extends EventEmitter {
 			);
 		}
 		try {
-			const decodedNodeInfo = decodeNodeInfo(this._rpcSchemas.nodeInfo, response.data);
-			this._updateFromProtocolPeerInfo(decodedNodeInfo);
+			const receivedNodeInfo = decodeNodeInfo(this._rpcSchemas.nodeInfo, response.data);
+			this._updateFromProtocolPeerInfo(receivedNodeInfo);
 		} catch (error) {
 			this.emit(EVENT_FAILED_PEER_INFO_UPDATE, error);
 

--- a/elements/lisk-p2p/test/functional/actions/peer_banning.ts
+++ b/elements/lisk-p2p/test/functional/actions/peer_banning.ts
@@ -15,6 +15,7 @@
 import { wait } from '../../utils/helpers';
 import { createNetwork, destroyNetwork, SEED_PEER_IP } from '../../utils/network_setup';
 import { P2P, events, p2pTypes } from '../../../src/index';
+import { P2PConfig } from '../../../src/types';
 
 const { EVENT_BAN_PEER, EVENT_CLOSE_INBOUND } = events;
 
@@ -24,10 +25,18 @@ describe('Peer banning mechanism', () => {
 	const PEER_BAN_TIME = 100;
 
 	beforeEach(async () => {
-		const customConfig = () => ({
+		const customConfig = (index: number): Partial<P2PConfig> => ({
 			peerBanTime: PEER_BAN_TIME,
+			fixedPeers:
+				index === 1
+					? [
+							{
+								ipAddress: SEED_PEER_IP,
+								port: 5001,
+							},
+					  ]
+					: [],
 		});
-
 		p2pNodeList = await createNetwork({ customConfig });
 	});
 
@@ -104,6 +113,12 @@ describe('Peer banning mechanism', () => {
 			const updatedConnectedPeers = p2pNodeList[0].getConnectedPeers();
 
 			expect(updatedConnectedPeers.map(peer => peer.port)).toEqual(
+				expect.arrayContaining([badPeer.port]),
+			);
+
+			await wait(200);
+
+			expect(p2pNodeList[0].getConnectedPeers().map(peer => peer.port)).toEqual(
 				expect.arrayContaining([badPeer.port]),
 			);
 		});

--- a/elements/lisk-p2p/test/unit/p2p.ts
+++ b/elements/lisk-p2p/test/unit/p2p.ts
@@ -24,6 +24,7 @@ describe('p2p', () => {
 		ipAddress: `120.0.0.${i}`,
 		port: 5000 + i,
 	}));
+	const previousPeers = generatedPeers.slice(4, 5);
 
 	beforeEach(async () => {
 		p2pNode = new P2P({
@@ -32,7 +33,7 @@ describe('p2p', () => {
 			blacklistedIPs: generatedPeers.slice(6).map(peer => peer.ipAddress),
 			fixedPeers: generatedPeers.slice(0, 6),
 			whitelistedPeers: generatedPeers.slice(2, 3),
-			previousPeers: generatedPeers.slice(4, 5),
+			previousPeers,
 			connectTimeout: 5000,
 			maxOutboundConnections: 20,
 			maxInboundConnections: 100,
@@ -74,6 +75,12 @@ describe('p2p', () => {
 					.filter(peer => peer.internalState?.peerKind === 'fixedPeer')
 					.map(peer => peer.peerId),
 			);
+		});
+
+		it('should have previous peers passed from the config', () => {
+			expect(
+				[...p2pNode.getDisconnectedPeers(), ...p2pNode.getConnectedPeers()].map(p => p.ipAddress),
+			).toContain(previousPeers[0].ipAddress);
 		});
 
 		it('should reject at multiple start attempt', async () => {

--- a/elements/lisk-p2p/test/unit/peer/base.ts
+++ b/elements/lisk-p2p/test/unit/peer/base.ts
@@ -14,7 +14,6 @@
  */
 import { codec } from '@liskhq/lisk-codec';
 import { SCServerSocket } from 'socketcluster-server';
-import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import { Peer, PeerConfig } from '../../../src/peer';
 import {
 	DEFAULT_REPUTATION_SCORE,
@@ -38,11 +37,10 @@ import {
 	EVENT_FAILED_TO_FETCH_PEER_INFO,
 	PROTOCOL_EVENTS_TO_RATE_LIMIT,
 } from '../../../src/events';
-import { RPCResponseError, InvalidNodeInfoError } from '../../../src/errors';
+import { RPCResponseError } from '../../../src/errors';
 import { getNetgroup, constructPeerId } from '../../../src/utils';
 import { p2pTypes } from '../../../src';
 import { peerInfoSchema, nodeInfoSchema } from '../../../src/schema';
-import * as codecUtils from '../../../src/utils/codec';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const createSocketStubInstance = () => <SCServerSocket>({
@@ -577,11 +575,11 @@ describe('peer/base', () => {
 
 		describe('when request() succeeds', () => {
 			describe('when nodeInfo contains malformed information', () => {
-				const invalidData = { data: getRandomBytes(10).toString('hex') };
+				const invalidData = {
+					data:
+						'0b4bfc826a027f228c21da9e4ce2eef156f0742719b6b2466ec706b15441025f638f748b22adfab873561587be7285be3e3888cd9acdce226e342cf196fbc2c5',
+				};
 				beforeEach(() => {
-					jest.spyOn(codecUtils, 'decodeNodeInfo').mockImplementation(() => {
-						throw new InvalidNodeInfoError('Invalid node Info');
-					});
 					jest.spyOn(defaultPeer as any, 'request').mockResolvedValue(invalidData);
 					jest.spyOn(defaultPeer, 'emit');
 					jest.spyOn(defaultPeer, 'applyPenalty');

--- a/framework/test/functional/network/banning/invalid_block_bytes.spec.ts
+++ b/framework/test/functional/network/banning/invalid_block_bytes.spec.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { P2P } from '@liskhq/lisk-p2p';
-import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import { Application } from '../../../../src';
 import {
 	createApplication,
@@ -42,11 +41,12 @@ describe('Public block related P2P endpoints with invalid block', () => {
 
 	describe('postBlock with random block bytes', () => {
 		it('should not accept the block and ban the peer', async () => {
-			// const { lastBlock } = app['_node']['_chain'];
+			const invalidBytesString =
+				'17f7ca093a17c174afa4a9ac48e27c6ea08b345d325d54c5433df2a73850c04b3a2b503d04ed37b30deaa3d429dc7e6b159a';
 			p2p.sendToPeer(
 				{
 					event: 'postBlock',
-					data: { block: getRandomBytes(5000).toString('hex') },
+					data: { block: invalidBytesString },
 				},
 				getPeerID(app),
 			);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5759 

### How was it solved?

-  Test to check if whitelisted peers are always allowed to connect back
8dac687
- Add test to check if banned peer is never allowed to connect back
68ae823
- Add tests for previousPeers a4d8156

### How was it tested?

Run tests under `elements/lisk-p2p` and `framework`
