### PR TITLE
Expose getBytes functions from lisk-transactions - Closes #6058

### DIFF
--- a/elements/lisk-transactions/src/index.ts
+++ b/elements/lisk-transactions/src/index.ts
@@ -15,5 +15,5 @@
 
 export { computeMinFee } from './fee';
 export { convertBeddowsToLSK, convertLSKToBeddows } from './format';
-export { getSigningBytes, signTransaction, signMultiSignatureTransaction } from './sign';
+export { getBytes, getSigningBytes, signTransaction, signMultiSignatureTransaction } from './sign';
 export { validateTransaction } from './validate';


### PR DESCRIPTION
### What was the problem?

This PR resolves #6058 

### How was it solved?

- Exposed `getBytes` function

### How was it tested?

- require `lisk-sdk` and the transactions namespace should have getBytes function