### PR TITLE
Unformatted JSON-RPC request crashes the application - Closes #6026

### DIFF
--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -167,10 +167,28 @@ export class Bus {
 	public async invoke<T>(
 		rawRequest: string | JSONRPC.RequestObject,
 	): Promise<JSONRPC.ResponseObjectWithResult<T>> {
-		const request =
+		let request!: JSONRPC.RequestObject;
+
+		// As the request can be invoked from external source, so we should validate if it exists and valid JSON object
+		if (!rawRequest) {
+			this.logger.error('Empty invoke request.');
+			throw new JSONRPC.JSONRPCError(
+				'Invalid invoke request.',
+				JSONRPC.errorResponse(null, JSONRPC.invalidRequest()),
+			);
+		}
+
+		try {
+			request =
 			typeof rawRequest === 'string'
 				? (JSON.parse(rawRequest) as JSONRPC.RequestObject)
 				: rawRequest;
+		} catch (error) {
+			throw new JSONRPC.JSONRPCError(
+				'Invalid invoke request.',
+				JSONRPC.errorResponse(null, JSONRPC.invalidRequest()),
+			);
+		}
 
 		try {
 			JSONRPC.validateJSONRPCRequest(request as never);
@@ -225,10 +243,28 @@ export class Bus {
 	}
 
 	public publish(rawRequest: string | JSONRPC.NotificationRequest): void {
-		const request =
+		let request!: JSONRPC.NotificationRequest;
+
+		// As the request can be invoked from external source, so we should validate if it exists and valid JSON object
+		if (!rawRequest) {
+			this.logger.error('Empty publish request.');
+			throw new JSONRPC.JSONRPCError(
+				'Invalid publish request.',
+				JSONRPC.errorResponse(null, JSONRPC.invalidRequest()),
+			);
+		}
+
+		try {
+			request =
 			typeof rawRequest === 'string'
-				? (JSON.parse(rawRequest) as JSONRPC.NotificationRequest)
+				? (JSON.parse(rawRequest) as JSONRPC.RequestObject)
 				: rawRequest;
+		} catch (error) {
+			throw new JSONRPC.JSONRPCError(
+				'Invalid publish request.',
+				JSONRPC.errorResponse(null, JSONRPC.invalidRequest()),
+			);
+		}
 
 		try {
 			JSONRPC.validateJSONRPCNotification(request as never);

--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -180,9 +180,9 @@ export class Bus {
 
 		try {
 			request =
-			typeof rawRequest === 'string'
-				? (JSON.parse(rawRequest) as JSONRPC.RequestObject)
-				: rawRequest;
+				typeof rawRequest === 'string'
+					? (JSON.parse(rawRequest) as JSONRPC.RequestObject)
+					: rawRequest;
 		} catch (error) {
 			throw new JSONRPC.JSONRPCError(
 				'Invalid invoke request.',
@@ -256,9 +256,9 @@ export class Bus {
 
 		try {
 			request =
-			typeof rawRequest === 'string'
-				? (JSON.parse(rawRequest) as JSONRPC.RequestObject)
-				: rawRequest;
+				typeof rawRequest === 'string'
+					? (JSON.parse(rawRequest) as JSONRPC.RequestObject)
+					: rawRequest;
 		} catch (error) {
 			throw new JSONRPC.JSONRPCError(
 				'Invalid publish request.',

--- a/framework/test/unit/controller/bus.spec.ts
+++ b/framework/test/unit/controller/bus.spec.ts
@@ -219,23 +219,17 @@ describe('Bus', () => {
 
 		it('should throw error if invoked without request', async () => {
 			// Act && Assert
-			await expect(bus.invoke(undefined as never)).rejects.toThrow(
-				'Invalid invoke request.',
-			);
+			await expect(bus.invoke(undefined as never)).rejects.toThrow('Invalid invoke request.');
 		});
 
 		it('should throw error if invoked with invalid json', async () => {
 			// Act && Assert
-			await expect(bus.invoke('\n')).rejects.toThrow(
-				'Invalid invoke request.',
-			);
+			await expect(bus.invoke('\n')).rejects.toThrow('Invalid invoke request.');
 		});
 
 		it('should throw error if invoked with empty string', async () => {
 			// Act && Assert
-			await expect(bus.invoke('')).rejects.toThrow(
-				'Invalid invoke request.',
-			);
+			await expect(bus.invoke('')).rejects.toThrow('Invalid invoke request.');
 		});
 
 		it('should throw error if invoked without method', async () => {
@@ -246,9 +240,7 @@ describe('Bus', () => {
 			};
 
 			// Act && Assert
-			await expect(bus.invoke(jsonrpcRequest as never)).rejects.toThrow(
-				'Invalid invoke request.',
-			);
+			await expect(bus.invoke(jsonrpcRequest as never)).rejects.toThrow('Invalid invoke request.');
 		});
 
 		it('should throw error if invoked without id', async () => {
@@ -259,9 +251,7 @@ describe('Bus', () => {
 			};
 
 			// Act && Assert
-			await expect(bus.invoke(jsonrpcRequest as never)).rejects.toThrow(
-				'Invalid invoke request.',
-			);
+			await expect(bus.invoke(jsonrpcRequest as never)).rejects.toThrow('Invalid invoke request.');
 		});
 	});
 
@@ -285,23 +275,17 @@ describe('Bus', () => {
 
 		it('should throw error if called without notification', () => {
 			// Act && Assert
-			expect(() => bus.publish(undefined as never)).toThrow(
-				'Invalid publish request.',
-			);
+			expect(() => bus.publish(undefined as never)).toThrow('Invalid publish request.');
 		});
 
 		it('should throw error if called with invalid json', () => {
 			// Act && Assert
-			expect(() => bus.publish('\n')).toThrow(
-				'Invalid publish request.',
-			);
+			expect(() => bus.publish('\n')).toThrow('Invalid publish request.');
 		});
 
 		it('should throw error if called with empty string', () => {
 			// Act && Assert
-			expect(() => bus.publish('')).toThrow(
-				'Invalid publish request.',
-			);
+			expect(() => bus.publish('')).toThrow('Invalid publish request.');
 		});
 
 		it('should throw error if called with id', () => {
@@ -313,9 +297,7 @@ describe('Bus', () => {
 			};
 
 			// Act && Assert
-			expect(() => bus.publish(jsonrpcRequest as never)).toThrow(
-				'Invalid publish request.',
-			);
+			expect(() => bus.publish(jsonrpcRequest as never)).toThrow('Invalid publish request.');
 		});
 
 		it('should throw error if called without method', () => {
@@ -325,9 +307,7 @@ describe('Bus', () => {
 			};
 
 			// Act && Assert
-			expect(() => bus.publish(jsonrpcRequest as never)).toThrow(
-				'Invalid publish request.',
-			);
+			expect(() => bus.publish(jsonrpcRequest as never)).toThrow('Invalid publish request.');
 		});
 	});
 

--- a/framework/test/unit/controller/bus.spec.ts
+++ b/framework/test/unit/controller/bus.spec.ts
@@ -216,6 +216,53 @@ describe('Bus', () => {
 				`Action '${action.module}:${action.name}' is not registered to bus.`,
 			);
 		});
+
+		it('should throw error if invoked without request', async () => {
+			// Act && Assert
+			await expect(bus.invoke(undefined as never)).rejects.toThrow(
+				'Invalid invoke request.',
+			);
+		});
+
+		it('should throw error if invoked with invalid json', async () => {
+			// Act && Assert
+			await expect(bus.invoke('\n')).rejects.toThrow(
+				'Invalid invoke request.',
+			);
+		});
+
+		it('should throw error if invoked with empty string', async () => {
+			// Act && Assert
+			await expect(bus.invoke('')).rejects.toThrow(
+				'Invalid invoke request.',
+			);
+		});
+
+		it('should throw error if invoked without method', async () => {
+			// Arrange
+			const jsonrpcRequest = {
+				id: 1,
+				jsonrpc: '2.0',
+			};
+
+			// Act && Assert
+			await expect(bus.invoke(jsonrpcRequest as never)).rejects.toThrow(
+				'Invalid invoke request.',
+			);
+		});
+
+		it('should throw error if invoked without id', async () => {
+			// Arrange
+			const jsonrpcRequest = {
+				jsonrpc: '2.0',
+				method: 'module:action',
+			};
+
+			// Act && Assert
+			await expect(bus.invoke(jsonrpcRequest as never)).rejects.toThrow(
+				'Invalid invoke request.',
+			);
+		});
 	});
 
 	describe('#publish', () => {
@@ -234,6 +281,53 @@ describe('Bus', () => {
 
 			// Assert
 			expect(EventEmitter2.prototype.emit).toHaveBeenCalledWith(eventName, JSONRPCData);
+		});
+
+		it('should throw error if called without notification', () => {
+			// Act && Assert
+			expect(() => bus.publish(undefined as never)).toThrow(
+				'Invalid publish request.',
+			);
+		});
+
+		it('should throw error if called with invalid json', () => {
+			// Act && Assert
+			expect(() => bus.publish('\n')).toThrow(
+				'Invalid publish request.',
+			);
+		});
+
+		it('should throw error if called with empty string', () => {
+			// Act && Assert
+			expect(() => bus.publish('')).toThrow(
+				'Invalid publish request.',
+			);
+		});
+
+		it('should throw error if called with id', () => {
+			// Arrange
+			const jsonrpcRequest = {
+				id: 1,
+				jsonrpc: '2.0',
+				method: 'module:event',
+			};
+
+			// Act && Assert
+			expect(() => bus.publish(jsonrpcRequest as never)).toThrow(
+				'Invalid publish request.',
+			);
+		});
+
+		it('should throw error if called without method', () => {
+			// Arrange
+			const jsonrpcRequest = {
+				jsonrpc: '2.0',
+			};
+
+			// Act && Assert
+			expect(() => bus.publish(jsonrpcRequest as never)).toThrow(
+				'Invalid publish request.',
+			);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6026

### How was it solved?

- Add extra validation on request parsing

### How was it tested?

- Run framework unit tests 
- Follow the steps mentioned on the issue to test manually
