### PR TITLE
Reconstruct prometheus data - Closes #5941

### DIFF
--- a/framework-plugins/lisk-framework-forger-plugin/test/utils/application.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/utils/application.ts
@@ -14,7 +14,7 @@
 import * as os from 'os';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { Application } from 'lisk-framework';
+import { Application, PartialApplicationConfig } from 'lisk-framework';
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import { validator } from '@liskhq/lisk-validator';
 import * as configJSON from '../fixtures/config.json';
@@ -75,7 +75,12 @@ export const createApplication = async (
 				...options.appConfig?.plugins.forger,
 			},
 		},
-	};
+		rpc: {
+			enable: false,
+			port: 8080,
+			mode: 'ws',
+		},
+	} as PartialApplicationConfig;
 
 	// Update the genesis block JSON to avoid having very long calculations of missed blocks in tests
 	const genesisBlock = getGenesisBlockJSON({

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/prometheus.spec.ts
@@ -84,30 +84,28 @@ describe('networkStats', () => {
 	const prometheus = prometheusExport.getData(channelMock as any, sharedState);
 
 	const expectedExportData =
-		'# HELP Block Propagation\n' +
-		'# TYPE avg_times_block_received gauge\n' +
-		'avg_times_block_received 6\n\n' +
-		'# HELP Transaction Propagation\n' +
-		'# TYPE avg_times_transaction_received gauge\n' +
-		'avg_times_transaction_received 9\n\n' +
-		'# HELP Node Height\n' +
-		'# TYPE node_height gauge\n' +
-		'node_height 102\n\n' +
-		'# HELP Finalized Height\n' +
-		'# TYPE finalized_height gauge\n' +
-		'finalized_height 80\n\n' +
-		'# HELP Unconfirmed transactions\n' +
-		'# TYPE unconfirmed_transactions gauge\n' +
-		'unconfirmed_transactions 17\n\n' +
-		'# HELP Connected peers\n' +
-		'# TYPE connected_peers gauge\n' +
-		'connected_peers 3\n\n' +
-		'# HELP Disconnected peers\n' +
-		'# TYPE disconnected_peers gauge\n' +
-		'disconnected_peers 3\n\n' +
-		'# HELP Fork events\n' +
-		'# TYPE fork_events gauge\n' +
-		'fork_events 3\n\n';
+		'# HELP lisk_avg_times_blocks_received_info Average number of times blocks received\n' +
+		'# TYPE lisk_avg_times_blocks_received_info gauge\n' +
+		`lisk_avg_times_blocks_received_info ${sharedState.blocks.averageReceivedBlocks}\n\n` +
+		'# HELP lisk_avg_times_transactions_received_info Average number of times transactions received\n' +
+		'# TYPE lisk_avg_times_transactions_received_info gauge\n' +
+		`lisk_avg_times_transactions_received_info ${sharedState.transactions.averageReceivedTransactions}\n\n` +
+		'# HELP lisk_node_height_total Node Height\n' +
+		'# TYPE lisk_node_height_total gauge\n' +
+		`lisk_node_height_total ${nodeInfo.height}\n\n` +
+		'# HELP lisk_finalized_height_total Finalized Height\n' +
+		'# TYPE lisk_finalized_height_total gauge\n' +
+		`lisk_finalized_height_total ${nodeInfo.finalizedHeight}\n\n` +
+		'# HELP lisk_unconfirmed_transactions_total Unconfirmed transactions\n' +
+		'# TYPE lisk_unconfirmed_transactions_total gauge\n' +
+		`lisk_unconfirmed_transactions_total ${nodeInfo.unconfirmedTransactions}\n\n` +
+		'# HELP lisk_peers_total Total number of peers\n' +
+		'# TYPE lisk_peers_total gauge\n' +
+		`lisk_peers_total{state="connected"} ${connectedPeers.length}\n` +
+		`lisk_peers_total{state="disconnected"} ${disconnectedPeers.length}\n\n` +
+		'# HELP lisk_fork_events_total Fork events\n' +
+		'# TYPE lisk_fork_events_total gauge\n' +
+		`lisk_fork_events_total ${sharedState.forks.forkEventCount}\n\n`;
 
 	beforeEach(() => {
 		when(channelMock.invoke)
@@ -124,6 +122,7 @@ describe('networkStats', () => {
 		const next = jest.fn();
 
 		const res = {
+			set: jest.fn(),
 			status: jest.fn().mockImplementation(_code => res),
 			send: jest.fn().mockImplementation(_param => res),
 		} as any;
@@ -132,6 +131,7 @@ describe('networkStats', () => {
 		await prometheus({} as Request, res, next);
 
 		// Assert
+		expect(res.set).toHaveBeenCalledWith('Content-Type', 'text/plain');
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.send).toHaveBeenCalledWith(expectedExportData);
 	});
@@ -140,6 +140,7 @@ describe('networkStats', () => {
 		// Arrange
 		const next = jest.fn();
 		const res = {
+			set: jest.fn(),
 			status: jest.fn().mockImplementation(_code => res),
 			send: jest.fn().mockImplementation(_param => res),
 		} as any;

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/test/utils/application.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/test/utils/application.ts
@@ -14,7 +14,7 @@
 import * as os from 'os';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { Application } from 'lisk-framework';
+import { Application, PartialApplicationConfig } from 'lisk-framework';
 import { validator } from '@liskhq/lisk-validator';
 import * as configJSON from '../fixtures/config.json';
 import * as genesisBlock from '../fixtures/genesis_block.json';
@@ -73,7 +73,12 @@ export const getApplication = (
 				encryptedPassphrase: defaultAccount.encryptedPassphrase,
 			},
 		},
-	};
+		rpc: {
+			enable: false,
+			port: 8080,
+			mode: 'ws',
+		},
+	} as PartialApplicationConfig;
 
 	const app = Application.defaultApplication(genesisBlock, config);
 	app.registerPlugin(ReportMisbehaviorPlugin, { loadAsChildProcess: false });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5941

### How was it solved?

- Use grouping for peers
- Add metric name in HELP
- Improve metric names

Export data looks like,

```ts
# HELP lisk_avg_times_blocks_received_info Average number of times blocks received
# TYPE lisk_avg_times_blocks_received_info gauge
lisk_avg_times_blocks_received_info 0

# HELP lisk_avg_times_transactions_received_info Average number of times transactions received
# TYPE lisk_avg_times_transactions_received_info gauge
lisk_avg_times_transactions_received_info 0

# HELP lisk_node_height_total Node Height
# TYPE lisk_node_height_total gauge
lisk_node_height_total 506

# HELP lisk_finalized_height_total Finalized Height
# TYPE lisk_finalized_height_total gauge
lisk_finalized_height_total 346

# HELP lisk_unconfirmed_transactions_total Unconfirmed transactions
# TYPE lisk_unconfirmed_transactions_total gauge
lisk_unconfirmed_transactions_total 0

# HELP lisk_peers_total Total number of peers
# TYPE lisk_peers_total gauge
lisk_peers_total{state="connected"} 0
lisk_peers_total{state="disconnected"} 0

# HELP lisk_fork_events_total Fork events
# TYPE lisk_fork_events_total gauge
lisk_fork_events_total 0

```

### How was it tested?

Run `node framework/test/test_app/index.js` and check http://localhost:4003/api/prometheus/metrics
