### PR TITLE
Fix BFT compliance check  - Closes #6047

### DIFF
--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -25,6 +25,7 @@ import {
 import { EVENT_BFT_FINALIZED_HEIGHT_CHANGED, FinalityManager } from './finality_manager';
 import * as forkChoiceRule from './fork_choice_rule';
 import { BFTPersistedValues, ForkStatus } from './types';
+import { BFT_ROUND_THRESHOLD } from './constant';
 
 export const EVENT_BFT_BLOCK_FINALIZED = 'EVENT_BFT_BLOCK_FINALIZED';
 
@@ -162,13 +163,12 @@ export class BFT extends EventEmitter {
 	): Promise<boolean> {
 		assert(blockHeader, 'No block was provided to be verified');
 
-		const roundsThreshold = 3;
 		const validators = await getValidators(stateStore);
 		const numberOfVotingValidators = validators.filter(
 			validator => validator.isConsensusParticipant,
 		).length;
 
-		const heightThreshold = numberOfVotingValidators * roundsThreshold;
+		const heightThreshold = numberOfVotingValidators * BFT_ROUND_THRESHOLD;
 
 		// Special case to avoid reducing the reward of delegates forging for the first time before the `heightThreshold` height
 		if (blockHeader.asset.maxHeightPreviouslyForged === 0) {

--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -179,19 +179,22 @@ export class BFT extends EventEmitter {
 			return false;
 		}
 
+		// If maxHeightPreviouslyForged is not in threshold, it is BFT compliant
+		if (blockHeader.height - blockHeader.asset.maxHeightPreviouslyForged > heightThreshold) {
+			return true;
+		}
+
 		const maxHeightPreviouslyForgedBlock = stateStore.chain.lastBlockHeaders.find(
 			bftHeader => bftHeader.height === blockHeader.asset.maxHeightPreviouslyForged,
 		);
 
-		// If maxHeightPreviouslyForgedBlock is not in the last blocks (default 309), it is BFT complient
-		if (maxHeightPreviouslyForgedBlock === undefined) {
-			return true;
+		if (!maxHeightPreviouslyForgedBlock) {
+			throw new Error(
+				`Block at height ${blockHeader.asset.maxHeightPreviouslyForged} must be in the lastBlockHeaders.`,
+			);
 		}
 
-		if (
-			blockHeader.height - blockHeader.asset.maxHeightPreviouslyForged <= heightThreshold &&
-			!blockHeader.generatorPublicKey.equals(maxHeightPreviouslyForgedBlock.generatorPublicKey)
-		) {
+		if (!blockHeader.generatorPublicKey.equals(maxHeightPreviouslyForgedBlock.generatorPublicKey)) {
 			return false;
 		}
 

--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -175,15 +175,22 @@ export class BFT extends EventEmitter {
 			return true;
 		}
 
+		if (blockHeader.height <= blockHeader.asset.maxHeightPreviouslyForged) {
+			return false;
+		}
+
 		const maxHeightPreviouslyForgedBlock = stateStore.chain.lastBlockHeaders.find(
 			bftHeader => bftHeader.height === blockHeader.asset.maxHeightPreviouslyForged,
 		);
 
+		// If maxHeightPreviouslyForgedBlock is not in the last blocks (default 309), it is BFT complient
+		if (maxHeightPreviouslyForgedBlock === undefined) {
+			return true;
+		}
+
 		if (
-			!maxHeightPreviouslyForgedBlock ||
-			blockHeader.asset.maxHeightPreviouslyForged >= blockHeader.height ||
-			(blockHeader.height - blockHeader.asset.maxHeightPreviouslyForged <= heightThreshold &&
-				!blockHeader.generatorPublicKey.equals(maxHeightPreviouslyForgedBlock.generatorPublicKey))
+			blockHeader.height - blockHeader.asset.maxHeightPreviouslyForged <= heightThreshold &&
+			!blockHeader.generatorPublicKey.equals(maxHeightPreviouslyForgedBlock.generatorPublicKey)
 		) {
 			return false;
 		}


### PR DESCRIPTION
### What was the problem?

This PR resolves #6047 

### How was it solved?

- Fix the condition that if the max height previously forged block is not in the cache, return true

### How was it tested?

- Add specific test when the block is not in the cache
