### PR TITLE
Save diff every block and when deleting block throw error if diff does not exist - Closes #5837

### DIFF
--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -410,15 +410,9 @@ export class Storage {
 		}
 		// Take the diff to revert back states
 		const diffKey = `${DB_KEY_DIFF_STATE}:${heightStr}`;
+
 		// If there is no diff, the key might not exist
-		let stateDiff = Buffer.alloc(0);
-		try {
-			stateDiff = await this._db.get(diffKey);
-		} catch (err) {
-			if (!(err instanceof NotFoundError)) {
-				throw err;
-			}
-		}
+		const stateDiff = await this._db.get(diffKey);
 
 		const { created: createdStates, updated: updatedStates, deleted: deletedStates } = codec.decode<
 			StateDiff

--- a/elements/lisk-chain/src/state_store/state_store.ts
+++ b/elements/lisk-chain/src/state_store/state_store.ts
@@ -46,10 +46,8 @@ const saveDiff = (
 		diffToEncode.deleted = diffToEncode.deleted.concat(diff.deleted);
 	}
 
-	if (diffToEncode.created.length || diffToEncode.updated.length || diffToEncode.deleted.length) {
-		const encodedDiff = codec.encode(stateDiffSchema, diffToEncode);
-		batch.put(`${DB_KEY_DIFF_STATE}:${height}`, encodedDiff);
-	}
+	const encodedDiff = codec.encode(stateDiffSchema, diffToEncode);
+	batch.put(`${DB_KEY_DIFF_STATE}:${height}`, encodedDiff);
 };
 
 export class StateStore {

--- a/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
+++ b/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
@@ -468,30 +468,14 @@ describe('dataAccess.blocks', () => {
 			).toEqual(BigInt(200));
 		});
 
-		it('should delete block and all related indexes when there is no diff', async () => {
+		it('should the error when there is no diff', async () => {
 			// Deleting temp blocks to test the saving
 			await db.del(`diff:${formatInt(blocks[2].header.height)}`);
 			await dataAccess.clearTempBlocks();
-			await dataAccess.deleteBlock(blocks[2], stateStore as any);
 
-			await expect(
-				db.exists(`blocks:id:${blocks[2].header.id.toString('binary')}`),
-			).resolves.toBeFalse();
-			await expect(
-				db.exists(`blocks:height:${formatInt(blocks[2].header.height)}`),
-			).resolves.toBeFalse();
-			await expect(
-				db.exists(`transactions:blockID:${blocks[2].header.id.toString('binary')}`),
-			).resolves.toBeFalse();
-			await expect(
-				db.exists(`transactions:id:${blocks[2].payload[0].id.toString('binary')}`),
-			).resolves.toBeFalse();
-			await expect(
-				db.exists(`transactions:id:${blocks[2].payload[1].id.toString('binary')}`),
-			).resolves.toBeFalse();
-			await expect(
-				db.exists(`tempBlocks:height:${formatInt(blocks[2].header.height)}`),
-			).resolves.toBeFalse();
+			await expect(dataAccess.deleteBlock(blocks[2], stateStore as any)).rejects.toThrow(
+				'Specified key diff:0000012e does not exist',
+			);
 		});
 
 		it('should delete block and all related indexes and save to temp', async () => {

--- a/elements/lisk-chain/test/integration/state_store/save_diff.spec.ts
+++ b/elements/lisk-chain/test/integration/state_store/save_diff.spec.ts
@@ -284,16 +284,23 @@ describe('stateStore.finalize.saveDiff', () => {
 			expect(decodedDiff).toMatchSnapshot();
 		});
 
-		it('should not save any diff if state was not changed', async () => {
+		it('should save empty diff if state was not changed', async () => {
 			// Arrange
-			// Create
-			const fakeHeight = '7';
+			const fakeHeight = '3';
 			const batch = db.batch();
+
+			// Act
 			stateStore.finalize(fakeHeight, batch);
 			await batch.write();
+			const diff = await db.get(`${DB_KEY_DIFF_STATE}:${fakeHeight}`);
+			const decodedDiff = codec.decode(stateDiffSchema, diff);
 
 			// Assert
-			await expect(db.get(`${DB_KEY_DIFF_STATE}:${fakeHeight}`)).toReject();
+			expect(decodedDiff).toStrictEqual({
+				updated: [],
+				created: [],
+				deleted: [],
+			});
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5837

### How was it solved?

- Updated state store to store empty diff if no change in the state
- Update data access to throw error if no diff found for a block 

### How was it tested?

Updated respective integration tests  for use cases. 
