### PR TITLE
Delegate without valid hash onion is unable to forge - Closes #5793

### DIFF
--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -15,16 +15,16 @@
 import { codec } from '@liskhq/lisk-codec';
 import * as assert from 'assert';
 import { EventEmitter } from 'events';
-
 import {
 	BlockHeader,
 	Chain,
 	CONSENSUS_STATE_FINALIZED_HEIGHT_KEY,
 	getValidators,
+	StateStore,
 } from '@liskhq/lisk-chain';
 import { EVENT_BFT_FINALIZED_HEIGHT_CHANGED, FinalityManager } from './finality_manager';
 import * as forkChoiceRule from './fork_choice_rule';
-import { BFTPersistedValues, ForkStatus, StateStore } from './types';
+import { BFTPersistedValues, ForkStatus } from './types';
 
 export const EVENT_BFT_BLOCK_FINALIZED = 'EVENT_BFT_BLOCK_FINALIZED';
 
@@ -96,7 +96,7 @@ export class BFT extends EventEmitter {
 
 	public async verifyBlockHeader(blockHeader: BlockHeader, stateStore: StateStore): Promise<void> {
 		const isCompliant = await this.isBFTProtocolCompliant(blockHeader, stateStore);
-		const reward = this._chain.calculateReward(blockHeader.height);
+		const reward = this._chain.calculateExpectedReward(blockHeader, stateStore);
 		const expectedReward = isCompliant ? reward : reward / BigInt(4);
 		if (blockHeader.reward !== expectedReward) {
 			throw new Error(

--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -14,14 +14,13 @@
 
 import { codec } from '@liskhq/lisk-codec';
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
-import { BlockHeader, Chain, getValidators } from '@liskhq/lisk-chain';
+import { BlockHeader, Chain, getValidators, StateStore } from '@liskhq/lisk-chain';
 import * as assert from 'assert';
 import * as Debug from 'debug';
 import { EventEmitter } from 'events';
 import { dataStructures } from '@liskhq/lisk-utils';
 import { BFT_ROUND_THRESHOLD } from './constant';
 import {
-	StateStore,
 	BFTChainDisjointError,
 	BFTForkChoiceRuleError,
 	BFTInvalidAttributeError,

--- a/elements/lisk-bft/src/types.ts
+++ b/elements/lisk-bft/src/types.ts
@@ -13,7 +13,7 @@
  */
 /* eslint-disable max-classes-per-file */
 
-import { BlockHeader, Account } from '@liskhq/lisk-chain';
+import { BlockHeader } from '@liskhq/lisk-chain';
 
 export enum ForkStatus {
 	IDENTICAL_BLOCK = 1,
@@ -55,21 +55,3 @@ export interface BFTPersistedValues {
 }
 
 export type BlockHeaderWithReceivedAt = BlockHeader & { receivedAt?: number };
-
-export interface StateStore {
-	readonly account: {
-		readonly get: (primaryValue: Buffer) => Promise<Account>;
-		readonly getUpdated: () => ReadonlyArray<Account>;
-		// eslint-disable-next-line @typescript-eslint/method-signature-style
-		set(key: Buffer, value: Account): void;
-	};
-	readonly consensus: {
-		readonly get: (key: string) => Promise<Buffer | undefined>;
-		readonly set: (key: string, value: Buffer) => void;
-	};
-	readonly chain: {
-		readonly get: (key: string) => Promise<Buffer | undefined>;
-		readonly set: (key: string, value: Buffer) => void;
-		readonly lastBlockHeaders: ReadonlyArray<BlockHeader>;
-	};
-}

--- a/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
@@ -20,6 +20,7 @@ import {
 	validatorsSchema,
 	Validator,
 	BlockHeader,
+	StateStore,
 } from '@liskhq/lisk-chain';
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import * as scenario4DelegatesMissedSlots from '../bft_specs/4_delegates_missed_slots.json';
@@ -44,7 +45,7 @@ const bftScenarios = [
 	scenario11DelegatesPartialSwitch,
 ];
 
-const preVotesAndCommits = async (stateStore: StateStoreMock) => {
+const preVotesAndCommits = async (stateStore: StateStore) => {
 	const delegateLedgerBuffer = await stateStore.consensus.get(CONSENSUS_STATE_VALIDATOR_LEDGER_KEY);
 
 	const delegateLedger = codec.decode<VotingLedger>(
@@ -71,7 +72,7 @@ const preVotesAndCommits = async (stateStore: StateStoreMock) => {
 
 describe('FinalityManager', () => {
 	let chainStub: Chain;
-	let stateStore: StateStoreMock;
+	let stateStore: StateStore;
 
 	describe('addBlockHeader', () => {
 		for (const scenario of bftScenarios) {
@@ -98,7 +99,7 @@ describe('FinalityManager', () => {
 						threshold: Math.floor((scenario.config.activeDelegates * 2) / 3) + 1,
 					});
 
-					stateStore = new StateStoreMock();
+					stateStore = (new StateStoreMock() as unknown) as StateStore;
 
 					const blockHeaders = (scenario.testCases as any).map((tc: any) =>
 						convertHeader(tc.input.blockHeader),
@@ -134,7 +135,7 @@ describe('FinalityManager', () => {
 							CONSENSUS_STATE_VALIDATORS_KEY,
 							codec.encode(validatorsSchema, { validators: validatorsMap.values() }),
 						);
-						stateStore.chain.lastBlockHeaders = filteredBlockHeaders;
+						(stateStore.chain as any).lastBlockHeaders = filteredBlockHeaders;
 
 						// Act
 						await finalityManager.addBlockHeader(

--- a/elements/lisk-bft/test/protocol_specs/bft_invalid_block_headers_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_invalid_block_headers_protocol_specs.spec.ts
@@ -18,6 +18,7 @@ import {
 	Validator,
 	CONSENSUS_STATE_VALIDATORS_KEY,
 	validatorsSchema,
+	StateStore,
 } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import * as invalidBlockHeaderSpec from '../bft_specs/bft_invalid_block_headers.json';
@@ -28,7 +29,7 @@ import { convertHeader } from '../fixtures/blocks';
 
 describe('FinalityManager', () => {
 	describe('addBlockHeader', () => {
-		let stateStore: StateStoreMock;
+		let stateStore: StateStore;
 		let chainStub: Chain;
 
 		beforeEach(() => {
@@ -43,7 +44,7 @@ describe('FinalityManager', () => {
 				},
 				numberOfValidators: 103,
 			} as unknown) as Chain;
-			stateStore = new StateStoreMock();
+			stateStore = (new StateStoreMock() as unknown) as StateStore;
 		});
 
 		invalidBlockHeaderSpec.testCases.forEach(testCase => {
@@ -62,7 +63,7 @@ describe('FinalityManager', () => {
 					codec.encode(validatorsSchema, { validators: validatorsMap.values() }),
 				);
 				// Arrange
-				stateStore.chain.lastBlockHeaders = testCase.config.blockHeaders.map(bh =>
+				(stateStore.chain as any).lastBlockHeaders = testCase.config.blockHeaders.map(bh =>
 					convertHeader(bh),
 				);
 

--- a/elements/lisk-bft/test/unit/bft.spec.ts
+++ b/elements/lisk-bft/test/unit/bft.spec.ts
@@ -20,6 +20,7 @@ import {
 	CONSENSUS_STATE_FINALIZED_HEIGHT_KEY,
 	CONSENSUS_STATE_VALIDATORS_KEY,
 	validatorsSchema,
+	StateStore,
 } from '@liskhq/lisk-chain';
 import { createFakeBlockHeader } from '../fixtures/blocks';
 import {
@@ -59,7 +60,7 @@ describe('bft', () => {
 		beforeEach(() => {
 			lastBlock = createFakeBlockHeader({ height: 1, version: 2 });
 			chainStub = ({
-				calculateReward: jest.fn(),
+				calculateExpectedReward: jest.fn(),
 				slots: {
 					getSlotNumber: jest.fn(),
 					isWithinTimeslot: jest.fn(),
@@ -96,7 +97,7 @@ describe('bft', () => {
 
 		describe('#init', () => {
 			it('should initialize finality manager', async () => {
-				const stateStore = new StateStoreMock();
+				const stateStore = (new StateStoreMock() as unknown) as StateStore;
 				const bft = new BFT(bftParams);
 
 				await bft.init(stateStore);
@@ -106,7 +107,7 @@ describe('bft', () => {
 
 			it('should set the finality height to the value from chain state', async () => {
 				const finalizedHeight = 5;
-				const stateStore = new StateStoreMock(
+				const stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(BFTFinalizedHeightCodecSchema, {
@@ -119,7 +120,7 @@ describe('bft', () => {
 						}),
 					},
 					{ lastBlockHeaders: [lastBlock] },
-				);
+				) as unknown) as StateStore;
 				const bft = new BFT(bftParams);
 
 				await bft.init(stateStore);
@@ -131,7 +132,7 @@ describe('bft', () => {
 		describe('#verifyBlockHeader', () => {
 			let bft: BFT;
 			let blocks: BlockHeader[];
-			let stateStore: StateStoreMock;
+			let stateStore: StateStore;
 
 			beforeEach(async () => {
 				// Arrange
@@ -143,7 +144,7 @@ describe('bft', () => {
 				});
 
 				bft = new BFT(bftParams);
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(BFTFinalizedHeightCodecSchema, {
@@ -158,13 +159,13 @@ describe('bft', () => {
 						}),
 					},
 					{ lastBlockHeaders: blocks },
-				);
+				) as unknown) as StateStore;
 				await bft.init(stateStore);
 			});
 
 			describe('when BFT protocol is followed', () => {
 				it('should resolve without error', async () => {
-					(chainStub.calculateReward as jest.Mock).mockReturnValue(BigInt(500000000));
+					(chainStub.calculateExpectedReward as jest.Mock).mockReturnValue(BigInt(500000000));
 					const blockHeader = {
 						height: 102,
 						reward: BigInt(500000000),
@@ -183,7 +184,7 @@ describe('bft', () => {
 
 			describe('when BFT protocol is not followed', () => {
 				it('should throw an error if reward is not deducted', async () => {
-					(chainStub.calculateReward as jest.Mock).mockReturnValue(BigInt(500000000));
+					(chainStub.calculateExpectedReward as jest.Mock).mockReturnValue(BigInt(500000000));
 					const blockHeader = {
 						height: 203,
 						reward: BigInt(500000000),
@@ -222,10 +223,10 @@ describe('bft', () => {
 			};
 
 			let bft: BFT;
-			let stateStore: StateStoreMock;
+			let stateStore: StateStore;
 
 			beforeEach(async () => {
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(BFTFinalizedHeightCodecSchema, {
@@ -246,7 +247,7 @@ describe('bft', () => {
 						}),
 					},
 					{ lastBlockHeaders: [lastBlock] },
-				);
+				) as unknown) as StateStore;
 
 				bft = new BFT(bftParams);
 				await bft.init(stateStore);
@@ -272,7 +273,7 @@ describe('bft', () => {
 		describe('#isBFTProtocolCompliant', () => {
 			let bft: BFT;
 			let blocks: BlockHeader[];
-			let stateStore: StateStoreMock;
+			let stateStore: StateStore;
 
 			beforeEach(async () => {
 				// Arrange
@@ -284,7 +285,7 @@ describe('bft', () => {
 				});
 
 				bft = new BFT(bftParams);
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(BFTFinalizedHeightCodecSchema, {
@@ -299,7 +300,7 @@ describe('bft', () => {
 						}),
 					},
 					{ lastBlockHeaders: blocks },
-				);
+				) as unknown) as StateStore;
 				await bft.init(stateStore);
 			});
 

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -21,6 +21,7 @@ import {
 	Chain,
 	CONSENSUS_STATE_VALIDATORS_KEY,
 	validatorsSchema,
+	StateStore,
 } from '@liskhq/lisk-chain';
 import {
 	FinalityManager,
@@ -102,13 +103,17 @@ describe('finality_manager', () => {
 		});
 
 		describe('verifyBlockHeaders', () => {
-			let stateStore: StateStoreMock;
+			let stateStore: StateStore;
 
 			it('should throw error if maxHeightPrevoted is not accurate', async () => {
 				// Add the header directly to list so verifyBlockHeaders can be validated against it
 				const bftHeaders = generateValidHeaders(finalityManager.processingThreshold + 1);
 
-				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: bftHeaders });
+				stateStore = (new StateStoreMock(
+					[],
+					{},
+					{ lastBlockHeaders: bftHeaders },
+				) as unknown) as StateStore;
 
 				const header = createFakeBlockHeader({
 					asset: { maxHeightPrevoted: 10 },
@@ -145,7 +150,7 @@ describe('finality_manager', () => {
 						},
 					],
 				};
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_VALIDATOR_LEDGER_KEY]: codec.encode(
@@ -154,14 +159,18 @@ describe('finality_manager', () => {
 						),
 					},
 					{ lastBlockHeaders: bftHeaders },
-				);
+				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(header, stateStore)).resolves.toBeTrue();
 			});
 
 			it("should return true if validator didn't forge any block previously", async () => {
 				const header = createFakeBlockHeader();
-				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [] });
+				stateStore = (new StateStoreMock(
+					[],
+					{},
+					{ lastBlockHeaders: [] },
+				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(header, stateStore)).resolves.toBeTruthy();
 			});
@@ -186,7 +195,11 @@ describe('finality_manager', () => {
 					height: 9,
 				});
 
-				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+				stateStore = (new StateStoreMock(
+					[],
+					{},
+					{ lastBlockHeaders: [lastBlock] },
+				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTForkChoiceRuleError,
@@ -210,7 +223,11 @@ describe('finality_manager', () => {
 					},
 					height: 10,
 				});
-				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+				stateStore = (new StateStoreMock(
+					[],
+					{},
+					{ lastBlockHeaders: [lastBlock] },
+				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTForkChoiceRuleError,
@@ -230,7 +247,11 @@ describe('finality_manager', () => {
 					},
 				});
 
-				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+				stateStore = (new StateStoreMock(
+					[],
+					{},
+					{ lastBlockHeaders: [lastBlock] },
+				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTChainDisjointError,
@@ -255,7 +276,11 @@ describe('finality_manager', () => {
 					},
 				});
 
-				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+				stateStore = (new StateStoreMock(
+					[],
+					{},
+					{ lastBlockHeaders: [lastBlock] },
+				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
 					BFTLowerChainBranchError,
@@ -264,7 +289,11 @@ describe('finality_manager', () => {
 
 			it('should return true if headers are valid', async () => {
 				const [lastBlock, currentBlock] = generateValidHeaders(2);
-				stateStore = new StateStoreMock([], {}, { lastBlockHeaders: [lastBlock] });
+				stateStore = (new StateStoreMock(
+					[],
+					{},
+					{ lastBlockHeaders: [lastBlock] },
+				) as unknown) as StateStore;
 
 				await expect(
 					finalityManager.verifyBlockHeaders(currentBlock, stateStore),
@@ -277,12 +306,12 @@ describe('finality_manager', () => {
 				validators: [],
 				ledger: [],
 			};
-			let stateStore: StateStoreMock;
+			let stateStore: StateStore;
 			let bftHeaders: ReadonlyArray<BlockHeader>;
 
 			beforeEach(() => {
 				bftHeaders = generateValidHeaders(finalityManager.processingThreshold + 1);
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_FINALIZED_HEIGHT_KEY]: codec.encode(BFTFinalizedHeightCodecSchema, {
@@ -301,7 +330,7 @@ describe('finality_manager', () => {
 						}),
 					},
 					{ lastBlockHeaders: bftHeaders },
-				);
+				) as unknown) as StateStore;
 			});
 
 			it('should call verifyBlockHeaders with the provided header', async () => {
@@ -345,7 +374,7 @@ describe('finality_manager', () => {
 						maxHeightPreviouslyForged: 0,
 					},
 				});
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_VALIDATORS_KEY]: codec.encode(validatorsSchema, {
@@ -359,7 +388,7 @@ describe('finality_manager', () => {
 						}),
 					},
 					{ lastBlockHeaders: bftHeaders },
-				);
+				) as unknown) as StateStore;
 
 				jest.spyOn(finalityManager, 'updatePreVotesPreCommits');
 				await finalityManager.addBlockHeader(header1, stateStore);
@@ -384,7 +413,7 @@ describe('finality_manager', () => {
 						maxHeightPreviouslyForged: 0,
 					},
 				});
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_VALIDATORS_KEY]: codec.encode(validatorsSchema, {
@@ -398,7 +427,7 @@ describe('finality_manager', () => {
 						}),
 					},
 					{ lastBlockHeaders: bftHeaders },
-				);
+				) as unknown) as StateStore;
 
 				jest.spyOn(finalityManager, 'updatePreVotesPreCommits');
 				await finalityManager.addBlockHeader(header1, stateStore);
@@ -452,7 +481,7 @@ describe('finality_manager', () => {
 					const addr = getAddressFromPublicKey(header.generatorPublicKey);
 					addressMap.set(addr, addr);
 				}
-				stateStore = new StateStoreMock(
+				stateStore = (new StateStoreMock(
 					[],
 					{
 						[CONSENSUS_STATE_VALIDATORS_KEY]: codec.encode(validatorsSchema, {
@@ -462,7 +491,7 @@ describe('finality_manager', () => {
 						}),
 					},
 					{ lastBlockHeaders: bftHeaders },
-				);
+				) as unknown) as StateStore;
 
 				try {
 					for (const header of headers) {

--- a/elements/lisk-chain/src/block_reward.ts
+++ b/elements/lisk-chain/src/block_reward.ts
@@ -26,7 +26,10 @@ export const calculateMilestone = (height: number, blockRewardArgs: BlockRewardO
 	return location;
 };
 
-export const calculateReward = (height: number, blockRewardArgs: BlockRewardOptions): bigint => {
+export const calculateDefaultReward = (
+	height: number,
+	blockRewardArgs: BlockRewardOptions,
+): bigint => {
 	if (height < blockRewardArgs.rewardOffset) {
 		return BigInt(0);
 	}

--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -581,7 +581,7 @@ export class Forger {
 		if (!isBFTProtocolCompliant) {
 			header.reward /= BigInt(4);
 			this._logger.warn(
-				{ originalReward: reward.toString(), deducted: header.reward.toString() },
+				{ originalReward: reward.toString(), deductedReward: header.reward.toString() },
 				'Deducting reward due to BFT violation',
 			);
 		}
@@ -591,7 +591,7 @@ export class Forger {
 			const originalReward = header.reward.toString();
 			header.reward = BigInt(0);
 			this._logger.warn(
-				{ originalReward, deducted: header.reward.toString() },
+				{ originalReward, deductedReward: header.reward.toString() },
 				'Deducting reward due to SeedReveal violation',
 			);
 		}

--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -537,7 +537,7 @@ export class Forger {
 		const maxHeightPreviouslyForged = forgerInfo?.height ?? 0;
 		const maxHeightPrevoted = await this._bftModule.getMaxHeightPrevoted();
 		const stateStore = await this._chainModule.newStateStore();
-		const reward = this._chainModule.calculateReward(height);
+		const reward = this._chainModule.calculateDefaultReward(height);
 		let size = 0;
 
 		const blockTransactions = [];

--- a/framework/test/unit/node/forger/forger.spec.ts
+++ b/framework/test/unit/node/forger/forger.spec.ts
@@ -96,7 +96,7 @@ describe('forger', () => {
 				}),
 				encodeBlockHeader: jest.fn().mockImplementation(() => getRandomBytes(100)),
 			},
-			calculateReward: jest.fn().mockReturnValue(BigInt(500000000)),
+			calculateDefaultReward: jest.fn().mockReturnValue(BigInt(500000000)),
 			newStateStore: jest.fn().mockResolvedValue(stateStoreMock),
 			isValidSeedReveal: jest.fn().mockReturnValue(true),
 			constants: {

--- a/framework/test/unit/node/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
+++ b/framework/test/unit/node/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
@@ -620,7 +620,7 @@ describe('block_synchronization_mechanism', () => {
 					const receivedBlock = createValidDefaultBlock({
 						header: {
 							height: lastBlock.header.height + 304,
-							reward: chainModule.calculateReward(lastBlock.header.height + 304),
+							reward: chainModule.calculateDefaultReward(lastBlock.header.height + 304),
 						},
 					});
 

--- a/framework/test/utils/node/block.ts
+++ b/framework/test/utils/node/block.ts
@@ -15,6 +15,7 @@
 
 import { Block, Transaction } from '@liskhq/lisk-chain';
 import { Node } from '../../../src/node';
+import { getUsedHashOnions, setUsedHashOnions } from '../../../src/node/forger/data_access';
 
 interface Option {
 	lastBlock?: Block;
@@ -39,6 +40,61 @@ export const createBlock = async (
 			: (currentKeypair as { publicKey: Buffer; privateKey: Buffer }),
 		timestamp,
 		seedReveal: Buffer.from('00000000000000000000000000000000', 'hex'),
+		transactions,
+		previousBlock: lastBlock,
+	});
+};
+
+export const createValidBlock = async (
+	node: Node,
+	transactions: Transaction[] = [],
+	targetValidator?: Buffer,
+	skipMode = false,
+): Promise<Block> => {
+	const { lastBlock } = node['_chain'];
+	let currentSlot = node['_chain'].slots.getSlotNumber(lastBlock.header.timestamp) + 1;
+	let timestamp = node['_chain'].slots.getSlotTime(currentSlot);
+	let validator = await node['_chain'].getValidator(timestamp);
+	if (targetValidator) {
+		while (
+			(skipMode && validator.address.equals(targetValidator)) ||
+			(!skipMode && !validator.address.equals(targetValidator))
+		) {
+			currentSlot += 1;
+			timestamp = node['_chain'].slots.getSlotTime(currentSlot);
+			validator = await node['_chain'].getValidator(timestamp);
+		}
+	}
+
+	const delegateAddress = validator.address;
+	const nextHeight = lastBlock.header.height + 1;
+	const usedHashOnions = await getUsedHashOnions(node['_forgerDB']);
+	const nextHashOnion = node['_forger']['_getNextHashOnion'](
+		usedHashOnions,
+		validator.address,
+		nextHeight,
+	);
+	const index = usedHashOnions.findIndex(
+		ho => ho.address.equals(delegateAddress) && ho.count === nextHashOnion.count,
+	);
+	const nextUsedHashOnion = {
+		count: nextHashOnion.count,
+		address: delegateAddress,
+		height: nextHeight,
+	};
+	if (index > -1) {
+		// Overwrite the hash onion if it exists
+		usedHashOnions[index] = nextUsedHashOnion;
+	} else {
+		usedHashOnions.push(nextUsedHashOnion);
+	}
+	await setUsedHashOnions(node['_forgerDB'], usedHashOnions);
+
+	const currentKeypair = node['_forger']['_keypairs'].get(validator.address);
+	return node['_forger']['_create']({
+		keypair: currentKeypair as { publicKey: Buffer; privateKey: Buffer },
+		timestamp,
+		seedReveal: nextHashOnion.hash,
 		transactions,
 		previousBlock: lastBlock,
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5793 

### How was it solved?

- Expose a function to return expected reward which also take seed reveal in consideration
- Use expected reward to calculate quarter fee

### How was it tested?

- Add integration test
- Run a node from scratch and wait for 1 round, and change seed reveal of on one of the delegate, and check if the delegate creates a block with 0 reward and being accepted
