### PR TITLE
lisk-genesis create genesis block function does not order address by length - Closes #5800

### DIFF
--- a/elements/lisk-genesis/src/create.ts
+++ b/elements/lisk-genesis/src/create.ts
@@ -90,7 +90,15 @@ export const createGenesisBlock = (params: GenesisBlockParams): GenesisBlock => 
 
 	const accounts: ReadonlyArray<Account> = params.accounts
 		.map(account => createAccount(account, defaultAccount))
-		.sort((a, b): number => a.address.compare(b.address));
+		.sort((a, b): number => {
+			if (a.address.length < b.address.length) {
+				return -1;
+			}
+			if (a.address.length > b.address.length) {
+				return 1;
+			}
+			return a.address.compare(b.address);
+		});
 
 	const initDelegates: ReadonlyArray<Buffer> = [...params.initDelegates].sort((a, b): number =>
 		a.compare(b),

--- a/elements/lisk-genesis/test/create.spec.ts
+++ b/elements/lisk-genesis/test/create.spec.ts
@@ -154,6 +154,40 @@ describe('create', () => {
 				accountsSortedAddresses,
 			);
 		});
+
+		it('should sort accounts with variable lengths of address lexicographically', () => {
+			// Arrange
+			const accounts = objects.cloneDeep(validGenesisBlockParams.accounts) as Account[];
+			accounts.push({
+				address: Buffer.from('8789de4316d79d22', 'hex'),
+				token: {
+					balance: BigInt('12300000000'),
+				},
+			});
+
+			const accountsSortedAddresses = accounts
+				.map(a => a.address)
+				.sort((a, b) => {
+					if (a.length < b.length) {
+						return -1;
+					}
+					if (a.length > b.length) {
+						return 1;
+					}
+					return a.compare(b);
+				});
+
+			// Act
+			const genesisBlock = createGenesisBlock({
+				...validGenesisBlockParams,
+				accounts,
+			});
+
+			// Assert
+			expect(genesisBlock.header.asset.accounts.map(a => a.address)).toEqual(
+				accountsSortedAddresses,
+			);
+		});
 	});
 
 	describe('getGenesisBlockJSON', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5800 

### How was it solved?

-  Include account address sort by lower and higher lengths

### How was it tested?

- Added unit test
