### PR TITLE
Resolve relative root path - Closes #6035

### DIFF
--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/forging_info.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/forging_info.spec.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { Application } from 'lisk-framework';
+import { Application, systemDirs } from 'lisk-framework';
 import { createIPCClient } from '@liskhq/lisk-api-client';
 import {
 	createApplication,
@@ -29,7 +29,7 @@ describe('forger:getForgingInfo action', () => {
 	beforeAll(async () => {
 		app = await createApplication('forging_info_spec');
 		await waitNBlocks(app, 1);
-		liskClient = await createIPCClient(`${app.config.rootPath}/${app.config.label}`);
+		liskClient = await createIPCClient(systemDirs(app.config.label, app.config.rootPath).dataPath);
 	});
 
 	afterAll(async () => {

--- a/framework-plugins/lisk-framework-forger-plugin/test/functional/voters.spec.ts
+++ b/framework-plugins/lisk-framework-forger-plugin/test/functional/voters.spec.ts
@@ -11,7 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { Application } from 'lisk-framework';
+import { Application, systemDirs } from 'lisk-framework';
 import { createIPCClient } from '@liskhq/lisk-api-client';
 import { createApplication, closeApplication, waitNBlocks, waitTill } from '../utils/application';
 import { createVoteTransaction } from '../utils/transactions';
@@ -26,7 +26,7 @@ describe('forger:getVoters action', () => {
 		app = await createApplication('forger_functional_voters');
 		// The test application generates a dynamic genesis block so we need to get the networkID like this
 		networkIdentifier = app['_node'].networkIdentifier;
-		liskClient = await createIPCClient(`${app.config.rootPath}/${app.config.label}`);
+		liskClient = await createIPCClient(systemDirs(app.config.label, app.config.rootPath).dataPath);
 	});
 
 	afterAll(async () => {

--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -13,7 +13,6 @@
  */
 
 import * as fs from 'fs-extra';
-import * as os from 'os';
 import * as path from 'path';
 import * as psList from 'ps-list';
 import * as assert from 'assert';
@@ -140,7 +139,6 @@ export class Application {
 			config.label ?? `lisk-${config.genesisConfig?.communityIdentifier}`;
 
 		const mergedConfig = objects.mergeDeep({}, appConfig, config) as ApplicationConfig;
-		mergedConfig.rootPath = mergedConfig.rootPath.replace('~', os.homedir());
 		const applicationConfigErrors = validator.validate(applicationConfigSchema, mergedConfig);
 		if (applicationConfigErrors.length) {
 			throw new LiskValidationError(applicationConfigErrors);

--- a/framework/src/system_dirs.ts
+++ b/framework/src/system_dirs.ts
@@ -12,14 +12,18 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import * as os from 'os';
 import * as path from 'path';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/explicit-function-return-type
-export const systemDirs = (appLabel: string, rootPath: string) => ({
-	dataPath: path.resolve(path.join(rootPath, appLabel)),
-	data: path.resolve(path.join(rootPath, appLabel, 'data')),
-	tmp: path.resolve(path.join(rootPath, appLabel, 'tmp')),
-	logs: path.resolve(path.join(rootPath, appLabel, 'logs')),
-	sockets: path.resolve(path.join(rootPath, appLabel, 'tmp', 'sockets')),
-	pids: path.resolve(path.join(rootPath, appLabel, 'tmp', 'pids')),
-});
+export const systemDirs = (appLabel: string, rootPath: string) => {
+	const rootPathWithoutTilde = rootPath.replace('~', os.homedir());
+	return {
+		dataPath: path.resolve(path.join(rootPathWithoutTilde, appLabel)),
+		data: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'data')),
+		tmp: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'tmp')),
+		logs: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'logs')),
+		sockets: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'tmp', 'sockets')),
+		pids: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'tmp', 'pids')),
+	};
+};

--- a/framework/src/system_dirs.ts
+++ b/framework/src/system_dirs.ts
@@ -12,18 +12,18 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import * as os from 'os';
-import * as path from 'path';
+import { homedir } from 'os';
+import { join, resolve } from 'path';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/explicit-function-return-type
 export const systemDirs = (appLabel: string, rootPath: string) => {
-	const rootPathWithoutTilde = rootPath.replace('~', os.homedir());
+	const rootPathWithoutTilde = rootPath.replace('~', homedir());
 	return {
-		dataPath: path.resolve(path.join(rootPathWithoutTilde, appLabel)),
-		data: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'data')),
-		tmp: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'tmp')),
-		logs: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'logs')),
-		sockets: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'tmp', 'sockets')),
-		pids: path.resolve(path.join(rootPathWithoutTilde, appLabel, 'tmp', 'pids')),
+		dataPath: resolve(join(rootPathWithoutTilde, appLabel)),
+		data: resolve(join(rootPathWithoutTilde, appLabel, 'data')),
+		tmp: resolve(join(rootPathWithoutTilde, appLabel, 'tmp')),
+		logs: resolve(join(rootPathWithoutTilde, appLabel, 'logs')),
+		sockets: resolve(join(rootPathWithoutTilde, appLabel, 'tmp', 'sockets')),
+		pids: resolve(join(rootPathWithoutTilde, appLabel, 'tmp', 'pids')),
 	};
 };

--- a/framework/src/system_dirs.ts
+++ b/framework/src/system_dirs.ts
@@ -16,10 +16,10 @@ import * as path from 'path';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/explicit-function-return-type
 export const systemDirs = (appLabel: string, rootPath: string) => ({
-	dataPath: path.join(rootPath, appLabel),
-	data: path.join(rootPath, appLabel, 'data'),
-	tmp: path.join(rootPath, appLabel, 'tmp'),
-	logs: path.join(rootPath, appLabel, 'logs'),
-	sockets: path.join(rootPath, appLabel, 'tmp', 'sockets'),
-	pids: path.join(rootPath, appLabel, 'tmp', 'pids'),
+	dataPath: path.resolve(rootPath, appLabel),
+	data: path.resolve(rootPath, appLabel, 'data'),
+	tmp: path.resolve(rootPath, appLabel, 'tmp'),
+	logs: path.resolve(rootPath, appLabel, 'logs'),
+	sockets: path.resolve(rootPath, appLabel, 'tmp', 'sockets'),
+	pids: path.resolve(rootPath, appLabel, 'tmp', 'pids'),
 });

--- a/framework/src/system_dirs.ts
+++ b/framework/src/system_dirs.ts
@@ -16,10 +16,10 @@ import * as path from 'path';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/explicit-function-return-type
 export const systemDirs = (appLabel: string, rootPath: string) => ({
-	dataPath: path.resolve(rootPath, appLabel),
-	data: path.resolve(rootPath, appLabel, 'data'),
-	tmp: path.resolve(rootPath, appLabel, 'tmp'),
-	logs: path.resolve(rootPath, appLabel, 'logs'),
-	sockets: path.resolve(rootPath, appLabel, 'tmp', 'sockets'),
-	pids: path.resolve(rootPath, appLabel, 'tmp', 'pids'),
+	dataPath: path.resolve(path.join(rootPath, appLabel)),
+	data: path.resolve(path.join(rootPath, appLabel, 'data')),
+	tmp: path.resolve(path.join(rootPath, appLabel, 'tmp')),
+	logs: path.resolve(path.join(rootPath, appLabel, 'logs')),
+	sockets: path.resolve(path.join(rootPath, appLabel, 'tmp', 'sockets')),
+	pids: path.resolve(path.join(rootPath, appLabel, 'tmp', 'pids')),
 });

--- a/framework/test/unit/application.spec.ts
+++ b/framework/test/unit/application.spec.ts
@@ -83,7 +83,7 @@ describe('Application', () => {
 	(createLogger as jest.Mock).mockReturnValue(loggerMock);
 
 	beforeEach(() => {
-		jest.spyOn(os, 'homedir').mockReturnValue('~');
+		jest.spyOn(os, 'homedir').mockReturnValue('/user');
 		jest.spyOn(IPCServer.prototype, 'start').mockResolvedValue();
 		jest.spyOn(WSServer.prototype, 'start').mockResolvedValue(jest.fn() as never);
 		jest.spyOn(Node.prototype, 'init').mockResolvedValue();
@@ -134,7 +134,7 @@ describe('Application', () => {
 
 		it('should set rootPath if provided', () => {
 			// Arrange
-			const customRootPath = './my-lisk-folder';
+			const customRootPath = '/my-lisk-folder';
 			const configWithCustomRootPath = objects.cloneDeep(config);
 			configWithCustomRootPath.rootPath = customRootPath;
 
@@ -668,7 +668,6 @@ describe('Application', () => {
 		let _nodeDBSpy: jest.SpyInstance<any, unknown[]>;
 
 		beforeEach(async () => {
-			config.rootPath = '/lisk';
 			app = Application.defaultApplication(genesisBlockJSON, config);
 			await app.run();
 			jest.spyOn(fs, 'readdirSync').mockReturnValue(fakeSocketFiles);
@@ -697,7 +696,7 @@ describe('Application', () => {
 		it('should call clearControllerPidFileSpy method with correct pid file location', async () => {
 			const unlinkSyncSpy = jest.spyOn(fs, 'unlinkSync').mockReturnValue();
 			await app.shutdown();
-			expect(unlinkSyncSpy).toHaveBeenCalledWith('/lisk/devnet/tmp/pids/controller.pid');
+			expect(unlinkSyncSpy).toHaveBeenCalledWith('/user/.lisk/devnet/tmp/pids/controller.pid');
 		});
 	});
 });

--- a/framework/test/unit/application.spec.ts
+++ b/framework/test/unit/application.spec.ts
@@ -134,7 +134,7 @@ describe('Application', () => {
 
 		it('should set rootPath if provided', () => {
 			// Arrange
-			const customRootPath = '/my-lisk-folder';
+			const customRootPath = './my-lisk-folder';
 			const configWithCustomRootPath = objects.cloneDeep(config);
 			configWithCustomRootPath.rootPath = customRootPath;
 
@@ -668,6 +668,7 @@ describe('Application', () => {
 		let _nodeDBSpy: jest.SpyInstance<any, unknown[]>;
 
 		beforeEach(async () => {
+			config.rootPath = '/lisk';
 			app = Application.defaultApplication(genesisBlockJSON, config);
 			await app.run();
 			jest.spyOn(fs, 'readdirSync').mockReturnValue(fakeSocketFiles);
@@ -696,7 +697,7 @@ describe('Application', () => {
 		it('should call clearControllerPidFileSpy method with correct pid file location', async () => {
 			const unlinkSyncSpy = jest.spyOn(fs, 'unlinkSync').mockReturnValue();
 			await app.shutdown();
-			expect(unlinkSyncSpy).toHaveBeenCalledWith('~/.lisk/devnet/tmp/pids/controller.pid');
+			expect(unlinkSyncSpy).toHaveBeenCalledWith('/lisk/devnet/tmp/pids/controller.pid');
 		});
 	});
 });

--- a/framework/test/unit/controller/controller.spec.ts
+++ b/framework/test/unit/controller/controller.spec.ts
@@ -13,6 +13,7 @@
  */
 
 import * as childProcess from 'child_process';
+import * as os from 'os';
 import { when } from 'jest-when';
 import { BasePlugin } from '../../../src';
 
@@ -74,7 +75,7 @@ describe('Controller Class', () => {
 		publish: jest.fn(),
 	};
 	const config = {
-		rootPath: '/lisk',
+		rootPath: '/user/.lisk',
 		rpc: {
 			enable: false,
 			mode: 'ipc',
@@ -96,7 +97,7 @@ describe('Controller Class', () => {
 		pids: `${config.rootPath}/${appLabel}/tmp/pids`,
 	};
 	const configController = {
-		dataPath: '/lisk/#LABEL',
+		dataPath: '/user/.lisk/#LABEL',
 		dirs: systemDirs,
 		socketsPath: {
 			root: `unix://${systemDirs.sockets}`,
@@ -126,6 +127,7 @@ describe('Controller Class', () => {
 		jest
 			.spyOn(childProcess, 'fork')
 			.mockReturnValue((childProcessMock as unknown) as childProcess.ChildProcess);
+		jest.spyOn(os, 'homedir').mockReturnValue('/user');
 	});
 
 	afterEach(async () => {

--- a/framework/test/unit/controller/controller.spec.ts
+++ b/framework/test/unit/controller/controller.spec.ts
@@ -74,7 +74,7 @@ describe('Controller Class', () => {
 		publish: jest.fn(),
 	};
 	const config = {
-		rootPath: '~/.lisk',
+		rootPath: '/lisk',
 		rpc: {
 			enable: false,
 			mode: 'ipc',
@@ -96,7 +96,7 @@ describe('Controller Class', () => {
 		pids: `${config.rootPath}/${appLabel}/tmp/pids`,
 	};
 	const configController = {
-		dataPath: '~/.lisk/#LABEL',
+		dataPath: '/lisk/#LABEL',
 		dirs: systemDirs,
 		socketsPath: {
 			root: `unix://${systemDirs.sockets}`,

--- a/framework/test/unit/system_dirs.spec.ts
+++ b/framework/test/unit/system_dirs.spec.ts
@@ -12,25 +12,87 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import * as os from 'os';
 import { systemDirs } from '../../src/system_dirs';
+
+beforeEach(() => {
+	jest.spyOn(os, 'homedir').mockReturnValue('/user');
+});
 
 describe('systemDirs', () => {
 	it('Should return directories configuration with given app label.', () => {
 		// Arrange
 		const appLabel = 'LABEL';
-		const rootPath = '/lisk';
+		const rootPath = '~/.lisk';
 
 		// Act
 		const dirsObj = systemDirs(appLabel, rootPath);
 
 		// Assert
 		expect(dirsObj).toEqual({
-			dataPath: `${rootPath}/${appLabel}`,
-			data: `${rootPath}/${appLabel}/data`,
-			tmp: `${rootPath}/${appLabel}/tmp`,
-			logs: `${rootPath}/${appLabel}/logs`,
-			sockets: `${rootPath}/${appLabel}/tmp/sockets`,
-			pids: `${rootPath}/${appLabel}/tmp/pids`,
+			dataPath: `/user/.lisk/${appLabel}`,
+			data: `/user/.lisk/${appLabel}/data`,
+			tmp: `/user/.lisk/${appLabel}/tmp`,
+			logs: `/user/.lisk/${appLabel}/logs`,
+			sockets: `/user/.lisk/${appLabel}/tmp/sockets`,
+			pids: `/user/.lisk/${appLabel}/tmp/pids`,
+		});
+	});
+
+	it('Should be able to resolve relative path correctly.', () => {
+		// Arrange
+		const appLabel = 'LABEL';
+		const rootPath = '/user/../.lisk';
+
+		// Act
+		const dirsObj = systemDirs(appLabel, rootPath);
+
+		// Assert
+		expect(dirsObj).toEqual({
+			dataPath: `/.lisk/${appLabel}`,
+			data: `/.lisk/${appLabel}/data`,
+			tmp: `/.lisk/${appLabel}/tmp`,
+			logs: `/.lisk/${appLabel}/logs`,
+			sockets: `/.lisk/${appLabel}/tmp/sockets`,
+			pids: `/.lisk/${appLabel}/tmp/pids`,
+		});
+	});
+
+	it('Should be able to resolve absolute path correctly.', () => {
+		// Arrange
+		const appLabel = 'LABEL';
+		const rootPath = '/customPath/.lisk';
+
+		// Act
+		const dirsObj = systemDirs(appLabel, rootPath);
+
+		// Assert
+		expect(dirsObj).toEqual({
+			dataPath: `/customPath/.lisk/${appLabel}`,
+			data: `/customPath/.lisk/${appLabel}/data`,
+			tmp: `/customPath/.lisk/${appLabel}/tmp`,
+			logs: `/customPath/.lisk/${appLabel}/logs`,
+			sockets: `/customPath/.lisk/${appLabel}/tmp/sockets`,
+			pids: `/customPath/.lisk/${appLabel}/tmp/pids`,
+		});
+	});
+
+	it('Should be able to resolve home path correctly.', () => {
+		// Arrange
+		const appLabel = 'LABEL';
+		const rootPath = '~/.lisk';
+
+		// Act
+		const dirsObj = systemDirs(appLabel, rootPath);
+
+		// Assert
+		expect(dirsObj).toEqual({
+			dataPath: `/user/.lisk/${appLabel}`,
+			data: `/user/.lisk/${appLabel}/data`,
+			tmp: `/user/.lisk/${appLabel}/tmp`,
+			logs: `/user/.lisk/${appLabel}/logs`,
+			sockets: `/user/.lisk/${appLabel}/tmp/sockets`,
+			pids: `/user/.lisk/${appLabel}/tmp/pids`,
 		});
 	});
 });

--- a/framework/test/unit/system_dirs.spec.ts
+++ b/framework/test/unit/system_dirs.spec.ts
@@ -18,7 +18,7 @@ describe('systemDirs', () => {
 	it('Should return directories configuration with given app label.', () => {
 		// Arrange
 		const appLabel = 'LABEL';
-		const rootPath = '~/.lisk';
+		const rootPath = '/lisk';
 
 		// Act
 		const dirsObj = systemDirs(appLabel, rootPath);


### PR DESCRIPTION
### What was the problem?

This PR resolves #6035 

### How was it solved?

* Add logic to resolve root path while creating system directories

### How was it tested?

* Updated unit tests
* Tested manually 
```
config.rootPath = './store';
app = Application.defaultApplication(genesisBlock, config);
app.run();
```
