### PR TITLE
Separate action and p2p endpoint - Closes #6034

### DIFF
--- a/elements/lisk-api-client/src/types.ts
+++ b/elements/lisk-api-client/src/types.ts
@@ -22,12 +22,18 @@ export interface JSONRPCNotification<T> {
 	readonly params?: T;
 }
 
+export interface JSONRPCError {
+	code: number;
+	message: string;
+	data?: string | number | boolean | Record<string, unknown>;
+}
+
 export interface JSONRPCResponse<T> {
 	readonly id: number;
 	readonly jsonrpc: string;
 	readonly method: never;
 	readonly params: never;
-	readonly error?: { code: number; message: string; data?: string };
+	readonly error?: JSONRPCError;
 	readonly result?: T;
 }
 

--- a/elements/lisk-api-client/src/utils.ts
+++ b/elements/lisk-api-client/src/utils.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { JSONRPCError } from './types';
+
+export const convertRPCError = (error: JSONRPCError): Error =>
+	new Error(typeof error.data === 'string' ? error.data : error.message);

--- a/elements/lisk-api-client/src/ws_channel.ts
+++ b/elements/lisk-api-client/src/ws_channel.ts
@@ -16,6 +16,7 @@
 import * as WebSocket from 'isomorphic-ws';
 import { EventEmitter } from 'events';
 import { JSONRPCMessage, JSONRPCNotification, EventCallback } from './types';
+import { convertRPCError } from './utils';
 
 const CONNECTION_TIMEOUT = 2000;
 const ACKNOWLEDGMENT_TIMEOUT = 2000;
@@ -172,7 +173,7 @@ export class WSChannel {
 
 			if (this._pendingRequests[id]) {
 				if (res.error) {
-					this._pendingRequests[id].reject(new Error(res.error.data ?? res.error.data));
+					this._pendingRequests[id].reject(convertRPCError(res.error));
 				} else {
 					this._pendingRequests[id].resolve(res.result);
 				}

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/forging.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/forging.spec.ts
@@ -144,13 +144,10 @@ describe('api/forging', () => {
 
 				// Assert
 				expect(status).toEqual(500);
-				expect(response).toEqual({
-					errors: [
-						{
-							message: 'Failed to enable forging as the node is not synced to the network.',
-						},
-					],
-				});
+				expect(response.errors).toHaveLength(1);
+				expect(response.errors[0].message).toEqual(
+					'Failed to enable forging as the node is not synced to the network.',
+				);
 			});
 
 			it('should fail to enable forging when overwrite is false and maxHeightPreviouslyForged does not match', async () => {
@@ -172,13 +169,10 @@ describe('api/forging', () => {
 
 				// Assert
 				expect(status).toEqual(500);
-				expect(response).toEqual({
-					errors: [
-						{
-							message: 'Failed to enable forging as the node is not synced to the network.',
-						},
-					],
-				});
+				expect(response.errors).toHaveLength(1);
+				expect(response.errors[0].message).toEqual(
+					'Failed to enable forging as the node is not synced to the network.',
+				);
 			});
 
 			it('should respond with 400 and error message when address is not hex format', async () => {

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/peers.spec.ts
@@ -72,13 +72,8 @@ describe('Peers endpoint', () => {
 				const { response, status } = await callNetwork(axios.get(getURL('/api/peers')));
 				// Assert
 				expect(status).toBe(500);
-				expect(response).toEqual({
-					errors: [
-						{
-							message: 'test',
-						},
-					],
-				});
+				expect(response.errors).toHaveLength(1);
+				expect(response.errors[0].message).toEqual('test');
 			});
 		});
 	});

--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -385,25 +385,12 @@ export class Application {
 				getTransactionsFromPool: {
 					handler: () => this._node.actions.getTransactionsFromPool(),
 				},
-				getTransactions: {
-					handler: async (params?: Record<string, unknown>) =>
-						this._node.actions.getTransactions(params as { data: unknown; peerId: string }),
-				},
 				postTransaction: {
 					handler: async (params?: Record<string, unknown>) =>
 						this._node.actions.postTransaction((params as unknown) as EventPostTransactionData),
 				},
 				getLastBlock: {
-					handler: (params?: Record<string, unknown>) =>
-						this._node.actions.getLastBlock(params as { peerId: string }),
-				},
-				getBlocksFromId: {
-					handler: async (params?: Record<string, unknown>) =>
-						this._node.actions.getBlocksFromId(params as { data: unknown; peerId: string }),
-				},
-				getHighestCommonBlock: {
-					handler: async (params?: Record<string, unknown>) =>
-						this._node.actions.getHighestCommonBlock(params as { data: unknown; peerId: string }),
+					handler: () => this._node.actions.getLastBlock(),
 				},
 				getAccount: {
 					handler: async (params?: Record<string, unknown>) =>

--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -389,8 +389,8 @@ export class Bus {
 					.then(data => {
 						cb(null, data as JSONRPC.ResponseObjectWithResult);
 					})
-					.catch(error => {
-						cb(error);
+					.catch((error: JSONRPC.JSONRPCError) => {
+						cb(error, error.response);
 					});
 			},
 		);
@@ -407,8 +407,8 @@ export class Bus {
 				.then(data => {
 					socket.send(JSON.stringify(data as JSONRPC.ResponseObjectWithResult));
 				})
-				.catch(error => {
-					socket.send(JSON.stringify((error as JSONRPC.JSONRPCError).response));
+				.catch((error: JSONRPC.JSONRPCError) => {
+					socket.send(JSON.stringify(error.response));
 				});
 		});
 	}

--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -61,6 +61,16 @@ interface ChannelInfo {
 	readonly type: ChannelType;
 }
 
+const parseError = (id: JSONRPC.ID, err: Error | JSONRPC.JSONRPCError): JSONRPC.JSONRPCError => {
+	if (err instanceof JSONRPC.JSONRPCError) {
+		return err;
+	}
+	return new JSONRPC.JSONRPCError(
+		err.message,
+		JSONRPC.errorResponse(id, JSONRPC.internalError(err.message)),
+	);
+};
+
 export class Bus {
 	public logger: Logger;
 
@@ -217,13 +227,17 @@ export class Bus {
 		const actionParams = action.params;
 		const channelInfo = this.channels[action.module];
 		if (channelInfo.type === ChannelType.InMemory) {
-			const result = await (channelInfo.channel as BaseChannel).invoke<T>(
-				actionFullName,
-				actionParams,
-			);
-			return action.buildJSONRPCResponse({
-				result,
-			}) as JSONRPC.ResponseObjectWithResult<T>;
+			try {
+				const result = await (channelInfo.channel as BaseChannel).invoke<T>(
+					actionFullName,
+					actionParams,
+				);
+				return action.buildJSONRPCResponse({
+					result,
+				}) as JSONRPC.ResponseObjectWithResult<T>;
+			} catch (error) {
+				throw parseError(action.id, error);
+			}
 		}
 
 		// For child process channel
@@ -233,7 +247,7 @@ export class Bus {
 				action.toJSONRPCRequest(),
 				(err: Error | undefined, data: JSONRPC.ResponseObjectWithResult<T>) => {
 					if (err) {
-						return reject(err);
+						return reject(parseError(action.id, err));
 					}
 
 					return resolve(data);
@@ -370,23 +384,13 @@ export class Bus {
 
 		this._ipcServer.rpcServer.expose(
 			'invoke',
-			(action: string | JSONRPC.RequestObject, cb: NodeCallback) => {
-				this.invoke(action)
+			(message: string | JSONRPC.RequestObject, cb: NodeCallback) => {
+				this.invoke(message)
 					.then(data => {
 						cb(null, data as JSONRPC.ResponseObjectWithResult);
 					})
 					.catch(error => {
-						if (error instanceof JSONRPC.JSONRPCError) {
-							cb(error);
-							return;
-						}
-						const parsedAction = Action.fromJSONRPCRequest(action);
-						cb(
-							new JSONRPC.JSONRPCError(
-								(error as Error).message,
-								JSONRPC.errorResponse(parsedAction.id, JSONRPC.invalidRequest()),
-							),
-						);
+						cb(error);
 					});
 			},
 		);
@@ -404,19 +408,7 @@ export class Bus {
 					socket.send(JSON.stringify(data as JSONRPC.ResponseObjectWithResult));
 				})
 				.catch(error => {
-					if (error instanceof JSONRPC.JSONRPCError) {
-						return socket.send(JSON.stringify(error.response));
-					}
-					const parsedAction = Action.fromJSONRPCRequest(message);
-
-					return socket.send(
-						JSON.stringify(
-							JSONRPC.errorResponse(
-								parsedAction.id,
-								JSONRPC.internalError((error as Error).message),
-							),
-						),
-					);
+					socket.send(JSON.stringify((error as JSONRPC.JSONRPCError).response));
 				});
 		});
 	}

--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -376,7 +376,17 @@ export class Bus {
 						cb(null, data as JSONRPC.ResponseObjectWithResult);
 					})
 					.catch(error => {
-						cb(error as JSONRPC.ResponseObjectWithError);
+						if (error instanceof JSONRPC.JSONRPCError) {
+							cb(error);
+							return;
+						}
+						const parsedAction = Action.fromJSONRPCRequest(action);
+						cb(
+							new JSONRPC.JSONRPCError(
+								(error as Error).message,
+								JSONRPC.errorResponse(parsedAction.id, JSONRPC.invalidRequest()),
+							),
+						);
 					});
 			},
 		);

--- a/framework/src/controller/channels/ipc_channel.ts
+++ b/framework/src/controller/channels/ipc_channel.ts
@@ -166,17 +166,10 @@ export class IPCChannel extends BaseChannel {
 			this._rpcClient.call(
 				'invoke',
 				action.toJSONRPCRequest(),
-				(
-					err: JSONRPC.ResponseObjectWithError | undefined,
-					res: JSONRPC.ResponseObjectWithResult<T>,
-				) => {
+				(err: JSONRPC.JSONRPCError | undefined, res: JSONRPC.ResponseObjectWithResult<T>) => {
 					if (err) {
 						return reject(err);
 					}
-					if (res.error) {
-						return reject(res.error);
-					}
-
 					return resolve(res.result);
 				},
 			);

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -58,7 +58,8 @@ export interface handlePostTransactionReturn {
 	message?: string;
 	errors?: Error[] | Error;
 }
-export interface HandleRPCGetTransactionsReturn {
+
+interface HandleRPCGetTransactionsReturn {
 	transactions: string[];
 }
 

--- a/framework/test/functional/rpc-api/ipc/ipc_client.spec.ts
+++ b/framework/test/functional/rpc-api/ipc/ipc_client.spec.ts
@@ -91,8 +91,8 @@ describe('api client ipc mode', () => {
 
 		it('should throw an error when action fails due to missing argument', async () => {
 			// Assert
-			await expect(client.invoke('app:getBlocksFromId')).rejects.toThrow(
-				'Peer not found: undefined',
+			await expect(client.invoke('app:getAccount')).rejects.toThrow(
+				'The first argument must be of type string or an instance of Buffer',
 			);
 		});
 

--- a/framework/test/functional/rpc-api/ws/ws_client.spec.ts
+++ b/framework/test/functional/rpc-api/ws/ws_client.spec.ts
@@ -86,8 +86,8 @@ describe('api client ws mode', () => {
 
 		it('should throw an error when action fails due to missing argument', async () => {
 			// Assert
-			await expect(client.invoke('app:getBlocksFromId')).rejects.toThrow(
-				'Peer not found: undefined',
+			await expect(client.invoke('app:getAccount')).rejects.toThrow(
+				'The first argument must be of type string or an instance of Buffer',
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6034 

### How was it solved?

- Remove actions which is undocumented and meant for P2P communications from application
- Register those specific functions to the P2P communication
- Keep the `getLastBlock` action as this was used both for the action and P2P

### How was it tested?

- Functional tests should work as it is
- Call the `app:getLastBlock` actions more than 10 times in loop
- Run a node with this change and try to sync with the the node
