### PR TITLE
Remove peers HTTP API functional test - Closes #5958

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -29,20 +29,6 @@ describe('Peers endpoint', () => {
 
 	describe('/api/peers', () => {
 		describe('400 - Invalid query values', () => {
-			it('should respond with 400 and error message when passed incorrect state value', async () => {
-				const { response, status } = await callNetwork(axios.get(getURL('/api/peers?state=xxx')));
-				// Assert
-				expect(status).toBe(400);
-				expect(response).toEqual({
-					errors: [
-						{
-							message:
-								'Lisk validator found 1 error[s]:\nshould be equal to one of the allowed values',
-						},
-					],
-				});
-			});
-
 			it('should respond with 400 and error message when passed incorrect limit value', async () => {
 				const { response, status } = await callNetwork(axios.get(getURL('/api/peers?limit=123xy')));
 				// Assert

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -15,11 +15,9 @@ import { Application } from 'lisk-framework';
 import axios from 'axios';
 import { when } from 'jest-when';
 import { createApplication, closeApplication, getURL, callNetwork } from './utils/application';
-import { generatePeers } from './utils/peers';
 
 describe('Peers endpoint', () => {
 	let app: Application;
-	const peers = generatePeers();
 
 	beforeAll(async () => {
 		app = await createApplication('peers');
@@ -30,48 +28,6 @@ describe('Peers endpoint', () => {
 	});
 
 	describe('/api/peers', () => {
-		describe('200 - Success', () => {
-			// TODO: https://github.com/LiskHQ/lisk-sdk/issues/5958
-			// eslint-disable-next-line jest/no-disabled-tests
-			it.skip('should respond with 100 connected peers as limit has 100 default value', async () => {
-				// Arrange
-				app['_channel'].invoke = jest.fn();
-				// Mock channel invoke only when app:getConnectedPeers is called
-				when(app['_channel'].invoke)
-					.calledWith('app:getConnectedPeers')
-					.mockResolvedValue(peers as never);
-
-				// Act
-				const { response, status } = await callNetwork(axios.get(getURL('/api/peers')));
-
-				// Assert
-				expect(response.data).toEqual(peers.slice(0, 100));
-				expect(response.meta).toEqual({ count: peers.length, limit: 100, offset: 0 });
-				expect(status).toBe(200);
-			});
-
-			// TODO: https://github.com/LiskHQ/lisk-sdk/issues/5958
-			// eslint-disable-next-line jest/no-disabled-tests
-			it.skip('should respond with all disconnected peers when all query parameters are passed', async () => {
-				// Arrange
-				app['_channel'].invoke = jest.fn();
-				// Mock channel invoke only when app:getDisconnectedPeers is called
-				when(app['_channel'].invoke)
-					.calledWith('app:getDisconnectedPeers')
-					.mockResolvedValue(peers as never);
-
-				// Act
-				const { response, status } = await callNetwork(
-					axios.get(getURL('/api/peers?state=disconnected&limit=100&offset=2')),
-				);
-
-				// Assert
-				expect(response.data).toEqual(peers.slice(2, 102));
-				expect(response.meta).toEqual({ count: peers.length, limit: 100, offset: 2 });
-				expect(status).toBe(200);
-			});
-		});
-
 		describe('400 - Invalid query values', () => {
 			it('should respond with 400 and error message when passed incorrect state value', async () => {
 				const { response, status } = await callNetwork(axios.get(getURL('/api/peers?state=xxx')));


### PR DESCRIPTION
### What was the problem?

This PR resolves #5958 

### How was it solved?

* Remove mock functional tests for peers & cleanup

### How was it tested?

* Run the test suite
