### PR TITLE
Fix chain state roll back - Closes #5833

### DIFF
--- a/elements/lisk-chain/src/state_store/chain_state_store.ts
+++ b/elements/lisk-chain/src/state_store/chain_state_store.ts
@@ -120,7 +120,7 @@ export class ChainStateStore {
 			if (initialValue !== undefined && !initialValue.equals(updatedValue)) {
 				stateDiff.updated.push({
 					key: dbKey,
-					value: updatedValue,
+					value: initialValue,
 				});
 			} else if (initialValue === undefined) {
 				stateDiff.created.push(dbKey);

--- a/elements/lisk-chain/test/unit/state_store/chain_state.spec.ts
+++ b/elements/lisk-chain/test/unit/state_store/chain_state.spec.ts
@@ -131,8 +131,21 @@ describe('state store / chain_state', () => {
 		});
 
 		it('should return state diff with created and updated values after finalize', () => {
+			const originalValue = Buffer.from('original-value');
+			(stateStore.chain as any)['_initialValue'] = { existing: originalValue };
+			// Act
+			stateStore.chain.set('existing', Buffer.from('value-new'));
+			stateStore.chain.set('key3', Buffer.from('value3'));
+			stateStore.chain.set('key3', Buffer.from('value4'));
+			stateStore.chain.set('key4', Buffer.from('value5'));
+			stateDiff = stateStore.chain.finalize(batchStub);
 			expect(stateDiff).toStrictEqual({
-				updated: [],
+				updated: [
+					{
+						key: 'chain:existing',
+						value: originalValue,
+					},
+				],
 				created: ['chain:key3', 'chain:key4'],
 				deleted: [],
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5833 

### How was it solved?

- Change chain state to save initial value as diff

### How was it tested?

- Sync to alphanet up to 300 and restart
- it should roll back to 206 and continue to sync
