### PR TITLE
Update finalized height not to be assigned with lower value - Closes #5807

### DIFF
--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -317,21 +317,20 @@ export class FinalityManager extends EventEmitter {
 			.reverse()
 			.find(key => ledger[key].preCommits >= this.preCommitThreshold);
 
+		if (!highestHeightPreCommitted) {
+			return false;
+		}
+
 		// Store current finalizedHeight
 		const previouslyFinalizedHeight = this.finalizedHeight;
-
-		if (highestHeightPreCommitted) {
-			const nextFinalizedHeight = parseInt(highestHeightPreCommitted, 10);
-			// If finalized height is lower, do not set
-			if (nextFinalizedHeight < previouslyFinalizedHeight) {
-				return false;
-			}
-			this.finalizedHeight = nextFinalizedHeight;
+		const nextFinalizedHeight = parseInt(highestHeightPreCommitted, 10);
+		// If finalized height is lower or equal, do not set
+		if (nextFinalizedHeight <= previouslyFinalizedHeight) {
+			return false;
 		}
 
-		if (previouslyFinalizedHeight !== this.finalizedHeight) {
-			this.emit(EVENT_BFT_FINALIZED_HEIGHT_CHANGED, this.finalizedHeight);
-		}
+		this.finalizedHeight = nextFinalizedHeight;
+		this.emit(EVENT_BFT_FINALIZED_HEIGHT_CHANGED, this.finalizedHeight);
 
 		return true;
 	}

--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -321,7 +321,12 @@ export class FinalityManager extends EventEmitter {
 		const previouslyFinalizedHeight = this.finalizedHeight;
 
 		if (highestHeightPreCommitted) {
-			this.finalizedHeight = parseInt(highestHeightPreCommitted, 10);
+			const nextFinalizedHeight = parseInt(highestHeightPreCommitted, 10);
+			// If finalized height is lower, do not set
+			if (nextFinalizedHeight < previouslyFinalizedHeight) {
+				return false;
+			}
+			this.finalizedHeight = nextFinalizedHeight;
 		}
 
 		if (previouslyFinalizedHeight !== this.finalizedHeight) {

--- a/elements/lisk-chain/src/state_store/consensus_state_store.ts
+++ b/elements/lisk-chain/src/state_store/consensus_state_store.ts
@@ -96,12 +96,14 @@ export class ConsensusStateStore {
 			const updatedValue = this._data[key] as Buffer;
 			batch.put(dbKey, updatedValue);
 
+			// finalized height should never be saved to diff, since it will not changed
+			if (key === CONSENSUS_STATE_FINALIZED_HEIGHT_KEY) {
+				continue;
+			}
+
+			// Save diff of changed state
 			const initialValue = this._initialValue[key];
-			if (
-				initialValue !== undefined &&
-				!initialValue.equals(updatedValue) &&
-				key !== CONSENSUS_STATE_FINALIZED_HEIGHT_KEY
-			) {
+			if (initialValue !== undefined && !initialValue.equals(updatedValue)) {
 				stateDiff.updated.push({
 					key: dbKey,
 					value: initialValue,

--- a/elements/lisk-chain/test/unit/state_store/consensus_state.spec.ts
+++ b/elements/lisk-chain/test/unit/state_store/consensus_state.spec.ts
@@ -103,6 +103,7 @@ describe('state store / chain_state', () => {
 
 		it('should call storage for all the updated keys', () => {
 			// Act
+			stateStore.consensus.set('finalizedHeight', Buffer.from('3'));
 			stateStore.consensus.set('key3', Buffer.from('value3'));
 			stateStore.consensus.set('key3', Buffer.from('value4'));
 			stateStore.consensus.set('key4', Buffer.from('value5'));
@@ -110,9 +111,18 @@ describe('state store / chain_state', () => {
 			// Assert
 			expect(batchStub.put).toHaveBeenCalledWith('consensus:key3', Buffer.from('value4'));
 			expect(batchStub.put).toHaveBeenCalledWith('consensus:key4', Buffer.from('value5'));
+			expect(batchStub.put).toHaveBeenCalledWith('consensus:finalizedHeight', Buffer.from('3'));
 		});
 
 		it('should return state diff with created and updated values after finalize', () => {
+			// Act
+			stateStore.consensus.set('finalizedHeight', Buffer.from('3'));
+			stateStore.consensus.set('key3', Buffer.from('value3'));
+			stateStore.consensus.set('key3', Buffer.from('value4'));
+			stateStore.consensus.set('key4', Buffer.from('value5'));
+			stateDiff = stateStore.consensus.finalize(batchStub);
+
+			// Assert
 			expect(stateDiff).toStrictEqual({
 				updated: [],
 				created: ['consensus:key3', 'consensus:key4'],


### PR DESCRIPTION
### What was the problem?

This PR resolves #5807 

### How was it solved?

- Update not to change finalized height if the calculated value is lower than original
- Never set the finalized height to diff

### How was it tested?

- Add tests
- Sync and stop the node many times, observe finalized height by `lisk-chain node:info` and check if it never decrease
