### PR TITLE
Add validation to check the network data before using - Closes #6019

### DIFF
--- a/framework-plugins/lisk-framework-monitor-plugin/src/schema.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/schema.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+export const postBlockEventSchema = {
+	id: 'monitor/postBlockEvent',
+	type: 'object',
+	required: ['block'],
+	properties: {
+		block: {
+			type: 'string',
+			format: 'hex',
+		},
+	},
+};
+
+export const transactionAnnouncementSchema = {
+	id: 'monitor/transactionAnnouncement',
+	type: 'object',
+	required: ['transactionIds'],
+	properties: {
+		transactionIds: {
+			type: 'array',
+			items: {
+				type: 'string',
+				format: 'hex',
+			},
+		},
+	},
+};

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/subscribe_event.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/subscribe_event.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { MonitorPlugin } from '../../src';
+
+describe('subscribe to event', () => {
+	let monitorPlugin: MonitorPlugin;
+	let subscribeMock: jest.Mock;
+	beforeEach(() => {
+		subscribeMock = jest.fn();
+		const channelMock = {
+			subscribe: subscribeMock,
+		};
+		monitorPlugin = new (MonitorPlugin as any)();
+		(monitorPlugin as any)._channel = channelMock;
+	});
+
+	it('should register listener to network:event', () => {
+		// Act
+		monitorPlugin['_subscribeToEvents']();
+		// Assert
+		expect(subscribeMock).toHaveBeenCalledTimes(2);
+		expect(subscribeMock).toHaveBeenCalledWith('app:network:event', expect.any(Function));
+	});
+
+	it('should not handle block when data is invalid', () => {
+		// Arrange
+		jest.spyOn(monitorPlugin as any, '_handlePostBlock');
+		// Act
+		monitorPlugin['_subscribeToEvents']();
+		subscribeMock.mock.calls[0][1]({ event: 'postBlock', data: null });
+		// Assert
+		expect(monitorPlugin['_handlePostBlock']).not.toHaveBeenCalled();
+	});
+
+	it('should not handle transaction when data is invalid', () => {
+		// Arrange
+		jest.spyOn(monitorPlugin as any, '_handlePostTransactionAnnounce');
+		// Act
+		monitorPlugin['_subscribeToEvents']();
+		subscribeMock.mock.calls[0][1]({
+			event: 'postTransactionsAnnouncement',
+			data: { transactionIds: [1, 2, 3] },
+		});
+		// Assert
+		expect(monitorPlugin['_handlePostTransactionAnnounce']).not.toHaveBeenCalled();
+	});
+});

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/transaction.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/transaction.spec.ts
@@ -16,7 +16,7 @@ import { randomBytes } from 'crypto';
 import { MonitorPlugin } from '../../src/monitor_plugin';
 
 describe('_handlePostTransactionAnnounce', () => {
-	let MonitorPluginInstance: MonitorPlugin;
+	let monitorPluginInstance: MonitorPlugin;
 	const channelMock = {
 		registerToBus: jest.fn(),
 		once: jest.fn(),
@@ -33,24 +33,24 @@ describe('_handlePostTransactionAnnounce', () => {
 	} as any;
 
 	beforeEach(async () => {
-		MonitorPluginInstance = new (MonitorPlugin as any)();
-		await MonitorPluginInstance.load(channelMock);
+		monitorPluginInstance = new (MonitorPlugin as any)();
+		await monitorPluginInstance.load(channelMock);
 	});
 
 	it('should add new transactions to state', () => {
 		// Arrange
 		const transactionIds = [...Array(4).keys()].map(() => randomBytes(64).toString('hex'));
-		const MonitorInstance = MonitorPluginInstance as any;
+		const monitorInstance = monitorPluginInstance as any;
 		// Act
-		MonitorInstance._handlePostTransactionAnnounce({ transactionIds });
+		monitorInstance._handlePostTransactionAnnounce({ transactionIds });
 		// Assert
-		expect(Object.keys(MonitorInstance._state.transactions)).toEqual(transactionIds);
+		expect(Object.keys(monitorInstance._state.transactions)).toEqual(transactionIds);
 	});
 
 	it('should increment count for existing transaction id', () => {
 		// Arrange
 		const transactionIds = [...Array(4).keys()].map(() => randomBytes(64).toString('hex'));
-		const MonitorInstance = MonitorPluginInstance as any;
+		const MonitorInstance = monitorPluginInstance as any;
 		// Act
 		MonitorInstance._handlePostTransactionAnnounce({ transactionIds });
 		MonitorInstance._handlePostTransactionAnnounce({ transactionIds: [transactionIds[0]] });
@@ -60,7 +60,7 @@ describe('_handlePostTransactionAnnounce', () => {
 });
 
 describe('_cleanUpTransactionStats', () => {
-	let MonitorPluginInstance: MonitorPlugin;
+	let monitorPluginInstance: MonitorPlugin;
 	const channelMock = {
 		registerToBus: jest.fn(),
 		once: jest.fn(),
@@ -77,27 +77,27 @@ describe('_cleanUpTransactionStats', () => {
 	} as any;
 
 	beforeEach(async () => {
-		MonitorPluginInstance = new (MonitorPlugin as any)();
-		await MonitorPluginInstance.load(channelMock);
+		monitorPluginInstance = new (MonitorPlugin as any)();
+		await monitorPluginInstance.load(channelMock);
 	});
 
 	it('should remove transaction stats that are more than 10 minutes old', () => {
 		// Arrange
 		const transactionIds = [...Array(4).keys()].map(() => randomBytes(64).toString('hex'));
-		const MonitorInstance = MonitorPluginInstance as any;
+		const monitorInstance = monitorPluginInstance as any;
 		const now = Date.now();
 		Date.now = jest.fn(() => now);
 		// Act
-		MonitorInstance._handlePostTransactionAnnounce({ transactionIds });
+		monitorInstance._handlePostTransactionAnnounce({ transactionIds });
 		// Assert
-		expect(Object.keys(MonitorInstance._state.transactions)).toEqual(transactionIds);
+		expect(Object.keys(monitorInstance._state.transactions)).toEqual(transactionIds);
 
 		Date.now = jest.fn(() => now + 600001);
 
 		const newTransactions = [randomBytes(64).toString('hex'), randomBytes(64).toString('hex')];
 
-		MonitorInstance._handlePostTransactionAnnounce({ transactionIds: newTransactions });
+		monitorInstance._handlePostTransactionAnnounce({ transactionIds: newTransactions });
 
-		expect(Object.keys(MonitorInstance._state.transactions)).toEqual(newTransactions);
+		expect(Object.keys(monitorInstance._state.transactions)).toEqual(newTransactions);
 	});
 });

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/src/schema.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/src/schema.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+export const postBlockEventSchema = {
+	id: 'report-misbehavior/postBlockEvent',
+	type: 'object',
+	required: ['block'],
+	properties: {
+		block: {
+			type: 'string',
+			format: 'hex',
+		},
+	},
+};

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/test/unit/subscribe_event.spec.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/test/unit/subscribe_event.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { codec } from '@liskhq/lisk-codec';
+import { ReportMisbehaviorPlugin } from '../../src';
+
+describe('subscribe to event', () => {
+	let reportMisbehaviorPlugin: ReportMisbehaviorPlugin;
+	let subscribeMock: jest.Mock;
+	beforeEach(() => {
+		subscribeMock = jest.fn();
+		const channelMock = {
+			subscribe: subscribeMock,
+		};
+		reportMisbehaviorPlugin = new (ReportMisbehaviorPlugin as any)();
+		(reportMisbehaviorPlugin as any)._channel = channelMock;
+	});
+
+	it('should register listener to network:event', () => {
+		// Act
+		reportMisbehaviorPlugin['_subscribeToChannel']();
+		// Assert
+		expect(subscribeMock).toHaveBeenCalledTimes(1);
+		expect(subscribeMock).toHaveBeenCalledWith('app:network:event', expect.any(Function));
+	});
+
+	it('should not decode block when data is invalid', () => {
+		jest.spyOn(codec, 'decode');
+		// Act
+		reportMisbehaviorPlugin['_subscribeToChannel']();
+		subscribeMock.mock.calls[0][1]({ event: 'postBlock', data: null });
+		// Assert
+		expect(codec.decode).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6019 

### How was it solved?

- Add validation before using the network data

### How was it tested?

- Add unit test
- Link with core and run reportMisbehavior and monitor plugins, and try to send invalid postBlock data to the node. Observe it will not crash the plugin
