### PR TITLE
Add endpoint to support prometheus - Closes 5887

### DIFF
--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/index.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/index.ts
@@ -15,5 +15,6 @@ import * as blocks from './blocks';
 import * as transactions from './transactions';
 import * as network from './network';
 import * as forks from './forks';
+import * as prometheusExport from './prometheus';
 
-export { blocks, transactions, network, forks };
+export { blocks, transactions, network, forks, prometheusExport };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
@@ -40,9 +40,15 @@ export const getNetworkStats = (channel: BaseChannel) => async (
 ): Promise<void> => {
 	try {
 		const networkStats: { [key: string]: unknown } = await channel.invoke('app:getNetworkStats');
-		const connectedPeers = await channel.invoke('app:getConnectedPeers');
-		const majorityHeight = getMajorityHeight(connectedPeers as PeerInfo[]);
-		const data = { ...networkStats, majorityHeight };
+		const connectedPeers: PeerInfo[] = await channel.invoke('app:getConnectedPeers');
+		const disconnectedPeers: PeerInfo[] = await channel.invoke('app:getDisconnectedPeers');
+		const majorityHeight = getMajorityHeight(connectedPeers);
+		const totalPeers = {
+			connected: connectedPeers.length,
+			disconnected: disconnectedPeers.length,
+		};
+
+		const data = { ...networkStats, majorityHeight, totalPeers };
 
 		res.status(200).json({ data, meta: {} });
 	} catch (err) {

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Request, Response, NextFunction } from 'express';
+import { BaseChannel } from 'lisk-framework';
+import { SharedState, PeerInfo } from '../types';
+
+interface PrometheusData {
+	varName: string;
+	help: string;
+	type: string;
+	value: number;
+}
+
+enum PROMETHEUS_TYPE {
+	guage = 'guage',
+	counter = 'counter',
+	histogram = 'histogram',
+}
+
+interface NodeInfo {
+	readonly height: number;
+	readonly finalizedHeight: number;
+	readonly unconfirmedTransactions: number;
+}
+
+const prometheusExporter = (data: PrometheusData[]) => {
+	let exportData = '';
+	for (const param of data) {
+		exportData += `# HELP ${param.help}\n# TYPE ${param.varName} ${param.type}\n${param.varName} ${param.value}\n\n`;
+	}
+
+	return exportData;
+};
+
+export const getData = (channel: BaseChannel, state: SharedState) => async (
+	_req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	try {
+		const connectedPeers: PeerInfo[] = await channel.invoke('app:getConnectedPeers');
+		const disconnectedPeers: PeerInfo[] = await channel.invoke('app:getDisconnectedPeers');
+		const nodeInfo: NodeInfo = await channel.invoke('app:getNodeInfo');
+
+		const data: PrometheusData[] = [
+			{
+				help: 'Block Propagation',
+				type: PROMETHEUS_TYPE.guage,
+				value: state.blocks.averageReceivedBlocks,
+				varName: 'avg_times_block_received',
+			},
+			{
+				help: 'Transaction Propagation',
+				type: PROMETHEUS_TYPE.guage,
+				value: state.transactions.averageReceivedTransactions,
+				varName: 'avg_times_transaction_received',
+			},
+			{
+				help: 'Node Height',
+				type: PROMETHEUS_TYPE.guage,
+				value: nodeInfo.height,
+				varName: 'node_height',
+			},
+			{
+				help: 'Finalized Height',
+				type: PROMETHEUS_TYPE.guage,
+				value: nodeInfo.finalizedHeight,
+				varName: 'finalized_height',
+			},
+			{
+				help: 'Unconfirmed transactions',
+				type: PROMETHEUS_TYPE.guage,
+				value: nodeInfo.unconfirmedTransactions,
+				varName: 'unconfirmed_transactions',
+			},
+			{
+				help: 'Connected peers',
+				type: PROMETHEUS_TYPE.guage,
+				value: connectedPeers.length,
+				varName: 'connected_peers',
+			},
+			{
+				help: 'Disconnected peers',
+				type: PROMETHEUS_TYPE.guage,
+				value: disconnectedPeers.length,
+				varName: 'disconnected_peers',
+			},
+			{
+				help: 'Fork events',
+				type: PROMETHEUS_TYPE.guage,
+				value: state.forks.forkEventCount,
+				varName: 'fork_events',
+			},
+		];
+
+		res.status(200).json({ data: prometheusExporter(data), meta: {} });
+	} catch (err) {
+		next(err);
+	}
+};

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
@@ -104,7 +104,7 @@ export const getData = (channel: BaseChannel, state: SharedState) => async (
 			},
 		];
 
-		res.status(200).json({ data: prometheusExporter(data), meta: {} });
+		res.status(200).send(prometheusExporter(data));
 	} catch (err) {
 		next(err);
 	}

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
@@ -23,7 +23,7 @@ interface PrometheusData {
 }
 
 enum PROMETHEUS_TYPE {
-	guage = 'guage',
+	gauge = 'gauge',
 	counter = 'counter',
 	histogram = 'histogram',
 }
@@ -56,49 +56,49 @@ export const getData = (channel: BaseChannel, state: SharedState) => async (
 		const data: PrometheusData[] = [
 			{
 				help: 'Block Propagation',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: state.blocks.averageReceivedBlocks,
 				varName: 'avg_times_block_received',
 			},
 			{
 				help: 'Transaction Propagation',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: state.transactions.averageReceivedTransactions,
 				varName: 'avg_times_transaction_received',
 			},
 			{
 				help: 'Node Height',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: nodeInfo.height,
 				varName: 'node_height',
 			},
 			{
 				help: 'Finalized Height',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: nodeInfo.finalizedHeight,
 				varName: 'finalized_height',
 			},
 			{
 				help: 'Unconfirmed transactions',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: nodeInfo.unconfirmedTransactions,
 				varName: 'unconfirmed_transactions',
 			},
 			{
 				help: 'Connected peers',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: connectedPeers.length,
 				varName: 'connected_peers',
 			},
 			{
 				help: 'Disconnected peers',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: disconnectedPeers.length,
 				varName: 'disconnected_peers',
 			},
 			{
 				help: 'Fork events',
-				type: PROMETHEUS_TYPE.guage,
+				type: PROMETHEUS_TYPE.gauge,
 				value: state.forks.forkEventCount,
 				varName: 'fork_events',
 			},

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -86,38 +86,6 @@ export class MonitorPlugin extends BasePlugin {
 		this._channel = channel;
 
 		this._state = {
-			network: {
-				outgoing: {
-					count: 0,
-					networkHeight: {
-						majorityHeight: 0,
-						numberOfPeers: 0,
-					},
-					connectStats: {
-						connects: 0,
-						disconnects: 0,
-					},
-				},
-				incoming: {
-					count: 0,
-					networkHeight: {
-						majorityHeight: 0,
-						numberOfPeers: 0,
-					},
-					connectStats: {
-						connects: 0,
-						disconnects: 0,
-					},
-				},
-				totalPeers: {
-					connected: 0,
-					disconnected: 0,
-				},
-				banning: {
-					totalBannedPeers: 0,
-					bannedPeers: {},
-				},
-			},
 			forks: {
 				forkEventCount: 0,
 				blockHeaders: {},
@@ -182,6 +150,10 @@ export class MonitorPlugin extends BasePlugin {
 		);
 		this._app.get('/api/stats/network', controllers.network.getNetworkStats(this._channel));
 		this._app.get('/api/stats/forks', controllers.forks.getForkStats(this._state));
+		this._app.get(
+			'/api/prometheus/metrics',
+			controllers.prometheusExport.getData(this._channel, this._state),
+		);
 	}
 
 	private _subscribeToEvents(): void {

--- a/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
@@ -29,12 +29,6 @@ export interface Options {
 	};
 }
 
-interface BannedPeer {
-	timeUntilUnBan: Date;
-	reason: string;
-	banCount: number;
-}
-
 interface BlockHeader {
 	// eslint-disable-next-line @typescript-eslint/ban-types
 	blockHeader: object;
@@ -52,38 +46,6 @@ export interface BlockPropagationStats {
 }
 
 export interface SharedState {
-	network: {
-		outgoing: {
-			count: number;
-			networkHeight: {
-				majorityHeight: number;
-				numberOfPeers: number;
-			};
-			connectStats: {
-				connects: number;
-				disconnects: number;
-			};
-		};
-		incoming: {
-			count: number;
-			networkHeight: {
-				majorityHeight: number;
-				numberOfPeers: number;
-			};
-			connectStats: {
-				connects: number;
-				disconnects: number;
-			};
-		};
-		totalPeers: {
-			connected: number;
-			disconnected: number;
-		};
-		banning: {
-			totalBannedPeers: number;
-			bannedPeers: Record<string, BannedPeer>;
-		};
-	};
 	forks: {
 		forkEventCount: number;
 		blockHeaders: Record<string, BlockHeader>;

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/network.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/network.spec.ts
@@ -18,7 +18,7 @@ import { PeerInfo } from '../../src/types';
 import { network as networkController } from '../../src/controllers';
 
 describe('networkStats', () => {
-	const peers: Partial<PeerInfo>[] = [
+	const connectedPeers: Partial<PeerInfo>[] = [
 		{ options: { height: 51 } },
 		{ options: { height: 52 } },
 		{ options: { height: 52 } },
@@ -39,6 +39,24 @@ describe('networkStats', () => {
 		{ options: { height: 53 } },
 		{ options: { height: 53 } },
 	]; // Majority is of 7 peers with height 52
+
+	const disconnectedPeers: Partial<PeerInfo>[] = [
+		{
+			ipAddress: '127.0.0.1',
+			port: 5004,
+			options: { height: 2 },
+		},
+		{
+			ipAddress: '127.0.0.1',
+			port: 5005,
+			options: { height: 34 },
+		},
+		{
+			ipAddress: '127.0.0.1',
+			port: 5006,
+			options: { height: 51 },
+		},
+	];
 
 	const defaultNetworkStats = {
 		startTime: Date.now(),
@@ -62,6 +80,10 @@ describe('networkStats', () => {
 		totalMessagesReceived: {},
 		totalRequestsReceived: {},
 		majorityHeight: { height: 52, count: 7 },
+		totalPeers: {
+			connected: connectedPeers.length,
+			disconnected: disconnectedPeers.length,
+		},
 	};
 
 	const channelMock = {
@@ -74,7 +96,9 @@ describe('networkStats', () => {
 			.calledWith('app:getNetworkStats')
 			.mockResolvedValue(defaultNetworkStats)
 			.calledWith('app:getConnectedPeers')
-			.mockResolvedValue(peers);
+			.mockResolvedValue(connectedPeers)
+			.calledWith('app:getDisconnectedPeers')
+			.mockResolvedValue(disconnectedPeers);
 	});
 
 	it('should add new transactions to state', async () => {

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
@@ -85,28 +85,28 @@ describe('networkStats', () => {
 
 	const expectedExportData =
 		'# HELP Block Propagation\n' +
-		'# TYPE avg_times_block_received guage\n' +
+		'# TYPE avg_times_block_received gauge\n' +
 		'avg_times_block_received 6\n\n' +
 		'# HELP Transaction Propagation\n' +
-		'# TYPE avg_times_transaction_received guage\n' +
+		'# TYPE avg_times_transaction_received gauge\n' +
 		'avg_times_transaction_received 9\n\n' +
 		'# HELP Node Height\n' +
-		'# TYPE node_height guage\n' +
+		'# TYPE node_height gauge\n' +
 		'node_height 102\n\n' +
 		'# HELP Finalized Height\n' +
-		'# TYPE finalized_height guage\n' +
+		'# TYPE finalized_height gauge\n' +
 		'finalized_height 80\n\n' +
 		'# HELP Unconfirmed transactions\n' +
-		'# TYPE unconfirmed_transactions guage\n' +
+		'# TYPE unconfirmed_transactions gauge\n' +
 		'unconfirmed_transactions 17\n\n' +
 		'# HELP Connected peers\n' +
-		'# TYPE connected_peers guage\n' +
+		'# TYPE connected_peers gauge\n' +
 		'connected_peers 3\n\n' +
 		'# HELP Disconnected peers\n' +
-		'# TYPE disconnected_peers guage\n' +
+		'# TYPE disconnected_peers gauge\n' +
 		'disconnected_peers 3\n\n' +
 		'# HELP Fork events\n' +
-		'# TYPE fork_events guage\n' +
+		'# TYPE fork_events gauge\n' +
 		'fork_events 3\n\n';
 
 	beforeEach(() => {

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { when } from 'jest-when';
+import { Request } from 'express';
+import { PeerInfo, SharedState } from '../../src/types';
+import { prometheusExport } from '../../src/controllers';
+
+describe('networkStats', () => {
+	const connectedPeers: Partial<PeerInfo>[] = [
+		{
+			ipAddress: '127.0.0.1',
+			port: 5001,
+			options: { height: 102 },
+		},
+		{
+			ipAddress: '127.0.0.1',
+			port: 5002,
+			options: { height: 102 },
+		},
+		{
+			ipAddress: '127.0.0.1',
+			port: 5003,
+			options: { height: 101 },
+		},
+	];
+
+	const disconnectedPeers: Partial<PeerInfo>[] = [
+		{
+			ipAddress: '127.0.0.1',
+			port: 5004,
+			options: { height: 2 },
+		},
+		{
+			ipAddress: '127.0.0.1',
+			port: 5005,
+			options: { height: 34 },
+		},
+		{
+			ipAddress: '127.0.0.1',
+			port: 5006,
+			options: { height: 51 },
+		},
+	];
+
+	const nodeInfo = {
+		finalizedHeight: 80,
+		height: 102,
+		unconfirmedTransactions: 17,
+	};
+
+	const channelMock = {
+		invoke: jest.fn(),
+	};
+
+	const sharedState: SharedState = {
+		blocks: {
+			averageReceivedBlocks: 6,
+			blocks: {},
+			connectedPeers: connectedPeers.length,
+		},
+		transactions: {
+			averageReceivedTransactions: 9,
+			transactions: {},
+			connectedPeers: connectedPeers.length,
+		},
+		forks: {
+			blockHeaders: {},
+			forkEventCount: 3,
+		},
+	};
+
+	const prometheus = prometheusExport.getData(channelMock as any, sharedState);
+
+	const expectedExportData =
+		'# HELP Block Propagation\n' +
+		'# TYPE avg_times_block_received guage\n' +
+		'avg_times_block_received 6\n\n' +
+		'# HELP Transaction Propagation\n' +
+		'# TYPE avg_times_transaction_received guage\n' +
+		'avg_times_transaction_received 9\n\n' +
+		'# HELP Node Height\n' +
+		'# TYPE node_height guage\n' +
+		'node_height 102\n\n' +
+		'# HELP Finalized Height\n' +
+		'# TYPE finalized_height guage\n' +
+		'finalized_height 80\n\n' +
+		'# HELP Unconfirmed transactions\n' +
+		'# TYPE unconfirmed_transactions guage\n' +
+		'unconfirmed_transactions 17\n\n' +
+		'# HELP Connected peers\n' +
+		'# TYPE connected_peers guage\n' +
+		'connected_peers 3\n\n' +
+		'# HELP Disconnected peers\n' +
+		'# TYPE disconnected_peers guage\n' +
+		'disconnected_peers 3\n\n' +
+		'# HELP Fork events\n' +
+		'# TYPE fork_events guage\n' +
+		'fork_events 3\n\n';
+
+	beforeEach(() => {
+		when(channelMock.invoke)
+			.calledWith('app:getConnectedPeers')
+			.mockResolvedValue(connectedPeers)
+			.calledWith('app:getDisconnectedPeers')
+			.mockResolvedValue(disconnectedPeers)
+			.calledWith('app:getNodeInfo')
+			.mockResolvedValue(nodeInfo);
+	});
+
+	it('should return node metrics in prometheus format', async () => {
+		// Arrange
+		const next = jest.fn();
+
+		const res = {
+			status: jest.fn().mockImplementation(_code => res),
+			json: jest.fn().mockImplementation(_param => res),
+		} as any;
+
+		// Act
+		await prometheus({} as Request, res, next);
+
+		// Assert
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({ data: expectedExportData, meta: {} });
+	});
+
+	it('should throw error when any channel action fails', async () => {
+		// Arrange
+		const next = jest.fn();
+		const res = {
+			status: jest.fn().mockImplementation(_code => res),
+			json: jest.fn().mockImplementation(_param => res),
+		} as any;
+
+		const error = new Error('Something went wrong');
+		channelMock.invoke.mockRejectedValue(error);
+
+		// Act
+		await prometheus({} as Request, res, next);
+
+		// Assert
+		expect(next).toHaveBeenCalledWith(error);
+	});
+});

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
@@ -125,7 +125,7 @@ describe('networkStats', () => {
 
 		const res = {
 			status: jest.fn().mockImplementation(_code => res),
-			json: jest.fn().mockImplementation(_param => res),
+			send: jest.fn().mockImplementation(_param => res),
 		} as any;
 
 		// Act
@@ -133,7 +133,7 @@ describe('networkStats', () => {
 
 		// Assert
 		expect(res.status).toHaveBeenCalledWith(200);
-		expect(res.json).toHaveBeenCalledWith({ data: expectedExportData, meta: {} });
+		expect(res.send).toHaveBeenCalledWith(expectedExportData);
 	});
 
 	it('should throw error when any channel action fails', async () => {
@@ -141,7 +141,7 @@ describe('networkStats', () => {
 		const next = jest.fn();
 		const res = {
 			status: jest.fn().mockImplementation(_code => res),
-			json: jest.fn().mockImplementation(_param => res),
+			send: jest.fn().mockImplementation(_param => res),
 		} as any;
 
 		const error = new Error('Something went wrong');


### PR DESCRIPTION
### What was the problem?

This PR resolves #5887

### How was it solved?

- 🔥 Remove networkStats from sharedState 8e85edc
      Since we no longer maintain networkStats within the plugin we don't need its type and initialization in sharedState

- 🌱 Add prometheus export controller #5887 39d1b35
       Controller that collects relevant data from channel actions and sharedState and export it to prometheus export format

- ✅ Tests for prometheus export data b3bb51c

- ♻️ Add totalPeers with connected and disconnected peers count as described in #5885 313a557

### How was it tested?

`npm run test:unit` under `framework-plugin/lisk-framework-monitor-plugin`
