### PR TITLE
Reject outgoing connection on receiving unexpected messages 

### DIFF
--- a/elements/lisk-p2p/src/peer/outbound.ts
+++ b/elements/lisk-p2p/src/peer/outbound.ts
@@ -128,7 +128,7 @@ export class OutboundPeer extends Peer {
 			connectTimeout,
 			ackTimeout,
 			multiplex: false,
-			autoConnect: false,
+			autoConnect: true,
 			autoReconnect: false,
 			maxPayload: this._peerConfig.wsMaxPayload,
 		};
@@ -194,6 +194,15 @@ export class OutboundPeer extends Peer {
 		// Bind RPC and remote event handlers
 		outboundSocket.on(REMOTE_SC_EVENT_RPC_REQUEST, this._handleRawRPC);
 		outboundSocket.on(REMOTE_SC_EVENT_MESSAGE, this._handleRawMessage);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
+		const transportSocket = (outboundSocket as any).transport;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+		if (transportSocket?.socket && transportSocket.socket.on) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+			transportSocket.socket.on(REMOTE_EVENT_PING, () => this.applyPenalty(100));
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+			transportSocket.socket.on(REMOTE_EVENT_PONG, () => this.applyPenalty(100));
+		}
 	}
 
 	// All event handlers for the outbound socket should be unbound in this method.

--- a/elements/lisk-p2p/test/integration/reject_unexpected_messages.ts
+++ b/elements/lisk-p2p/test/integration/reject_unexpected_messages.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { P2P, events } from '../../src/index';
+
+import {
+	createNetwork,
+	destroyNetwork,
+	NETWORK_CREATION_WAIT_TIME,
+	SEED_PEER_IP,
+} from '../utils/network_setup';
+import { wait } from '../utils/helpers';
+import { constructPeerId } from '../../src/utils';
+
+import { Peer } from '../../src/peer';
+
+describe('Reject control messages', () => {
+	let p2pNodeList: ReadonlyArray<P2P> = [];
+	let bannedPeers: any[] = [];
+
+	beforeEach(async () => {
+		p2pNodeList = await createNetwork({
+			networkDiscoveryWaitTime: 0,
+			networkSize: 3,
+		});
+
+		bannedPeers = [];
+		for (const p2p of p2pNodeList) {
+			// eslint-disable-next-line no-loop-func
+			p2p.on(events.EVENT_BAN_PEER, peerId => {
+				bannedPeers.push(peerId);
+			});
+		}
+
+		await Promise.all(p2pNodeList.map(async p2p => p2p.start()));
+
+		await wait(NETWORK_CREATION_WAIT_TIME);
+	});
+
+	afterEach(async () => {
+		await destroyNetwork(p2pNodeList);
+	});
+
+	describe('#ping', () => {
+		it('should ban peer when receive ping message on an outgoing connection', async () => {
+			// Arrange & Act
+			const firstNode = p2pNodeList[0];
+			const secondNode = p2pNodeList[1];
+
+			const peer = firstNode['_peerPool'].getPeer(
+				constructPeerId(SEED_PEER_IP, secondNode.config.port),
+			) as Peer;
+			// Send ping to the inbound peer
+			(peer['_socket'] as any).socket.ping();
+
+			await wait(100);
+			// Assert
+			expect(secondNode.getConnectedPeers().map(p => p.port)).not.toContain(firstNode.config.port);
+			expect(bannedPeers.length).toBeGreaterThan(0);
+		});
+
+		it('should ban peer when receive ping message on an incoming connection', async () => {
+			// Arrange & Act
+			const secondNode = p2pNodeList[1];
+			const thirdNode = p2pNodeList[2];
+
+			const peer = thirdNode['_peerPool']['_peerMap'].get(
+				`${SEED_PEER_IP}:${secondNode.config.port}`,
+			) as Peer;
+			// Send ping to the outbound peer
+			(peer['_socket'] as any).transport.socket.ping();
+
+			await wait(100);
+			// // Assert
+			expect(secondNode.getConnectedPeers().map(p => p.port)).not.toContain(thirdNode.config.port);
+			expect(bannedPeers.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('#pong', () => {
+		it('should ban peer when receive pong message on an outgoing connection', async () => {
+			// Arrange & Act
+			const firstNode = p2pNodeList[0];
+			const secondNode = p2pNodeList[1];
+
+			const peer = firstNode['_peerPool'].getPeer(
+				constructPeerId(SEED_PEER_IP, secondNode.config.port),
+			) as Peer;
+			// Send pong to the inbound peer
+			(peer['_socket'] as any).socket.pong();
+
+			await wait(200);
+			// Assert
+			expect(secondNode.getConnectedPeers().map(p => p.port)).not.toContain(firstNode.config.port);
+			expect(bannedPeers.length).toBeGreaterThan(0);
+		});
+
+		it('should ban peer when receive pong message on an incoming connection', async () => {
+			// Arrange & Act
+			const secondNode = p2pNodeList[1];
+			const thirdNode = p2pNodeList[2];
+
+			const peer = thirdNode['_peerPool']['_peerMap'].get(
+				`${SEED_PEER_IP}:${secondNode.config.port}`,
+			) as Peer;
+			// Send pong to the outbound peer
+			(peer['_socket'] as any).transport.socket.pong();
+
+			await wait(100);
+			// // Assert
+			expect(secondNode.getConnectedPeers().map(p => p.port)).not.toContain(thirdNode.config.port);
+			expect(bannedPeers.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/elements/lisk-p2p/test/unit/peer/outbound.ts
+++ b/elements/lisk-p2p/test/unit/peer/outbound.ts
@@ -198,7 +198,7 @@ describe('peer/outbound', () => {
 					connectTimeout: DEFAULT_CONNECT_TIMEOUT,
 					ackTimeout: DEFAULT_ACK_TIMEOUT,
 					multiplex: false,
-					autoConnect: false,
+					autoConnect: true,
 					autoReconnect: false,
 					maxPayload: defaultOutboundPeerConfig.wsMaxPayload,
 				};


### PR DESCRIPTION
### What was the problem?

This PR resolves #5861 

### How was it solved?

- Ban the peer on receiving control frames on outgoing connection
- Add tests for outgoing/incoming connections for control frames

### How was it tested?

Connect to or receive connection from a peer and send control frames to see if the peer bans the node
