### PR TITLE
Export monitoring and report misbehavior plugins from sdk - Closes #5900

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -36,6 +36,8 @@
 		"@liskhq/lisk-db": "^0.1.0-alpha.0",
 		"@liskhq/lisk-framework-forger-plugin": "^0.1.0-alpha.1",
 		"@liskhq/lisk-framework-http-api-plugin": "^0.1.0-alpha.1",
+		"@liskhq/lisk-framework-monitor-plugin": "^0.1.0",
+		"@liskhq/lisk-framework-report-misbehavior-plugin": "^0.1.0",
 		"@liskhq/lisk-genesis": "^0.1.0-alpha.1",
 		"@liskhq/lisk-p2p": "^0.6.0-alpha.2",
 		"@liskhq/lisk-passphrase": "^3.0.1-alpha.0",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -27,6 +27,8 @@ export * as genesis from '@liskhq/lisk-genesis';
 export { codec, Schema } from '@liskhq/lisk-codec';
 export * from '@liskhq/lisk-framework-http-api-plugin';
 export * from '@liskhq/lisk-framework-forger-plugin';
+export * from '@liskhq/lisk-framework-monitor-plugin';
+export * from '@liskhq/lisk-framework-report-misbehavior-plugin';
 export * from 'lisk-framework';
 
 export { genesisBlockDevnet, configDevnet } from './samples';


### PR DESCRIPTION
### What was the problem?

This PR resolves #5900 

### How was it solved?

- Exporting monitoring and report misbehavior plugins

### How was it tested?

require `lisk-sdk`