### PR TITLE
Remove unused roundLength from lisk-genesis - Closes #5821

### DIFF
--- a/elements/lisk-genesis/src/types.ts
+++ b/elements/lisk-genesis/src/types.ts
@@ -36,8 +36,6 @@ export interface GenesisBlockParams {
 	readonly accounts: ReadonlyArray<Account>;
 	// List fo initial delegate addresses used during the bootstrap period to forge blocks
 	readonly initDelegates: ReadonlyArray<Buffer>;
-	// Number of blocks per round
-	readonly roundLength: number;
 	// Account Schema for the genesis block
 	readonly accountAssetSchemas: accountAssetSchemas;
 	// Number of rounds for bootstrap period, default is 3

--- a/elements/lisk-genesis/test/fixtures/index.ts
+++ b/elements/lisk-genesis/test/fixtures/index.ts
@@ -214,7 +214,6 @@ export const validGenesisBlockParams = {
 		'454690a1c37838326007519a7ce1c8a6a495df50898f1ebd69d22fbcedf9689a',
 		'hex',
 	),
-	roundLength: 103,
 	initDelegates: validDelegateAccounts.map(a => a.address),
 	accounts: [...validAccounts, ...validDelegateAccounts] as Account[],
 	accountAssetSchemas: defaultAccountModules,

--- a/framework-plugins/lisk-framework-forger-plugin/test/utils/genesis_block.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/utils/genesis_block.ts
@@ -159,7 +159,6 @@ export const getGenesisBlockJSON = ({
 	const updatedGenesisBlock = createGenesisBlock({
 		initDelegates: genesisBlock.header.asset.initDelegates,
 		initRounds: genesisBlock.header.asset.initRounds,
-		roundLength: 103,
 		timestamp,
 		accounts: genesisBlock.header.asset.accounts,
 		accountAssetSchemas: defaultAccountSchema,


### PR DESCRIPTION
### What was the problem?

This PR resolves #5821

### How was it solved?

Removed the unused function parameter attribute. 

### How was it tested?

Run all unit tests. 
