### PR TITLE
Create account namespace for API client - Closes #5927

### DIFF
--- a/elements/lisk-api-client/src/account.ts
+++ b/elements/lisk-api-client/src/account.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { codec } from '@liskhq/lisk-codec';
+import { Channel, RegisteredSchemas } from './types';
+
+export class Account {
+	private readonly _channel: Channel;
+	private readonly _schemas: RegisteredSchemas;
+
+	public constructor(channel: Channel, schemas: RegisteredSchemas) {
+		this._channel = channel;
+		this._schemas = schemas;
+	}
+
+	public async get(address: Buffer): Promise<Record<string, unknown>> {
+		const accountHex: string = await this._channel.invoke('app:getAccount', {
+			address: address.toString('hex'),
+		});
+
+		return this.decode(Buffer.from(accountHex, 'hex'));
+	}
+
+	public encode(input: Record<string, unknown>): Buffer {
+		return codec.encode(this._schemas.account, input);
+	}
+
+	public decode(input: Buffer): Record<string, unknown> {
+		return codec.decode(this._schemas.account, input);
+	}
+}

--- a/elements/lisk-api-client/src/api_client.ts
+++ b/elements/lisk-api-client/src/api_client.ts
@@ -14,12 +14,14 @@
  */
 import { EventCallback, Channel, RegisteredSchemas, NodeInfo } from './types';
 import { Node } from './node';
+import { Account } from './account';
 
 export class APIClient {
 	private readonly _channel: Channel;
 	private _schemas!: RegisteredSchemas;
 	private _nodeInfo!: NodeInfo;
 	private _node!: Node;
+	private _account!: Account;
 
 	public constructor(channel: Channel) {
 		this._channel = channel;
@@ -27,6 +29,7 @@ export class APIClient {
 
 	public async init(): Promise<void> {
 		this._node = new Node(this._channel);
+		this._account = new Account(this._channel, this._schemas);
 		this._schemas = await this._channel.invoke<RegisteredSchemas>('app:getSchema');
 		this._nodeInfo = await this._node.getNodeInfo();
 	}
@@ -51,5 +54,9 @@ export class APIClient {
 		// eslint-disable-next-line no-console
 		console.log(this._schemas, this._nodeInfo);
 		return this._node;
+	}
+
+	public get account(): Account {
+		return this._account;
 	}
 }

--- a/elements/lisk-api-client/test/unit/account.spec.ts
+++ b/elements/lisk-api-client/test/unit/account.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { when } from 'jest-when';
+import { codec } from '@liskhq/lisk-codec';
+import { Channel } from '../../src/types';
+import { Account } from '../../src/account';
+
+describe('account', () => {
+	let channel: Channel;
+	let account: Account;
+
+	const sampleAccount = {
+		address: Buffer.from('9d0149b0962d44bfc08a9f64d5afceb6281d7fb5', 'hex'),
+		token: { balance: BigInt('0') },
+	};
+
+	const accountSchema = {
+		$id: 'accountSchema',
+		type: 'object',
+		properties: {
+			address: { dataType: 'bytes', fieldNumber: 1 },
+			token: {
+				type: 'object',
+				fieldNumber: 2,
+				properties: {
+					balance: {
+						fieldNumber: 1,
+						dataType: 'uint64',
+					},
+				},
+			},
+		},
+	};
+
+	const encodedAccountBuffer = codec.encode(accountSchema, sampleAccount);
+	const encodedAccountHex = encodedAccountBuffer.toString('hex');
+
+	beforeEach(() => {
+		channel = {
+			connect: jest.fn(),
+			disconnect: jest.fn(),
+			invoke: jest.fn(),
+			subscribe: jest.fn(),
+		};
+		account = new Account(channel, { account: accountSchema } as any);
+	});
+
+	describe('Account', () => {
+		describe('constructor', () => {
+			it('should initialize with channel', () => {
+				expect(account['_channel']).toBe(channel);
+			});
+		});
+
+		describe('get', () => {
+			it('should invoke app:getAccount', async () => {
+				// Arrange
+				when(channel.invoke as any)
+					.calledWith('app:getAccount', { address: '9d0149b0962d44bfc08a9f64d5afceb6281d7fb5' })
+					.mockResolvedValue(encodedAccountHex as never);
+
+				// Act
+				const receivedAccount = await account.get(sampleAccount.address);
+
+				// Assert
+				expect(channel.invoke).toHaveBeenCalledTimes(1);
+				expect(channel.invoke).toHaveBeenCalledWith('app:getAccount', {
+					address: '9d0149b0962d44bfc08a9f64d5afceb6281d7fb5',
+				});
+				expect(receivedAccount).toEqual(sampleAccount);
+			});
+		});
+
+		describe('encode', () => {
+			it('should return encoded account', () => {
+				// Act
+				const encodedAccount = account.encode(sampleAccount);
+				// Assert
+				expect(encodedAccount).toEqual(encodedAccountBuffer);
+			});
+		});
+
+		describe('decode', () => {
+			it('should return decoded account', () => {
+				// Act
+				const accountDecoded = account.decode(encodedAccountBuffer);
+				// // Assert
+				expect(accountDecoded).toEqual(sampleAccount);
+			});
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5927 

### How was it solved?

- 🌱 Add account for APIClient ea0dbcf
- ✅ Add tests for account API Client b18ad7c

### How was it tested?

`npm run test` under `elements/lisk-api-client`
