### PR TITLE
Implement block namespace for APIClient - Closes #5926

### DIFF
--- a/elements/lisk-api-client/package.json
+++ b/elements/lisk-api-client/package.json
@@ -37,6 +37,7 @@
 	},
 	"dependencies": {
 		"@liskhq/lisk-codec": "^0.1.0-alpha.0",
+		"@liskhq/lisk-cryptography": "^3.0.0-alpha.0",
 		"pm2-axon": "4.0.0",
 		"pm2-axon-rpc": "0.6.0"
 	},

--- a/elements/lisk-api-client/package.json
+++ b/elements/lisk-api-client/package.json
@@ -42,6 +42,7 @@
 		"pm2-axon-rpc": "0.6.0"
 	},
 	"devDependencies": {
+		"@liskhq/lisk-chain": "^0.2.0-alpha.2",
 		"@types/node": "12.12.11",
 		"@types/jest": "26.0.13",
 		"@types/jest-when": "2.7.1",

--- a/elements/lisk-api-client/src/api_client.ts
+++ b/elements/lisk-api-client/src/api_client.ts
@@ -15,6 +15,7 @@
 import { EventCallback, Channel, RegisteredSchemas, NodeInfo } from './types';
 import { Node } from './node';
 import { Account } from './account';
+import { Block } from './block';
 
 export class APIClient {
 	private readonly _channel: Channel;
@@ -22,6 +23,7 @@ export class APIClient {
 	private _nodeInfo!: NodeInfo;
 	private _node!: Node;
 	private _account!: Account;
+	private _block!: Block;
 
 	public constructor(channel: Channel) {
 		this._channel = channel;
@@ -30,6 +32,7 @@ export class APIClient {
 	public async init(): Promise<void> {
 		this._node = new Node(this._channel);
 		this._account = new Account(this._channel, this._schemas);
+		this._block = new Block(this._channel, this._schemas);
 		this._schemas = await this._channel.invoke<RegisteredSchemas>('app:getSchema');
 		this._nodeInfo = await this._node.getNodeInfo();
 	}
@@ -58,5 +61,9 @@ export class APIClient {
 
 	public get account(): Account {
 		return this._account;
+	}
+
+	public get block(): Block {
+		return this._block;
 	}
 }

--- a/elements/lisk-api-client/src/block.ts
+++ b/elements/lisk-api-client/src/block.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Channel, RegisteredSchemas } from './types';
+import { decodeBlock, encodeBlock } from './codec';
+
+export class Block {
+	private readonly _channel: Channel;
+	private readonly _schema: RegisteredSchemas;
+
+	public constructor(channel: Channel, registeredSchema: RegisteredSchemas) {
+		this._channel = channel;
+		this._schema = registeredSchema;
+	}
+
+	public async get(id: Buffer): Promise<Record<string, unknown>> {
+		const blockHex = await this._channel.invoke<string>('app:getBlockByID', {
+			id: id.toString('hex'),
+		});
+		const blockBytes = Buffer.from(blockHex, 'hex');
+		return decodeBlock(blockBytes, this._schema);
+	}
+
+	public async getByHeight(height: number): Promise<Record<string, unknown>> {
+		const blockHex = await this._channel.invoke<string>('app:getBlockByHeight', { height });
+		const blockBytes = Buffer.from(blockHex, 'hex');
+		return decodeBlock(blockBytes, this._schema);
+	}
+
+	public encode(input: {
+		header: Record<string, unknown>;
+		payload: Record<string, unknown>[];
+	}): Buffer {
+		return encodeBlock(input, this._schema);
+	}
+
+	public decode(input: Buffer): Record<string, unknown> {
+		return decodeBlock(input, this._schema);
+	}
+}

--- a/elements/lisk-api-client/src/codec.ts
+++ b/elements/lisk-api-client/src/codec.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2020 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -46,9 +46,11 @@ export const decodeTransaction = (
 	}>(registeredSchema.transaction, encodedTransaction);
 	const assetSchema = getTransactionAssetSchema(transaction, registeredSchema);
 	const asset = codec.decode(assetSchema, transaction.asset);
+	const txId = hash(encodedTransaction);
 	return {
 		...transaction,
 		asset,
+		txId,
 	};
 };
 

--- a/elements/lisk-api-client/src/codec.ts
+++ b/elements/lisk-api-client/src/codec.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2019 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { codec, Schema } from '@liskhq/lisk-codec';
+import { hash } from '@liskhq/lisk-cryptography';
+import { RegisteredSchemas } from './types';
+
+export const getTransactionAssetSchema = (
+	transaction: Record<string, unknown>,
+	registeredSchema: RegisteredSchemas,
+): Schema => {
+	const txAssetSchema = registeredSchema.transactionsAssets.find(
+		assetSchema =>
+			assetSchema.moduleID === transaction.moduleID && assetSchema.assetID === transaction.assetID,
+	);
+	if (!txAssetSchema) {
+		throw new Error(
+			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+			`ModuleID: ${transaction.moduleID} AssetID: ${transaction.assetID} is not registered.`,
+		);
+	}
+	return txAssetSchema.schema;
+};
+
+export const decodeTransaction = (
+	encodedTransaction: Buffer,
+	registeredSchema: RegisteredSchemas,
+): Record<string, unknown> => {
+	const transaction = codec.decode<{
+		[key: string]: unknown;
+		asset: Buffer;
+		moduleID: number;
+		assetID: number;
+	}>(registeredSchema.transaction, encodedTransaction);
+	const assetSchema = getTransactionAssetSchema(transaction, registeredSchema);
+	const asset = codec.decode(assetSchema, transaction.asset);
+	return {
+		...transaction,
+		asset,
+	};
+};
+
+export const encodeTransaction = (
+	transaction: Record<string, unknown>,
+	registeredSchema: RegisteredSchemas,
+): Buffer => {
+	const assetSchema = getTransactionAssetSchema(transaction, registeredSchema);
+	const encodedAsset = codec.encode(assetSchema, transaction.asset as Record<string, unknown>);
+
+	const decodedTransaction = codec.encode(registeredSchema.transaction, {
+		...transaction,
+		asset: encodedAsset,
+	});
+
+	return decodedTransaction;
+};
+
+export const decodeBlock = (
+	encodedBlock: Buffer,
+	registeredSchema: RegisteredSchemas,
+): Record<string, unknown> => {
+	const block = codec.decode<{ header: Buffer; payload: Buffer[] }>(
+		registeredSchema.block,
+		encodedBlock,
+	);
+
+	const header = codec.decode<{ [key: string]: unknown; version: number; asset: Buffer }>(
+		registeredSchema.blockHeader,
+		block.header,
+	);
+	const id = hash(block.header);
+	const assetSchema = registeredSchema.blockHeadersAssets[header.version];
+	if (!assetSchema) {
+		throw new Error(`Block header asset version ${header.version} is not registered.`);
+	}
+	const asset = codec.decode(assetSchema, header.asset);
+	const payload = [];
+	for (const tx of block.payload) {
+		payload.push(decodeTransaction(tx, registeredSchema));
+	}
+
+	return {
+		header: {
+			...header,
+			asset,
+			id,
+		},
+		payload,
+	};
+};
+
+export const encodeBlock = (
+	block: { header: Record<string, unknown>; payload: Record<string, unknown>[] },
+	registeredSchema: RegisteredSchemas,
+): Buffer => {
+	const encodedPayload = block.payload.map(p => encodeTransaction(p, registeredSchema));
+	const assetSchema = registeredSchema.blockHeadersAssets[block.header.version as number];
+	if (!assetSchema) {
+		throw new Error(
+			`Block header asset version ${block.header.version as number} is not registered.`,
+		);
+	}
+	const encodedBlockAsset = codec.encode(
+		assetSchema,
+		block.header.asset as Record<string, unknown>,
+	);
+	const encodedBlockHeader = codec.encode(registeredSchema.blockHeader, {
+		...block.header,
+		asset: encodedBlockAsset,
+	});
+
+	return codec.encode(registeredSchema.block, {
+		header: encodedBlockHeader,
+		payload: encodedPayload,
+	});
+};

--- a/elements/lisk-api-client/src/codec.ts
+++ b/elements/lisk-api-client/src/codec.ts
@@ -46,11 +46,11 @@ export const decodeTransaction = (
 	}>(registeredSchema.transaction, encodedTransaction);
 	const assetSchema = getTransactionAssetSchema(transaction, registeredSchema);
 	const asset = codec.decode(assetSchema, transaction.asset);
-	const txId = hash(encodedTransaction);
+	const id = hash(encodedTransaction);
 	return {
 		...transaction,
 		asset,
-		txId,
+		id,
 	};
 };
 

--- a/elements/lisk-api-client/test/unit/block.spec.ts
+++ b/elements/lisk-api-client/test/unit/block.spec.ts
@@ -19,20 +19,48 @@ import {
 	blockHeaderAssetSchema,
 	transactionSchema,
 } from '@liskhq/lisk-chain';
-import { codec } from '@liskhq/lisk-codec';
 import { Channel } from '../../src/types';
 import { Block } from '../../src/block';
 
 describe('block', () => {
 	let channel: Channel;
 	let block: Block;
-
+	const sampleHeight = 1;
 	const encodedBlock =
-		'0acd01080210c38ec1fc0518a2012220c736b8cfb669ff453118230c71d7dc433797b5b30da6b9d89a14457f1b56faa12a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85532209bcf519c9e0a8e66b3939f9d592b5a1728141ea3253b7d3a2424a44575c5f4e738004216087410001a1060fce85c0ca51ca1c72c589c9f651f574a40396edc8e940c5f5829d382c10cae3c2f7f24a5a9bb42ef8c545439e1a2e83951f87bc894816d7b90958b411a37b816c9e2d597dd52d7847d5a73f411ded65303';
+		'0ad601080210a7feddfc0518b0c90c2220e69286cc8efdfc794a3aabc7755415bd201832b80c29493d9f2c50e597aab4562a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8553220e91e2241030b0dad7022ec05d98343394043e0f31bc63f296ed07cce35cbd3d53880cab5ee01421a08cdc80c10ecc80c1a10fe22dd75b833d917e98539f586954ba54a40fb67faefdb95a624a83cb02115c5aacd6d22bd7074e69f2b31f0a261570e27518e2d93eb2ffb1e0eaf9ab0ce5b69889672ea344ff6e4d4bdc315c299fc2d010e';
 	const encodedBlockBuffer = Buffer.from(encodedBlock, 'hex');
-
-	const blockId = '4f7e41f5744c0c2a434f13afb186b77fb4b176a5298f91ed866680ff5ef13a6d';
-	const id = Buffer.from(blockId, 'hex');
+	const sampleBlock = {
+		header: {
+			version: 2,
+			timestamp: 1603764007,
+			height: 206000,
+			previousBlockID: Buffer.from(
+				'e69286cc8efdfc794a3aabc7755415bd201832b80c29493d9f2c50e597aab456',
+				'hex',
+			),
+			transactionRoot: Buffer.from(
+				'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+				'hex',
+			),
+			generatorPublicKey: Buffer.from(
+				'e91e2241030b0dad7022ec05d98343394043e0f31bc63f296ed07cce35cbd3d5',
+				'hex',
+			),
+			reward: BigInt('500000000'),
+			asset: {
+				maxHeightPreviouslyForged: 205901,
+				maxHeightPrevoted: 205932,
+				seedReveal: Buffer.from('fe22dd75b833d917e98539f586954ba5', 'hex'),
+			},
+			signature: Buffer.from(
+				'fb67faefdb95a624a83cb02115c5aacd6d22bd7074e69f2b31f0a261570e27518e2d93eb2ffb1e0eaf9ab0ce5b69889672ea344ff6e4d4bdc315c299fc2d010e',
+				'hex',
+			),
+			id: Buffer.from('ff960b7762cad26b2b6e22e47e9aecbb933f7238ecb54ec36e212260dba82db7', 'hex'),
+		},
+		payload: [],
+	};
+	const blockId = sampleBlock.header.id;
 	const accountSchema = {
 		$id: 'accountSchema',
 		type: 'object',
@@ -82,10 +110,6 @@ describe('block', () => {
 		],
 	} as any;
 
-	const { header, payload } = codec.decode(schema.block, encodedBlockBuffer);
-	const blockHeader = codec.decode(schema.blockHeader, header);
-	const sampleBlock = { blockHeader, payload };
-
 	beforeEach(() => {
 		channel = {
 			connect: jest.fn(),
@@ -106,11 +130,13 @@ describe('block', () => {
 		describe('get', () => {
 			it('should invoke app:getBlockByID', async () => {
 				// Act
-				await block.get(id);
+				await block.get(blockId);
 
 				// Assert
 				expect(channel.invoke).toHaveBeenCalledTimes(1);
-				expect(channel.invoke).toHaveBeenCalledWith('app:getBlockByID', { id: blockId });
+				expect(channel.invoke).toHaveBeenCalledWith('app:getBlockByID', {
+					id: blockId.toString('hex'),
+				});
 			});
 		});
 
@@ -120,18 +146,20 @@ describe('block', () => {
 				await block.getByHeight(1);
 
 				// Assert
-				expect(channel.invoke).toHaveBeenCalledTimes(1);
-				expect(channel.invoke).toHaveBeenCalledWith('app:getBlockByHeight');
+				expect(channel.invoke).toHaveBeenCalledTimes(sampleHeight);
+				expect(channel.invoke).toHaveBeenCalledWith('app:getBlockByHeight', {
+					height: sampleHeight,
+				});
 			});
 		});
 
 		describe('encode', () => {
 			it('should return encoded block', () => {
 				// Act
-				const _encodedBlock = block.encode(sampleBlock as any);
+				const returnedBlock = block.encode(sampleBlock as any);
 
 				// Assert
-				expect(_encodedBlock).toEqual(encodedBlock);
+				expect(returnedBlock).toEqual(encodedBlockBuffer);
 			});
 		});
 
@@ -141,7 +169,7 @@ describe('block', () => {
 				const decodedBlock = block.decode(encodedBlockBuffer);
 
 				// Assert
-				expect(decodedBlock).toEqual(encodedBlock);
+				expect(decodedBlock).toEqual(sampleBlock);
 			});
 		});
 	});

--- a/elements/lisk-api-client/test/unit/block.spec.ts
+++ b/elements/lisk-api-client/test/unit/block.spec.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import {
+	blockHeaderSchema,
+	blockSchema,
+	blockHeaderAssetSchema,
+	transactionSchema,
+} from '@liskhq/lisk-chain';
+import { codec } from '@liskhq/lisk-codec';
+import { Channel } from '../../src/types';
+import { Block } from '../../src/block';
+
+describe('block', () => {
+	let channel: Channel;
+	let block: Block;
+
+	const encodedBlock =
+		'0acd01080210c38ec1fc0518a2012220c736b8cfb669ff453118230c71d7dc433797b5b30da6b9d89a14457f1b56faa12a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85532209bcf519c9e0a8e66b3939f9d592b5a1728141ea3253b7d3a2424a44575c5f4e738004216087410001a1060fce85c0ca51ca1c72c589c9f651f574a40396edc8e940c5f5829d382c10cae3c2f7f24a5a9bb42ef8c545439e1a2e83951f87bc894816d7b90958b411a37b816c9e2d597dd52d7847d5a73f411ded65303';
+	const encodedBlockBuffer = Buffer.from(encodedBlock, 'hex');
+
+	const blockId = '4f7e41f5744c0c2a434f13afb186b77fb4b176a5298f91ed866680ff5ef13a6d';
+	const id = Buffer.from(blockId, 'hex');
+	const accountSchema = {
+		$id: 'accountSchema',
+		type: 'object',
+		properties: {
+			sequence: {
+				type: 'object',
+				fieldNumber: 3,
+				properties: {
+					nonce: {
+						fieldNumber: 1,
+						dataType: 'uint64',
+					},
+				},
+			},
+		},
+	};
+	const schema = {
+		account: accountSchema,
+		block: blockSchema,
+		blockHeader: blockHeaderSchema,
+		blockHeadersAssets: {
+			2: blockHeaderAssetSchema,
+		},
+		transaction: transactionSchema,
+		transactionAssets: [
+			{
+				moduleID: 5,
+				moduleName: 'dpos',
+				assetID: 3,
+				assetName: 'reportDelegateMisbehavior',
+				schema: {
+					$id: 'lisk/dpos/pom',
+					type: 'object',
+					required: ['header1', 'header2'],
+					properties: {
+						header1: {
+							...blockHeaderSchema,
+							fieldNumber: 1,
+						},
+						header2: {
+							...blockHeaderSchema,
+							fieldNumber: 2,
+						},
+					},
+				},
+			},
+		],
+	} as any;
+
+	const { header, payload } = codec.decode(schema.block, encodedBlockBuffer);
+	const blockHeader = codec.decode(schema.blockHeader, header);
+	const sampleBlock = { blockHeader, payload };
+
+	beforeEach(() => {
+		channel = {
+			connect: jest.fn(),
+			disconnect: jest.fn(),
+			invoke: jest.fn().mockResolvedValue(encodedBlock),
+			subscribe: jest.fn(),
+		};
+		block = new Block(channel, schema);
+	});
+
+	describe('Block', () => {
+		describe('constructor', () => {
+			it('should initialize with channel', () => {
+				expect(block['_channel']).toBe(channel);
+			});
+		});
+
+		describe('get', () => {
+			it('should invoke app:getBlockByID', async () => {
+				// Act
+				await block.get(id);
+
+				// Assert
+				expect(channel.invoke).toHaveBeenCalledTimes(1);
+				expect(channel.invoke).toHaveBeenCalledWith('app:getBlockByID', { id: blockId });
+			});
+		});
+
+		describe('getByHeight', () => {
+			it('should invoke app:getBlockByHeight', async () => {
+				// Act
+				await block.getByHeight(1);
+
+				// Assert
+				expect(channel.invoke).toHaveBeenCalledTimes(1);
+				expect(channel.invoke).toHaveBeenCalledWith('app:getBlockByHeight');
+			});
+		});
+
+		describe('encode', () => {
+			it('should return encoded block', () => {
+				// Act
+				const _encodedBlock = block.encode(sampleBlock as any);
+
+				// Assert
+				expect(_encodedBlock).toEqual(encodedBlock);
+			});
+		});
+
+		describe('decode', () => {
+			it('should return decoded block', () => {
+				// Act
+				const decodedBlock = block.decode(encodedBlockBuffer);
+
+				// Assert
+				expect(decodedBlock).toEqual(encodedBlock);
+			});
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #5926 

### How was it solved?

* Add logic to encode & decode transactions & blocks received by API client
* Define namespace & utility functions for blocks in API client
* Initialize block namespace in API client

### How was it tested?

* Add unit tests for block namespace
