### PR TITLE
Error transaction id string is unreadable format - Closes #5786

### DIFF
--- a/framework/src/modules/sequence/sequence_module.ts
+++ b/framework/src/modules/sequence/sequence_module.ts
@@ -52,7 +52,7 @@ export class SequenceModule extends BaseModule {
 		// Throw error when tx nonce is lower than the account nonce
 		if (transaction.nonce < senderAccount.sequence.nonce) {
 			throw new InvalidNonceError(
-				`Transaction with id:${transaction.id.toString()} nonce is lower than account nonce`,
+				`Transaction with id:${transaction.id.toString('hex')} nonce is lower than account nonce`,
 				transaction.nonce,
 				senderAccount.sequence.nonce,
 			);
@@ -70,7 +70,7 @@ export class SequenceModule extends BaseModule {
 		// Throw error when tx nonce is not equal to account nonce
 		if (transaction.nonce !== senderAccount.sequence.nonce) {
 			throw new NonceOutOfBoundsError(
-				`Transaction with id:${transaction.id.toString()} nonce is not equal to account nonce`,
+				`Transaction with id:${transaction.id.toString('hex')} nonce is not equal to account nonce`,
 				transaction.nonce,
 				senderAccount.sequence.nonce,
 			);

--- a/framework/test/integration/node/processor/process_block.spec.ts
+++ b/framework/test/integration/node/processor/process_block.spec.ts
@@ -326,7 +326,7 @@ describe('Process block', () => {
 		});
 
 		describe('when block has tie break BFT properties', () => {
-			it('should repace the last block', async () => {
+			it('should replace the last block', async () => {
 				const { lastBlock } = node['_chain'];
 				const currentSlot = node['_chain'].slots.getSlotNumber(lastBlock.header.timestamp) + 1;
 				const timestamp = node['_chain'].slots.getSlotTime(currentSlot);
@@ -352,7 +352,7 @@ describe('Process block', () => {
 				);
 				(tieBreakBlock.header as any).signature = signature;
 				(tieBreakBlock.header as any).receivedAt = timestamp;
-				// There is no other way to mutate the time so that the tieBreak block is received at currect slot
+				// There is no other way to mutate the time so that the tieBreak block is received at current slot
 				jest.spyOn(node['_chain'].slots, 'timeSinceGenesis').mockReturnValue(timestamp);
 				(node['_chain'].lastBlock.header as any).receivedAt = timestamp + 2;
 				// mutate the last block so that the last block was not received in the timeslot

--- a/framework/test/unit/modules/sequence/sequence_module.spec.ts
+++ b/framework/test/unit/modules/sequence/sequence_module.spec.ts
@@ -98,7 +98,7 @@ describe('sequence module', () => {
 			expect(receivedError).toBeInstanceOf(InvalidNonceError);
 			expect(receivedError.code).toEqual('ERR_INVALID_NONCE');
 			expect(receivedError.message).toContain(
-				`Transaction with id:${transaction.id.toString()} nonce is lower than account nonce`,
+				`Transaction with id:${transaction.id.toString('hex')} nonce is lower than account nonce`,
 			);
 			expect(receivedError.actual).toEqual(transaction.nonce.toString());
 			expect(receivedError.expected).toEqual(senderAccount.sequence.nonce.toString());
@@ -125,7 +125,7 @@ describe('sequence module', () => {
 			expect(receivedError).toBeInstanceOf(NonceOutOfBoundsError);
 			expect(receivedError.code).toEqual('ERR_NONCE_OUT_OF_BOUNDS');
 			expect(receivedError.message).toContain(
-				`Transaction with id:${transaction.id.toString()} nonce is not equal to account nonce`,
+				`Transaction with id:${transaction.id.toString('hex')} nonce is not equal to account nonce`,
 			);
 			expect(receivedError.actual).toEqual(transaction.nonce.toString());
 			expect(receivedError.expected).toEqual(senderAccount.sequence.nonce.toString());


### PR DESCRIPTION
### What was the problem?

This PR resolves #5786

### How was it solved?

- Converting string to `hex`
- Fixed typo

### How was it tested?

- Updated unit test