### PR TITLE
Update monitor plugin api controller to actions - Closes #5944

### DIFF
--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/forks.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/forks.ts
@@ -11,20 +11,20 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { Request, Response } from 'express';
 import { SharedState } from '../types';
 
-export const getForkStats = (state: SharedState) => async (
-	_req: Request,
-	res: Response,
-	// eslint-disable-next-line @typescript-eslint/require-await
-): Promise<void> => {
-	const { forks } = state;
-	res.json({
-		data: {
-			forkEventCount: forks.forkEventCount,
-			blockHeaders: forks.blockHeaders,
-		},
-		meta: {},
-	});
-};
+interface BlockHeader {
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	blockHeader: object;
+	timeReceived: number;
+}
+
+interface ForkStats {
+	readonly forkEventCount: number;
+	blockHeaders: Record<string, BlockHeader>;
+}
+
+export const getForkStats = (state: SharedState): ForkStats => ({
+	forkEventCount: state.forks.forkEventCount,
+	blockHeaders: state.forks.blockHeaders,
+});

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
@@ -37,9 +37,9 @@ const getMajorityHeight = (peers: PeerInfo[]): { height: number; count: number }
 };
 
 export const getNetworkStats = async (channel: BaseChannel): Promise<NetworkStats> => {
-	const networkStats: { [key: string]: unknown } = await channel.invoke('app:getNetworkStats');
-	const connectedPeers: PeerInfo[] = await channel.invoke('app:getConnectedPeers');
-	const disconnectedPeers: PeerInfo[] = await channel.invoke('app:getDisconnectedPeers');
+	const networkStats = await channel.invoke<Record<string, unknown>>('app:getNetworkStats');
+	const connectedPeers = await channel.invoke<PeerInfo[]>('app:getConnectedPeers');
+	const disconnectedPeers = await channel.invoke<PeerInfo[]>('app:getDisconnectedPeers');
 	const majorityHeight = getMajorityHeight(connectedPeers);
 	const totalPeers = {
 		connected: connectedPeers.length,

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/network.ts
@@ -11,9 +11,12 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { Request, Response, NextFunction } from 'express';
 import { BaseChannel } from 'lisk-framework';
 import { PeerInfo } from '../types';
+
+interface NetworkStats {
+	[key: string]: unknown;
+}
 
 const getMajorityHeight = (peers: PeerInfo[]): { height: number; count: number } => {
 	const heightHistogram = {} as { [key: number]: number };
@@ -33,25 +36,15 @@ const getMajorityHeight = (peers: PeerInfo[]): { height: number; count: number }
 	return majority;
 };
 
-export const getNetworkStats = (channel: BaseChannel) => async (
-	_req: Request,
-	res: Response,
-	next: NextFunction,
-): Promise<void> => {
-	try {
-		const networkStats: { [key: string]: unknown } = await channel.invoke('app:getNetworkStats');
-		const connectedPeers: PeerInfo[] = await channel.invoke('app:getConnectedPeers');
-		const disconnectedPeers: PeerInfo[] = await channel.invoke('app:getDisconnectedPeers');
-		const majorityHeight = getMajorityHeight(connectedPeers);
-		const totalPeers = {
-			connected: connectedPeers.length,
-			disconnected: disconnectedPeers.length,
-		};
+export const getNetworkStats = async (channel: BaseChannel): Promise<NetworkStats> => {
+	const networkStats: { [key: string]: unknown } = await channel.invoke('app:getNetworkStats');
+	const connectedPeers: PeerInfo[] = await channel.invoke('app:getConnectedPeers');
+	const disconnectedPeers: PeerInfo[] = await channel.invoke('app:getDisconnectedPeers');
+	const majorityHeight = getMajorityHeight(connectedPeers);
+	const totalPeers = {
+		connected: connectedPeers.length,
+		disconnected: disconnectedPeers.length,
+	};
 
-		const data = { ...networkStats, majorityHeight, totalPeers };
-
-		res.status(200).json({ data, meta: {} });
-	} catch (err) {
-		next(err);
-	}
+	return { ...networkStats, majorityHeight, totalPeers };
 };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
@@ -14,8 +14,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { BaseChannel } from 'lisk-framework';
 import { SharedState, PeerInfo } from '../types';
-// eslint-disable-next-line import/no-cycle
-import { blocks, transactions } from '.';
+import { getBlockStats } from './blocks';
+import { getTransactionStats } from './transactions';
 
 interface PrometheusData {
 	readonly metric: string;
@@ -64,8 +64,8 @@ export const getData = (channel: BaseChannel, state: SharedState) => async (
 		const connectedPeers: PeerInfo[] = await channel.invoke('app:getConnectedPeers');
 		const disconnectedPeers: PeerInfo[] = await channel.invoke('app:getDisconnectedPeers');
 		const nodeInfo: NodeInfo = await channel.invoke('app:getNodeInfo');
-		const blockStats = await blocks.getBlockStats(channel, state);
-		const transactionStats = await transactions.getTransactionStats(channel, state);
+		const blockStats = await getBlockStats(channel, state);
+		const transactionStats = await getTransactionStats(channel, state);
 
 		const data: PrometheusData[] = [
 			{

--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/prometheus.ts
@@ -14,6 +14,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { BaseChannel } from 'lisk-framework';
 import { SharedState, PeerInfo } from '../types';
+// eslint-disable-next-line import/no-cycle
+import { blocks, transactions } from '.';
 
 interface PrometheusData {
 	readonly metric: string;
@@ -62,6 +64,8 @@ export const getData = (channel: BaseChannel, state: SharedState) => async (
 		const connectedPeers: PeerInfo[] = await channel.invoke('app:getConnectedPeers');
 		const disconnectedPeers: PeerInfo[] = await channel.invoke('app:getDisconnectedPeers');
 		const nodeInfo: NodeInfo = await channel.invoke('app:getNodeInfo');
+		const blockStats = await blocks.getBlockStats(channel, state);
+		const transactionStats = await transactions.getTransactionStats(channel, state);
 
 		const data: PrometheusData[] = [
 			{
@@ -71,7 +75,7 @@ export const getData = (channel: BaseChannel, state: SharedState) => async (
 				values: [
 					{
 						key: '',
-						value: state.blocks.averageReceivedBlocks,
+						value: blockStats.averageReceivedBlocks,
 					},
 				],
 			},
@@ -82,7 +86,7 @@ export const getData = (channel: BaseChannel, state: SharedState) => async (
 				values: [
 					{
 						key: '',
-						value: state.transactions.averageReceivedTransactions,
+						value: transactionStats.averageReceivedTransactions,
 					},
 				],
 			},

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -81,7 +81,7 @@ export class MonitorPlugin extends BasePlugin {
 				controllers.transactions.getTransactionStats(this._channel, this._state),
 			getBlockStats: async () => controllers.blocks.getBlockStats(this._channel, this._state),
 			getNetworkStats: async () => controllers.network.getNetworkStats(this._channel),
-			getForkStats: async () => controllers.forks.getForkStats(this._state),
+			getForkStats: () => controllers.forks.getForkStats(this._state),
 		};
 	}
 

--- a/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
@@ -35,7 +35,7 @@ interface BlockHeader {
 	timeReceived: number;
 }
 
-interface TransactionPropagationStats {
+export interface TransactionPropagationStats {
 	count: number;
 	timeReceived: number;
 }
@@ -50,16 +50,8 @@ export interface SharedState {
 		forkEventCount: number;
 		blockHeaders: Record<string, BlockHeader>;
 	};
-	transactions: {
-		transactions: Record<string, TransactionPropagationStats>;
-		averageReceivedTransactions: number;
-		connectedPeers: number;
-	};
-	blocks: {
-		blocks: { [key: string]: BlockPropagationStats };
-		averageReceivedBlocks: number;
-		connectedPeers: number;
-	};
+	transactions: Record<string, TransactionPropagationStats>;
+	blocks: { [key: string]: BlockPropagationStats };
 }
 
 export interface PeerInfo {

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/index.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/index.spec.ts
@@ -44,7 +44,7 @@ describe('_handlePostTransactionAnnounce', () => {
 		// Act
 		MonitorInstance._handlePostTransactionAnnounce({ transactionIds });
 		// Assert
-		expect(Object.keys(MonitorInstance._state.transactions.transactions)).toEqual(transactionIds);
+		expect(Object.keys(MonitorInstance._state.transactions)).toEqual(transactionIds);
 	});
 
 	it('should increment count for existing transaction id', () => {
@@ -55,7 +55,7 @@ describe('_handlePostTransactionAnnounce', () => {
 		MonitorInstance._handlePostTransactionAnnounce({ transactionIds });
 		MonitorInstance._handlePostTransactionAnnounce({ transactionIds: [transactionIds[0]] });
 		// Assert
-		expect(MonitorInstance._state.transactions.transactions[transactionIds[0]].count).toBe(2);
+		expect(MonitorInstance._state.transactions[transactionIds[0]].count).toBe(2);
 	});
 });
 
@@ -90,7 +90,7 @@ describe('_cleanUpTransactionStats', () => {
 		// Act
 		MonitorInstance._handlePostTransactionAnnounce({ transactionIds });
 		// Assert
-		expect(Object.keys(MonitorInstance._state.transactions.transactions)).toEqual(transactionIds);
+		expect(Object.keys(MonitorInstance._state.transactions)).toEqual(transactionIds);
 
 		Date.now = jest.fn(() => now + 600001);
 
@@ -98,6 +98,6 @@ describe('_cleanUpTransactionStats', () => {
 
 		MonitorInstance._handlePostTransactionAnnounce({ transactionIds: newTransactions });
 
-		expect(Object.keys(MonitorInstance._state.transactions.transactions)).toEqual(newTransactions);
+		expect(Object.keys(MonitorInstance._state.transactions)).toEqual(newTransactions);
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5944 

### How was it solved?

♻️ Add actions for all the controllers 7595a14

♻️ Update controllers to be served as actions d5ccdec

♻️ Update Prometheus API to use block and transaction controller ad519a5

✅ Update tests for blocks, transactions and network ce068a1

### How was it tested?

Run `npm run test:unit` under `framework-plugins/lisk-framework-monitor-plugin` 

To test it manually,

1. Add below code to  `framework/src/node/network/network.ts` in `public async bootstrap()` method
  ```
  setTimeout(async () => {
			console.log('NETWORK STATS', await this._channel.invoke('monitor:getNetworkStats'));
			console.log('BLOCK STATS', await this._channel.invoke('monitor:getBlockStats'));
			console.log('TRX STATS', await this._channel.invoke('monitor:getTransactionStats'));
			console.log('FORK STATS', await this._channel.invoke('monitor:getForkStats'));
		}, 5000);
  ```
2. Build plugin and framework
```
  > yarn workspace @liskhq/lisk-framework-monitor-plugin build
  > yarn workspace lisk-framework build
```
3. Run `node framework/test/test_app/index.js` and check the logs, after 5 seconds you should see all the result from the actions
