### PR TITLE
Update sodium-native and buffer library - Closes #6024

### DIFF
--- a/elements/lisk-chain/test/unit/process.spec.ts
+++ b/elements/lisk-chain/test/unit/process.spec.ts
@@ -228,7 +228,7 @@ describe('chain/process block', () => {
 				block = createValidDefaultBlock({ header: { generatorPublicKey: Buffer.alloc(0) } });
 				// Act & assert
 				expect(() => chainInstance.validateBlockHeader(block)).toThrow(
-					'public_key must be a buffer of size',
+					'"pk" must be crypto_sign_PUBLICKEYBYTES bytes long',
 				);
 			});
 		});
@@ -240,7 +240,7 @@ describe('chain/process block', () => {
 				(block.header as any).signature = Buffer.alloc(0);
 				// Act & assert
 				expect(() => chainInstance.validateBlockHeader(block)).toThrow(
-					'signature must be a buffer of size',
+					'"sig" must be at least crypto_sign_BYTES bytes long',
 				);
 			});
 		});

--- a/elements/lisk-client/package.json
+++ b/elements/lisk-client/package.json
@@ -57,7 +57,7 @@
 		"@liskhq/lisk-tree": "^0.1.0-alpha.0",
 		"@liskhq/lisk-utils": "^0.1.0-debug.3",
 		"@liskhq/lisk-validator": "^0.5.0-debug.3",
-		"buffer": "liskHQ/buffer#4d498e6"
+		"buffer": "6.0.3"
 	},
 	"devDependencies": {
 		"@types/jest": "26.0.13",

--- a/elements/lisk-cryptography/package.json
+++ b/elements/lisk-cryptography/package.json
@@ -42,7 +42,7 @@
 		"varuint-bitcoin": "1.1.2"
 	},
 	"optionalDependencies": {
-		"sodium-native": "2.4.6"
+		"sodium-native": "3.2.0"
 	},
 	"devDependencies": {
 		"@types/ed2curve": "0.2.2",

--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -89,9 +89,7 @@ export const decryptMessageWithPassphrase = (
 	} catch (error) {
 		if (
 			// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-			(error as Error).message.match(
-				/bad nonce size|nonce must be a buffer of size crypto_box_NONCEBYTES/,
-			)
+			(error as Error).message.match(/bad nonce size|"n" must be crypto_box_NONCEBYTES bytes long/)
 		) {
 			throw new Error('Expected nonce to be 24 bytes.');
 		}

--- a/elements/lisk-cryptography/src/nacl/fast.ts
+++ b/elements/lisk-cryptography/src/nacl/fast.ts
@@ -92,9 +92,8 @@ export const getKeyPair: NaclInterface['getKeyPair'] = hashedSeed => {
 
 export const getPublicKey: NaclInterface['getPublicKey'] = privateKey => {
 	const publicKeyBytes = Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES);
-	const privateKeyBytes = Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES);
 
-	sodium.crypto_sign_seed_keypair(publicKeyBytes, privateKeyBytes, privateKey);
+	sodium.crypto_sign_ed25519_sk_to_pk(publicKeyBytes, privateKey);
 
 	return publicKeyBytes;
 };

--- a/elements/lisk-cryptography/test/nacl/nacl.spec.ts
+++ b/elements/lisk-cryptography/test/nacl/nacl.spec.ts
@@ -123,8 +123,8 @@ describe('nacl', () => {
 					expect(Buffer.from(publicKey).toString('hex')).toEqual(defaultPublicKey);
 				});
 
-				it('should create a publicKey when private key is 32 bytes', () => {
-					publicKey = getPublicKey(Buffer.from(defaultPrivateKey, 'hex').slice(0, 32));
+				it('should create a publicKey when private key is 64 bytes', () => {
+					publicKey = getPublicKey(Buffer.from(defaultPrivateKey, 'hex'));
 					expect(Buffer.from(publicKey).toString('hex')).toEqual(defaultPublicKey);
 				});
 

--- a/elements/lisk-cryptography/types/sodium-native/index.d.ts
+++ b/elements/lisk-cryptography/types/sodium-native/index.d.ts
@@ -24,6 +24,7 @@ declare module 'sodium-native' {
 		publicKey: Buffer,
 	): boolean;
 	export function randombytes_buf(buffer: Buffer): void;
+	export function crypto_sign_ed25519_sk_to_pk(publicKey: Buffer, privateKey: Buffer): void;
 	export function crypto_sign_seed_keypair(
 		publicKey: Buffer,
 		privateKey: Buffer,

--- a/framework/package.json
+++ b/framework/package.json
@@ -58,7 +58,7 @@
 		"pm2-axon": "3.3.0",
 		"pm2-axon-rpc": "0.5.1",
 		"ps-list": "7.0.0",
-		"sodium-native": "2.4.6",
+		"sodium-native": "3.2.0",
 		"ws": "7.3.1"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base64id@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
@@ -3415,6 +3420,14 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
+buffer@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 buffer@^5.0.2, buffer@^5.2.1:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
@@ -3423,7 +3436,7 @@ buffer@^5.0.2, buffer@^5.2.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-buffer@^5.5.0, buffer@liskHQ/buffer#4d498e6:
+buffer@^5.5.0:
   version "5.6.0"
   resolved "https://codeload.github.com/liskHQ/buffer/tar.gz/4d498e6acd7f2a20073b10d31961b86c6be530b8"
   dependencies:
@@ -6475,6 +6488,11 @@ ieee754@^1.1.4:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
@@ -8962,6 +8980,11 @@ node-gyp-build@^4.1.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.0.tgz#2c2b05f461f4178641a6ce2d7159f04094e9376d"
   integrity sha512-4oiumOLhCDU9Rronz8PZ5S4IvT39H5+JEv/hps9V8s7RSLhsac0TCP78ulnHXOo8X1wdpPiTayGlM1jr4IbnaQ==
 
+node-gyp-build@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
+
 node-gyp-build@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.1.1.tgz#d7270b5d86717068d114cc57fff352f96d745feb"
@@ -11112,6 +11135,14 @@ sodium-native@2.4.6:
     ini "^1.3.5"
     nan "^2.14.0"
     node-gyp-build "^4.1.0"
+
+sodium-native@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-3.2.0.tgz#68a9469b96edadffef320cbce51294ad5f72a37f"
+  integrity sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==
+  dependencies:
+    ini "^1.3.5"
+    node-gyp-build "^4.2.0"
 
 sort-keys@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What was the problem?

This PR resolves #6024 

### How was it solved?

- Update sodium-native and update to use new function
- Update buffer library

### How was it tested?

- All test should work as before except the `getPublicKey` usage
