### PR TITLE
Create network stats controller for monitor plugin - Closes #5885

### DIFF
--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -287,11 +287,8 @@ export class P2P extends EventEmitter {
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerPoolRPC = (request: P2PRequest): void => {
-			if (!this._networkStats.totalRequestsReceived[request.procedure]) {
-				this._networkStats.totalRequestsReceived[request.procedure] = 0;
-			}
-
-			this._networkStats.totalRequestsReceived[request.procedure] += 1;
+			this._networkStats.totalRequestsReceived[request.procedure] =
+				this._networkStats.totalRequestsReceived[request.procedure] + 1 || 1;
 			// Process protocol messages
 			switch (request.procedure) {
 				case REMOTE_EVENT_RPC_GET_PEERS_LIST:
@@ -309,11 +306,8 @@ export class P2P extends EventEmitter {
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerPoolMessage = (message: P2PMessagePacket): void => {
-			if (!this._networkStats.totalMessagesReceived[message.event]) {
-				this._networkStats.totalMessagesReceived[message.event] = 0;
-			}
-
-			this._networkStats.totalMessagesReceived[message.event] += 1;
+			this._networkStats.totalMessagesReceived[message.event] =
+				this._networkStats.totalMessagesReceived[message.event] + 1 || 1;
 			// Re-emit the message for external use.
 			if (message.event === REMOTE_EVENT_POST_NODE_INFO) {
 				// This 'decode' only happens with the successful case after decoding in "peer"

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -265,10 +265,12 @@ export class P2P extends EventEmitter {
 		this._networkStats = {
 			startTime: Date.now(),
 			incoming: {
+				count: 0,
 				connects: 0,
 				disconnects: 0,
 			},
 			outgoing: {
+				count: 0,
 				connects: 0,
 				disconnects: 0,
 			},
@@ -643,6 +645,10 @@ export class P2P extends EventEmitter {
 	}
 
 	public getNetworkStats(): NetworkStats {
+		const { inboundCount, outboundCount } = this._peerPool.getPeersCountPerKind();
+		this._networkStats.outgoing.count = outboundCount;
+		this._networkStats.incoming.count = inboundCount;
+
 		return this._networkStats;
 	}
 

--- a/elements/lisk-p2p/src/p2p.ts
+++ b/elements/lisk-p2p/src/p2p.ts
@@ -91,6 +91,7 @@ import {
 	ProtocolPeerInfo,
 	RPCSchemas,
 	PeerInfo,
+	NetworkStats,
 } from './types';
 import {
 	assignInternalInfo,
@@ -197,6 +198,7 @@ export class P2P extends EventEmitter {
 	private readonly _secret: number;
 	private readonly _rpcSchemas: RPCSchemas;
 	private _peerServer?: PeerServer;
+	private readonly _networkStats: NetworkStats;
 
 	private readonly _handlePeerPoolRPC: (request: P2PRequest) => void;
 	private readonly _handlePeerPoolMessage: (message: P2PMessagePacket) => void;
@@ -260,8 +262,34 @@ export class P2P extends EventEmitter {
 		codec.addSchema(this._rpcSchemas.peerInfo);
 		codec.addSchema(this._rpcSchemas.nodeInfo);
 
+		this._networkStats = {
+			startTime: Date.now(),
+			incoming: {
+				connects: 0,
+				disconnects: 0,
+			},
+			outgoing: {
+				connects: 0,
+				disconnects: 0,
+			},
+			banning: {
+				bannedPeers: {},
+				totalBannedPeers: 0,
+			},
+			totalErrors: 0,
+			totalPeersDiscovered: 0,
+			totalRemovedPeers: 0,
+			totalMessagesReceived: {},
+			totalRequestsReceived: {},
+		};
+
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerPoolRPC = (request: P2PRequest): void => {
+			if (!this._networkStats.totalRequestsReceived[request.procedure]) {
+				this._networkStats.totalRequestsReceived[request.procedure] = 0;
+			}
+
+			this._networkStats.totalRequestsReceived[request.procedure] += 1;
 			// Process protocol messages
 			switch (request.procedure) {
 				case REMOTE_EVENT_RPC_GET_PEERS_LIST:
@@ -279,6 +307,11 @@ export class P2P extends EventEmitter {
 
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerPoolMessage = (message: P2PMessagePacket): void => {
+			if (!this._networkStats.totalMessagesReceived[message.event]) {
+				this._networkStats.totalMessagesReceived[message.event] = 0;
+			}
+
+			this._networkStats.totalMessagesReceived[message.event] += 1;
 			// Re-emit the message for external use.
 			if (message.event === REMOTE_EVENT_POST_NODE_INFO) {
 				// This 'decode' only happens with the successful case after decoding in "peer"
@@ -299,6 +332,8 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handleOutboundPeerConnect = (peerInfo: P2PPeerInfo): void => {
+			this._networkStats.outgoing.connects += 1;
+
 			if (!this._peerBook.hasPeer(peerInfo)) {
 				this._peerBook.addPeer(peerInfo);
 			}
@@ -322,6 +357,7 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handlePeerCloseOutbound = (closePacket: P2PClosePacket): void => {
+			this._networkStats.outgoing.disconnects += 1;
 			const { peerInfo } = closePacket;
 			// Update connection kind when closing connection
 			if (this._peerBook.getPeer(closePacket.peerInfo)) {
@@ -337,6 +373,7 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handlePeerCloseInbound = (closePacket: P2PClosePacket): void => {
+			this._networkStats.incoming.disconnects += 1;
 			const { peerInfo } = closePacket;
 			// Update connection kind when closing connection
 			if (this._peerBook.getPeer(closePacket.peerInfo)) {
@@ -352,6 +389,7 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handleFailedInboundPeerConnect = (err: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER, err);
 		};
@@ -370,6 +408,7 @@ export class P2P extends EventEmitter {
 					});
 				}
 
+				this._networkStats.incoming.connects += 1;
 				// Re-emit the message to allow it to bubble up the class hierarchy.
 				this.emit(EVENT_NEW_INBOUND_PEER, incomingPeerConnection.peerInfo);
 
@@ -396,6 +435,7 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handleRemovePeer = (peerId: string): void => {
+			this._networkStats.totalRemovedPeers += 1;
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_REMOVE_PEER, peerId);
 		};
@@ -415,21 +455,25 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handleFailedPeerInfoUpdate = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_PEER_INFO_UPDATE, error);
 		};
 
 		this._handleFailedToFetchPeerInfo = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_TO_FETCH_PEER_INFO, error);
 		};
 
 		this._handleFailedToFetchPeers = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_TO_FETCH_PEERS, error);
 		};
 
 		this._handleFailedToCollectPeerDetails = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_TO_COLLECT_PEER_DETAILS_ON_CONNECT, error);
 		};
@@ -443,6 +487,18 @@ export class P2P extends EventEmitter {
 
 			this._peerBook.addBannedPeer(peerId, banTime);
 
+			this._networkStats.banning.totalBannedPeers += 1;
+
+			if (!this._networkStats.banning.bannedPeers[peerId]) {
+				this._networkStats.banning.bannedPeers[peerId] = {
+					banCount: 1,
+					lastBanTime: Date.now(),
+				};
+			} else {
+				this._networkStats.banning.bannedPeers[peerId].banCount += 1;
+				this._networkStats.banning.bannedPeers[peerId].lastBanTime = Date.now();
+			}
+
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_BAN_PEER, peerId);
 		};
@@ -454,6 +510,7 @@ export class P2P extends EventEmitter {
 			}
 
 			if (this._peerBook.addPeer(detailedPeerInfo)) {
+				this._networkStats.totalPeersDiscovered += 1;
 				// Re-emit the message to allow it to bubble up the class hierarchy.
 				// Only emit event when a peer is discovered for the first time.
 				this.emit(EVENT_DISCOVERED_PEER, detailedPeerInfo);
@@ -461,21 +518,25 @@ export class P2P extends EventEmitter {
 		};
 
 		this._handleFailedToPushNodeInfo = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the error to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_TO_PUSH_NODE_INFO, error);
 		};
 
 		this._handleFailedToSendMessage = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the error to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_FAILED_TO_SEND_MESSAGE, error);
 		};
 
 		this._handleOutboundSocketError = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the error to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_OUTBOUND_SOCKET_ERROR, error);
 		};
 
 		this._handleInboundSocketError = (error: Error): void => {
+			this._networkStats.totalErrors += 1;
 			// Re-emit the error to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_INBOUND_SOCKET_ERROR, error);
 		};
@@ -579,6 +640,10 @@ export class P2P extends EventEmitter {
 				port: peer.port,
 				peerId: peer.peerId,
 			}));
+	}
+
+	public getNetworkStats(): NetworkStats {
+		return this._networkStats;
 	}
 
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {

--- a/elements/lisk-p2p/src/types.ts
+++ b/elements/lisk-p2p/src/types.ts
@@ -224,3 +224,33 @@ export interface PeerLists {
 	readonly whitelisted: ReadonlyArray<P2PPeerInfo>;
 	readonly previousPeers: ReadonlyArray<P2PPeerInfo>;
 }
+
+export interface NetworkStats {
+	readonly outgoing: {
+		connects: number;
+		disconnects: number;
+	};
+	readonly incoming: {
+		connects: number;
+		disconnects: number;
+	};
+	readonly banning: {
+		totalBannedPeers: number;
+		bannedPeers: {
+			[key: string]: {
+				lastBanTime: number;
+				banCount: number;
+			};
+		};
+	};
+	totalErrors: number;
+	totalRemovedPeers: number;
+	totalMessagesReceived: {
+		[key: string]: number;
+	};
+	totalRequestsReceived: {
+		[key: string]: number;
+	};
+	totalPeersDiscovered: number;
+	readonly startTime: number;
+}

--- a/elements/lisk-p2p/src/types.ts
+++ b/elements/lisk-p2p/src/types.ts
@@ -227,10 +227,12 @@ export interface PeerLists {
 
 export interface NetworkStats {
 	readonly outgoing: {
+		count: number;
 		connects: number;
 		disconnects: number;
 	};
 	readonly incoming: {
+		count: number;
 		connects: number;
 		disconnects: number;
 	};

--- a/elements/lisk-p2p/test/functional/actions/get_network_stats.ts
+++ b/elements/lisk-p2p/test/functional/actions/get_network_stats.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { P2P } from '../../../src/index';
+import { destroyNetwork } from '../../utils/network_setup';
+import { wait } from '../../utils/helpers';
+import {
+	EVENT_BAN_PEER,
+	EVENT_CLOSE_INBOUND,
+	EVENT_CLOSE_OUTBOUND,
+	EVENT_CONNECT_OUTBOUND,
+	EVENT_DISCOVERED_PEER,
+	EVENT_MESSAGE_RECEIVED,
+	EVENT_NEW_INBOUND_PEER,
+	EVENT_REMOVE_PEER,
+	EVENT_REQUEST_RECEIVED,
+} from '../../../src/events';
+import { NetworkStats } from '../../../src/types';
+
+describe('getNetworkStats', () => {
+	let p2pNodeList: ReadonlyArray<P2P> = [];
+	let firstNode: P2P;
+	let secondNode: P2P;
+	let thirdNode: P2P;
+	let networkStats: NetworkStats;
+
+	beforeEach(async () => {
+		// Only has incoming connection from second and third node
+		firstNode = new P2P({
+			port: 5000,
+			maxOutboundConnections: 0,
+			nodeInfo: {
+				networkIdentifier: 'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+				networkVersion: '1.1',
+				options: {},
+				nonce: 'nonce',
+				advertiseAddress: true,
+			},
+		});
+
+		secondNode = new P2P({
+			port: 5001,
+			seedPeers: [{ ipAddress: '127.0.0.1', port: 5000 }],
+			nodeInfo: {
+				networkIdentifier: 'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+				networkVersion: '1.1',
+				options: {},
+				nonce: 'nonce',
+				advertiseAddress: true,
+			},
+		});
+
+		thirdNode = new P2P({
+			port: 5002,
+			seedPeers: [
+				{ ipAddress: '127.0.0.1', port: 5000 },
+				{ ipAddress: '127.0.0.1', port: 5001 },
+			],
+			nodeInfo: {
+				networkIdentifier: 'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+				networkVersion: '1.1',
+				options: {},
+				nonce: 'nonce',
+				advertiseAddress: true,
+			},
+		});
+
+		p2pNodeList = [firstNode, secondNode, thirdNode];
+
+		networkStats = {
+			startTime: Date.now(),
+			incoming: {
+				count: 0,
+				connects: 0,
+				disconnects: 0,
+			},
+			outgoing: {
+				count: 0,
+				connects: 0,
+				disconnects: 0,
+			},
+			banning: {
+				bannedPeers: {},
+				totalBannedPeers: 0,
+			},
+			totalErrors: 0,
+			totalPeersDiscovered: 0,
+			totalRemovedPeers: 0,
+			totalMessagesReceived: {},
+			totalRequestsReceived: {},
+		};
+
+		firstNode.on(EVENT_REQUEST_RECEIVED, request => {
+			if (!networkStats.totalRequestsReceived[request.procedure]) {
+				networkStats.totalRequestsReceived[request.procedure] = 0;
+			}
+			networkStats.totalRequestsReceived[request.procedure] += 1;
+		});
+
+		firstNode.on(EVENT_MESSAGE_RECEIVED, message => {
+			if (!networkStats.totalMessagesReceived[message.event]) {
+				networkStats.totalMessagesReceived[message.event] = 0;
+			}
+			networkStats.totalMessagesReceived[message.event] += 1;
+		});
+
+		firstNode.on(EVENT_CLOSE_INBOUND, () => {
+			networkStats.incoming.disconnects += 1;
+		});
+		firstNode.on(EVENT_NEW_INBOUND_PEER, () => {
+			networkStats.incoming.connects += 1;
+		});
+
+		firstNode.on(EVENT_CLOSE_OUTBOUND, () => {
+			networkStats.outgoing.disconnects += 1;
+		});
+		firstNode.on(EVENT_CONNECT_OUTBOUND, () => {
+			networkStats.outgoing.connects += 1;
+		});
+
+		firstNode.on(EVENT_REMOVE_PEER, () => {
+			networkStats.totalRemovedPeers += 1;
+		});
+		firstNode.on(EVENT_DISCOVERED_PEER, () => {
+			networkStats.totalPeersDiscovered += 1;
+		});
+		firstNode.on(EVENT_BAN_PEER, peerId => {
+			networkStats.banning.totalBannedPeers += 1;
+			if (!networkStats.banning.bannedPeers[peerId]) {
+				networkStats.banning.bannedPeers[peerId].banCount = 0;
+			}
+
+			networkStats.banning.bannedPeers[peerId].banCount += 1;
+			networkStats.banning.bannedPeers[peerId].lastBanTime = Date.now();
+		});
+
+		for (const p2p of p2pNodeList) {
+			await p2p.start();
+			await wait(100);
+		}
+	});
+
+	afterEach(async () => {
+		await destroyNetwork(p2pNodeList);
+	});
+
+	it('should return a valid networkStats object', async () => {
+		const { inboundCount, outboundCount } = firstNode['_peerPool'].getPeersCountPerKind();
+		const firstNodeStats = firstNode.getNetworkStats();
+
+		// Incoming
+		expect(inboundCount).toEqual(firstNodeStats.incoming.count);
+		expect(firstNodeStats.incoming.connects).toEqual(networkStats.incoming.connects);
+		expect(firstNodeStats.incoming.disconnects).toEqual(0);
+
+		// Outgoing
+		expect(outboundCount).toEqual(firstNodeStats.outgoing.count);
+		expect(firstNodeStats.outgoing.connects).toEqual(networkStats.outgoing.connects);
+		expect(firstNodeStats.outgoing.disconnects).toEqual(0);
+
+		// Banning
+		expect(firstNodeStats.banning.totalBannedPeers).toEqual(networkStats.banning.totalBannedPeers);
+		expect(firstNodeStats.banning.bannedPeers).toEqual({});
+
+		// totals
+		expect(firstNodeStats.totalMessagesReceived).toEqual(networkStats.totalMessagesReceived);
+		expect(firstNodeStats.totalRequestsReceived).toEqual(networkStats.totalRequestsReceived);
+		expect(firstNodeStats.totalRemovedPeers).toEqual(networkStats.totalRemovedPeers);
+		expect(firstNodeStats.totalPeersDiscovered).toEqual(networkStats.totalPeersDiscovered);
+
+		// Shutdown third node
+		await thirdNode.stop();
+		await wait(50);
+
+		// Should capture incoming disconnect count
+		expect(firstNode.getNetworkStats().incoming.disconnects).toEqual(1);
+	});
+});

--- a/elements/lisk-p2p/test/unit/p2p.ts
+++ b/elements/lisk-p2p/test/unit/p2p.ts
@@ -93,6 +93,69 @@ describe('p2p', () => {
 		});
 	});
 
+	describe('p2p without peers', () => {
+		let p2pNodeWithoutPeers: P2P;
+
+		beforeEach(async () => {
+			p2pNodeWithoutPeers = new P2P({
+				port: 5001,
+				nodeInfo: {
+					networkIdentifier: 'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
+					networkVersion: '1.1',
+					options: {},
+					nonce: 'nonce',
+					advertiseAddress: true,
+				},
+			});
+
+			await p2pNodeWithoutPeers.start();
+		});
+
+		afterEach(async () => {
+			await p2pNodeWithoutPeers.stop();
+		});
+
+		it('should return no peers', () => {
+			expect(p2pNodeWithoutPeers.getConnectedPeers()).toEqual([]);
+			expect(p2pNodeWithoutPeers.getDisconnectedPeers()).toEqual([]);
+			expect(p2pNodeWithoutPeers.getTriedPeers()).toEqual([]);
+		});
+
+		it('should fail on request', async () => {
+			await expect(p2pNodeWithoutPeers.request({ procedure: 'getlastBlock' })).rejects.toThrow(
+				'Request failed due to no peers found in peer selection',
+			);
+		});
+
+		it('should fail on requestFromPeer', async () => {
+			await expect(
+				p2pNodeWithoutPeers.requestFromPeer({ procedure: 'getlastBlock' }, '127.0.0.1:5000'),
+			).rejects.toThrow('Request failed because a peer with id 127.0.0.1:5000 could not be found');
+		});
+
+		it('should return network stats', () => {
+			const connectStats = {
+				count: 0,
+				connects: 0,
+				disconnects: 0,
+			};
+
+			const banningStats = {
+				totalBannedPeers: 0,
+				bannedPeers: {},
+			};
+
+			expect(p2pNodeWithoutPeers.getNetworkStats().incoming).toEqual(connectStats);
+			expect(p2pNodeWithoutPeers.getNetworkStats().outgoing).toEqual(connectStats);
+			expect(p2pNodeWithoutPeers.getNetworkStats().banning).toEqual(banningStats);
+			expect(p2pNodeWithoutPeers.getNetworkStats().totalMessagesReceived).toEqual({});
+			expect(p2pNodeWithoutPeers.getNetworkStats().totalRequestsReceived).toEqual({});
+			expect(p2pNodeWithoutPeers.getNetworkStats().totalErrors).toEqual(0);
+			expect(p2pNodeWithoutPeers.getNetworkStats().totalPeersDiscovered).toEqual(0);
+			expect(p2pNodeWithoutPeers.getNetworkStats().totalRemovedPeers).toEqual(0);
+		});
+	});
+
 	describe('when custom schema is passed', () => {
 		let firstNode: P2P;
 

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
@@ -13,6 +13,25 @@
  */
 import { Request, Response, NextFunction } from 'express';
 import { BaseChannel } from 'lisk-framework';
+import { PeerInfo } from '../types';
+
+const getMajorityHeight = (peers: PeerInfo[]): { height: number; count: number } => {
+	const heightHistogram = {} as { [key: number]: number };
+	const majority = {
+		height: 0,
+		count: 0,
+	};
+	for (const { options } of peers) {
+		const height = options.height as number;
+		heightHistogram[height] = heightHistogram[height] ? heightHistogram[height] + 1 : 1;
+		if (heightHistogram[height] > majority.count) {
+			majority.count = heightHistogram[height];
+			majority.height = height;
+		}
+	}
+
+	return majority;
+};
 
 export const getNetworkStats = (channel: BaseChannel) => async (
 	_req: Request,
@@ -20,9 +39,12 @@ export const getNetworkStats = (channel: BaseChannel) => async (
 	next: NextFunction,
 ): Promise<void> => {
 	try {
-		const networkStats = await channel.invoke('app:getNetworkStats');
+		const networkStats: { [key: string]: unknown } = await channel.invoke('app:getNetworkStats');
+		const connectedPeers = await channel.invoke('app:getConnectedPeers');
+		const majorityHeight = getMajorityHeight(connectedPeers as PeerInfo[]);
+		const data = { ...networkStats, majorityHeight };
 
-		res.status(200).send({ data: networkStats, meta: {} });
+		res.status(200).json({ data, meta: {} });
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
@@ -23,7 +23,7 @@ const getMajorityHeight = (peers: PeerInfo[]): { height: number; count: number }
 	};
 	for (const { options } of peers) {
 		const height = options.height as number;
-		heightHistogram[height] = heightHistogram[height] ? heightHistogram[height] + 1 : 1;
+		heightHistogram[height] = heightHistogram[height] + 1 || 1;
 		if (heightHistogram[height] > majority.count) {
 			majority.count = heightHistogram[height];
 			majority.height = height;

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
@@ -11,8 +11,19 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import * as blocks from './blocks';
-import * as transactions from './transactions';
-import * as network from './network';
+import { Request, Response, NextFunction } from 'express';
+import { BaseChannel } from 'lisk-framework';
 
-export { blocks, transactions, network };
+export const getNetworkStats = (channel: BaseChannel) => async (
+	_req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	try {
+		const networkStats = await channel.invoke('app:getNetworkStats');
+
+		res.status(200).send({ data: networkStats, meta: {} });
+	} catch (err) {
+		next(err);
+	}
+};

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -176,6 +176,7 @@ export class MonitorPlugin extends BasePlugin {
 			'/api/stats/blocks',
 			controllers.blocks.getBlockStats(this._channel, this._state),
 		);
+		this._app.get('/api/stats/network', controllers.network.getNetworkStats(this._channel));
 	}
 
 	private _subscribeToEvents(): void {

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/network.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/network.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { when } from 'jest-when';
+import { Request } from 'express';
+import { PeerInfo } from '../../src/types';
+import { network as networkController } from '../../src/controllers';
+
+describe('networkStats', () => {
+	const peers: Partial<PeerInfo>[] = [
+		{ options: { height: 51 } },
+		{ options: { height: 52 } },
+		{ options: { height: 52 } },
+		{ options: { height: 52 } },
+		{ options: { height: 49 } },
+		{ options: { height: 0 } },
+		{ options: { height: 23 } },
+		{ options: { height: 23 } },
+		{ options: { height: 52 } },
+		{ options: { height: 52 } },
+		{ options: { height: 55 } },
+		{ options: { height: 52 } },
+		{ options: { height: 52 } },
+		{ options: { height: 53 } },
+		{ options: { height: 53 } },
+		{ options: { height: 53 } },
+		{ options: { height: 53 } },
+		{ options: { height: 53 } },
+		{ options: { height: 53 } },
+	]; // Majority is of 7 peers with height 52
+
+	const defaultNetworkStats = {
+		startTime: Date.now(),
+		incoming: {
+			count: 0,
+			connects: 0,
+			disconnects: 0,
+		},
+		outgoing: {
+			count: 0,
+			connects: 0,
+			disconnects: 0,
+		},
+		banning: {
+			bannedPeers: {},
+			totalBannedPeers: 0,
+		},
+		totalErrors: 0,
+		totalPeersDiscovered: 0,
+		totalRemovedPeers: 0,
+		totalMessagesReceived: {},
+		totalRequestsReceived: {},
+		majorityHeight: { height: 52, count: 7 },
+	};
+
+	const channelMock = {
+		invoke: jest.fn(),
+	};
+	const network = networkController.getNetworkStats(channelMock as any);
+
+	beforeEach(() => {
+		when(channelMock.invoke)
+			.calledWith('app:getNetworkStats')
+			.mockResolvedValue(defaultNetworkStats)
+			.calledWith('app:getConnectedPeers')
+			.mockResolvedValue(peers);
+	});
+
+	it('should add new transactions to state', async () => {
+		// Arrange
+		const next = jest.fn();
+
+		const res = {
+			status: jest.fn().mockImplementation(_code => res),
+			json: jest.fn().mockImplementation(_param => res),
+		} as any;
+
+		// Act
+		await network({} as Request, res, next);
+
+		// Assert
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({ data: defaultNetworkStats, meta: {} });
+	});
+
+	it('should throw error when any channel action fails', async () => {
+		// Arrange
+		const next = jest.fn();
+		const res = {
+			status: jest.fn().mockImplementation(_code => res),
+			json: jest.fn().mockImplementation(_param => res),
+		} as any;
+
+		const error = new Error('Something went wrong');
+		channelMock.invoke.mockRejectedValue(error);
+
+		// Act
+		await network({} as Request, res, next);
+
+		// Assert
+		expect(next).toHaveBeenCalledWith(error);
+	});
+});

--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -345,6 +345,9 @@ export class Application {
 				getDisconnectedPeers: {
 					handler: (_action: ActionInfoObject) => this._node.actions.getDisconnectedPeers(),
 				},
+				getNetworkStats: {
+					handler: (_action: ActionInfoObject) => this._node.actions.getNetworkStats(),
+				},
 				getForgers: {
 					handler: async (_action: ActionInfoObject) => this._node.actions.getValidators(),
 				},

--- a/framework/src/node/network/network.ts
+++ b/framework/src/node/network/network.ts
@@ -458,6 +458,10 @@ export class Network {
 		});
 	}
 
+	public getNetworkStats(): liskP2P.p2pTypes.NetworkStats {
+		return this._p2p.getNetworkStats();
+	}
+
 	public getDisconnectedPeers(): ReadonlyArray<liskP2P.p2pTypes.PeerInfo> {
 		const peers = this._p2p.getDisconnectedPeers();
 		return peers.map(peer => {

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -491,6 +491,7 @@ export class Node {
 			}),
 			getConnectedPeers: () => this._networkModule.getConnectedPeers(),
 			getDisconnectedPeers: () => this._networkModule.getDisconnectedPeers(),
+			getNetworkStats: () => this._networkModule.getNetworkStats(),
 		};
 	}
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5885 

### How was it solved?

🌱 Add getNetworkStats to lisk-p2p 982cbf2
🌱 Add network controller for networkStats 6f7957f
♻️ Add count for incoming and outgoing 79c95ba
✅ Add functional and unit tests for network stats 45d9591
🌱 Add majorityHeight calculation and property to networkStats ad69748
✅ Add unit test for networkStats controller ee1db02

### How was it tested?

Run `npm run test:unit`, `npm run test:integration`, `npm run test:functional` under `elements/lisk-p2p`
Run `npm run test:unit` under `framework-plugins/lisk-framework-monitor-plugin/`
