### PR TITLE
Add missing commander descriptions - Closes #6054

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -53,11 +53,17 @@
 			"account": {
 				"description": "Commands relating to Lisk accounts."
 			},
+			"hash-onion": {
+				"description": "Create hash onions to be used by the forger."
+			},
 			"help": {
 				"description": "Displays help."
 			},
 			"message": {
 				"description": "Commands relating to user messages."
+			},
+			"network-identifier": {
+				"description": "Creates network identifier for the given genesis block id and community identifier."
 			},
 			"passphrase": {
 				"description": "Commands relating to Lisk passphrases."

--- a/commander/package.json
+++ b/commander/package.json
@@ -63,7 +63,7 @@
 				"description": "Commands relating to user messages."
 			},
 			"network-identifier": {
-				"description": "Creates network identifier for the given genesis block id and community identifier."
+				"description": "Create network identifier for a given genesis block id and community identifier."
 			},
 			"passphrase": {
 				"description": "Commands relating to Lisk passphrases."


### PR DESCRIPTION
### What was the problem?

This PR resolves #6054 

### How was it solved?

* Add missing commander descriptions

### How was it tested?

Tested manually `./commander/bin/run --help`
