### PR TITLE
Fix IPC error handling - Closes #6002

### DIFF
--- a/framework/src/controller/channels/ipc_channel.ts
+++ b/framework/src/controller/channels/ipc_channel.ts
@@ -166,7 +166,10 @@ export class IPCChannel extends BaseChannel {
 					res: JSONRPC.ResponseObjectWithResult<T>,
 				) => {
 					if (err) {
-						return reject(res.error ?? err);
+						return reject(err);
+					}
+					if (res.error) {
+						return reject(res.error);
 					}
 
 					return resolve(res.result);

--- a/framework/test/integration/controller/ipc_channel.spec.ts
+++ b/framework/test/integration/controller/ipc_channel.spec.ts
@@ -63,6 +63,14 @@ describe('IPCChannel', () => {
 			divideByThree: {
 				handler: (action: any) => action.params.val / 3,
 			},
+			withError: {
+				handler: (action: any) => {
+					if (action.params.val === 1) {
+						throw new Error('Invalid request');
+					}
+					return 0;
+				},
+			},
 		},
 	};
 
@@ -218,6 +226,12 @@ describe('IPCChannel', () => {
 				).rejects.toThrow(
 					`Action name "${beta.moduleAlias}:${invalidActionName}" must be a valid name with module name and action name.`,
 				);
+			});
+
+			it('should be rejected with error', async () => {
+				await expect(
+					alphaChannel.invoke(`${beta.moduleAlias}:withError`, { val: 1 }),
+				).rejects.toThrow('Invalid request');
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6002 

### How was it solved?

- Handled `err` case and `res.error` case separately

### How was it tested?

- Add integration test case
