### PR TITLE
Lisk Client for browser - Closes #4163,#3348

### DIFF
--- a/elements/lisk-client/package.json
+++ b/elements/lisk-client/package.json
@@ -20,7 +20,12 @@
 		"node": ">=12.13.0 <=12",
 		"npm": ">=6.12.0"
 	},
-	"main": "dist-node/index.js",
+	"main": "dist-browser/index.js",
+	"exports": {
+		"node": "./dist-node/index.js",
+		"default": "./dist-browser/index.js"
+	},
+	"types": "dist-node/index.d.ts",
 	"scripts": {
 		"prestart": "./scripts/prestart.sh",
 		"start": "./scripts/start.sh",


### PR DESCRIPTION
### What was the problem?

This PR resolves #4163,#3348

### How was it solved?

- Added conditional exports and matched fallback `default` export to browser specific build. 
- Added types support from package definition  

### How was it tested?

- Used Rollup and Webpack to test the package in web build 

### Additional Information 

- For Rollup these two plugins are required to use `@rollup/plugin-node-resolve` and `@rollup/plugin-commonjs`
- For Webpack we still have to override `Buffer`, otherwise webpack override with its own buffer package. Use below code for reference. 

```
  plugins: [
    new ProvidePlugin({
      Buffer: ['buffer', 'Buffer'],
    })
  ]
```

Additional information can be found on: 

https://nodejs.org/api/packages.html#packages_conditional_exports
https://github.com/defunctzombie/package-browser-field-spec
