### PR TITLE
Create Monitor Plugin for incoming block statistics - Closes #5295

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/controllers/peers.ts
@@ -41,7 +41,7 @@ enum PeerState {
 	disconnected = 'disconnected',
 }
 
-interface PeerInfo {
+export interface PeerInfo {
 	readonly ipAddress: string;
 	readonly port: number;
 	readonly networkIdentifier: string;

--- a/framework-plugins/lisk-framework-monitor-plugin/package.json
+++ b/framework-plugins/lisk-framework-monitor-plugin/package.json
@@ -40,6 +40,9 @@
 	"dependencies": {
 		"@liskhq/lisk-utils": "^0.1.0-alpha.1",
 		"@liskhq/lisk-validator": "^0.5.0-alpha.0",
+		"@liskhq/lisk-cryptography": "^3.0.0-alpha.0",
+		"@liskhq/lisk-codec": "^0.1.0-alpha.0",
+		"@liskhq/lisk-chain": "^0.2.0-alpha.2",
 		"cors": "2.8.5",
 		"express": "4.17.1",
 		"express-rate-limit": "5.1.3",

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/blocks.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/blocks.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Request, Response } from 'express';
+import { BaseChannel } from 'lisk-framework';
+import { BlockPropagationStats, PeerInfo, SharedState } from '../types';
+
+const getAverageReceivedBlocks = (blocks: { [key: string]: BlockPropagationStats }) => {
+	let totalCount = 0;
+
+	for (const blockStat of Object.values(blocks)) {
+		totalCount += blockStat.count;
+	}
+
+	return totalCount / Object.keys(blocks).length;
+};
+
+export const getBlockStats = (channel: BaseChannel, state: SharedState) => async (
+	_req: Request,
+	res: Response,
+): Promise<void> => {
+	const connectedPeers = await channel.invoke<ReadonlyArray<PeerInfo>>('app:getConnectedPeers');
+	res.status(200).json({
+		meta: {},
+		data: {
+			...state.blocks,
+			averageReceivedBlocks: getAverageReceivedBlocks(state.blocks.blocks),
+			connectedPeers: connectedPeers.length,
+		},
+	});
+};

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/index.ts
@@ -11,7 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-
+import * as blocks from './blocks';
 import * as transactions from './transactions';
 
-export { transactions };
+export { blocks, transactions };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -12,9 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { Server } from 'http';
-import { BasePlugin, PluginInfo } from 'lisk-framework';
+import { RawBlock, RawBlockHeader } from '@liskhq/lisk-chain';
+import { codec } from '@liskhq/lisk-codec';
+import { hash } from '@liskhq/lisk-cryptography';
 import { objects } from '@liskhq/lisk-utils';
-import type { ActionsDefinition, BaseChannel, EventsArray, EventInfoObject } from 'lisk-framework';
+import {
+	ActionsDefinition,
+	BaseChannel,
+	BasePlugin,
+	EventInfoObject,
+	EventPostBlockData,
+	EventsArray,
+	PluginInfo,
+} from 'lisk-framework';
 import * as express from 'express';
 import type { Express } from 'express';
 import * as cors from 'cors';
@@ -162,6 +172,10 @@ export class MonitorPlugin extends BasePlugin {
 			'/api/stats/transactions',
 			controllers.transactions.getTransactionStats(this._channel, this._state),
 		);
+		this._app.get(
+		'/api/stats/blocks',
+			controllers.blocks.getBlockStats(this._channel, this._state),
+		);
 	}
 
 	private _subscribeToEvents(): void {
@@ -174,6 +188,10 @@ export class MonitorPlugin extends BasePlugin {
 
 			if (event === 'postTransactionsAnnouncement') {
 				this._handlePostTransactionAnnounce(data as { transactionIds: string[] });
+			}
+
+			if (event === 'postBlock') {
+				this._handlePostBlock(data as EventPostBlockData);
 			}
 		});
 	}
@@ -200,6 +218,32 @@ export class MonitorPlugin extends BasePlugin {
 				expiryTime
 			) {
 				delete this._state.transactions.transactions[transactionID];
+			}
+		}
+	}
+
+	private _handlePostBlock(data: EventPostBlockData) {
+		const blockBytes = Buffer.from(data.block, 'hex');
+		const blockId = hash(blockBytes);
+		const decodedBlock = codec.decode<RawBlock>(this.schemas.block, blockBytes);
+		const decodedBlockHeader = codec.decode<RawBlockHeader>(
+			this.schemas.blockHeader,
+			decodedBlock.header,
+		);
+		if (!this._state.blocks.blocks[blockId.toString('binary')]) {
+			this._state.blocks.blocks[blockId.toString('binary')] = {
+				count: 0,
+				height: decodedBlockHeader.height,
+			};
+		}
+
+		this._state.blocks.blocks[blockId.toString('binary')].count += 1;
+
+		// Clean up blocks older than current height minus 300 blocks
+		for (const id of Object.keys(this._state.blocks.blocks)) {
+			const blockInfo = this._state.blocks.blocks[id];
+			if (blockInfo.height < decodedBlockHeader.height - 300) {
+				delete this._state.blocks.blocks[id];
 			}
 		}
 	}

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -224,20 +224,21 @@ export class MonitorPlugin extends BasePlugin {
 
 	private _handlePostBlock(data: EventPostBlockData) {
 		const blockBytes = Buffer.from(data.block, 'hex');
-		const blockId = hash(blockBytes);
 		const decodedBlock = codec.decode<RawBlock>(this.schemas.block, blockBytes);
 		const decodedBlockHeader = codec.decode<RawBlockHeader>(
 			this.schemas.blockHeader,
 			decodedBlock.header,
 		);
-		if (!this._state.blocks.blocks[blockId.toString('binary')]) {
-			this._state.blocks.blocks[blockId.toString('binary')] = {
+		const blockId = hash(decodedBlock.header);
+
+		if (!this._state.blocks.blocks[blockId.toString('hex')]) {
+			this._state.blocks.blocks[blockId.toString('hex')] = {
 				count: 0,
 				height: decodedBlockHeader.height,
 			};
 		}
 
-		this._state.blocks.blocks[blockId.toString('binary')].count += 1;
+		this._state.blocks.blocks[blockId.toString('hex')].count += 1;
 
 		// Clean up blocks older than current height minus 300 blocks
 		for (const id of Object.keys(this._state.blocks.blocks)) {

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -61,7 +61,7 @@ export class MonitorPlugin extends BasePlugin {
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	public get defaults(): object {
+	public get defaults(): Record<string, unknown> {
 		return config.defaultConfig;
 	}
 
@@ -173,7 +173,7 @@ export class MonitorPlugin extends BasePlugin {
 			controllers.transactions.getTransactionStats(this._channel, this._state),
 		);
 		this._app.get(
-		'/api/stats/blocks',
+			'/api/stats/blocks',
 			controllers.blocks.getBlockStats(this._channel, this._state),
 		);
 	}

--- a/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
@@ -46,6 +46,11 @@ interface TransactionPropagationStats {
 	timeReceived: number;
 }
 
+export interface BlockPropagationStats {
+	count: number;
+	height: number;
+}
+
 export interface SharedState {
 	network: {
 		outgoing: {
@@ -89,7 +94,7 @@ export interface SharedState {
 		connectedPeers: number;
 	};
 	blocks: {
-		blocks: Record<string, number>;
+		blocks: { [key: string]: BlockPropagationStats };
 		averageReceivedBlocks: number;
 		connectedPeers: number;
 	};

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/blocks.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/blocks.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { blockHeaderSchema, blockSchema } from '@liskhq/lisk-chain';
+import { codec } from '@liskhq/lisk-codec';
+import { MonitorPlugin } from '../../src';
+
+describe('_handlePostBlock', () => {
+	let monitorPlugin: MonitorPlugin;
+	let blockHeaderString: string;
+	let encodedBlock: string;
+	const channelMock = {
+		registerToBus: jest.fn(),
+		once: jest.fn(),
+		publish: jest.fn(),
+		subscribe: jest.fn(),
+		isValidEventName: jest.fn(),
+		isValidActionName: jest.fn(),
+		invoke: jest.fn(),
+		eventsList: [],
+		actionsList: [],
+		actions: {},
+		moduleAlias: '',
+		options: {},
+	} as any;
+
+	beforeEach(async () => {
+		monitorPlugin = new (MonitorPlugin as any)();
+		await monitorPlugin.load(channelMock);
+		monitorPlugin.schemas = { block: blockSchema, blockHeader: blockHeaderSchema } as any;
+		blockHeaderString =
+			'080210c08db7011880ea3022209696342ed355848b4cd6d7c77093121ae3fc10f449447f41044972174e75bc2b2a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8553220addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca93880c8afa025421a08e0dc2a10e0dc2a1a10c8c557b5dba8527c0e760124128fd15c4a40d90764813046127a50acf4b449fccad057944e7665ab065d7057e56983e42abe55a3cbc1eb35a8c126f54597d0a0b426f2ad9a2d62769185ad8e3b4a5b3af909';
+		encodedBlock = codec
+			.encode(blockSchema, { header: Buffer.from(blockHeaderString, 'hex'), payload: [] })
+			.toString('hex');
+	});
+
+	it('should update the plugin state with new block info', () => {
+		const expectedState = {
+			averageReceivedBlocks: 0,
+			blocks: {
+				'706a8b678f1d4a9ad585f50ba06ef242c5598d22c03f13eacc230e041014dbb7': {
+					count: 1,
+					height: 800000,
+				},
+			},
+			connectedPeers: 0,
+		};
+		(monitorPlugin as any)._handlePostBlock({ block: encodedBlock });
+
+		expect((monitorPlugin as any)._state.blocks).toEqual(expectedState);
+	});
+
+	it('should remove blocks in state older than 300 blocks', () => {
+		(monitorPlugin as any)._state.blocks.blocks = { oldBlockId: { count: 1, height: 0 } };
+		(monitorPlugin as any)._handlePostBlock({ block: encodedBlock });
+
+		expect((monitorPlugin as any)._state.blocks.blocks['oldBlockId']).toBeUndefined();
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5295 

### How was it solved?

- Receive and store incoming new blocks
- Decode new block and block headers
- Store block stats `count` and `height` for each unique block
- Clean up blocks older than 300 blocks of newest incoming block
- Create api endpoint to monitor block stats
- Add tests for monitor plugin blocks

### How was it tested?

Added relevant unit tests for the block handler in monitor plugin. 
