### PR TITLE
Add production flag on shrinkwrap - Closes #6030

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -39,7 +39,7 @@
 		"test:watch:min": "npm run test:watch -- --reporter=min",
 		"prebuild": "if test -d dist; then rm -r dist; fi; rm -f tsconfig.tsbuildinfo",
 		"build": "tsc",
-		"prepack": "oclif-dev manifest && npm shrinkwrap",
+		"prepack": "oclif-dev manifest && npm shrinkwrap --production",
 		"prepublishOnly": "rm -r ./node_modules && npm install && npm run lint && npm run build"
 	},
 	"oclif": {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6030 

### How was it solved?
Add production flag to avoid dev dependencies in srhinkwrap

### How was it tested?
npm run prepack
