### PR TITLE
Fix maxHeightPrevoted to be initialized with the genesis height - Closes #5893

### DIFF
--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -66,17 +66,17 @@ export const BFTVotingLedgerSchema = {
 			fieldNumber: 2,
 			items: {
 				type: 'object',
-				required: ['height', 'preVotes', 'preCommits'],
+				required: ['height', 'prevotes', 'precommits'],
 				properties: {
 					height: {
 						dataType: 'uint32',
 						fieldNumber: 1,
 					},
-					preVotes: {
+					prevotes: {
 						dataType: 'uint32',
 						fieldNumber: 2,
 					},
-					preCommits: {
+					precommits: {
 						dataType: 'uint32',
 						fieldNumber: 3,
 					},
@@ -96,12 +96,12 @@ interface ValidatorsState {
 
 interface LedgerState {
 	height: number;
-	preVotes: number;
-	preCommits: number;
+	prevotes: number;
+	precommits: number;
 }
 
 interface LedgerMap {
-	[key: string]: { preVotes: number; preCommits: number };
+	[key: string]: { prevotes: number; precommits: number };
 }
 
 interface ValidatorState {
@@ -174,7 +174,7 @@ export class FinalityManager extends EventEmitter {
 		await this.verifyBlockHeaders(blockHeader, stateStore);
 
 		// Update the pre-votes and pre-commits
-		await this.updatePreVotesPreCommits(blockHeader, stateStore, lastBlockHeaders);
+		await this.updatePrevotesPrecommits(blockHeader, stateStore, lastBlockHeaders);
 
 		// Update the pre-voted confirmed and finalized height
 		await this.updateFinalizedHeight(stateStore);
@@ -186,12 +186,12 @@ export class FinalityManager extends EventEmitter {
 		return this;
 	}
 
-	public async updatePreVotesPreCommits(
+	public async updatePrevotesPrecommits(
 		header: BlockHeader,
 		stateStore: StateStore,
 		bftBlockHeaders: ReadonlyArray<BlockHeader>,
 	): Promise<boolean> {
-		debug('updatePreVotesPreCommits invoked');
+		debug('updatePrevotesPrecommits invoked');
 		// If validator forged a block with higher or same height previously
 		// That means he is forging on other chain and we don't count any
 		// Pre-votes and pre-commits from him
@@ -244,13 +244,13 @@ export class FinalityManager extends EventEmitter {
 
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 			const ledgerState = ledgerMap[j] || {
-				preVotes: 0,
-				preCommits: 0,
+				prevotes: 0,
+				precommits: 0,
 			};
 
-			if (ledgerState.preVotes >= this.preVoteThreshold) {
+			if (ledgerState.prevotes >= this.preVoteThreshold) {
 				// Increase the pre-commit for particular height
-				ledgerState.preCommits += 1;
+				ledgerState.precommits += 1;
 
 				// Keep track of the last pre-commit point
 				validatorState.maxPreCommitHeight = j;
@@ -278,11 +278,11 @@ export class FinalityManager extends EventEmitter {
 		for (let j = minPreVoteHeight; j <= maxPreVoteHeight; j += 1) {
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 			const ledgerState = ledgerMap[j] || {
-				preVotes: 0,
-				preCommits: 0,
+				prevotes: 0,
+				precommits: 0,
 			};
 
-			ledgerState.preVotes += 1;
+			ledgerState.prevotes += 1;
 
 			// Update ledger map
 			ledgerMap[j] = ledgerState;
@@ -315,7 +315,7 @@ export class FinalityManager extends EventEmitter {
 
 		const highestHeightPreCommitted = Object.keys(ledger)
 			.reverse()
-			.find(key => ledger[key].preCommits >= this.preCommitThreshold);
+			.find(key => ledger[key].precommits >= this.preCommitThreshold);
 
 		if (!highestHeightPreCommitted) {
 			return false;
@@ -419,7 +419,7 @@ export class FinalityManager extends EventEmitter {
 
 		const maxHeightPreVoted = Object.keys(ledger)
 			.reverse()
-			.find(key => ledger[key].preVotes >= this.preVoteThreshold);
+			.find(key => ledger[key].prevotes >= this.preVoteThreshold);
 
 		return maxHeightPreVoted ? parseInt(maxHeightPreVoted, 10) : this.finalizedHeight;
 	}
@@ -496,8 +496,8 @@ export class FinalityManager extends EventEmitter {
 		const ledger = votingLedger.ledger.reduce((prev: LedgerMap, curr) => {
 			// eslint-disable-next-line no-param-reassign
 			prev[curr.height] = {
-				preVotes: curr.preVotes,
-				preCommits: curr.preCommits,
+				prevotes: curr.prevotes,
+				precommits: curr.precommits,
 			};
 
 			return prev;

--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -344,7 +344,7 @@ export class FinalityManager extends EventEmitter {
 
 		const bftBlockHeaders = stateStore.chain.lastBlockHeaders;
 		const { ledger } = await this._getVotingLedger(stateStore);
-		const { preVoted: chainMaxHeightPrevoted } = this._getChainMaxHeightStatus(ledger);
+		const chainMaxHeightPrevoted = this._calculateMaxHeightPrevoted(ledger);
 		// We need minimum processingThreshold to decide
 		// If maxHeightPrevoted is correct
 		if (
@@ -411,27 +411,17 @@ export class FinalityManager extends EventEmitter {
 			CONSENSUS_STATE_VALIDATOR_LEDGER_KEY,
 		);
 		const { ledger } = this._decodeVotingLedger(bftState);
-		const { preVoted } = this._getChainMaxHeightStatus(ledger);
-
-		return preVoted;
+		return this._calculateMaxHeightPrevoted(ledger);
 	}
 
-	private _getChainMaxHeightStatus(ledger: LedgerMap): { preVoted: number; preCommitted: number } {
+	private _calculateMaxHeightPrevoted(ledger: LedgerMap): number {
 		debug('updatePreVotedAndFinalizedHeight invoked');
 
 		const highestHeightPreVoted = Object.keys(ledger)
 			.reverse()
 			.find(key => ledger[key].preVotes >= this.preVoteThreshold);
 
-		const preVoted = highestHeightPreVoted ? parseInt(highestHeightPreVoted, 10) : 0;
-
-		const highestHeightPreCommitted = Object.keys(ledger)
-			.reverse()
-			.find(key => ledger[key].preCommits >= this.preCommitThreshold);
-
-		const preCommitted = highestHeightPreCommitted ? parseInt(highestHeightPreCommitted, 10) : 0;
-
-		return { preVoted, preCommitted };
+		return highestHeightPreVoted ? parseInt(highestHeightPreVoted, 10) : this.finalizedHeight;
 	}
 
 	/**

--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -417,11 +417,11 @@ export class FinalityManager extends EventEmitter {
 	private _calculateMaxHeightPrevoted(ledger: LedgerMap): number {
 		debug('updatePreVotedAndFinalizedHeight invoked');
 
-		const highestHeightPreVoted = Object.keys(ledger)
+		const maxHeightPreVoted = Object.keys(ledger)
 			.reverse()
 			.find(key => ledger[key].preVotes >= this.preVoteThreshold);
 
-		return highestHeightPreVoted ? parseInt(highestHeightPreVoted, 10) : this.finalizedHeight;
+		return maxHeightPreVoted ? parseInt(maxHeightPreVoted, 10) : this.finalizedHeight;
 	}
 
 	/**

--- a/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
@@ -167,7 +167,7 @@ describe('FinalityManager', () => {
 							CONSENSUS_STATE_VALIDATOR_LEDGER_KEY,
 						);
 						const { ledger } = finalityManager['_decodeVotingLedger'](updatedBftLedgers);
-						const { preVoted } = finalityManager['_getChainMaxHeightStatus'](ledger);
+						const preVoted = finalityManager['_calculateMaxHeightPrevoted'](ledger);
 						expect(preVoted).toEqual(testCase.output.preVotedConfirmedHeight);
 					});
 				}

--- a/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
@@ -45,7 +45,7 @@ const bftScenarios = [
 	scenario11DelegatesPartialSwitch,
 ];
 
-const preVotesAndCommits = async (stateStore: StateStore) => {
+const prevotesAndCommits = async (stateStore: StateStore) => {
 	const delegateLedgerBuffer = await stateStore.consensus.get(CONSENSUS_STATE_VALIDATOR_LEDGER_KEY);
 
 	const delegateLedger = codec.decode<VotingLedger>(
@@ -53,21 +53,21 @@ const preVotesAndCommits = async (stateStore: StateStore) => {
 		(delegateLedgerBuffer as unknown) as Buffer,
 	);
 
-	const preCommits = delegateLedger.ledger.reduce((acc: any, curr) => {
-		if (curr.preCommits > 0) {
-			acc[curr.height] = curr.preCommits;
+	const precommits = delegateLedger.ledger.reduce((acc: any, curr) => {
+		if (curr.precommits > 0) {
+			acc[curr.height] = curr.precommits;
 		}
 		return acc;
 	}, {});
 
-	const preVotes = delegateLedger.ledger.reduce((acc: any, curr) => {
-		if (curr.preVotes > 0) {
-			acc[curr.height] = curr.preVotes;
+	const prevotes = delegateLedger.ledger.reduce((acc: any, curr) => {
+		if (curr.prevotes > 0) {
+			acc[curr.height] = curr.prevotes;
 		}
 		return acc;
 	}, {});
 
-	return { preCommits, preVotes };
+	return { precommits, prevotes };
 };
 
 describe('FinalityManager', () => {
@@ -144,7 +144,7 @@ describe('FinalityManager', () => {
 						);
 
 						// Arrange &  Assert
-						const { preCommits, preVotes } = await preVotesAndCommits(stateStore);
+						const { precommits, prevotes } = await prevotesAndCommits(stateStore);
 						const expectedPreCommits: any = { ...testCase.output.preCommits };
 
 						Object.keys(expectedPreCommits)
@@ -157,9 +157,9 @@ describe('FinalityManager', () => {
 								delete expectedPreCommits[key];
 							});
 
-						expect(preCommits).toEqual(expectedPreCommits);
+						expect(precommits).toEqual(expectedPreCommits);
 
-						expect(preVotes).toEqual(testCase.output.preVotes);
+						expect(prevotes).toEqual(testCase.output.preVotes);
 
 						expect(finalityManager.finalizedHeight).toEqual(testCase.output.finalizedHeight);
 

--- a/elements/lisk-bft/test/unit/bft.spec.ts
+++ b/elements/lisk-bft/test/unit/bft.spec.ts
@@ -216,8 +216,8 @@ describe('bft', () => {
 				ledger: [
 					{
 						height: block1.height,
-						preVotes: 1,
-						preCommits: 0,
+						prevotes: 1,
+						precommits: 0,
 					},
 				],
 			};

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -157,8 +157,8 @@ describe('finality_manager', () => {
 					ledger: [
 						{
 							height: 10,
-							preVotes: 69,
-							preCommits: 0,
+							prevotes: 69,
+							precommits: 0,
 						},
 					],
 				};
@@ -360,7 +360,7 @@ describe('finality_manager', () => {
 				expect(finalityManager.verifyBlockHeaders).toHaveBeenCalledWith(header1, stateStore);
 			});
 
-			it('should call updatePreVotesPreCommits with the provided header', async () => {
+			it('should call updatePrevotesPrecommits with the provided header', async () => {
 				const header1 = createFakeBlockHeader({
 					height: 2,
 					asset: {
@@ -368,11 +368,11 @@ describe('finality_manager', () => {
 					},
 					generatorPublicKey: bftHeaders[102].generatorPublicKey,
 				});
-				jest.spyOn(finalityManager, 'updatePreVotesPreCommits');
+				jest.spyOn(finalityManager, 'updatePrevotesPrecommits');
 				await finalityManager.addBlockHeader(header1, stateStore);
 
-				expect(finalityManager.updatePreVotesPreCommits).toHaveBeenCalledTimes(1);
-				expect(finalityManager.updatePreVotesPreCommits).toHaveBeenCalledWith(
+				expect(finalityManager.updatePrevotesPrecommits).toHaveBeenCalledTimes(1);
+				expect(finalityManager.updatePrevotesPrecommits).toHaveBeenCalledWith(
 					header1,
 					stateStore,
 					bftHeaders,
@@ -402,11 +402,11 @@ describe('finality_manager', () => {
 					{ lastBlockHeaders: bftHeaders },
 				) as unknown) as StateStore;
 
-				jest.spyOn(finalityManager, 'updatePreVotesPreCommits');
+				jest.spyOn(finalityManager, 'updatePrevotesPrecommits');
 				await finalityManager.addBlockHeader(header1, stateStore);
 
-				expect(finalityManager.updatePreVotesPreCommits).toHaveBeenCalledTimes(1);
-				expect(finalityManager.updatePreVotesPreCommits).toHaveBeenCalledWith(
+				expect(finalityManager.updatePrevotesPrecommits).toHaveBeenCalledTimes(1);
+				expect(finalityManager.updatePrevotesPrecommits).toHaveBeenCalledWith(
 					header1,
 					stateStore,
 					bftHeaders,
@@ -414,7 +414,7 @@ describe('finality_manager', () => {
 
 				// Ignores a standby validator from prevotes and precommit calculations
 				await expect(
-					finalityManager.updatePreVotesPreCommits(header1, stateStore, bftHeaders),
+					finalityManager.updatePrevotesPrecommits(header1, stateStore, bftHeaders),
 				).resolves.toEqual(false);
 			});
 
@@ -441,11 +441,11 @@ describe('finality_manager', () => {
 					{ lastBlockHeaders: bftHeaders },
 				) as unknown) as StateStore;
 
-				jest.spyOn(finalityManager, 'updatePreVotesPreCommits');
+				jest.spyOn(finalityManager, 'updatePrevotesPrecommits');
 				await finalityManager.addBlockHeader(header1, stateStore);
 
-				expect(finalityManager.updatePreVotesPreCommits).toHaveBeenCalledTimes(1);
-				expect(finalityManager.updatePreVotesPreCommits).toHaveBeenCalledWith(
+				expect(finalityManager.updatePrevotesPrecommits).toHaveBeenCalledTimes(1);
+				expect(finalityManager.updatePrevotesPrecommits).toHaveBeenCalledWith(
 					header1,
 					stateStore,
 					bftHeaders,
@@ -453,7 +453,7 @@ describe('finality_manager', () => {
 
 				// Ignores a standby validator from prevotes and precommit calculations
 				await expect(
-					finalityManager.updatePreVotesPreCommits(header1, stateStore, bftHeaders),
+					finalityManager.updatePrevotesPrecommits(header1, stateStore, bftHeaders),
 				).resolves.toEqual(false);
 			});
 
@@ -540,8 +540,8 @@ describe('finality_manager', () => {
 							ledger: [
 								{
 									height: 200,
-									preVotes: 99,
-									preCommits: 99,
+									prevotes: 99,
+									precommits: 99,
 								},
 							],
 						}),

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -100,6 +100,18 @@ describe('finality_manager', () => {
 						}),
 				).toThrow('Invalid number of validators for BFT property');
 			});
+
+			it('should inititialize maxHeightPrevoted to the finalizedHeight', async () => {
+				const nonZeroFinalizedHeight = 10000000;
+				finalityManager = new FinalityManager({
+					chain: chainStub,
+					finalizedHeight: nonZeroFinalizedHeight,
+					threshold,
+				});
+				await expect(finalityManager.getMaxHeightPrevoted()).resolves.toEqual(
+					nonZeroFinalizedHeight,
+				);
+			});
 		});
 
 		describe('verifyBlockHeaders', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #5893 

### How was it solved?

- Update to use finzlied height when prevote does not exist. When prevote does not exist, finalizedHeight should be the height at the genesis block. Therefore, indirectly it is setting to the genesis block height

### How was it tested?

- Add unit test to see if it will be initialized
