### PR TITLE
Add getUnlockings action on dpos module - Closes #5843

### DIFF
--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -26,7 +26,7 @@ import {
 } from '../types';
 import { BaseAsset } from './base_asset';
 
-export interface BaseModuleChannel {
+interface BaseModuleChannel {
 	publish(name: string, data?: object): void;
 }
 

--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -26,7 +26,7 @@ import {
 } from '../types';
 import { BaseAsset } from './base_asset';
 
-interface Channel {
+export interface BaseModuleChannel {
 	publish(name: string, data?: object): void;
 }
 
@@ -37,7 +37,7 @@ export abstract class BaseModule {
 	public actions: Actions = {};
 	public events: string[] = [];
 	public accountSchema?: AccountSchema;
-	protected _channel!: Channel;
+	protected _channel!: BaseModuleChannel;
 	protected _dataAccess!: BaseModuleDataAccess;
 	public abstract name: string;
 	public abstract id: number;
@@ -46,7 +46,7 @@ export abstract class BaseModule {
 		this.config = genesisConfig;
 	}
 
-	public init(input: { channel: Channel; dataAccess: BaseModuleDataAccess }): void {
+	public init(input: { channel: BaseModuleChannel; dataAccess: BaseModuleDataAccess }): void {
 		this._channel = input.channel;
 		this._dataAccess = input.dataAccess;
 	}

--- a/framework/src/modules/dpos/types.ts
+++ b/framework/src/modules/dpos/types.ts
@@ -32,6 +32,14 @@ export interface UnlockingAccountAsset {
 	readonly amount: bigint;
 	readonly unvoteHeight: number;
 }
+
+export interface UnlockingInfoJSON {
+	readonly delegateAddress: string;
+	readonly amount: string;
+	readonly unvoteHeight: number;
+	readonly minUnlockHeight: number;
+}
+
 export interface VoteAccountAsset {
 	readonly delegateAddress: Buffer;
 	// Amount for some delegate can be updated

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -26,12 +26,14 @@ import {
 	transactionSchema,
 	getAccountSchemaWithDefault,
 	getRegisteredBlockAssetSchema,
+	AccountDefaultProps,
 } from '@liskhq/lisk-chain';
 import { EVENT_BFT_BLOCK_FINALIZED, BFT } from '@liskhq/lisk-bft';
 import { getNetworkIdentifier } from '@liskhq/lisk-cryptography';
 import { TransactionPool, events as txPoolEvents } from '@liskhq/lisk-transaction-pool';
 import { KVStore, NotFoundError } from '@liskhq/lisk-db';
 import { jobHandlers } from '@liskhq/lisk-utils';
+import { deprecate } from 'util';
 import { Forger } from './forger';
 import {
 	Transport,
@@ -255,9 +257,14 @@ export class Node {
 						customModuleChannel.publish(name, data),
 				},
 				dataAccess: {
-					getAccount: async (address: Buffer) =>
-						this._chain.dataAccess.getAccountByAddress(address),
+					getAccount: deprecate(
+						async (address: Buffer) => this._chain.dataAccess.getAccountByAddress(address),
+						'This function will be removed in next release. Please use `getAccountByAddress` instead.',
+					),
 					getChainState: async (key: string) => this._chain.dataAccess.getChainState(key),
+					getAccountByAddress: async <T = AccountDefaultProps>(address: Buffer) =>
+						this._chain.dataAccess.getAccountByAddress<T>(address),
+					getLastBlockHeader: async () => this._chain.dataAccess.getLastBlockHeader(),
 				},
 			});
 		}

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -260,7 +260,10 @@ export interface Consensus {
 // Base Module
 export interface BaseModuleDataAccess {
 	getChainState(key: string): Promise<Buffer | undefined>;
+	/** @deprecated */
 	getAccount(address: Buffer): Promise<Account>;
+	getAccountByAddress<T>(address: Buffer): Promise<Account<T>>;
+	getLastBlockHeader(): Promise<BlockHeader>;
 }
 
 export interface RegisteredModule {

--- a/framework/test/unit/modules/dpos/dpos_module.spec.ts
+++ b/framework/test/unit/modules/dpos/dpos_module.spec.ts
@@ -12,21 +12,24 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { GenesisBlock, Account, testing } from '@liskhq/lisk-chain';
-import { DPOSAccountProps, DPoSModule } from '../../../../src/modules/dpos';
-import * as dataAccess from '../../../../src/modules/dpos/data_access';
-import * as delegates from '../../../../src/modules/dpos/delegates';
-import * as randomSeed from '../../../../src/modules/dpos/random_seed';
+import { Account, GenesisBlock, testing } from '@liskhq/lisk-chain';
+import { when } from 'jest-when';
 import {
 	AfterBlockApplyContext,
 	AfterGenesisBlockApplyContext,
 	GenesisConfig,
 } from '../../../../src';
+import { DPOSAccountProps, DPoSModule } from '../../../../src/modules/dpos';
+import * as dataAccess from '../../../../src/modules/dpos/data_access';
+import * as delegates from '../../../../src/modules/dpos/delegates';
+import * as randomSeed from '../../../../src/modules/dpos/random_seed';
 import { Rounds } from '../../../../src/modules/dpos/rounds';
 import {
 	createValidDefaultBlock,
 	genesisBlock as createGenesisBlock,
 } from '../../../fixtures/blocks';
+import { createFakeDefaultAccount } from '../../../utils/node';
+
 import Mock = jest.Mock;
 
 jest.mock('../../../../src/modules/dpos/data_access');
@@ -36,9 +39,15 @@ jest.mock('../../../../src/modules/dpos/random_seed');
 const { StateStoreMock } = testing;
 
 describe('DPoSModule', () => {
-	let dposModule: DPoSModule;
+	let dposModule!: DPoSModule;
 	let genesisConfig: GenesisConfig;
 	const reducerHandlerMock = { invoke: jest.fn() };
+	const dataAccessMock = {
+		getAccountByAddress: jest.fn(),
+	};
+	const channelMock = {
+		publish: jest.fn(),
+	};
 
 	beforeEach(() => {
 		genesisConfig = {
@@ -261,6 +270,190 @@ describe('DPoSModule', () => {
 			it('should not update validators', () => {
 				expect(randomSeed.generateRandomSeeds).not.toHaveBeenCalled();
 				expect(delegates.updateDelegateList).not.toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('actions', () => {
+		let unvoteHeight: number;
+		let account: any;
+		let delegate: any;
+		let unlockObj;
+
+		beforeEach(() => {
+			dposModule = new DPoSModule(genesisConfig);
+			dposModule.init({ channel: channelMock, dataAccess: dataAccessMock as any });
+
+			unvoteHeight = 50059;
+			account = createFakeDefaultAccount({});
+			delegate = createFakeDefaultAccount({});
+
+			when(dataAccessMock.getAccountByAddress)
+				.calledWith(account.address)
+				.mockResolvedValue(account as never);
+
+			when(dataAccessMock.getAccountByAddress)
+				.calledWith(delegate.address)
+				.mockResolvedValue(delegate as never);
+		});
+
+		describe('getUnlockings', () => {
+			it('should throw error if address is not string', async () => {
+				await expect(
+					dposModule.actions.getUnlockings({
+						address: account.address,
+					}),
+				).rejects.toThrow('Address must be a string');
+			});
+
+			describe('self vote', () => {
+				it('should return minUnlockHeight = unvoteHeight + 260000 if delegate is not punished', async () => {
+					const minUnlockHeight = unvoteHeight + 260000;
+					unlockObj = {
+						delegateAddress: account.address,
+						amount: BigInt('20000'),
+						unvoteHeight,
+					};
+					account.dpos.unlocking.push(unlockObj);
+
+					const result = await dposModule.actions.getUnlockings({
+						address: account.address.toString('hex'),
+					});
+
+					expect(result).toEqual([
+						{
+							delegateAddress: unlockObj.delegateAddress.toString('hex'),
+							amount: unlockObj.amount.toString(),
+							unvoteHeight: unlockObj.unvoteHeight,
+							minUnlockHeight,
+						},
+					]);
+				});
+
+				it('should return minUnlockHeight = lastPomHeight + 780000 if delegate is punished', async () => {
+					const punishedHeight = unvoteHeight + 102;
+					const minUnlockHeight = punishedHeight + 780000;
+					unlockObj = {
+						delegateAddress: account.address,
+						amount: BigInt('20000'),
+						unvoteHeight,
+					};
+					account.dpos.unlocking.push(unlockObj);
+					account.dpos.delegate.pomHeights = [punishedHeight];
+
+					const result = await dposModule.actions.getUnlockings({
+						address: account.address.toString('hex'),
+					});
+
+					expect(result).toEqual([
+						{
+							delegateAddress: unlockObj.delegateAddress.toString('hex'),
+							amount: unlockObj.amount.toString(),
+							unvoteHeight: unlockObj.unvoteHeight,
+							minUnlockHeight,
+						},
+					]);
+				});
+
+				it('should return minUnlockHeight = lastPomHeight + 780000 if delegate is punished for maximum punished height', async () => {
+					const punishedHeight = unvoteHeight + 102;
+					const minUnlockHeight = punishedHeight + 780000;
+					unlockObj = {
+						delegateAddress: account.address,
+						amount: BigInt('20000'),
+						unvoteHeight,
+					};
+					account.dpos.unlocking.push(unlockObj);
+					account.dpos.delegate.pomHeights = [punishedHeight, unvoteHeight - 100];
+
+					const result = await dposModule.actions.getUnlockings({
+						address: account.address.toString('hex'),
+					});
+
+					expect(result).toEqual([
+						{
+							delegateAddress: unlockObj.delegateAddress.toString('hex'),
+							amount: unlockObj.amount.toString(),
+							unvoteHeight: unlockObj.unvoteHeight,
+							minUnlockHeight,
+						},
+					]);
+				});
+			});
+
+			describe('other delegate vote', () => {
+				it('should return minUnlockHeight = unvoteHeight + 2000 if delegate is not punished', async () => {
+					const minUnlockHeight = unvoteHeight + 2000;
+					unlockObj = {
+						delegateAddress: delegate.address,
+						amount: BigInt('20000'),
+						unvoteHeight,
+					};
+					account.dpos.unlocking.push(unlockObj);
+
+					const result = await dposModule.actions.getUnlockings({
+						address: account.address.toString('hex'),
+					});
+
+					expect(result).toEqual([
+						{
+							delegateAddress: unlockObj.delegateAddress.toString('hex'),
+							amount: unlockObj.amount.toString(),
+							unvoteHeight: unlockObj.unvoteHeight,
+							minUnlockHeight,
+						},
+					]);
+				});
+
+				it('should return minUnlockHeight = lastPomHeight + 260000 if delegate is punished', async () => {
+					const punishedHeight = unvoteHeight + 102;
+					const minUnlockHeight = punishedHeight + 260000;
+					unlockObj = {
+						delegateAddress: delegate.address,
+						amount: BigInt('20000'),
+						unvoteHeight,
+					};
+					account.dpos.unlocking.push(unlockObj);
+					delegate.dpos.delegate.pomHeights = [punishedHeight];
+
+					const result = await dposModule.actions.getUnlockings({
+						address: account.address.toString('hex'),
+					});
+
+					expect(result).toEqual([
+						{
+							delegateAddress: unlockObj.delegateAddress.toString('hex'),
+							amount: unlockObj.amount.toString(),
+							unvoteHeight: unlockObj.unvoteHeight,
+							minUnlockHeight,
+						},
+					]);
+				});
+
+				it('should return minUnlockHeight = lastPomHeight + 260000 if delegate is punished for maximum punished height', async () => {
+					const punishedHeight = unvoteHeight + 102;
+					const minUnlockHeight = punishedHeight + 260000;
+					unlockObj = {
+						delegateAddress: delegate.address,
+						amount: BigInt('20000'),
+						unvoteHeight,
+					};
+					account.dpos.unlocking.push(unlockObj);
+					delegate.dpos.delegate.pomHeights = [punishedHeight, unvoteHeight - 49];
+
+					const result = await dposModule.actions.getUnlockings({
+						address: account.address.toString('hex'),
+					});
+
+					expect(result).toEqual([
+						{
+							delegateAddress: unlockObj.delegateAddress.toString('hex'),
+							amount: unlockObj.amount.toString(),
+							unvoteHeight: unlockObj.unvoteHeight,
+							minUnlockHeight,
+						},
+					]);
+				});
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5843

### How was it solved?

- Updated BaesModule._dataAccess to have new interface getAccountByAddress
- Updated BaesModule._dataAccess to have new interface getLastBlockHeader
- Deprecated BaesModule._dataAccess.getAccount
- Add getUnlockings actions to dpos module 

### How was it tested?

- Added relevant unit tests 
