### PR TITLE
Respond status code when client IP not allowed - Closes #6037

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
@@ -32,6 +32,7 @@ export const errorMiddleware = () => (
 	_next: NextFunction,
 ): void => {
 	let errors;
+	let responseCode = 500;
 
 	if (Array.isArray(err)) {
 		errors = err;
@@ -46,7 +47,11 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
-	const statusCode = err instanceof ErrorWithStatus ? err.statusCode : 500;
+	if (err instanceof ErrorWithStatus) {
+		const { statusCode, ...message } = err;
+		errors = message;
+		responseCode = statusCode;
+	}
 
-	res.status(statusCode).send({ errors });
+	res.status(responseCode).send({ errors });
 };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
@@ -38,5 +38,11 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
+	for (const error of errors) {
+		if (error.message === 'Access Denied') {
+			res.status(401).send({ errors });
+		}
+	}
+
 	res.status(500).send({ errors });
 };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
@@ -13,6 +13,14 @@
  */
 import { Request, Response, NextFunction } from 'express';
 
+export class ErrorWithStatus extends Error {
+	public statusCode: number;
+	public constructor(message: string, statusCode: number) {
+		super(message);
+		this.statusCode = statusCode;
+	}
+}
+
 interface ErrorWithDetails extends Error {
 	errors: Error[];
 }
@@ -38,11 +46,9 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
-	for (const error of errors) {
-		if (error.message === 'Access Denied') {
-			res.status(401).send({ errors });
-		}
-	}
+	const statusCode = (err as ErrorWithStatus).statusCode
+		? (err as ErrorWithStatus).statusCode
+		: 500;
 
-	res.status(500).send({ errors });
+	res.status(statusCode).send({ errors });
 };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/errors.ts
@@ -46,9 +46,7 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
-	const statusCode = (err as ErrorWithStatus).statusCode
-		? (err as ErrorWithStatus).statusCode
-		: 500;
+	const statusCode = err instanceof ErrorWithStatus ? err.statusCode : 500;
 
 	res.status(statusCode).send({ errors });
 };

--- a/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/whitelist.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/middlewares/whitelist.ts
@@ -13,6 +13,7 @@
  */
 import * as ip from 'ip';
 import { Request, Response, NextFunction } from 'express';
+import { ErrorWithStatus } from './errors';
 
 const defualtOption = { whiteList: [] };
 
@@ -49,5 +50,5 @@ export const whiteListMiddleware = ({
 		return;
 	}
 
-	next(new Error('Access Denied'));
+	next(new ErrorWithStatus('Access Denied', 401));
 };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
@@ -32,6 +32,7 @@ export const errorMiddleware = () => (
 	_next: NextFunction,
 ): void => {
 	let errors;
+	let responseCode = 500;
 
 	if (Array.isArray(err)) {
 		errors = err;
@@ -46,7 +47,11 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
-	const statusCode = err instanceof ErrorWithStatus ? err.statusCode : 500;
+	if (err instanceof ErrorWithStatus) {
+		const { statusCode, ...message } = err;
+		errors = message;
+		responseCode = statusCode;
+	}
 
-	res.status(statusCode).send({ errors });
+	res.status(responseCode).send({ errors });
 };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
@@ -38,5 +38,11 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
+	for (const error of errors) {
+		if (error.message === 'Access Denied') {
+			res.status(401).send({ errors });
+		}
+	}
+
 	res.status(500).send({ errors });
 };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
@@ -13,6 +13,14 @@
  */
 import { Request, Response, NextFunction } from 'express';
 
+export class ErrorWithStatus extends Error {
+	public statusCode: number;
+	public constructor(message: string, statusCode: number) {
+		super(message);
+		this.statusCode = statusCode;
+	}
+}
+
 interface ErrorWithDetails extends Error {
 	errors: Error[];
 }
@@ -38,11 +46,9 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
-	for (const error of errors) {
-		if (error.message === 'Access Denied') {
-			res.status(401).send({ errors });
-		}
-	}
+	const statusCode = (err as ErrorWithStatus).statusCode
+		? (err as ErrorWithStatus).statusCode
+		: 500;
 
-	res.status(500).send({ errors });
+	res.status(statusCode).send({ errors });
 };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/errors.ts
@@ -46,9 +46,7 @@ export const errorMiddleware = () => (
 		Object.defineProperty(error, 'message', { enumerable: true });
 	}
 
-	const statusCode = (err as ErrorWithStatus).statusCode
-		? (err as ErrorWithStatus).statusCode
-		: 500;
+	const statusCode = err instanceof ErrorWithStatus ? err.statusCode : 500;
 
 	res.status(statusCode).send({ errors });
 };

--- a/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/whitelist.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/middlewares/whitelist.ts
@@ -13,6 +13,7 @@
  */
 import * as ip from 'ip';
 import { Request, Response, NextFunction } from 'express';
+import { ErrorWithStatus } from './errors';
 
 const defualtOption = { whiteList: [] };
 
@@ -49,5 +50,5 @@ export const whiteListMiddleware = ({
 		return;
 	}
 
-	next(new Error('Access Denied'));
+	next(new ErrorWithStatus('Access Denied', 401));
 };


### PR DESCRIPTION
### What was the problem?

This PR resolves #6037

### How was it solved?

* Handle error status response

### How was it tested?
```
./bin/run sdk:link /path-to-lisk-sdk/lisk-sdk/sdk
./bin/run start --enable-http-api-plugin --http-api-plugin-port=5000 --http-api-plugin-whitelist=1.2.3.4
curl --verbose http://127.0.0.1:5000/api/node/info
```
