### PR TITLE
Add rate limit on getLastBlock, getBlocksFromId and getHighestCommonBlock - Closes #5844

### DIFF
--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -365,7 +365,8 @@ export class Application {
 						this._node.actions.postTransaction(action.params as EventPostTransactionData),
 				},
 				getLastBlock: {
-					handler: async (_action: ActionInfoObject) => this._node.actions.getLastBlock(),
+					handler: (action: ActionInfoObject) =>
+						this._node.actions.getLastBlock(action.params as { peerId: string }),
 				},
 				getBlocksFromId: {
 					handler: async (action: ActionInfoObject) =>

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -423,8 +423,8 @@ export class Node {
 				params: EventPostTransactionData,
 			): Promise<handlePostTransactionReturn> => this._transport.handleEventPostTransaction(params),
 			// eslint-disable-next-line @typescript-eslint/require-await
-			getLastBlock: async (): Promise<string> =>
-				this._chain.dataAccess.encode(this._chain.lastBlock).toString('hex'),
+			getLastBlock: (params: { peerId: string }): string =>
+				this._transport.handleRPCGetLastBlock(params.peerId),
 			getBlocksFromId: async (params: { data: unknown; peerId: string }): Promise<string[]> =>
 				this._transport.handleRPCGetBlocksFromId(params.data, params.peerId),
 			getHighestCommonBlock: async (params: {

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -431,7 +431,7 @@ export class Node {
 				data: unknown;
 				peerId: string;
 			}): Promise<string | undefined> =>
-				this._transport.handleRPCGetGetHighestCommonBlock(params.data, params.peerId),
+				this._transport.handleRPCGetHighestCommonBlock(params.data, params.peerId),
 			getSchema: () => this.getSchema(),
 			getRegisteredModules: () => this.getRegisteredModules(),
 			getNodeInfo: () => ({

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -36,11 +36,9 @@ import { ApplyPenaltyError } from '../../errors';
 
 const DEFAULT_RATE_RESET_TIME = 10000;
 const DEFAULT_RATE_LIMIT_FREQUENCY = 3;
-const DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY = {
-	getBlocksFromId: 100,
-	getLastBlock: 10,
-	getHighestCommonBlock: 10,
-};
+const DEFAULT_LAST_BLOCK_RATE_LIMIT_FREQUENCY = 10;
+const DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY = 10;
+const DEFAULT_BLOCKS_FROM_IDS_RATE_LIMIT_FREQUENCY = 100;
 const DEFAULT_RELEASE_LIMIT = 100;
 const DEFAULT_RELEASE_INTERVAL = 5000;
 
@@ -138,16 +136,12 @@ export class Transport {
 	}
 
 	public handleRPCGetLastBlock(peerId: string): string {
-		this._addRateLimit('getLastBlock', peerId, DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getLastBlock);
+		this._addRateLimit('getLastBlock', peerId, DEFAULT_LAST_BLOCK_RATE_LIMIT_FREQUENCY);
 		return this._chainModule.dataAccess.encode(this._chainModule.lastBlock).toString('hex');
 	}
 
 	public async handleRPCGetBlocksFromId(data: unknown, peerId: string): Promise<string[]> {
-		this._addRateLimit(
-			'getBlocksFromId',
-			peerId,
-			DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getBlocksFromId,
-		);
+		this._addRateLimit('getBlocksFromId', peerId, DEFAULT_BLOCKS_FROM_IDS_RATE_LIMIT_FREQUENCY);
 		const errors = validator.validate(schemas.getBlocksFromIdRequest, data as object);
 
 		if (errors.length) {
@@ -189,11 +183,7 @@ export class Transport {
 		data: unknown,
 		peerId: string,
 	): Promise<string | undefined> {
-		this._addRateLimit(
-			'getHighestCommonBlock',
-			peerId,
-			DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getHighestCommonBlock,
-		);
+		this._addRateLimit('getHighestCommonBlock', peerId, DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY);
 		const errors = validator.validate(schemas.getHighestCommonBlockRequest, data as object);
 
 		if (errors.length) {

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -176,7 +176,7 @@ export class Transport {
 		return blocks.map(block => this._chainModule.dataAccess.encode(block).toString('hex'));
 	}
 
-	public async handleRPCGetGetHighestCommonBlock(
+	public async handleRPCGetHighestCommonBlock(
 		data: unknown,
 		peerId: string,
 	): Promise<string | undefined> {

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -36,6 +36,11 @@ import { ApplyPenaltyError } from '../../errors';
 
 const DEFAULT_RATE_RESET_TIME = 10000;
 const DEFAULT_RATE_LIMIT_FREQUENCY = 3;
+const DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY = {
+	getBlocksFromId: 100,
+	getLastBlock: 10,
+	getHighestCommonBlock: 10,
+};
 const DEFAULT_RELEASE_LIMIT = 100;
 const DEFAULT_RELEASE_INTERVAL = 5000;
 
@@ -133,12 +138,16 @@ export class Transport {
 	}
 
 	public handleRPCGetLastBlock(peerId: string): string {
-		this._addRateLimit('getLastBlock', peerId, DEFAULT_RATE_LIMIT_FREQUENCY);
+		this._addRateLimit('getLastBlock', peerId, DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getLastBlock);
 		return this._chainModule.dataAccess.encode(this._chainModule.lastBlock).toString('hex');
 	}
 
 	public async handleRPCGetBlocksFromId(data: unknown, peerId: string): Promise<string[]> {
-		this._addRateLimit('getBlocksFromId', peerId, DEFAULT_RATE_LIMIT_FREQUENCY);
+		this._addRateLimit(
+			'getBlocksFromId',
+			peerId,
+			DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getBlocksFromId,
+		);
 		const errors = validator.validate(schemas.getBlocksFromIdRequest, data as object);
 
 		if (errors.length) {
@@ -180,7 +189,11 @@ export class Transport {
 		data: unknown,
 		peerId: string,
 	): Promise<string | undefined> {
-		this._addRateLimit('getHighestCommonBlock', peerId, DEFAULT_RATE_LIMIT_FREQUENCY);
+		this._addRateLimit(
+			'getHighestCommonBlock',
+			peerId,
+			DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getHighestCommonBlock,
+		);
 		const errors = validator.validate(schemas.getHighestCommonBlockRequest, data as object);
 
 		if (errors.length) {

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -132,7 +132,13 @@ export class Transport {
 		});
 	}
 
+	public handleRPCGetLastBlock(peerId: string): string {
+		this._addRateLimit('getLastBlock', peerId, DEFAULT_RATE_LIMIT_FREQUENCY);
+		return this._chainModule.dataAccess.encode(this._chainModule.lastBlock).toString('hex');
+	}
+
 	public async handleRPCGetBlocksFromId(data: unknown, peerId: string): Promise<string[]> {
+		this._addRateLimit('getBlocksFromId', peerId, DEFAULT_RATE_LIMIT_FREQUENCY);
 		const errors = validator.validate(schemas.getBlocksFromIdRequest, data as object);
 
 		if (errors.length) {
@@ -174,6 +180,7 @@ export class Transport {
 		data: unknown,
 		peerId: string,
 	): Promise<string | undefined> {
+		this._addRateLimit('getHighestCommonBlock', peerId, DEFAULT_RATE_LIMIT_FREQUENCY);
 		const errors = validator.validate(schemas.getHighestCommonBlockRequest, data as object);
 
 		if (errors.length) {

--- a/framework/test/unit/node/transport/transport.spec.ts
+++ b/framework/test/unit/node/transport/transport.spec.ts
@@ -684,12 +684,16 @@ describe('Transport', () => {
 
 	describe('Handle rate limiting', () => {
 		const defaultPeerId = 'peer-id';
-		describe('when getLastBlock is called more than 3 times within 10 sec', () => {
+		const DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY = {
+			getBlocksFromId: 100,
+			getLastBlock: 10,
+			getHighestCommonBlock: 10,
+		};
+		describe(`when getLastBlock is called more than ${DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getLastBlock} times within 10 sec`, () => {
 			it('should apply penalty', () => {
-				transport.handleRPCGetLastBlock(defaultPeerId);
-				transport.handleRPCGetLastBlock(defaultPeerId);
-				transport.handleRPCGetLastBlock(defaultPeerId);
-				transport.handleRPCGetLastBlock(defaultPeerId);
+				[...new Array(DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getLastBlock + 1)].map(() =>
+					transport.handleRPCGetLastBlock(defaultPeerId),
+				);
 
 				jest.advanceTimersByTime(defaultRateLimit);
 				expect(networkStub.applyPenaltyOnPeer).toHaveBeenCalledWith({
@@ -699,12 +703,11 @@ describe('Transport', () => {
 			});
 		});
 
-		describe('when getBlocksFromId is called more than 3 times within 10 sec', () => {
-			it('should apply penalty', async () => {
-				await transport.handleRPCGetBlocksFromId({ blockId: '123' }, defaultPeerId);
-				await transport.handleRPCGetBlocksFromId({ blockId: '123' }, defaultPeerId);
-				await transport.handleRPCGetBlocksFromId({ blockId: '123' }, defaultPeerId);
-				await transport.handleRPCGetBlocksFromId({ blockId: '123' }, defaultPeerId);
+		describe(`when getBlocksFromId is called more than ${DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getBlocksFromId} times within 10 sec`, () => {
+			it('should apply penalty', () => {
+				[...new Array(DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getBlocksFromId + 1)].map(async () =>
+					transport.handleRPCGetBlocksFromId({ blockId: '123' }, defaultPeerId),
+				);
 
 				jest.advanceTimersByTime(defaultRateLimit);
 				expect(networkStub.applyPenaltyOnPeer).toHaveBeenCalledWith({
@@ -714,16 +717,15 @@ describe('Transport', () => {
 			});
 		});
 
-		describe('when getHighestCommonBlock is called more than 3 times within 10 sec', () => {
+		describe(`when getHighestCommonBlock is called more than ${DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getHighestCommonBlock} times within 10 sec`, () => {
 			const validData = {
 				ids: ['15196562876801949910'],
 			};
 
 			it('should apply penalty when called ', async () => {
-				await transport.handleRPCGetHighestCommonBlock(validData, defaultPeerId);
-				await transport.handleRPCGetHighestCommonBlock(validData, defaultPeerId);
-				await transport.handleRPCGetHighestCommonBlock(validData, defaultPeerId);
-				await transport.handleRPCGetHighestCommonBlock(validData, defaultPeerId);
+				[...new Array(DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getHighestCommonBlock + 1)].map(async () =>
+					transport.handleRPCGetHighestCommonBlock(validData, defaultPeerId),
+				);
 
 				jest.advanceTimersByTime(defaultRateLimit);
 				expect(networkStub.applyPenaltyOnPeer).toHaveBeenCalledWith({

--- a/framework/test/unit/node/transport/transport.spec.ts
+++ b/framework/test/unit/node/transport/transport.spec.ts
@@ -684,14 +684,13 @@ describe('Transport', () => {
 
 	describe('Handle rate limiting', () => {
 		const defaultPeerId = 'peer-id';
-		const DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY = {
-			getBlocksFromId: 100,
-			getLastBlock: 10,
-			getHighestCommonBlock: 10,
-		};
-		describe(`when getLastBlock is called more than ${DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getLastBlock} times within 10 sec`, () => {
+		const DEFAULT_LAST_BLOCK_RATE_LIMIT_FREQUENCY = 10;
+		const DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY = 10;
+		const DEFAULT_BLOCKS_FROM_IDS_RATE_LIMIT_FREQUENCY = 100;
+
+		describe(`when getLastBlock is called more than ${DEFAULT_LAST_BLOCK_RATE_LIMIT_FREQUENCY} times within 10 sec`, () => {
 			it('should apply penalty', () => {
-				[...new Array(DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getLastBlock + 1)].map(() =>
+				[...new Array(DEFAULT_LAST_BLOCK_RATE_LIMIT_FREQUENCY + 1)].map(() =>
 					transport.handleRPCGetLastBlock(defaultPeerId),
 				);
 
@@ -703,9 +702,9 @@ describe('Transport', () => {
 			});
 		});
 
-		describe(`when getBlocksFromId is called more than ${DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getBlocksFromId} times within 10 sec`, () => {
+		describe(`when getBlocksFromId is called more than ${DEFAULT_BLOCKS_FROM_IDS_RATE_LIMIT_FREQUENCY} times within 10 sec`, () => {
 			it('should apply penalty', () => {
-				[...new Array(DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getBlocksFromId + 1)].map(async () =>
+				[...new Array(DEFAULT_BLOCKS_FROM_IDS_RATE_LIMIT_FREQUENCY + 1)].map(async () =>
 					transport.handleRPCGetBlocksFromId({ blockId: '123' }, defaultPeerId),
 				);
 
@@ -717,13 +716,13 @@ describe('Transport', () => {
 			});
 		});
 
-		describe(`when getHighestCommonBlock is called more than ${DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getHighestCommonBlock} times within 10 sec`, () => {
+		describe(`when getHighestCommonBlock is called more than ${DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY} times within 10 sec`, () => {
 			const validData = {
 				ids: ['15196562876801949910'],
 			};
 
 			it('should apply penalty when called ', async () => {
-				[...new Array(DEFAULT_BLOCK_RATE_LIMIT_FREQUENCY.getHighestCommonBlock + 1)].map(async () =>
+				[...new Array(DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY + 1)].map(async () =>
 					transport.handleRPCGetHighestCommonBlock(validData, defaultPeerId),
 				);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5844 

### How was it solved?

- Add rate limiting for `getLastBlock, getBlocksFromId and getHighestCommonBlock`

### How was it tested?

- Added unit tests