### PR TITLE
Update to have headers contradicting check as pure function - Closes #5894 

### DIFF
--- a/elements/lisk-bft/src/finality_manager.ts
+++ b/elements/lisk-bft/src/finality_manager.ts
@@ -20,12 +20,8 @@ import * as Debug from 'debug';
 import { EventEmitter } from 'events';
 import { dataStructures } from '@liskhq/lisk-utils';
 import { BFT_ROUND_THRESHOLD } from './constant';
-import {
-	BFTChainDisjointError,
-	BFTForkChoiceRuleError,
-	BFTInvalidAttributeError,
-	BFTLowerChainBranchError,
-} from './types';
+import { BFTInvalidAttributeError, BFTError } from './types';
+import { areHeadersContradicting } from './header_contradicting';
 
 // eslint-disable-next-line new-cap
 const debug = Debug('lisk:bft:consensus_manager');
@@ -365,42 +361,8 @@ export class FinalityManager extends EventEmitter {
 			return true;
 		}
 
-		// Order the two block headers such that earlierBlock must be forged first
-		let earlierBlock = validatorLastBlock;
-		let laterBlock = blockHeader;
-		const higherMaxHeightPreviouslyForged =
-			earlierBlock.asset.maxHeightPreviouslyForged > laterBlock.asset.maxHeightPreviouslyForged;
-		const sameMaxHeightPreviouslyForged =
-			earlierBlock.asset.maxHeightPreviouslyForged === laterBlock.asset.maxHeightPreviouslyForged;
-		const higherMaxHeightPrevoted =
-			earlierBlock.asset.maxHeightPrevoted > laterBlock.asset.maxHeightPrevoted;
-		const sameMaxHeightPrevoted =
-			earlierBlock.asset.maxHeightPrevoted === laterBlock.asset.maxHeightPrevoted;
-		const higherHeight = earlierBlock.height > laterBlock.height;
-		if (
-			higherMaxHeightPreviouslyForged ||
-			(sameMaxHeightPreviouslyForged && higherMaxHeightPrevoted) ||
-			(sameMaxHeightPreviouslyForged && sameMaxHeightPrevoted && higherHeight)
-		) {
-			[earlierBlock, laterBlock] = [laterBlock, earlierBlock];
-		}
-
-		if (
-			earlierBlock.asset.maxHeightPrevoted === laterBlock.asset.maxHeightPrevoted &&
-			earlierBlock.height >= laterBlock.height
-		) {
-			/* Violation of the fork choice rule as validator moved to different chain
-			 without strictly larger maxHeightPreviouslyForged or larger height as
-			 justification. This in particular happens, if a validator is double forging. */
-			throw new BFTForkChoiceRuleError();
-		}
-
-		if (earlierBlock.height > laterBlock.asset.maxHeightPreviouslyForged) {
-			throw new BFTChainDisjointError();
-		}
-
-		if (earlierBlock.asset.maxHeightPrevoted > laterBlock.asset.maxHeightPrevoted) {
-			throw new BFTLowerChainBranchError();
+		if (areHeadersContradicting(validatorLastBlock, blockHeader)) {
+			throw new BFTError();
 		}
 
 		return true;

--- a/elements/lisk-bft/src/header_contradicting.ts
+++ b/elements/lisk-bft/src/header_contradicting.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { BlockHeader } from '@liskhq/lisk-chain';
+
+export const areHeadersContradicting = (b1: BlockHeader, b2: BlockHeader): boolean => {
+	let earlierBlock = b1;
+	let laterBlock = b2;
+	const higherMaxHeightPreviouslyForged =
+		earlierBlock.asset.maxHeightPreviouslyForged > laterBlock.asset.maxHeightPreviouslyForged;
+	const sameMaxHeightPreviouslyForged =
+		earlierBlock.asset.maxHeightPreviouslyForged === laterBlock.asset.maxHeightPreviouslyForged;
+	const higherMaxHeightPrevoted =
+		earlierBlock.asset.maxHeightPrevoted > laterBlock.asset.maxHeightPrevoted;
+	const sameMaxHeightPrevoted =
+		earlierBlock.asset.maxHeightPrevoted === laterBlock.asset.maxHeightPrevoted;
+	const higherHeight = earlierBlock.height > laterBlock.height;
+	if (
+		higherMaxHeightPreviouslyForged ||
+		(sameMaxHeightPreviouslyForged && higherMaxHeightPrevoted) ||
+		(sameMaxHeightPreviouslyForged && sameMaxHeightPrevoted && higherHeight)
+	) {
+		[earlierBlock, laterBlock] = [laterBlock, earlierBlock];
+	}
+	// Blocks by different delegates are never contradicting
+	if (!earlierBlock.generatorPublicKey.equals(laterBlock.generatorPublicKey)) {
+		return false;
+	}
+	// No contradiction, as block headers are the same
+	if (earlierBlock.id.equals(laterBlock.id)) {
+		return false;
+	}
+	if (
+		earlierBlock.asset.maxHeightPrevoted === laterBlock.asset.maxHeightPrevoted &&
+		earlierBlock.height >= laterBlock.height
+	) {
+		/* Violation of the fork choice rule as validator moved to different chain
+		 without strictly larger maxHeightPreviouslyForged or larger height as
+		 justification. This in particular happens, if a validator is double forging. */
+		return true;
+	}
+
+	if (earlierBlock.height > laterBlock.asset.maxHeightPreviouslyForged) {
+		return true;
+	}
+
+	if (earlierBlock.asset.maxHeightPrevoted > laterBlock.asset.maxHeightPrevoted) {
+		return true;
+	}
+	return false;
+};

--- a/elements/lisk-bft/src/index.ts
+++ b/elements/lisk-bft/src/index.ts
@@ -15,3 +15,4 @@
 export * from './bft';
 export * from './fork_choice_rule';
 export * from './types';
+export { areHeadersContradicting } from './header_contradicting';

--- a/elements/lisk-bft/src/types.ts
+++ b/elements/lisk-bft/src/types.ts
@@ -26,28 +26,6 @@ export enum ForkStatus {
 
 export class BFTError extends Error {}
 
-export class BFTChainDisjointError extends BFTError {
-	public constructor() {
-		super(
-			'Violation of disjointedness condition. If delegate forged a block of higher height earlier and later the block with lower height',
-		);
-	}
-}
-
-export class BFTLowerChainBranchError extends BFTError {
-	public constructor() {
-		super(
-			'Violation of the condition that delegate must choose the branch with largest maxHeightPrevoted',
-		);
-	}
-}
-
-export class BFTForkChoiceRuleError extends BFTError {
-	public constructor() {
-		super('Violation of fork choice rule, delegate moved to a different chain');
-	}
-}
-
 export class BFTInvalidAttributeError extends BFTError {}
 
 export interface BFTPersistedValues {

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -28,11 +28,7 @@ import {
 	CONSENSUS_STATE_VALIDATOR_LEDGER_KEY,
 	BFTVotingLedgerSchema,
 } from '../../src/finality_manager';
-import {
-	BFTChainDisjointError,
-	BFTForkChoiceRuleError,
-	BFTLowerChainBranchError,
-} from '../../src/types';
+import { BFTError } from '../../src/types';
 import { createFakeBlockHeader } from '../fixtures/blocks';
 import { StateStoreMock } from '../utils/state_store_mock';
 import { BFTFinalizedHeightCodecSchema } from '../../src';
@@ -202,7 +198,7 @@ describe('finality_manager', () => {
 				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
-					BFTForkChoiceRuleError,
+					BFTError,
 				);
 			});
 
@@ -230,7 +226,7 @@ describe('finality_manager', () => {
 				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
-					BFTForkChoiceRuleError,
+					BFTError,
 				);
 			});
 
@@ -254,7 +250,7 @@ describe('finality_manager', () => {
 				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
-					BFTChainDisjointError,
+					BFTError,
 				);
 			});
 
@@ -283,7 +279,7 @@ describe('finality_manager', () => {
 				) as unknown) as StateStore;
 
 				await expect(finalityManager.verifyBlockHeaders(currentBlock, stateStore)).rejects.toThrow(
-					BFTLowerChainBranchError,
+					BFTError,
 				);
 			});
 


### PR DESCRIPTION
### What was the problem? 

This PR resolves #5894 

### How was it solved?

- Refactor to have pure function to check contradicting block headers
- Update to use the pure function in validation and in `reportDelegateMisbehavior` asset

### How was it tested?

- All test should pass and behavior except error type should remain
