### PR TITLE
Fix inconsistency on the base32 address functions - Closes #6014

### DIFF
--- a/elements/lisk-cryptography/src/constants.ts
+++ b/elements/lisk-cryptography/src/constants.ts
@@ -14,3 +14,4 @@
  */
 export const SIGNED_MESSAGE_PREFIX = 'Lisk Signed Message:\n';
 export const BINARY_ADDRESS_LENGTH = 20;
+export const DEFAULT_BASE32_ADDRESS_PREFIX = 'lsk';

--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { BINARY_ADDRESS_LENGTH } from './constants';
+import { BINARY_ADDRESS_LENGTH, DEFAULT_BASE32_ADDRESS_PREFIX } from './constants';
 // eslint-disable-next-line import/no-cycle
 import { convertUInt5ToBase32, convertUIntArray } from './convert';
 import { hash } from './hash';
@@ -108,13 +108,26 @@ const addressToBase32 = (address: Buffer): string => {
 	return convertUInt5ToBase32(uint5Address.concat(uint5Checksum));
 };
 
-export const getBase32AddressFromPublicKey = (publicKey: Buffer, prefix: string): string =>
-	`${prefix}${addressToBase32(getAddressFromPublicKey(publicKey))}`;
+export const getBase32AddressFromPublicKey = (
+	publicKey: Buffer,
+	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+): string => `${prefix}${addressToBase32(getAddressFromPublicKey(publicKey))}`;
+
+export const getBase32AddressFromPassphrase = (
+	passphrase: string,
+	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+): string => {
+	const { publicKey } = getAddressAndPublicKeyFromPassphrase(passphrase);
+	return getBase32AddressFromPublicKey(publicKey, prefix);
+};
 
 const BASE32_ADDRESS_LENGTH = 41;
 const BASE32_CHARSET = 'zxvcpmbn3465o978uyrtkqew2adsjhfg';
 
-export const validateBase32Address = (address: string, prefix = 'lsk'): boolean => {
+export const validateBase32Address = (
+	address: string,
+	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+): boolean => {
 	if (address.length !== BASE32_ADDRESS_LENGTH) {
 		throw new Error('Address length does not match requirements. Expected 41 characters.');
 	}
@@ -142,7 +155,10 @@ export const validateBase32Address = (address: string, prefix = 'lsk'): boolean 
 	return true;
 };
 
-export const getAddressFromBase32Address = (base32Address: string, prefix = 'lsk'): Buffer => {
+export const getAddressFromBase32Address = (
+	base32Address: string,
+	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+): Buffer => {
 	validateBase32Address(base32Address);
 	// Ignore lsk prefix and checksum
 	const base32AddressNoPrefixNoChecksum = base32Address.substring(
@@ -157,5 +173,7 @@ export const getAddressFromBase32Address = (base32Address: string, prefix = 'lsk
 	return Buffer.from(integerSequence8);
 };
 
-export const getBase32AddressFromAddress = (address: Buffer, prefix = 'lsk'): string =>
-	`${prefix}${addressToBase32(address)}`;
+export const getBase32AddressFromAddress = (
+	address: Buffer,
+	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+): string => `${prefix}${addressToBase32(address)}`;

--- a/elements/lisk-cryptography/test/keys.spec.ts
+++ b/elements/lisk-cryptography/test/keys.spec.ts
@@ -23,6 +23,7 @@ import {
 	validateBase32Address,
 	getAddressFromBase32Address,
 	getBase32AddressFromAddress,
+	getBase32AddressFromPassphrase,
 } from '../src/keys';
 import { Keypair } from '../src/types';
 // Require is used for stubbing
@@ -129,6 +130,16 @@ describe('keys', () => {
 			const address = getBase32AddressFromPublicKey(publicKey, 'lsk');
 
 			expect(address).toBe(expectedBase32Address);
+		});
+	});
+
+	describe('#getBase32AddressFromPassphrase', () => {
+		it('should generate valid base32 address from passphrase', () => {
+			const passphrase =
+				'garden mass universe joke disorder fish reveal state course lottery near virus';
+			const address = getBase32AddressFromPassphrase(passphrase);
+
+			expect(validateBase32Address(address)).toBeTrue();
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6014 

### How was it solved?

- Add `getBase32AddressFromPassphrase`
- Update prefix to be optional consistently

### How was it tested?

- Added test case
