### PR TITLE
Create oclif commands skeleton in the template - Closes #6075

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -43,6 +43,9 @@
 		"prepack": "oclif-dev manifest && npm shrinkwrap && npm prune --production && npm shrinkwrap",
 		"prepublishOnly": "rm -r ./node_modules && npm install && npm run lint && npm run build"
 	},
+	"lisk": {
+		"addressPrefix": "lsk"
+	},
 	"oclif": {
 		"commands": "./dist/commands",
 		"bin": "lisk",
@@ -82,6 +85,7 @@
 		"/docs"
 	],
 	"dependencies": {
+		"lisk-sdk": "5.0.3",
 		"@liskhq/lisk-cryptography": "^3.0.0",
 		"@liskhq/lisk-passphrase": "^3.0.1",
 		"@liskhq/lisk-validator": "^0.5.0",
@@ -90,6 +94,7 @@
 		"@oclif/errors": "1.2.2",
 		"@oclif/plugin-autocomplete": "0.2.1",
 		"@oclif/plugin-help": "2.2.3",
+		"axios": "0.21.1",
 		"bip39": "3.0.2",
 		"chalk": "3.0.0",
 		"cli-table3": "0.5.1",

--- a/commander/package.json
+++ b/commander/package.json
@@ -87,6 +87,7 @@
 		"@liskhq/lisk-passphrase": "^3.0.1",
 		"@liskhq/lisk-validator": "^0.5.0",
 		"@oclif/command": "1.5.19",
+		"@oclif/parser": "3.8.5",
 		"@oclif/config": "1.14.0",
 		"@oclif/errors": "1.2.2",
 		"@oclif/plugin-autocomplete": "0.2.1",

--- a/commander/package.json
+++ b/commander/package.json
@@ -82,10 +82,15 @@
 		"/docs"
 	],
 	"dependencies": {
-		"lisk-sdk": "5.0.3",
+		"lisk-framework": "0.7.3",
+		"@liskhq/lisk-api-client": "5.0.2",
+		"@liskhq/lisk-codec": "0.1.0",
 		"@liskhq/lisk-cryptography": "^3.0.0",
+		"@liskhq/lisk-db": "0.1.0",
 		"@liskhq/lisk-passphrase": "^3.0.1",
+		"@liskhq/lisk-transactions": "5.0.1",
 		"@liskhq/lisk-validator": "^0.5.0",
+		"@liskhq/lisk-utils": "0.1.0",
 		"@oclif/command": "1.5.19",
 		"@oclif/parser": "3.8.5",
 		"@oclif/config": "1.14.0",

--- a/commander/package.json
+++ b/commander/package.json
@@ -43,9 +43,6 @@
 		"prepack": "oclif-dev manifest && npm shrinkwrap && npm prune --production && npm shrinkwrap",
 		"prepublishOnly": "rm -r ./node_modules && npm install && npm run lint && npm run build"
 	},
-	"lisk": {
-		"addressPrefix": "lsk"
-	},
 	"oclif": {
 		"commands": "./dist/commands",
 		"bin": "lisk",

--- a/commander/src/bootstrapping/commands/account/create.ts
+++ b/commander/src/bootstrapping/commands/account/create.ts
@@ -40,7 +40,7 @@ const createAccount = (prefix: string): AccountInfo => {
 	};
 };
 
-export default class CreateCommand extends Command {
+export class CreateCommand extends Command {
 	static description =
 		'Return randomly-generated mnemonic passphrase with its corresponding public/private key pair and Lisk address.';
 

--- a/commander/src/bootstrapping/commands/account/create.ts
+++ b/commander/src/bootstrapping/commands/account/create.ts
@@ -1,0 +1,76 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+
+import { passphrase, cryptography } from 'lisk-sdk';
+
+interface AccountInfo {
+	readonly address: string;
+	readonly binaryAddress: string;
+	readonly passphrase: string;
+	readonly privateKey: string;
+	readonly publicKey: string;
+}
+
+const createAccount = (prefix: string): AccountInfo => {
+	const generatedPassphrase = passphrase.Mnemonic.generateMnemonic();
+	const { privateKey, publicKey } = cryptography.getKeys(generatedPassphrase);
+	const binaryAddress = cryptography.getAddressFromPublicKey(publicKey);
+	const address = cryptography.getBase32AddressFromPublicKey(publicKey, prefix);
+
+	return {
+		passphrase: generatedPassphrase,
+		privateKey: privateKey.toString('hex'),
+		publicKey: publicKey.toString('hex'),
+		binaryAddress: binaryAddress.toString('hex'),
+		address,
+	};
+};
+
+export abstract class CreateCommand extends Command {
+	static description =
+		'Return randomly-generated mnemonic passphrase with its corresponding public/private key pair and Lisk address.';
+
+	static examples = ['account:create', 'account:create --count=3'];
+
+	static flags = {
+		count: flagParser.string({
+			char: 'c',
+			description: 'Number of accounts to create.',
+			default: '1',
+		}),
+	};
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const {
+			flags: { count },
+		} = this.parse(CreateCommand);
+		const numberOfAccounts = parseInt(count, 10);
+		if (
+			count !== numberOfAccounts.toString() ||
+			!Number.isInteger(numberOfAccounts) ||
+			numberOfAccounts <= 0
+		) {
+			throw new Error('Count flag must be an integer and greater than 0.');
+		}
+		const accounts = new Array(numberOfAccounts)
+			.fill(0)
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			.map(() => createAccount(this.config.pjson.lisk.addressPrefix));
+		this.log(JSON.stringify(accounts, undefined, ' '));
+	}
+}

--- a/commander/src/bootstrapping/commands/account/create.ts
+++ b/commander/src/bootstrapping/commands/account/create.ts
@@ -15,7 +15,8 @@
  */
 import { Command, flags as flagParser } from '@oclif/command';
 
-import { passphrase, cryptography } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as passphrase from '@liskhq/lisk-passphrase';
 
 interface AccountInfo {
 	readonly address: string;

--- a/commander/src/bootstrapping/commands/account/create.ts
+++ b/commander/src/bootstrapping/commands/account/create.ts
@@ -40,7 +40,7 @@ const createAccount = (prefix: string): AccountInfo => {
 	};
 };
 
-export abstract class CreateCommand extends Command {
+export default class CreateCommand extends Command {
 	static description =
 		'Return randomly-generated mnemonic passphrase with its corresponding public/private key pair and Lisk address.';
 

--- a/commander/src/bootstrapping/commands/account/get.ts
+++ b/commander/src/bootstrapping/commands/account/get.ts
@@ -14,7 +14,7 @@
  */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 
 interface Args {
 	readonly address: string;

--- a/commander/src/bootstrapping/commands/account/get.ts
+++ b/commander/src/bootstrapping/commands/account/get.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import BaseIPCCommand from '../base_ipc';
+
+interface Args {
+	readonly address: string;
+}
+
+export abstract class GetCommand extends BaseIPCCommand {
+	static description = 'Get account information for a given address.';
+
+	static args = [
+		{
+			name: 'address',
+			required: true,
+			description: 'Address of an account in a hex format.',
+		},
+	];
+
+	static examples = ['account:get ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815'];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+	};
+
+	async run(): Promise<void> {
+		const { args } = this.parse(GetCommand);
+		const { address } = args as Args;
+
+		if (!this._client) {
+			this.error('APIClient is not initialized.');
+		}
+
+		try {
+			const account = await this._client.account.get(Buffer.from(address, 'hex'));
+			this.printJSON(this._client.account.toJSON(account));
+		} catch (errors) {
+			const errorMessage = Array.isArray(errors)
+				? errors.map(err => (err as Error).message).join(',')
+				: errors;
+
+			if (/^Specified key accounts:address:(.*)does not exist/.test((errors as Error).message)) {
+				this.error(`Account with address '${address}' was not found.`);
+			} else {
+				this.error(errorMessage);
+			}
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/account/index.ts
+++ b/commander/src/bootstrapping/commands/account/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { CreateCommand as AccountCreateCommand } from './create';
+export { GetCommand as AccountGetCommand } from './get';
+export { ShowCommand as AccountShowCommand } from './show';
+export { ValidateCommand as AccountValidateCommand } from './validate';

--- a/commander/src/bootstrapping/commands/account/index.ts
+++ b/commander/src/bootstrapping/commands/account/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as AccountCreateCommand } from './create';
+export { CreateCommand as AccountCreateCommand } from './create';
 export { GetCommand as AccountGetCommand } from './get';
-export { default as AccountShowCommand } from './show';
-export { default as AccountValidateCommand } from './validate';
+export { ShowCommand as AccountShowCommand } from './show';
+export { ValidateCommand as AccountValidateCommand } from './validate';

--- a/commander/src/bootstrapping/commands/account/index.ts
+++ b/commander/src/bootstrapping/commands/account/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { CreateCommand as AccountCreateCommand } from './create';
+export { default as AccountCreateCommand } from './create';
 export { GetCommand as AccountGetCommand } from './get';
-export { ShowCommand as AccountShowCommand } from './show';
-export { ValidateCommand as AccountValidateCommand } from './validate';
+export { default as AccountShowCommand } from './show';
+export { default as AccountValidateCommand } from './validate';

--- a/commander/src/bootstrapping/commands/account/show.ts
+++ b/commander/src/bootstrapping/commands/account/show.ts
@@ -14,7 +14,7 @@
  *
  */
 import { Command, flags as flagParser } from '@oclif/command';
-import { cryptography } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
 
 import { flags as commonFlags } from '../../../utils/flags';
 import { getPassphraseFromPrompt } from '../../../utils/reader';

--- a/commander/src/bootstrapping/commands/account/show.ts
+++ b/commander/src/bootstrapping/commands/account/show.ts
@@ -1,0 +1,67 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import { cryptography } from 'lisk-sdk';
+
+import { flags as commonFlags } from '../../../utils/flags';
+import { getPassphraseFromPrompt } from '../../../utils/reader';
+
+const processInput = (
+	passphrase: string,
+	prefix: string,
+): {
+	privateKey: string;
+	publicKey: string;
+	address: string;
+	binaryAddress: string;
+} => {
+	const { privateKey, publicKey } = cryptography.getKeys(passphrase);
+	const binaryAddress = cryptography.getAddressFromPublicKey(publicKey);
+	const address = cryptography.getBase32AddressFromPublicKey(publicKey, prefix);
+
+	return {
+		privateKey: privateKey.toString('hex'),
+		publicKey: publicKey.toString('hex'),
+		address,
+		binaryAddress: binaryAddress.toString('hex'),
+	};
+};
+
+export abstract class ShowCommand extends Command {
+	static description = 'Show account information for a given passphrase.';
+
+	static examples = ['account:show'];
+
+	static flags = {
+		passphrase: flagParser.string(commonFlags.passphrase),
+	};
+
+	async run(): Promise<void> {
+		const {
+			flags: { passphrase: passphraseSource },
+		} = this.parse(ShowCommand);
+		const passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+
+		this.log(
+			JSON.stringify(
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+				processInput(passphrase, this.config.pjson.lisk.addressPrefix),
+				undefined,
+				' ',
+			),
+		);
+	}
+}

--- a/commander/src/bootstrapping/commands/account/show.ts
+++ b/commander/src/bootstrapping/commands/account/show.ts
@@ -40,7 +40,7 @@ const processInput = (
 	};
 };
 
-export abstract class ShowCommand extends Command {
+export default class ShowCommand extends Command {
 	static description = 'Show account information for a given passphrase.';
 
 	static examples = ['account:show'];

--- a/commander/src/bootstrapping/commands/account/show.ts
+++ b/commander/src/bootstrapping/commands/account/show.ts
@@ -40,7 +40,7 @@ const processInput = (
 	};
 };
 
-export default class ShowCommand extends Command {
+export class ShowCommand extends Command {
 	static description = 'Show account information for a given passphrase.';
 
 	static examples = ['account:show'];

--- a/commander/src/bootstrapping/commands/account/validate.ts
+++ b/commander/src/bootstrapping/commands/account/validate.ts
@@ -14,7 +14,7 @@
  *
  */
 import { Command } from '@oclif/command';
-import { cryptography } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
 
 interface Args {
 	readonly address: string;

--- a/commander/src/bootstrapping/commands/account/validate.ts
+++ b/commander/src/bootstrapping/commands/account/validate.ts
@@ -1,0 +1,56 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command } from '@oclif/command';
+import { cryptography } from 'lisk-sdk';
+
+interface Args {
+	readonly address: string;
+}
+
+export abstract class ValidateCommand extends Command {
+	static description = 'Validate base32 address.';
+
+	static examples = ['account:validate lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmux2g'];
+
+	static args = [
+		{
+			name: 'address',
+			required: true,
+			description: 'Address in base32 format to validate.',
+		},
+	];
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const { args } = this.parse(ValidateCommand);
+		const { address } = args as Args;
+
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			cryptography.validateBase32Address(address, this.config.pjson.lisk.addressPrefix);
+			const binaryAddress = cryptography.getAddressFromBase32Address(address).toString('hex');
+
+			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+			this.log(
+				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+				`Address ${address} is a valid base32 address and the corresponding binary address is ${binaryAddress}.`,
+			);
+		} catch (error) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+			this.error(error.message);
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/account/validate.ts
+++ b/commander/src/bootstrapping/commands/account/validate.ts
@@ -20,7 +20,7 @@ interface Args {
 	readonly address: string;
 }
 
-export abstract class ValidateCommand extends Command {
+export default class ValidateCommand extends Command {
 	static description = 'Validate base32 address.';
 
 	static examples = ['account:validate lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmux2g'];

--- a/commander/src/bootstrapping/commands/account/validate.ts
+++ b/commander/src/bootstrapping/commands/account/validate.ts
@@ -20,7 +20,7 @@ interface Args {
 	readonly address: string;
 }
 
-export default class ValidateCommand extends Command {
+export class ValidateCommand extends Command {
 	static description = 'Validate base32 address.';
 
 	static examples = ['account:validate lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmux2g'];

--- a/commander/src/bootstrapping/commands/base_forging.ts
+++ b/commander/src/bootstrapping/commands/base_forging.ts
@@ -29,7 +29,7 @@ interface Args {
 const isLessThanZero = (value: number | undefined | null): boolean =>
 	value === null || value === undefined || value < 0;
 
-export class BaseForgingCommand extends BaseIPCCommand {
+export abstract class BaseForgingCommand extends BaseIPCCommand {
 	static args = [
 		{
 			name: 'address',

--- a/commander/src/bootstrapping/commands/base_forging.ts
+++ b/commander/src/bootstrapping/commands/base_forging.ts
@@ -17,7 +17,7 @@ import * as inquirer from 'inquirer';
 import { flags as flagParser } from '@oclif/command';
 
 import { flags as commonFlags } from '../../utils/flags';
-import BaseIPCCommand from './base_ipc';
+import { BaseIPCCommand } from './base_ipc';
 
 interface Args {
 	readonly address: string;

--- a/commander/src/bootstrapping/commands/base_forging.ts
+++ b/commander/src/bootstrapping/commands/base_forging.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as inquirer from 'inquirer';
+import { flags as flagParser } from '@oclif/command';
+
+import { flags as commonFlags } from '../../utils/flags';
+import BaseIPCCommand from './base_ipc';
+
+interface Args {
+	readonly address: string;
+	readonly height?: number;
+	readonly maxHeightPreviouslyForged?: number;
+	readonly maxHeightPrevoted?: number;
+}
+
+const isLessThanZero = (value: number | undefined | null): boolean =>
+	value === null || value === undefined || value < 0;
+
+export class BaseForgingCommand extends BaseIPCCommand {
+	static args = [
+		{
+			name: 'address',
+			required: true,
+			description: 'Address of an account in a base32 format.',
+		},
+	];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+		password: flagParser.string(commonFlags.password),
+		overwrite: flagParser.boolean({
+			description: 'Overwrites the forger info',
+			default: false,
+		}),
+	};
+
+	protected forging!: boolean;
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(this.constructor as typeof BaseForgingCommand);
+		const { address, height, maxHeightPreviouslyForged, maxHeightPrevoted } = args as Args;
+		let password;
+
+		if (
+			this.forging &&
+			(isLessThanZero(height) ||
+				isLessThanZero(maxHeightPreviouslyForged) ||
+				isLessThanZero(maxHeightPrevoted))
+		) {
+			throw new Error(
+				'The maxHeightPreviouslyForged and maxHeightPrevoted parameter value must be greater than or equal to 0',
+			);
+		}
+
+		if (flags.password) {
+			password = flags.password;
+		} else {
+			const answers = await inquirer.prompt([
+				{
+					type: 'password',
+					message: 'Enter password to decrypt the encrypted passphrase: ',
+					name: 'password',
+					mask: '*',
+				},
+			]);
+			password = (answers as { password: string }).password;
+		}
+		if (!this._client) {
+			this.error('APIClient is not initialized.');
+		}
+		try {
+			const result = await this._client.invoke<{ address: string; forging: boolean }>(
+				'app:updateForgingStatus',
+				{
+					address,
+					password,
+					forging: this.forging,
+					height: Number(height ?? 0),
+					maxHeightPreviouslyForged: Number(maxHeightPreviouslyForged ?? 0),
+					maxHeightPrevoted: Number(maxHeightPrevoted ?? 0),
+					overwrite: flags.overwrite,
+				},
+			);
+			this.log('Forging status:');
+			this.printJSON(result);
+		} catch (error) {
+			this.error(error);
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -105,12 +105,7 @@ export default abstract class BaseIPCCommand extends Command {
 		if (this.baseIPCFlags.offline) {
 			// Read network genesis block and config from the folder
 			const { genesisBlock, config } = await getGenesisBlockAndConfig(this.baseIPCFlags.network);
-			const app = this.getApplication(genesisBlock, config, {
-				enableHTTPAPIPlugin: false,
-				enableForgerPlugin: false,
-				enableMonitorPlugin: false,
-				enableReportMisbehaviorPlugin: false,
-			});
+			const app = this.getApplication(genesisBlock, config);
 			this._schema = app.getSchema();
 			return;
 		}
@@ -195,6 +190,5 @@ export default abstract class BaseIPCCommand extends Command {
 	abstract getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,
-		options: Record<string, unknown>,
 	): Application;
 }

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -15,15 +15,16 @@
 
 import { Command, flags as flagParser } from '@oclif/command';
 import * as Parser from '@oclif/parser';
+import * as apiClient from '@liskhq/lisk-api-client';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import { codec } from '@liskhq/lisk-codec';
 import {
 	Application,
 	RegisteredSchema,
-	apiClient,
-	codec,
 	PartialApplicationConfig,
 	Transaction,
-	cryptography,
-} from 'lisk-sdk';
+} from 'lisk-framework';
+
 import { getDefaultPath, getGenesisBlockAndConfig } from '../../utils/path';
 import { flags as commonFlags } from '../../utils/flags';
 import { DEFAULT_NETWORK } from '../../constants';

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -14,6 +14,7 @@
  */
 
 import { Command, flags as flagParser } from '@oclif/command';
+import * as Parser from '@oclif/parser';
 import {
 	Application,
 	RegisteredSchema,
@@ -75,6 +76,8 @@ export abstract class BaseIPCCommand extends Command {
 		}),
 	};
 
+	static args = [] as Parser.args.Input;
+
 	public baseIPCFlags!: BaseIPCFlags;
 	protected _client: PromiseResolvedType<ReturnType<typeof apiClient.createIPCClient>> | undefined;
 	protected _schema!: RegisteredSchema;
@@ -84,11 +87,11 @@ export abstract class BaseIPCCommand extends Command {
 		if (error) {
 			// TODO: replace this logic with isApplicationRunning util and log the error accordingly
 			if (/^IPC Socket client connection timeout./.test((error as Error).message)) {
-				this.error(
+				super.error(
 					'Please ensure the app is up and running with ipc enabled before using the command!',
 				);
 			}
-			this.error(error instanceof Error ? error.message : error);
+			super.error(error instanceof Error ? error.message : error);
 		}
 		if (this._client) {
 			await this._client.disconnect();
@@ -119,9 +122,9 @@ export abstract class BaseIPCCommand extends Command {
 
 	printJSON(message?: unknown): void {
 		if (this.baseIPCFlags.pretty) {
-			this.log(JSON.stringify(message, undefined, '  '));
+			super.log(JSON.stringify(message, undefined, '  '));
 		} else {
-			this.log(JSON.stringify(message));
+			super.log(JSON.stringify(message));
 		}
 	}
 

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -53,7 +53,7 @@ export interface Codec {
 
 const prettyDescription = 'Prints JSON in pretty format rather than condensed.';
 
-export default abstract class BaseIPCCommand extends Command {
+export abstract class BaseIPCCommand extends Command {
 	static flags = {
 		pretty: flagParser.boolean({
 			description: prettyDescription,

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -100,7 +100,7 @@ export abstract class BaseIPCCommand extends Command {
 		this.baseIPCFlags = flags;
 		const dataPath = this.baseIPCFlags['data-path']
 			? this.baseIPCFlags['data-path']
-			: getDefaultPath();
+			: getDefaultPath(this.config.pjson.name);
 
 		if (this.baseIPCFlags.offline) {
 			// Read network genesis block and config from the folder

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -78,7 +78,7 @@ export abstract class BaseIPCCommand extends Command {
 
 	static args = [] as Parser.args.Input;
 
-	public baseIPCFlags!: BaseIPCFlags;
+	protected baseIPCFlags!: BaseIPCFlags;
 	protected _client: PromiseResolvedType<ReturnType<typeof apiClient.createIPCClient>> | undefined;
 	protected _schema!: RegisteredSchema;
 
@@ -120,7 +120,7 @@ export abstract class BaseIPCCommand extends Command {
 		this._schema = this._client.schemas;
 	}
 
-	printJSON(message?: unknown): void {
+	printJSON(message?: Record<string, unknown>): void {
 		if (this.baseIPCFlags.pretty) {
 			super.log(JSON.stringify(message, undefined, '  '));
 		} else {

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { Command, flags as flagParser } from '@oclif/command';
+import {
+	Application,
+	RegisteredSchema,
+	apiClient,
+	codec,
+	PartialApplicationConfig,
+	Transaction,
+	cryptography,
+} from 'lisk-sdk';
+import { getDefaultPath, getGenesisBlockAndConfig } from '../../utils/path';
+import { flags as commonFlags } from '../../utils/flags';
+import { DEFAULT_NETWORK } from '../../constants';
+import { PromiseResolvedType, Schema } from '../../types';
+import { isApplicationRunning } from '../../utils/application';
+
+interface BaseIPCFlags {
+	readonly 'data-path'?: string;
+	readonly network: string;
+	readonly offline?: boolean;
+	readonly pretty?: boolean;
+}
+
+export interface Codec {
+	decodeAccount: (data: Buffer | string) => Record<string, unknown>;
+	decodeBlock: (data: Buffer | string) => Record<string, unknown>;
+	decodeTransaction: (data: Buffer | string) => Record<string, unknown>;
+	encodeTransaction: (assetSchema: Schema, transactionObject: Record<string, unknown>) => string;
+	transactionFromJSON: (
+		assetSchema: Schema,
+		transactionObject: Record<string, unknown>,
+	) => Record<string, unknown>;
+	transactionToJSON: (
+		assetSchema: Schema,
+		transactionObject: Record<string, unknown>,
+	) => Record<string, unknown>;
+}
+
+const prettyDescription = 'Prints JSON in pretty format rather than condensed.';
+
+export default abstract class BaseIPCCommand extends Command {
+	static flags = {
+		pretty: flagParser.boolean({
+			description: prettyDescription,
+		}),
+		'data-path': flagParser.string({
+			...commonFlags.dataPath,
+			env: 'LISK_DATA_PATH',
+		}),
+		offline: flagParser.boolean({
+			...commonFlags.offline,
+			default: false,
+			hidden: true,
+		}),
+		network: flagParser.string({
+			...commonFlags.network,
+			env: 'LISK_NETWORK',
+			default: DEFAULT_NETWORK,
+			hidden: true,
+		}),
+	};
+
+	public baseIPCFlags!: BaseIPCFlags;
+	protected _client: PromiseResolvedType<ReturnType<typeof apiClient.createIPCClient>> | undefined;
+	protected _schema!: RegisteredSchema;
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async finally(error?: Error | string): Promise<void> {
+		if (error) {
+			// TODO: replace this logic with isApplicationRunning util and log the error accordingly
+			if (/^IPC Socket client connection timeout./.test((error as Error).message)) {
+				this.error(
+					'Please ensure the app is up and running with ipc enabled before using the command!',
+				);
+			}
+			this.error(error instanceof Error ? error.message : error);
+		}
+		if (this._client) {
+			await this._client.disconnect();
+		}
+	}
+
+	async init(): Promise<void> {
+		const { flags } = this.parse(this.constructor as typeof BaseIPCCommand);
+		this.baseIPCFlags = flags;
+		const dataPath = this.baseIPCFlags['data-path']
+			? this.baseIPCFlags['data-path']
+			: getDefaultPath();
+
+		if (this.baseIPCFlags.offline) {
+			// Read network genesis block and config from the folder
+			const { genesisBlock, config } = await getGenesisBlockAndConfig(this.baseIPCFlags.network);
+			const app = this.getApplication(genesisBlock, config, {
+				enableHTTPAPIPlugin: false,
+				enableForgerPlugin: false,
+				enableMonitorPlugin: false,
+				enableReportMisbehaviorPlugin: false,
+			});
+			this._schema = app.getSchema();
+			return;
+		}
+
+		if (!isApplicationRunning(dataPath)) {
+			throw new Error(`Application at data path ${dataPath} is not running.`);
+		}
+		this._client = await apiClient.createIPCClient(dataPath);
+		this._schema = this._client.schemas;
+	}
+
+	printJSON(message?: unknown): void {
+		if (this.baseIPCFlags.pretty) {
+			this.log(JSON.stringify(message, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(message));
+		}
+	}
+
+	protected getAssetSchema(
+		moduleID: number,
+		assetID: number,
+	): RegisteredSchema['transactionsAssets'][0] {
+		const assetSchema = this._schema.transactionsAssets.find(
+			schema => schema.moduleID === moduleID && schema.assetID === assetID,
+		);
+		if (!assetSchema) {
+			throw new Error(
+				`Transaction moduleID:${moduleID} with assetID:${assetID} is not registered in the application.`,
+			);
+		}
+		return assetSchema;
+	}
+
+	protected decodeTransaction(transactionHexStr: string): Record<string, unknown> {
+		const transactionBytes = Buffer.from(transactionHexStr, 'hex');
+		if (this._client) {
+			return this._client.transaction.decode(transactionBytes);
+		}
+		const id = cryptography.hash(transactionBytes);
+		const transaction = codec.decode<Transaction>(this._schema.transaction, transactionBytes);
+		const assetSchema = this.getAssetSchema(transaction.moduleID, transaction.assetID);
+		const asset = codec.decode<Record<string, unknown>>(assetSchema.schema, transaction.asset);
+		return {
+			...transaction,
+			asset,
+			id,
+		};
+	}
+
+	protected encodeTransaction(transaction: Record<string, unknown>): Buffer {
+		if (this._client) {
+			return this._client.transaction.encode(transaction);
+		}
+		const assetSchema = this.getAssetSchema(
+			transaction.moduleID as number,
+			transaction.assetID as number,
+		);
+		const assetBytes = codec.encode(assetSchema.schema, transaction.asset as object);
+		const txBytes = codec.encode(this._schema.transaction, { ...transaction, asset: assetBytes });
+		return txBytes;
+	}
+
+	protected transactionToJSON(transaction: Record<string, unknown>): Record<string, unknown> {
+		if (this._client) {
+			return this._client.transaction.toJSON(transaction);
+		}
+		const assetSchema = this.getAssetSchema(
+			transaction.moduleID as number,
+			transaction.assetID as number,
+		);
+		const assetJSON = codec.toJSON(assetSchema.schema, transaction.asset as object);
+		const { id, asset, ...txWithoutAsset } = transaction;
+		const txJSON = codec.toJSON(this._schema.transaction, txWithoutAsset);
+		return {
+			...txJSON,
+			asset: assetJSON,
+			id: Buffer.isBuffer(id) ? id.toString('hex') : undefined,
+		};
+	}
+
+	abstract getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+		options: Record<string, unknown>,
+	): Application;
+}

--- a/commander/src/bootstrapping/commands/base_ipc.ts
+++ b/commander/src/bootstrapping/commands/base_ipc.ts
@@ -87,11 +87,11 @@ export abstract class BaseIPCCommand extends Command {
 		if (error) {
 			// TODO: replace this logic with isApplicationRunning util and log the error accordingly
 			if (/^IPC Socket client connection timeout./.test((error as Error).message)) {
-				super.error(
+				this.error(
 					'Please ensure the app is up and running with ipc enabled before using the command!',
 				);
 			}
-			super.error(error instanceof Error ? error.message : error);
+			this.error(error instanceof Error ? error.message : error);
 		}
 		if (this._client) {
 			await this._client.disconnect();
@@ -122,9 +122,9 @@ export abstract class BaseIPCCommand extends Command {
 
 	printJSON(message?: Record<string, unknown>): void {
 		if (this.baseIPCFlags.pretty) {
-			super.log(JSON.stringify(message, undefined, '  '));
+			this.log(JSON.stringify(message, undefined, '  '));
 		} else {
-			super.log(JSON.stringify(message));
+			this.log(JSON.stringify(message));
 		}
 	}
 

--- a/commander/src/bootstrapping/commands/block/get.ts
+++ b/commander/src/bootstrapping/commands/block/get.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import BaseIPCCommand from '../base_ipc';
+
+interface Args {
+	readonly input: string;
+}
+interface BlockType<T = Buffer | string> {
+	header: {
+		[key: string]: unknown;
+		id?: T;
+		version: number;
+		asset: Record<string, unknown>;
+	};
+	payload: {
+		[key: string]: unknown;
+		id?: T;
+	}[];
+}
+
+export abstract class GetCommand extends BaseIPCCommand {
+	static description = 'Get block information for a given id or height.';
+
+	static args = [
+		{
+			name: 'input',
+			required: true,
+			description: 'Height in number or block id in hex format.',
+		},
+	];
+
+	static examples = [
+		'block:get e082e79d01016632c451c9df9276e486cb7f460dc793ff5b10d8f71eecec28b4',
+		'block:get 2',
+	];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+	};
+
+	async run(): Promise<void> {
+		const { args } = this.parse(GetCommand);
+		const { input } = args as Args;
+
+		let block;
+		if (!this._client) {
+			this.error('APIClient is not initialized.');
+		}
+		try {
+			if (!Number.isNaN(Number(input))) {
+				block = await this._client.block.getByHeight(parseInt(input, 10));
+			} else {
+				block = await this._client.block.get(Buffer.from(input, 'hex'));
+			}
+
+			this.printJSON(this._client.block.toJSON((block as unknown) as BlockType));
+		} catch (errors) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const errorMessage = Array.isArray(errors)
+				? errors.map(err => (err as Error).message).join(',')
+				: errors;
+
+			if (/^Specified key block(.*)does not exist/.test((errors as Error).message)) {
+				if (input) {
+					this.error('Block with given id or height was not found.');
+				}
+			} else {
+				this.error(errorMessage);
+			}
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/block/get.ts
+++ b/commander/src/bootstrapping/commands/block/get.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 
 interface Args {
 	readonly input: string;

--- a/commander/src/bootstrapping/commands/block/index.ts
+++ b/commander/src/bootstrapping/commands/block/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { GetCommand as BlockGetCommand } from './get';

--- a/commander/src/bootstrapping/commands/blockchain/download.ts
+++ b/commander/src/bootstrapping/commands/blockchain/download.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import { NETWORK, RELEASE_URL, DEFAULT_NETWORK } from '../../../constants';
+import { liskSnapshotUrl } from '../../../utils/commons';
+import { getFullPath } from '../../../utils/path';
+import { downloadAndValidate, getChecksum } from '../../../utils/download';
+import { flags as commonFlags } from '../../../utils/flags';
+
+export abstract class DownloadCommand extends Command {
+	static description = 'Download snapshot from <URL>.';
+
+	static examples = [
+		'download',
+		'download --network betanet',
+		'download --url https://downloads.lisk.io/lisk/mainnet/blockchain.db.tar.gz --output ./downloads',
+	];
+
+	static flags = {
+		network: flagParser.string({
+			...commonFlags.network,
+			env: 'LISK_NETWORK',
+			default: DEFAULT_NETWORK,
+		}),
+		output: flagParser.string({
+			char: 'o',
+			description:
+				'Directory path to specify where snapshot is downloaded. By default outputs the files to current working directory.',
+		}),
+		url: flagParser.string({
+			char: 'u',
+			description: 'The url to the snapshot.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(DownloadCommand);
+		const network = flags.network ? (flags.network as NETWORK) : DEFAULT_NETWORK;
+		const url = flags.url ? flags.url : liskSnapshotUrl(RELEASE_URL, network);
+		const dataPath = flags.output ? flags.output : process.cwd();
+		this.log(`Downloading snapshot from ${url} to ${getFullPath(dataPath)}`);
+
+		try {
+			await downloadAndValidate(url, dataPath);
+			const checksum = getChecksum(url, dataPath);
+			this.log(`Downloaded to path: ${dataPath}.`);
+			this.log(`Verified checksum: ${checksum}.`);
+		} catch (errors) {
+			this.error(
+				Array.isArray(errors) ? errors.map(err => (err as Error).message).join(',') : errors,
+			);
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/blockchain/download.ts
+++ b/commander/src/bootstrapping/commands/blockchain/download.ts
@@ -19,7 +19,7 @@ import { getFullPath } from '../../../utils/path';
 import { downloadAndValidate, getChecksum } from '../../../utils/download';
 import { flags as commonFlags } from '../../../utils/flags';
 
-export default class DownloadCommand extends Command {
+export class DownloadCommand extends Command {
 	static description = 'Download snapshot from <URL>.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/blockchain/download.ts
+++ b/commander/src/bootstrapping/commands/blockchain/download.ts
@@ -19,7 +19,7 @@ import { getFullPath } from '../../../utils/path';
 import { downloadAndValidate, getChecksum } from '../../../utils/download';
 import { flags as commonFlags } from '../../../utils/flags';
 
-export abstract class DownloadCommand extends Command {
+export default class DownloadCommand extends Command {
 	static description = 'Download snapshot from <URL>.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/blockchain/export.ts
+++ b/commander/src/bootstrapping/commands/blockchain/export.ts
@@ -18,7 +18,7 @@ import { join } from 'path';
 import { Command, flags as flagParser } from '@oclif/command';
 import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils/path';
 
-export default class ExportCommand extends Command {
+export class ExportCommand extends Command {
 	static description = 'Export to <FILE>.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/blockchain/export.ts
+++ b/commander/src/bootstrapping/commands/blockchain/export.ts
@@ -41,7 +41,9 @@ export class ExportCommand extends Command {
 
 	async run(): Promise<void> {
 		const { flags } = this.parse(ExportCommand);
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
 		const blockchainPath = getBlockchainDBPath(dataPath);
 		const exportPath = flags.output ? flags.output : process.cwd();
 

--- a/commander/src/bootstrapping/commands/blockchain/export.ts
+++ b/commander/src/bootstrapping/commands/blockchain/export.ts
@@ -18,7 +18,7 @@ import { join } from 'path';
 import { Command, flags as flagParser } from '@oclif/command';
 import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils/path';
 
-export abstract class ExportCommand extends Command {
+export default class ExportCommand extends Command {
 	static description = 'Export to <FILE>.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/blockchain/export.ts
+++ b/commander/src/bootstrapping/commands/blockchain/export.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as tar from 'tar';
+import { join } from 'path';
+import { Command, flags as flagParser } from '@oclif/command';
+import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils/path';
+
+export abstract class ExportCommand extends Command {
+	static description = 'Export to <FILE>.';
+
+	static examples = [
+		'blockchain:export',
+		'blockchain:export --data-path ./data --output ./my/path/',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			char: 'd',
+			description:
+				'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
+			env: 'LISK_DATA_PATH',
+		}),
+		output: flagParser.string({
+			char: 'o',
+			description: 'The output directory. Default will set to current working directory.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(ExportCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const blockchainPath = getBlockchainDBPath(dataPath);
+		const exportPath = flags.output ? flags.output : process.cwd();
+
+		this.log('Exporting blockchain:');
+		this.log(`   ${getFullPath(blockchainPath)}`);
+		const filePath = join(exportPath, 'blockchain.db.tar.gz');
+		await tar.create(
+			{
+				gzip: true,
+				file: filePath,
+				cwd: join(dataPath, 'data'),
+			},
+			['blockchain.db'],
+		);
+
+		this.log('Export completed:');
+		this.log(`   ${filePath}`);
+	}
+}

--- a/commander/src/bootstrapping/commands/blockchain/hash.ts
+++ b/commander/src/bootstrapping/commands/blockchain/hash.ts
@@ -19,7 +19,7 @@ import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils
 import { getPid, isApplicationRunning } from '../../../utils/application';
 import { getBlockchainDB } from '../../../utils/db';
 
-export abstract class HashCommand extends Command {
+export default class HashCommand extends Command {
 	static description = 'Generate SHA256 hash from <PATH>.';
 
 	static examples = ['blockchain:hash', 'blockchain:hash --data-path ./data'];

--- a/commander/src/bootstrapping/commands/blockchain/hash.ts
+++ b/commander/src/bootstrapping/commands/blockchain/hash.ts
@@ -36,7 +36,9 @@ export class HashCommand extends Command {
 	// eslint-disable-next-line @typescript-eslint/require-await
 	async run(): Promise<void> {
 		const { flags } = this.parse(HashCommand);
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
 		const blockchainPath = getBlockchainDBPath(dataPath);
 
 		if (isApplicationRunning(dataPath)) {

--- a/commander/src/bootstrapping/commands/blockchain/hash.ts
+++ b/commander/src/bootstrapping/commands/blockchain/hash.ts
@@ -19,7 +19,7 @@ import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils
 import { getPid, isApplicationRunning } from '../../../utils/application';
 import { getBlockchainDB } from '../../../utils/db';
 
-export default class HashCommand extends Command {
+export class HashCommand extends Command {
 	static description = 'Generate SHA256 hash from <PATH>.';
 
 	static examples = ['blockchain:hash', 'blockchain:hash --data-path ./data'];

--- a/commander/src/bootstrapping/commands/blockchain/hash.ts
+++ b/commander/src/bootstrapping/commands/blockchain/hash.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as crypto from 'crypto';
+import { Command, flags as flagParser } from '@oclif/command';
+import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils/path';
+import { getPid, isApplicationRunning } from '../../../utils/application';
+import { getBlockchainDB } from '../../../utils/db';
+
+export abstract class HashCommand extends Command {
+	static description = 'Generate SHA256 hash from <PATH>.';
+
+	static examples = ['blockchain:hash', 'blockchain:hash --data-path ./data'];
+
+	static flags = {
+		'data-path': flagParser.string({
+			char: 'd',
+			description:
+				'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
+			env: 'LISK_DATA_PATH',
+		}),
+	};
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const { flags } = this.parse(HashCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const blockchainPath = getBlockchainDBPath(dataPath);
+
+		if (isApplicationRunning(dataPath)) {
+			const errorMessage = `Can't generate hash for a running application. Application at data path ${dataPath} is running with pid ${getPid(
+				dataPath,
+			)}.`;
+
+			this.error(errorMessage);
+			return;
+		}
+
+		this.debug('Compressing data to generate hash.');
+		this.debug(`   ${getFullPath(blockchainPath)}`);
+
+		const db = getBlockchainDB(dataPath);
+		const stream = db.createReadStream({
+			keys: false,
+			values: true,
+		});
+
+		const dbHash = crypto.createHash('sha256');
+
+		const hash: Buffer = await new Promise((resolve, reject) => {
+			stream.on('data', (chunk: Buffer) => {
+				dbHash.update(chunk);
+			});
+
+			stream.on('error', error => {
+				reject(error);
+			});
+
+			stream.on('end', () => {
+				resolve(dbHash.digest());
+			});
+		});
+
+		this.debug('Hash generation completed.');
+
+		this.log(hash.toString('hex'));
+	}
+}

--- a/commander/src/bootstrapping/commands/blockchain/import.ts
+++ b/commander/src/bootstrapping/commands/blockchain/import.ts
@@ -19,7 +19,7 @@ import { Command, flags as flagParser } from '@oclif/command';
 import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils/path';
 import { extract } from '../../../utils/download';
 
-export abstract class ImportCommand extends Command {
+export default class ImportCommand extends Command {
 	static description = 'Import from <FILE>.';
 
 	static args = [

--- a/commander/src/bootstrapping/commands/blockchain/import.ts
+++ b/commander/src/bootstrapping/commands/blockchain/import.ts
@@ -19,7 +19,7 @@ import { Command, flags as flagParser } from '@oclif/command';
 import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils/path';
 import { extract } from '../../../utils/download';
 
-export default class ImportCommand extends Command {
+export class ImportCommand extends Command {
 	static description = 'Import from <FILE>.';
 
 	static args = [

--- a/commander/src/bootstrapping/commands/blockchain/import.ts
+++ b/commander/src/bootstrapping/commands/blockchain/import.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { Command, flags as flagParser } from '@oclif/command';
+import { getBlockchainDBPath, getDefaultPath, getFullPath } from '../../../utils/path';
+import { extract } from '../../../utils/download';
+
+export abstract class ImportCommand extends Command {
+	static description = 'Import from <FILE>.';
+
+	static args = [
+		{
+			name: 'filepath',
+			required: true,
+			description: 'Path to the gzipped blockchain data.',
+		},
+	];
+
+	static examples = [
+		'blockchain:import ./path/to/blockchain.db.tar.gz',
+		'blockchain:import ./path/to/blockchain.db.tar.gz --data-path ./lisk/',
+		'blockchain:import ./path/to/blockchain.db.tar.gz --data-path ./lisk/ --force',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			char: 'd',
+			description:
+				'Specifies which data path the application should use. Environment variable "LISK_DATA_PATH" can also be used.',
+			env: 'LISK_DATA_PATH',
+		}),
+		force: flagParser.boolean({
+			char: 'f',
+			description: 'Delete and overwrite existing blockchain data',
+			default: false,
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(ImportCommand);
+		const { filepath } = args;
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const blockchainDBPath = getBlockchainDBPath(dataPath);
+
+		if (path.extname(filepath) !== '.gz') {
+			this.error('The blockchain data file must be a gzip file.');
+		}
+
+		if (fs.existsSync(blockchainDBPath)) {
+			if (!flags.force) {
+				this.error(
+					`There is already a blockchain data file found at ${dataPath}. Use --force to override.`,
+				);
+			}
+			fs.removeSync(blockchainDBPath);
+		}
+
+		fs.ensureDirSync(blockchainDBPath);
+		this.log(`Importing blockchain from ${getFullPath(filepath)}`);
+
+		await extract(path.dirname(filepath), path.basename(filepath), blockchainDBPath);
+
+		this.log('Import completed.');
+		this.log(`   ${getFullPath(dataPath)}`);
+	}
+}

--- a/commander/src/bootstrapping/commands/blockchain/import.ts
+++ b/commander/src/bootstrapping/commands/blockchain/import.ts
@@ -53,7 +53,9 @@ export class ImportCommand extends Command {
 	async run(): Promise<void> {
 		const { args, flags } = this.parse(ImportCommand);
 		const { filepath } = args;
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
 		const blockchainDBPath = getBlockchainDBPath(dataPath);
 
 		if (path.extname(filepath) !== '.gz') {

--- a/commander/src/bootstrapping/commands/blockchain/index.ts
+++ b/commander/src/bootstrapping/commands/blockchain/index.ts
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as BlockchainDownloadCommand } from './download';
-export { default as BlockchainExportCommand } from './export';
-export { default as BlockchainHashCommand } from './hash';
-export { default as BlockchainImportCommand } from './import';
-export { default as BlockchainResetCommand } from './reset';
+export { DownloadCommand as BlockchainDownloadCommand } from './download';
+export { ExportCommand as BlockchainExportCommand } from './export';
+export { HashCommand as BlockchainHashCommand } from './hash';
+export { ImportCommand as BlockchainImportCommand } from './import';
+export { ResetCommand as BlockchainResetCommand } from './reset';

--- a/commander/src/bootstrapping/commands/blockchain/index.ts
+++ b/commander/src/bootstrapping/commands/blockchain/index.ts
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { DownloadCommand as BlockchainDownloadCommand } from './download';
-export { ExportCommand as BlockchainExportCommand } from './export';
-export { HashCommand as BlockchainHashCommand } from './hash';
-export { ImportCommand as BlockchainImportCommand } from './import';
-export { ResetCommand as BlockchainResetCommand } from './reset';
+export { default as BlockchainDownloadCommand } from './download';
+export { default as BlockchainExportCommand } from './export';
+export { default as BlockchainHashCommand } from './hash';
+export { default as BlockchainImportCommand } from './import';
+export { default as BlockchainResetCommand } from './reset';

--- a/commander/src/bootstrapping/commands/blockchain/index.ts
+++ b/commander/src/bootstrapping/commands/blockchain/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { DownloadCommand as BlockchainDownloadCommand } from './download';
+export { ExportCommand as BlockchainExportCommand } from './export';
+export { HashCommand as BlockchainHashCommand } from './hash';
+export { ImportCommand as BlockchainImportCommand } from './import';
+export { ResetCommand as BlockchainResetCommand } from './reset';

--- a/commander/src/bootstrapping/commands/blockchain/reset.ts
+++ b/commander/src/bootstrapping/commands/blockchain/reset.ts
@@ -19,7 +19,7 @@ import { flags as commonFlags } from '../../../utils/flags';
 import { getPid, isApplicationRunning } from '../../../utils/application';
 import { getBlockchainDB } from '../../../utils/db';
 
-export abstract class ResetCommand extends Command {
+export default class ResetCommand extends Command {
 	static description = 'Reset the blockchain data.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/blockchain/reset.ts
+++ b/commander/src/bootstrapping/commands/blockchain/reset.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import * as inquirer from 'inquirer';
+import { getDefaultPath } from '../../../utils/path';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getPid, isApplicationRunning } from '../../../utils/application';
+import { getBlockchainDB } from '../../../utils/db';
+
+export abstract class ResetCommand extends Command {
+	static description = 'Reset the blockchain data.';
+
+	static examples = [
+		'blockchain:reset',
+		'blockchain:reset --data-path ./lisk',
+		'blockchain:reset --yes',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			...commonFlags.dataPath,
+			env: 'LISK_DATA_PATH',
+		}),
+		yes: flagParser.boolean({
+			char: 'y',
+			description: 'Skip confirmation prompt.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(ResetCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const skipPrompt = flags.yes ?? false;
+
+		if (isApplicationRunning(dataPath)) {
+			const errorMessage = `Can't reset db while running application. Application at data path ${dataPath} is running with pid ${getPid(
+				dataPath,
+			)}.`;
+
+			this.error(errorMessage);
+		}
+
+		if (!skipPrompt) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const { answer } = await inquirer.prompt([
+				{
+					name: 'answer',
+					message: 'Are you sure you want to reset the db?',
+					type: 'list',
+					choices: ['yes', 'no'],
+				},
+			]);
+
+			if (answer === 'no') {
+				return;
+			}
+		}
+
+		const db = getBlockchainDB(dataPath);
+		await db.clear();
+		this.log('Blockchain data has been reset.');
+	}
+}

--- a/commander/src/bootstrapping/commands/blockchain/reset.ts
+++ b/commander/src/bootstrapping/commands/blockchain/reset.ts
@@ -41,7 +41,9 @@ export class ResetCommand extends Command {
 
 	async run(): Promise<void> {
 		const { flags } = this.parse(ResetCommand);
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
 		const skipPrompt = flags.yes ?? false;
 
 		if (isApplicationRunning(dataPath)) {

--- a/commander/src/bootstrapping/commands/blockchain/reset.ts
+++ b/commander/src/bootstrapping/commands/blockchain/reset.ts
@@ -19,7 +19,7 @@ import { flags as commonFlags } from '../../../utils/flags';
 import { getPid, isApplicationRunning } from '../../../utils/application';
 import { getBlockchainDB } from '../../../utils/db';
 
-export default class ResetCommand extends Command {
+export class ResetCommand extends Command {
 	static description = 'Reset the blockchain data.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/config/index.ts
+++ b/commander/src/bootstrapping/commands/config/index.ts
@@ -12,4 +12,4 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { ShowCommand as ConfigShowCommand } from './show';
+export { default as ConfigShowCommand } from './show';

--- a/commander/src/bootstrapping/commands/config/index.ts
+++ b/commander/src/bootstrapping/commands/config/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { ShowCommand as ConfigShowCommand } from './show';

--- a/commander/src/bootstrapping/commands/config/index.ts
+++ b/commander/src/bootstrapping/commands/config/index.ts
@@ -12,4 +12,4 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as ConfigShowCommand } from './show';
+export { ShowCommand as ConfigShowCommand } from './show';

--- a/commander/src/bootstrapping/commands/config/show.ts
+++ b/commander/src/bootstrapping/commands/config/show.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../utils/path';
 import { flags as commonFlags } from '../../../utils/flags';
 
-export abstract class ShowCommand extends Command {
+export default class ShowCommand extends Command {
 	static description = 'Show application config.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/config/show.ts
+++ b/commander/src/bootstrapping/commands/config/show.ts
@@ -14,7 +14,8 @@
  */
 import { Command, flags as flagParser } from '@oclif/command';
 import * as fs from 'fs-extra';
-import { ApplicationConfig, utils } from 'lisk-sdk';
+import { ApplicationConfig } from 'lisk-framework';
+import * as utils from '@liskhq/lisk-utils';
 import {
 	getDefaultPath,
 	splitPath,

--- a/commander/src/bootstrapping/commands/config/show.ts
+++ b/commander/src/bootstrapping/commands/config/show.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import * as fs from 'fs-extra';
+import { ApplicationConfig, utils } from 'lisk-sdk';
+import {
+	getDefaultPath,
+	splitPath,
+	getConfigDirs,
+	getNetworkConfigFilesPath,
+} from '../../../utils/path';
+import { flags as commonFlags } from '../../../utils/flags';
+
+export abstract class ShowCommand extends Command {
+	static description = 'Show application config.';
+
+	static examples = [
+		'config:show',
+		'config:show --pretty',
+		'config:show --config ./custom-config.json --data-path ./data',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			...commonFlags.dataPath,
+			env: 'LISK_DATA_PATH',
+		}),
+		config: flagParser.string({
+			char: 'c',
+			description:
+				'File path to a custom config. Environment variable "LISK_CONFIG_FILE" can also be used.',
+			env: 'LISK_CONFIG_FILE',
+		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(ShowCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const pathConfig = splitPath(dataPath);
+
+		// Validate dataPath/config if config for other network exists, throw error and exit unless overwrite-config is specified
+		const configDir = getConfigDirs(dataPath);
+		// If config file exist, do not copy unless overwrite-config is specified
+		if (configDir.length !== 1) {
+			this.error(`Folder in ${dataPath} does not contain valid config`);
+		}
+		// If genesis block file exist, do not copy unless overwrite-config is specified
+		const network = configDir[0];
+
+		// Read network genesis block and config from the folder
+		const { configFilePath } = getNetworkConfigFilesPath(dataPath, network);
+		// Get config from network config or config specified
+		let config = (await fs.readJSON(configFilePath)) as ApplicationConfig;
+
+		if (flags.config) {
+			const customConfig = (await fs.readJSON(flags.config)) as ApplicationConfig;
+			config = utils.objects.mergeDeep({}, config, customConfig) as ApplicationConfig;
+		}
+
+		config.rootPath = pathConfig.rootPath;
+		config.label = pathConfig.label;
+		config.version = this.config.pjson.version;
+
+		if (flags.pretty) {
+			this.log(JSON.stringify(config, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(config));
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/config/show.ts
+++ b/commander/src/bootstrapping/commands/config/show.ts
@@ -50,7 +50,9 @@ export class ShowCommand extends Command {
 
 	async run(): Promise<void> {
 		const { flags } = this.parse(ShowCommand);
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
 		const pathConfig = splitPath(dataPath);
 
 		// Validate dataPath/config if config for other network exists, throw error and exit unless overwrite-config is specified

--- a/commander/src/bootstrapping/commands/config/show.ts
+++ b/commander/src/bootstrapping/commands/config/show.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../utils/path';
 import { flags as commonFlags } from '../../../utils/flags';
 
-export default class ShowCommand extends Command {
+export class ShowCommand extends Command {
 	static description = 'Show application config.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/forger-info/export.ts
+++ b/commander/src/bootstrapping/commands/forger-info/export.ts
@@ -41,7 +41,9 @@ export abstract class ExportCommand extends Command {
 
 	async run(): Promise<void> {
 		const { flags } = this.parse(ExportCommand);
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
 		const forgerDataPath = getForgerDBPath(dataPath);
 		const exportPath = flags.output ? flags.output : process.cwd();
 

--- a/commander/src/bootstrapping/commands/forger-info/export.ts
+++ b/commander/src/bootstrapping/commands/forger-info/export.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as tar from 'tar';
+import { join } from 'path';
+import { Command, flags as flagParser } from '@oclif/command';
+import { getDefaultPath, getFullPath, getForgerDBPath } from '../../../utils/path';
+
+export abstract class ExportCommand extends Command {
+	static description = 'Export to <FILE>.';
+
+	static examples = [
+		'forger-info:export',
+		'forger-info:export --data-path ./data --output ./my/path/',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			char: 'd',
+			description:
+				'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
+			env: 'LISK_DATA_PATH',
+		}),
+		output: flagParser.string({
+			char: 'o',
+			description: 'The output directory. Default will set to current working directory.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(ExportCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const forgerDataPath = getForgerDBPath(dataPath);
+		const exportPath = flags.output ? flags.output : process.cwd();
+
+		this.log('Exporting ForgerInfo:');
+		this.log(`   ${getFullPath(forgerDataPath)}`);
+		const filePath = join(exportPath, 'forger.db.tar.gz');
+		await tar.create(
+			{
+				gzip: true,
+				file: filePath,
+				cwd: join(dataPath, 'data'),
+			},
+			['forger.db'],
+		);
+
+		this.log('Export completed:');
+		this.log(`   ${filePath}`);
+	}
+}

--- a/commander/src/bootstrapping/commands/forger-info/import.ts
+++ b/commander/src/bootstrapping/commands/forger-info/import.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Command, flags as flagParser } from '@oclif/command';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { getDefaultPath, getFullPath, getForgerDBPath } from '../../../utils/path';
+import * as downloadUtils from '../../../utils/download';
+
+interface Args {
+	readonly sourcePath: string;
+}
+
+export abstract class ImportCommand extends Command {
+	static description = 'Import from <FILE>.';
+
+	static args = [
+		{
+			name: 'sourcePath',
+			required: true,
+			description: 'Path to the forger-info zip file that you want to import.',
+		},
+	];
+
+	static examples = [
+		'forger-info:import ./my/path',
+		'forger-info:import --data-path ./data --force',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			char: 'd',
+			description:
+				'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
+			env: 'LISK_DATA_PATH',
+		}),
+		force: flagParser.boolean({
+			char: 'f',
+			description: 'To overwrite the existing data if present.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { args, flags } = this.parse(ImportCommand);
+		const { sourcePath } = args as Args;
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const forgerDBPath = getForgerDBPath(dataPath);
+
+		if (path.extname(sourcePath) !== '.gz') {
+			this.error('Forger data should be provided in gzip format.');
+		}
+
+		if (fs.existsSync(forgerDBPath)) {
+			if (!flags.force) {
+				this.error(`Forger data already exists at ${dataPath}. Use --force flag to overwrite`);
+			}
+			fs.removeSync(forgerDBPath);
+		}
+
+		fs.ensureDirSync(forgerDBPath);
+		this.log(`Importing forger data from ${getFullPath(sourcePath)}`);
+
+		await downloadUtils.extract(path.dirname(sourcePath), path.basename(sourcePath), forgerDBPath);
+
+		this.log('Import completed.');
+		this.log(`   ${getFullPath(dataPath)}`);
+	}
+}

--- a/commander/src/bootstrapping/commands/forger-info/import.ts
+++ b/commander/src/bootstrapping/commands/forger-info/import.ts
@@ -54,7 +54,9 @@ export abstract class ImportCommand extends Command {
 	async run(): Promise<void> {
 		const { args, flags } = this.parse(ImportCommand);
 		const { sourcePath } = args as Args;
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
 		const forgerDBPath = getForgerDBPath(dataPath);
 
 		if (path.extname(sourcePath) !== '.gz') {

--- a/commander/src/bootstrapping/commands/forger-info/index.ts
+++ b/commander/src/bootstrapping/commands/forger-info/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { ExportCommand as ForgerInfoExportCommand } from './export';
+export { ImportCommand as ForgerInfoImportCommand } from './import';

--- a/commander/src/bootstrapping/commands/forging/config.ts
+++ b/commander/src/bootstrapping/commands/forging/config.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { flags as flagParser, Command } from '@oclif/command';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { cryptography, validator } from 'lisk-sdk';
+import { encryptPassphrase } from '../../../utils/commons';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../../utils/reader';
+
+export abstract class ConfigCommand extends Command {
+	static description = 'Generate delegate forging config for given passphrase and password.';
+
+	static examples = [
+		'forging:config',
+		'forging:config --password your_password',
+		'forging:config --passphrase your_passphrase --password your_password --pretty',
+		'forging:config --count=1000000 --distance=2000 --output /tmp/forging_config.json',
+	];
+
+	static flags = {
+		password: flagParser.string({ ...commonFlags.password }),
+		passphrase: flagParser.string({ ...commonFlags.passphrase }),
+		count: flagParser.integer({
+			char: 'c',
+			description: 'Total number of hashes to produce',
+			default: 1000000,
+		}),
+		distance: flagParser.integer({
+			char: 'd',
+			description: 'Distance between each hashes',
+			default: 1000,
+		}),
+		output: flagParser.string({
+			char: 'o',
+			description: 'Output file path',
+		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const {
+			flags: {
+				count,
+				distance,
+				output,
+				passphrase: passphraseSource,
+				password: passwordSource,
+				pretty,
+			},
+		} = this.parse(ConfigCommand);
+
+		if (distance <= 0 || !validator.isValidInteger(distance)) {
+			throw new Error('Distance flag must be an integer and greater than 0.');
+		}
+
+		if (count <= 0 || !validator.isValidInteger(count)) {
+			throw new Error('Count flag must be an integer and greater than 0.');
+		}
+
+		if (output) {
+			const { dir } = path.parse(output);
+			fs.ensureDirSync(dir);
+		}
+
+		const seed = cryptography.generateHashOnionSeed();
+
+		const hashBuffers = cryptography.hashOnion(seed, count, distance);
+		const hashes = hashBuffers.map(buf => buf.toString('hex'));
+		const hashOnion = { count, distance, hashes };
+
+		const passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+		const address = cryptography.getAddressFromPassphrase(passphrase).toString('hex');
+		const password = passwordSource ?? (await getPasswordFromPrompt('password', true));
+		const { encryptedPassphrase } = encryptPassphrase(passphrase, password, false);
+		const message = { address, encryptedPassphrase, hashOnion };
+
+		if (output) {
+			if (pretty) {
+				fs.writeJSONSync(output, message, { spaces: ' ' });
+			} else {
+				fs.writeJSONSync(output, message);
+			}
+		} else {
+			this.printJSON(message, pretty);
+		}
+	}
+
+	public printJSON(message?: object, pretty = false): void {
+		if (pretty) {
+			this.log(JSON.stringify(message, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(message));
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/forging/config.ts
+++ b/commander/src/bootstrapping/commands/forging/config.ts
@@ -21,7 +21,7 @@ import { encryptPassphrase } from '../../../utils/commons';
 import { flags as commonFlags } from '../../../utils/flags';
 import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../../utils/reader';
 
-export default class ConfigCommand extends Command {
+export class ConfigCommand extends Command {
 	static description = 'Generate delegate forging config for given passphrase and password.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/forging/config.ts
+++ b/commander/src/bootstrapping/commands/forging/config.ts
@@ -16,7 +16,8 @@
 import { flags as flagParser, Command } from '@oclif/command';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { cryptography, validator } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as validator from '@liskhq/lisk-validator';
 import { encryptPassphrase } from '../../../utils/commons';
 import { flags as commonFlags } from '../../../utils/flags';
 import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../../utils/reader';

--- a/commander/src/bootstrapping/commands/forging/config.ts
+++ b/commander/src/bootstrapping/commands/forging/config.ts
@@ -21,7 +21,7 @@ import { encryptPassphrase } from '../../../utils/commons';
 import { flags as commonFlags } from '../../../utils/flags';
 import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../../utils/reader';
 
-export abstract class ConfigCommand extends Command {
+export default class ConfigCommand extends Command {
 	static description = 'Generate delegate forging config for given passphrase and password.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/forging/disable.ts
+++ b/commander/src/bootstrapping/commands/forging/disable.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { BaseForgingCommand } from '../base_forging';
+
+export abstract class DisableCommand extends BaseForgingCommand {
+	static description = 'Disable forging for given delegate address.';
+
+	static examples = [
+		'forging:disable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+		'forging:disable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 --data-path ./data',
+		'forging:disable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 --data-path ./data --password your_password',
+	];
+
+	static flags = {
+		...BaseForgingCommand.flags,
+	};
+
+	static args = [...BaseForgingCommand.args];
+
+	async init(): Promise<void> {
+		await super.init();
+		this.forging = false;
+	}
+}

--- a/commander/src/bootstrapping/commands/forging/enable.ts
+++ b/commander/src/bootstrapping/commands/forging/enable.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { BaseForgingCommand } from '../base_forging';
+
+export abstract class EnableCommand extends BaseForgingCommand {
+	static description = 'Enable forging for given delegate address.';
+
+	static examples = [
+		'forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10',
+		'forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10 --overwrite',
+		'forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10 --data-path ./data',
+		'forging:enable ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815 100 100 10 --data-path ./data --password your_password',
+	];
+
+	static flags = {
+		...BaseForgingCommand.flags,
+	};
+
+	static args = [
+		...BaseForgingCommand.args,
+		{
+			name: 'height',
+			required: true,
+			description: 'Last forged block height.',
+		},
+		{
+			name: 'maxHeightPreviouslyForged',
+			required: true,
+			description: 'Delegates largest previously forged height.',
+		},
+		{
+			name: 'maxHeightPrevoted',
+			required: true,
+			description: 'Delegates largest prevoted height for a block.',
+		},
+	];
+
+	async init(): Promise<void> {
+		await super.init();
+		this.forging = true;
+	}
+}

--- a/commander/src/bootstrapping/commands/forging/index.ts
+++ b/commander/src/bootstrapping/commands/forging/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { ConfigCommand as ForgingConfigCommand } from './config';
+export { default as ForgingConfigCommand } from './config';
 export { DisableCommand as ForgingDisableCommand } from './disable';
 export { EnableCommand as ForgingEnableCommand } from './enable';
 export { StatusCommand as ForgingStatusCommand } from './status';

--- a/commander/src/bootstrapping/commands/forging/index.ts
+++ b/commander/src/bootstrapping/commands/forging/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { ConfigCommand as ForgingConfigCommand } from './config';
+export { DisableCommand as ForgingDisableCommand } from './disable';
+export { EnableCommand as ForgingEnableCommand } from './enable';
+export { StatusCommand as ForgingStatusCommand } from './status';

--- a/commander/src/bootstrapping/commands/forging/index.ts
+++ b/commander/src/bootstrapping/commands/forging/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as ForgingConfigCommand } from './config';
+export { ConfigCommand as ForgingConfigCommand } from './config';
 export { DisableCommand as ForgingDisableCommand } from './disable';
 export { EnableCommand as ForgingEnableCommand } from './enable';
 export { StatusCommand as ForgingStatusCommand } from './status';

--- a/commander/src/bootstrapping/commands/forging/status.ts
+++ b/commander/src/bootstrapping/commands/forging/status.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 
 export abstract class StatusCommand extends BaseIPCCommand {
 	static description = 'Get forging information for the locally running node.';

--- a/commander/src/bootstrapping/commands/forging/status.ts
+++ b/commander/src/bootstrapping/commands/forging/status.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import BaseIPCCommand from '../base_ipc';
+
+export abstract class StatusCommand extends BaseIPCCommand {
+	static description = 'Get forging information for the locally running node.';
+
+	static examples = ['forging:status', 'forging:status --data-path ./sample --pretty'];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+	};
+
+	async run(): Promise<void> {
+		if (!this._client) {
+			this.error('APIClient is not initialized.');
+		}
+		const info = await this._client.invoke('app:getForgingStatus');
+		this.printJSON(info);
+	}
+}

--- a/commander/src/bootstrapping/commands/hash-onion.ts
+++ b/commander/src/bootstrapping/commands/hash-onion.ts
@@ -13,10 +13,11 @@
  *
  */
 
-import { cryptography, validator } from 'lisk-sdk';
 import Command, { flags as flagParser } from '@oclif/command';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as validator from '@liskhq/lisk-validator';
 
 export class HashOnionCommand extends Command {
 	static description = 'Create hash onions to be used by the forger.';

--- a/commander/src/bootstrapping/commands/hash-onion.ts
+++ b/commander/src/bootstrapping/commands/hash-onion.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { cryptography, validator } from 'lisk-sdk';
+import Command, { flags as flagParser } from '@oclif/command';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+export abstract class HashOnionCommand extends Command {
+	static description = 'Create hash onions to be used by the forger.';
+
+	static examples = [
+		'hash-onion --count=1000000 --distance=2000 --pretty',
+		'hash-onion --count=1000000 --distance=2000 --output ~/my_onion.json',
+	];
+
+	static flags = {
+		output: flagParser.string({
+			char: 'o',
+			description: 'Output file path',
+		}),
+		count: flagParser.integer({
+			char: 'c',
+			description: 'Total number of hashes to produce',
+			default: 1000000,
+		}),
+		distance: flagParser.integer({
+			char: 'd',
+			description: 'Distance between each hashes',
+			default: 1000,
+		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
+	};
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const {
+			flags: { output, count, distance, pretty },
+		} = this.parse(HashOnionCommand);
+
+		if (distance <= 0 || !validator.isValidInteger(distance)) {
+			throw new Error('Distance flag must be an integer and greater than 0.');
+		}
+
+		if (count <= 0 || !validator.isValidInteger(count)) {
+			throw new Error('Count flag must be an integer and greater than 0.');
+		}
+
+		if (output) {
+			const { dir } = path.parse(output);
+			fs.ensureDirSync(dir);
+		}
+
+		const seed = cryptography.generateHashOnionSeed();
+
+		const hashBuffers = cryptography.hashOnion(seed, count, distance);
+		const hashes = hashBuffers.map(buf => buf.toString('hex'));
+
+		const result = { count, distance, hashes };
+
+		if (output) {
+			if (pretty) {
+				fs.writeJSONSync(output, result, { spaces: ' ' });
+			} else {
+				fs.writeJSONSync(output, result);
+			}
+		} else {
+			this.printJSON(result, pretty);
+		}
+	}
+
+	public printJSON(message?: object, pretty = false): void {
+		if (pretty) {
+			this.log(JSON.stringify(message, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(message));
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/hash-onion.ts
+++ b/commander/src/bootstrapping/commands/hash-onion.ts
@@ -18,7 +18,7 @@ import Command, { flags as flagParser } from '@oclif/command';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-export abstract class HashOnionCommand extends Command {
+export class HashOnionCommand extends Command {
 	static description = 'Create hash onions to be used by the forger.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/node/index.ts
+++ b/commander/src/bootstrapping/commands/node/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { InfoCommand as NodeInfoCommand } from './info';

--- a/commander/src/bootstrapping/commands/node/info.ts
+++ b/commander/src/bootstrapping/commands/node/info.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import BaseIPCCommand from '../base_ipc';
+
+export abstract class InfoCommand extends BaseIPCCommand {
+	static description = 'Get node information from a running application.';
+
+	static examples = ['node:info', 'node:info --data-path ./lisk'];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+	};
+
+	async run(): Promise<void> {
+		if (!this._client) {
+			this.error('APIClient is not initialized.');
+		}
+		try {
+			const nodeInfo = await this._client.node.getNodeInfo();
+			this.printJSON(nodeInfo);
+		} catch (errors) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const errorMessage = Array.isArray(errors)
+				? errors.map(err => (err as Error).message).join(',')
+				: errors;
+
+			this.error(errorMessage);
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/node/info.ts
+++ b/commander/src/bootstrapping/commands/node/info.ts
@@ -29,7 +29,7 @@ export abstract class InfoCommand extends BaseIPCCommand {
 		}
 		try {
 			const nodeInfo = await this._client.node.getNodeInfo();
-			this.printJSON(nodeInfo);
+			this.printJSON((nodeInfo as unknown) as Record<string, unknown>);
 		} catch (errors) {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			const errorMessage = Array.isArray(errors)

--- a/commander/src/bootstrapping/commands/node/info.ts
+++ b/commander/src/bootstrapping/commands/node/info.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 
 export abstract class InfoCommand extends BaseIPCCommand {
 	static description = 'Get node information from a running application.';

--- a/commander/src/bootstrapping/commands/passphrase/decrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/decrypt.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { cryptography } from 'lisk-sdk';
+import Command, { flags as flagParser } from '@oclif/command';
+
+import { flags as commonFlags } from '../../../utils/flags';
+import { getPasswordFromPrompt } from '../../../utils/reader';
+
+interface Args {
+	readonly encryptedPassphrase?: string;
+}
+
+const processInputs = (password: string, encryptedPassphrase: string): Record<string, string> => {
+	const encryptedPassphraseObject = cryptography.parseEncryptedPassphrase(encryptedPassphrase);
+	const passphrase = cryptography.decryptPassphraseWithPassword(
+		encryptedPassphraseObject,
+		password,
+	);
+
+	return { passphrase };
+};
+
+export abstract class DecryptCommand extends Command {
+	static args = [
+		{
+			name: 'encryptedPassphrase',
+			description: 'Encrypted passphrase to decrypt.',
+			required: true,
+		},
+	];
+
+	static description =
+		'Decrypt secret passphrase using the password provided at the time of encryption.';
+
+	static examples = [
+		'passphrase:decrypt "iterations=1000000&cipherText=9b1c60&iv=5c8843f52ed3c0f2aa0086b0&salt=2240b7f1aa9c899894e528cf5b600e9c&tag=23c01112134317a63bcf3d41ea74e83b&version=1"',
+		'passphrase:decrypt "iterations=1000000&cipherText=9b1c60&iv=5c8843f52ed3c0f2aa0086b0&salt=2240b7f1aa9c899894e528cf5b600e9c&tag=23c01112134317a63bcf3d41ea74e83b&version=1" --password your-password',
+	];
+
+	static flags = {
+		password: flagParser.string(commonFlags.password),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const {
+			args,
+			flags: { password: passwordSource, pretty },
+		} = this.parse(DecryptCommand);
+		const { encryptedPassphrase }: Args = args;
+		const password = passwordSource ?? (await getPasswordFromPrompt('password', true));
+		const result = processInputs(password, encryptedPassphrase as string);
+		this.printJSON(result, pretty);
+	}
+
+	public printJSON(message?: object, pretty = false): void {
+		if (pretty) {
+			this.log(JSON.stringify(message, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(message));
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/passphrase/decrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/decrypt.ts
@@ -32,7 +32,7 @@ const processInputs = (password: string, encryptedPassphrase: string): Record<st
 	return { passphrase };
 };
 
-export abstract class DecryptCommand extends Command {
+export default class DecryptCommand extends Command {
 	static args = [
 		{
 			name: 'encryptedPassphrase',

--- a/commander/src/bootstrapping/commands/passphrase/decrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/decrypt.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { cryptography } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import Command, { flags as flagParser } from '@oclif/command';
 
 import { flags as commonFlags } from '../../../utils/flags';

--- a/commander/src/bootstrapping/commands/passphrase/decrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/decrypt.ts
@@ -32,7 +32,7 @@ const processInputs = (password: string, encryptedPassphrase: string): Record<st
 	return { passphrase };
 };
 
-export default class DecryptCommand extends Command {
+export class DecryptCommand extends Command {
 	static args = [
 		{
 			name: 'encryptedPassphrase',

--- a/commander/src/bootstrapping/commands/passphrase/encrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/encrypt.ts
@@ -21,7 +21,7 @@ import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../../utils/r
 const outputPublicKeyOptionDescription =
 	'Includes the public key in the output. This option is provided for the convenience of node operators.';
 
-export abstract class EncryptCommand extends Command {
+export default class EncryptCommand extends Command {
 	static description = 'Encrypt secret passphrase using password.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/passphrase/encrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/encrypt.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { flags as flagParser, Command } from '@oclif/command';
+
+import { encryptPassphrase } from '../../../utils/commons';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../../utils/reader';
+
+const outputPublicKeyOptionDescription =
+	'Includes the public key in the output. This option is provided for the convenience of node operators.';
+
+export abstract class EncryptCommand extends Command {
+	static description = 'Encrypt secret passphrase using password.';
+
+	static examples = [
+		'passphrase:encrypt',
+		'passphrase:encrypt --passphrase your-passphrase',
+		'passphrase:encrypt --password your-password',
+		'passphrase:encrypt --password your-password --passphrase your-passphrase --pretty',
+		'passphrase:encrypt --output-public-key',
+	];
+
+	static flags = {
+		password: flagParser.string(commonFlags.password),
+		passphrase: flagParser.string(commonFlags.passphrase),
+		'output-public-key': flagParser.boolean({
+			description: outputPublicKeyOptionDescription,
+		}),
+		pretty: flagParser.boolean({
+			description: 'Prints JSON in pretty format rather than condensed.',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const {
+			flags: {
+				passphrase: passphraseSource,
+				password: passwordSource,
+				'output-public-key': outputPublicKey,
+				pretty,
+			},
+		} = this.parse(EncryptCommand);
+
+		const passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+		const password = passwordSource ?? (await getPasswordFromPrompt('password', true));
+		const result = encryptPassphrase(passphrase, password, outputPublicKey);
+
+		this.printJSON(result, pretty);
+	}
+
+	public printJSON(message?: object, pretty = false): void {
+		if (pretty) {
+			this.log(JSON.stringify(message, undefined, '  '));
+		} else {
+			this.log(JSON.stringify(message));
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/passphrase/encrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/encrypt.ts
@@ -21,7 +21,7 @@ import { getPassphraseFromPrompt, getPasswordFromPrompt } from '../../../utils/r
 const outputPublicKeyOptionDescription =
 	'Includes the public key in the output. This option is provided for the convenience of node operators.';
 
-export default class EncryptCommand extends Command {
+export class EncryptCommand extends Command {
 	static description = 'Encrypt secret passphrase using password.';
 
 	static examples = [

--- a/commander/src/bootstrapping/commands/passphrase/index.ts
+++ b/commander/src/bootstrapping/commands/passphrase/index.ts
@@ -12,5 +12,5 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as PassphraseDecryptCommand } from './decrypt';
-export { default as PassphraseEncryptCommand } from './encrypt';
+export { DecryptCommand as PassphraseDecryptCommand } from './decrypt';
+export { EncryptCommand as PassphraseEncryptCommand } from './encrypt';

--- a/commander/src/bootstrapping/commands/passphrase/index.ts
+++ b/commander/src/bootstrapping/commands/passphrase/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { DecryptCommand as PassphraseDecryptCommand } from './decrypt';
+export { EncryptCommand as PassphraseEncryptCommand } from './encrypt';

--- a/commander/src/bootstrapping/commands/passphrase/index.ts
+++ b/commander/src/bootstrapping/commands/passphrase/index.ts
@@ -12,5 +12,5 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { DecryptCommand as PassphraseDecryptCommand } from './decrypt';
-export { EncryptCommand as PassphraseEncryptCommand } from './encrypt';
+export { default as PassphraseDecryptCommand } from './decrypt';
+export { default as PassphraseEncryptCommand } from './encrypt';

--- a/commander/src/bootstrapping/commands/sdk/index.ts
+++ b/commander/src/bootstrapping/commands/sdk/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { LinkCommand as SDKLinkCommand } from './link';

--- a/commander/src/bootstrapping/commands/sdk/index.ts
+++ b/commander/src/bootstrapping/commands/sdk/index.ts
@@ -12,4 +12,4 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { LinkCommand as SDKLinkCommand } from './link';
+export { default as SDKLinkCommand } from './link';

--- a/commander/src/bootstrapping/commands/sdk/index.ts
+++ b/commander/src/bootstrapping/commands/sdk/index.ts
@@ -12,4 +12,4 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-export { default as SDKLinkCommand } from './link';
+export { LinkCommand as SDKLinkCommand } from './link';

--- a/commander/src/bootstrapping/commands/sdk/link.ts
+++ b/commander/src/bootstrapping/commands/sdk/link.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Command } from '@oclif/command';
+import { symlink, pathExistsSync, removeSync } from 'fs-extra';
+import { join, isAbsolute } from 'path';
+
+export abstract class LinkCommand extends Command {
+	static description = 'Symlink specific SDK folder during development.';
+
+	static examples = ['sdk:link /path/to/lisk-sdk/sdk'];
+
+	static args = [
+		{ name: 'targetSDKFolder', required: true, description: 'The path to the lisk SDK folder' },
+	];
+
+	// eslint-disable-next-line class-methods-use-this, @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const {
+			args: { targetSDKFolder },
+		} = this.parse(LinkCommand);
+
+		if (!pathExistsSync(targetSDKFolder)) {
+			throw new Error(`Path '${targetSDKFolder as string}' does not exist or access denied.`);
+		}
+
+		const sdkLocalPath = join(__dirname, '../../../', 'node_modules', 'lisk-sdk');
+
+		// If targetSDK folder is relative path, it should be relative from the node_module
+		const targetSDKFolderFromNodeModule = isAbsolute(targetSDKFolder)
+			? targetSDKFolder
+			: join('../', targetSDKFolder);
+		removeSync(sdkLocalPath);
+		await symlink(targetSDKFolderFromNodeModule, sdkLocalPath);
+		this.log(`Linked '${targetSDKFolder as string}' to '${sdkLocalPath}'.`);
+	}
+}

--- a/commander/src/bootstrapping/commands/sdk/link.ts
+++ b/commander/src/bootstrapping/commands/sdk/link.ts
@@ -18,7 +18,7 @@ import { Command } from '@oclif/command';
 import { symlink, pathExistsSync, removeSync } from 'fs-extra';
 import { join, isAbsolute } from 'path';
 
-export abstract class LinkCommand extends Command {
+export default class LinkCommand extends Command {
 	static description = 'Symlink specific SDK folder during development.';
 
 	static examples = ['sdk:link /path/to/lisk-sdk/sdk'];

--- a/commander/src/bootstrapping/commands/sdk/link.ts
+++ b/commander/src/bootstrapping/commands/sdk/link.ts
@@ -18,7 +18,7 @@ import { Command } from '@oclif/command';
 import { symlink, pathExistsSync, removeSync } from 'fs-extra';
 import { join, isAbsolute } from 'path';
 
-export default class LinkCommand extends Command {
+export class LinkCommand extends Command {
 	static description = 'Symlink specific SDK folder during development.';
 
 	static examples = ['sdk:link /path/to/lisk-sdk/sdk'];

--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -110,8 +110,10 @@ export abstract class StartCommand extends Command {
 	// eslint-disable-next-line @typescript-eslint/require-await
 	async run(): Promise<void> {
 		const { flags } = this.parse(StartCommand);
-		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
-		this.log(`Starting Lisk Core at ${getFullPath(dataPath)}.`);
+		const dataPath = flags['data-path']
+			? flags['data-path']
+			: getDefaultPath(this.config.pjson.name);
+		this.log(`Starting Lisk ${this.config.pjson.name} at ${getFullPath(dataPath)}.`);
 		const pathConfig = splitPath(dataPath);
 
 		const defaultNetworkConfigs = getDefaultConfigDir();

--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -1,0 +1,336 @@
+/* eslint-disable no-param-reassign */
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Command, flags as flagParser } from '@oclif/command';
+import * as fs from 'fs-extra';
+import {
+	ApplicationConfig,
+	Application,
+	HTTPAPIPlugin,
+	MonitorPlugin,
+	PartialApplicationConfig,
+	utils,
+} from 'lisk-sdk';
+import {
+	getDefaultPath,
+	splitPath,
+	getFullPath,
+	getConfigDirs,
+	removeConfigDir,
+	ensureConfigDir,
+	getDefaultConfigDir,
+	getNetworkConfigFilesPath,
+	getDefaultNetworkConfigFilesPath,
+} from '../../utils/path';
+import { flags as commonFlags } from '../../utils/flags';
+import { DEFAULT_NETWORK } from '../../constants';
+
+interface Flags {
+	[key: string]: string | number | boolean | undefined;
+}
+
+const LOG_OPTIONS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
+
+const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
+	if (flags['http-api-plugin-port'] !== undefined) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
+		config.plugins[HTTPAPIPlugin.alias].port = flags['http-api-plugin-port'];
+	}
+	if (
+		flags['http-api-plugin-whitelist'] !== undefined &&
+		typeof flags['http-api-plugin-whitelist'] === 'string'
+	) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
+		config.plugins[HTTPAPIPlugin.alias].whiteList = flags['http-api-plugin-whitelist']
+			.split(',')
+			.filter(Boolean);
+	}
+	if (flags['monitor-plugin-port'] !== undefined) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[MonitorPlugin.alias] = config.plugins[MonitorPlugin.alias] ?? {};
+		config.plugins[MonitorPlugin.alias].port = flags['monitor-plugin-port'];
+	}
+	if (
+		flags['monitor-plugin-whitelist'] !== undefined &&
+		typeof flags['monitor-plugin-whitelist'] === 'string'
+	) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[MonitorPlugin.alias] = config.plugins[MonitorPlugin.alias] ?? {};
+		config.plugins[MonitorPlugin.alias].whiteList = flags['monitor-plugin-whitelist']
+			.split(',')
+			.filter(Boolean);
+	}
+};
+
+export abstract class StartCommand extends Command {
+	static description = 'Start Lisk Core Node.';
+
+	static examples = [
+		'start',
+		'start --network devnet --data-path /path/to/data-dir --log debug',
+		'start --network devnet --api-ws',
+		'start --network devnet --api-ws --api-ws-port 8888',
+		'start --network devnet --port 9000',
+		'start --network devnet --port 9002 --seed-peers 127.0.0.1:9001,127.0.0.1:9000',
+		'start --network testnet --overwrite-config',
+		'start --network testnet --config ~/my_custom_config.json',
+	];
+
+	static flags = {
+		'data-path': flagParser.string({
+			...commonFlags.dataPath,
+			env: 'LISK_DATA_PATH',
+		}),
+		network: flagParser.string({
+			...commonFlags.network,
+			env: 'LISK_NETWORK',
+			default: DEFAULT_NETWORK,
+		}),
+		config: flagParser.string({
+			char: 'c',
+			description:
+				'File path to a custom config. Environment variable "LISK_CONFIG_FILE" can also be used.',
+			env: 'LISK_CONFIG_FILE',
+		}),
+		'overwrite-config': flagParser.boolean({
+			description: 'Overwrite network configs if they exist already',
+			default: false,
+		}),
+		port: flagParser.integer({
+			char: 'p',
+			description:
+				'Open port for the peer to peer incoming connections. Environment variable "LISK_PORT" can also be used.',
+			env: 'LISK_PORT',
+		}),
+		'api-ipc': flagParser.boolean({
+			description:
+				'Enable IPC communication. This will also load up plugins in child process and communicate over IPC.',
+			default: false,
+			exclusive: ['api-ws'],
+		}),
+		'api-ws': flagParser.boolean({
+			description: 'Enable websocket communication for api-client.',
+			default: false,
+			exclusive: ['api-ipc'],
+		}),
+		'api-ws-port': flagParser.integer({
+			description: 'Port to be used for api-client websocket.',
+			dependsOn: ['api-ws'],
+		}),
+		'console-log': flagParser.string({
+			description:
+				'Console log level. Environment variable "LISK_CONSOLE_LOG_LEVEL" can also be used.',
+			env: 'LISK_CONSOLE_LOG_LEVEL',
+			options: LOG_OPTIONS,
+		}),
+		log: flagParser.string({
+			char: 'l',
+			description: 'File log level. Environment variable "LISK_FILE_LOG_LEVEL" can also be used.',
+			env: 'LISK_FILE_LOG_LEVEL',
+			options: LOG_OPTIONS,
+		}),
+		'seed-peers': flagParser.string({
+			env: 'LISK_SEED_PEERS',
+			description:
+				'Seed peers to initially connect to in format of comma separated "ip:port". IP can be DNS name or IPV4 format. Environment variable "LISK_SEED_PEERS" can also be used.',
+		}),
+		'enable-http-api-plugin': flagParser.boolean({
+			description:
+				'Enable HTTP API Plugin. Environment variable "LISK_ENABLE_HTTP_API_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_HTTP_API_PLUGIN',
+			default: false,
+		}),
+		'http-api-plugin-port': flagParser.integer({
+			description:
+				'Port to be used for HTTP API Plugin. Environment variable "LISK_HTTP_API_PLUGIN_PORT" can also be used.',
+			env: 'LISK_HTTP_API_PLUGIN_PORT',
+			dependsOn: ['enable-http-api-plugin'],
+		}),
+		'http-api-plugin-whitelist': flagParser.string({
+			description:
+				'List of IPs in comma separated value to allow the connection. Environment variable "LISK_HTTP_API_PLUGIN_WHITELIST" can also be used.',
+			env: 'LISK_HTTP_API_PLUGIN_WHITELIST',
+			dependsOn: ['enable-http-api-plugin'],
+		}),
+		'enable-forger-plugin': flagParser.boolean({
+			description:
+				'Enable Forger Plugin. Environment variable "LISK_ENABLE_FORGER_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_FORGER_PLUGIN',
+			default: false,
+		}),
+		'enable-monitor-plugin': flagParser.boolean({
+			description:
+				'Enable Monitor Plugin. Environment variable "LISK_ENABLE_MONITOR_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_MONITOR_PLUGIN',
+			default: false,
+		}),
+		'monitor-plugin-port': flagParser.integer({
+			description:
+				'Port to be used for Monitor Plugin. Environment variable "LISK_MONITOR_PLUGIN_PORT" can also be used.',
+			env: 'LISK_MONITOR_PLUGIN_PORT',
+			dependsOn: ['enable-monitor-plugin'],
+		}),
+		'monitor-plugin-whitelist': flagParser.string({
+			description:
+				'List of IPs in comma separated value to allow the connection. Environment variable "LISK_MONITOR_PLUGIN_WHITELIST" can also be used.',
+			env: 'LISK_MONITOR_PLUGIN_WHITELIST',
+			dependsOn: ['enable-monitor-plugin'],
+		}),
+		'enable-report-misbehavior-plugin': flagParser.boolean({
+			description:
+				'Enable ReportMisbehavior Plugin. Environment variable "LISK_ENABLE_REPORT_MISBEHAVIOR_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_MONITOR_PLUGIN',
+			default: false,
+		}),
+	};
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async run(): Promise<void> {
+		const { flags } = this.parse(StartCommand);
+		const dataPath = flags['data-path'] ? flags['data-path'] : getDefaultPath();
+		this.log(`Starting Lisk Core at ${getFullPath(dataPath)}.`);
+		const pathConfig = splitPath(dataPath);
+
+		const defaultNetworkConfigs = getDefaultConfigDir();
+		const defaultNetworkConfigDir = getConfigDirs(defaultNetworkConfigs);
+		if (!defaultNetworkConfigDir.includes(flags.network)) {
+			this.error(
+				`Network must be one of ${defaultNetworkConfigDir.join(',')} but received ${
+					flags.network
+				}.`,
+			);
+		}
+
+		// Validate dataPath/config if config for other network exists, throw error and exit unless overwrite-config is specified
+		const configDir = getConfigDirs(dataPath);
+		// If config file exist, do not copy unless overwrite-config is specified
+		if (configDir.length > 1 || (configDir.length === 1 && configDir[0] !== flags.network)) {
+			if (!flags['overwrite-config']) {
+				this.error(
+					`Datapath ${dataPath} already contains configs for ${configDir.join(
+						',',
+					)}. Please use --overwrite-config to overwrite the config.`,
+				);
+			}
+			// Remove other network configs
+			for (const configFolder of configDir) {
+				if (configFolder !== flags.network) {
+					removeConfigDir(dataPath, configFolder);
+				}
+			}
+		}
+		// If genesis block file exist, do not copy unless overwrite-config is specified
+		ensureConfigDir(dataPath, flags.network);
+
+		// Read network genesis block and config from the folder
+		const { genesisBlockFilePath, configFilePath } = getNetworkConfigFilesPath(
+			dataPath,
+			flags.network,
+		);
+		const {
+			genesisBlockFilePath: defaultGenesisBlockFilePath,
+			configFilePath: defaultConfigFilepath,
+		} = getDefaultNetworkConfigFilesPath(flags.network);
+		if (
+			!fs.existsSync(genesisBlockFilePath) ||
+			(fs.existsSync(genesisBlockFilePath) && flags['overwrite-config'])
+		) {
+			fs.copyFileSync(defaultGenesisBlockFilePath, genesisBlockFilePath);
+		}
+		if (
+			!fs.existsSync(configFilePath) ||
+			(fs.existsSync(configFilePath) && flags['overwrite-config'])
+		) {
+			fs.copyFileSync(defaultConfigFilepath, configFilePath);
+		}
+
+		// Get config from network config or config specified
+		const genesisBlock = await fs.readJSON(genesisBlockFilePath);
+		let config = await fs.readJSON(configFilePath);
+
+		if (flags.config) {
+			const customConfig: ApplicationConfig = await fs.readJSON(flags.config);
+			config = utils.objects.mergeDeep({}, config, customConfig) as ApplicationConfig;
+		}
+
+		config.rootPath = pathConfig.rootPath;
+		config.label = pathConfig.label;
+		config.version = this.config.pjson.version;
+		// Inject other properties specified
+		if (flags['api-ipc']) {
+			config.rpc = { enable: flags['api-ipc'], mode: 'ipc' };
+		}
+		if (flags['api-ws']) {
+			config.rpc = { enable: flags['api-ws'], mode: 'ws', port: flags['api-ws-port'] };
+		}
+		if (flags['console-log']) {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+			config.logger = config.logger ?? {};
+			config.logger.consoleLogLevel = flags['console-log'];
+		}
+		if (flags.log) {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+			config.logger = config.logger ?? {};
+			config.logger.fileLogLevel = flags.log;
+		}
+		if (flags.port) {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+			config.network = config.network ?? {};
+			config.network.port = flags.port;
+		}
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		if (flags['seed-peers']) {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+			config.network = config.network ?? {};
+			config.network.seedPeers = [];
+			const peers = flags['seed-peers'].split(',');
+			for (const seed of peers) {
+				const [ip, port] = seed.split(':');
+				if (!ip || !port || Number.isNaN(Number(port))) {
+					this.error('Invalid seed-peers, ip or port is invalid or not specified.');
+				}
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				config.network.seedPeers.push({ ip, port: Number(port) });
+			}
+		}
+		// Plugin configs
+		setPluginConfig(config, flags);
+
+		// Get application and start
+		try {
+			const app = this.getApplication(genesisBlock, config, {
+				enableHTTPAPIPlugin: flags['enable-http-api-plugin'],
+				enableForgerPlugin: flags['enable-forger-plugin'],
+				enableMonitorPlugin: flags['enable-monitor-plugin'],
+				enableReportMisbehaviorPlugin: flags['enable-report-misbehavior-plugin'],
+			});
+			await app.run();
+		} catch (errors) {
+			this.error(
+				Array.isArray(errors) ? errors.map(err => (err as Error).message).join(',') : errors,
+			);
+		}
+	}
+
+	abstract getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+		options: Record<string, unknown>,
+	): Application;
+}

--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -17,7 +17,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Command, flags as flagParser } from '@oclif/command';
 import * as fs from 'fs-extra';
-import { ApplicationConfig, Application, PartialApplicationConfig, utils } from 'lisk-sdk';
+import { ApplicationConfig, Application, PartialApplicationConfig } from 'lisk-framework';
+import * as utils from '@liskhq/lisk-utils';
+
 import {
 	getDefaultPath,
 	splitPath,

--- a/commander/src/bootstrapping/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/commands/transaction/create.ts
@@ -1,0 +1,258 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { flags as flagParser } from '@oclif/command';
+import { codec, cryptography, transactions, validator } from 'lisk-sdk';
+import BaseIPCCommand from '../base_ipc';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getAssetFromPrompt, getPassphraseFromPrompt } from '../../../utils/reader';
+import { DEFAULT_NETWORK } from '../../../constants';
+
+interface Args {
+	readonly moduleID: number;
+	readonly assetID: number;
+	readonly fee: string;
+}
+
+const isSequenceObject = (
+	input: Record<string, unknown>,
+	key: string,
+): input is { sequence: { nonce: bigint } } => {
+	const value = input[key];
+	if (typeof value !== 'object' || Array.isArray(value) || value === null) {
+		return false;
+	}
+	const sequence = value as Record<string, unknown>;
+	if (typeof sequence.nonce !== 'bigint') {
+		return false;
+	}
+	return true;
+};
+
+export abstract class CreateCommand extends BaseIPCCommand {
+	static strict = false;
+	static description =
+		'Create transaction which can be broadcasted to the network. Note: fee and amount should be in Beddows!!';
+
+	static args = [
+		{
+			name: 'moduleID',
+			required: true,
+			description: 'Registered transaction module id.',
+		},
+		{
+			name: 'assetID',
+			required: true,
+			description: 'Registered transaction asset id.',
+		},
+		{
+			name: 'fee',
+			required: true,
+			description: 'Transaction fee in Beddows.',
+		},
+	];
+
+	static examples = [
+		'transaction:create 2 0 100000000 --asset=\'{"amount":100000000,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}\'',
+		'transaction:create 2 0 100000000 --asset=\'{"amount":100000000,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}\' --json',
+		'transaction:create 2 0 100000000 --offline --network mainnet --network-identifier 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 --nonce 1 --asset=\'{"amount":100000000,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}\'',
+	];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+		'network-identifier': flagParser.string(commonFlags.networkIdentifier),
+		nonce: flagParser.string({
+			description: 'Nonce of the transaction.',
+		}),
+		'no-signature': flagParser.boolean({
+			description:
+				'Creates the transaction without a signature. Your passphrase will therefore not be required',
+		}),
+		passphrase: flagParser.string(commonFlags.passphrase),
+		'sender-public-key': flagParser.string({
+			char: 's',
+			description:
+				'Creates the transaction with provided sender publickey, when passphrase is not provided',
+		}),
+		asset: flagParser.string({
+			char: 'a',
+			description: 'Creates transaction with specific asset information',
+		}),
+		json: flagParser.boolean({
+			char: 'j',
+			description: 'Print the transaction in JSON format',
+		}),
+		offline: flagParser.boolean({
+			...commonFlags.offline,
+			hidden: false,
+			default: false,
+		}),
+		network: flagParser.string({
+			...commonFlags.network,
+			default: DEFAULT_NETWORK,
+			hidden: false,
+		}),
+	};
+
+	async run(): Promise<void> {
+		const {
+			args,
+			flags: {
+				'data-path': dataPath,
+				passphrase: passphraseSource,
+				'no-signature': noSignature,
+				'sender-public-key': senderPublicKeySource,
+				asset: assetSource,
+				json,
+				'network-identifier': networkIdentifierSource,
+				nonce: nonceSource,
+				offline,
+			},
+		} = this.parse(CreateCommand);
+		const { fee, moduleID, assetID } = args as Args;
+
+		if (offline && dataPath) {
+			throw new Error(
+				'Flag: --data-path should not be specified while creating transaction offline.',
+			);
+		}
+
+		if (!senderPublicKeySource && noSignature) {
+			throw new Error('Sender public key must be specified when no-signature flags is used.');
+		}
+
+		if (offline && !networkIdentifierSource) {
+			throw new Error(
+				'Flag: --network-identifier must be specified while creating transaction offline.',
+			);
+		}
+
+		if (offline && !nonceSource) {
+			throw new Error('Flag: --nonce must be specified while creating transaction offline.');
+		}
+
+		const assetSchema = this._schema.transactionsAssets.find(
+			as => as.moduleID === Number(moduleID) && as.assetID === Number(assetID),
+		);
+
+		if (!assetSchema) {
+			throw new Error(
+				`Transaction moduleID:${moduleID} with assetID:${assetID} is not registered in the application.`,
+			);
+		}
+
+		const rawAsset = assetSource
+			? JSON.parse(assetSource)
+			: await getAssetFromPrompt(assetSchema.schema);
+		const assetObject = codec.fromJSON(assetSchema.schema, rawAsset);
+
+		const assetErrors = validator.validator.validate(assetSchema.schema, assetObject);
+		if (assetErrors.length) {
+			throw new validator.LiskValidationError([...assetErrors]);
+		}
+
+		let networkIdentifier = networkIdentifierSource as string;
+		if (!offline) {
+			if (!this._client) {
+				this.error('APIClient is not initialized.');
+			}
+			const nodeInfo = await this._client.node.getNodeInfo();
+			networkIdentifier = nodeInfo.networkIdentifier;
+		}
+
+		if (!offline && networkIdentifierSource && networkIdentifier !== networkIdentifierSource) {
+			throw new Error(
+				`Invalid networkIdentifier specified, actual: ${networkIdentifierSource}, expected: ${networkIdentifier}.`,
+			);
+		}
+
+		const incompleteTransaction = {
+			moduleID: Number(moduleID),
+			assetID: Number(assetID),
+			nonce: nonceSource ? BigInt(nonceSource) : undefined,
+			fee: BigInt(fee),
+			senderPublicKey: senderPublicKeySource
+				? Buffer.from(senderPublicKeySource, 'hex')
+				: undefined,
+			asset: assetObject,
+			signatures: [],
+		};
+		let passphrase = '';
+
+		if (passphraseSource || !noSignature) {
+			passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+			const { publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(passphrase);
+			incompleteTransaction.senderPublicKey = publicKey;
+		}
+
+		if (!offline) {
+			if (!this._client) {
+				this.error('APIClient is not initialized.');
+			}
+			const address = cryptography.getAddressFromPublicKey(
+				incompleteTransaction.senderPublicKey as Buffer,
+			);
+			const account = await this._client.account.get(address);
+			if (!isSequenceObject(account, 'sequence')) {
+				this.error('Account does not have sequence property.');
+			}
+			incompleteTransaction.nonce = account.sequence.nonce;
+		}
+
+		if (!offline && nonceSource && BigInt(incompleteTransaction.nonce) > BigInt(nonceSource)) {
+			throw new Error(
+				`Invalid nonce specified, actual: ${nonceSource}, expected: ${(incompleteTransaction.nonce as bigint).toString()}`,
+			);
+		}
+
+		const { asset, ...transactionWithoutAsset } = incompleteTransaction;
+
+		const transactionErrors = validator.validator.validate(this._schema.transaction, {
+			...transactionWithoutAsset,
+			asset: Buffer.alloc(0),
+		});
+		if (transactionErrors.length) {
+			throw new validator.LiskValidationError([...transactionErrors]);
+		}
+
+		const transactionObject = {
+			...transactionWithoutAsset,
+			asset: assetObject,
+		};
+
+		if (!noSignature) {
+			transactions.signTransaction(
+				assetSchema.schema,
+				transactionObject,
+				Buffer.from(networkIdentifier, 'hex'),
+				passphrase,
+			);
+		}
+
+		if (json) {
+			this.printJSON({
+				transaction: this.encodeTransaction(transactionObject).toString('hex'),
+			});
+			this.printJSON({
+				transaction: this.transactionToJSON(transactionObject),
+			});
+		} else {
+			this.printJSON({
+				transaction: this.encodeTransaction(transactionObject).toString('hex'),
+			});
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/commands/transaction/create.ts
@@ -16,7 +16,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { flags as flagParser } from '@oclif/command';
 import { codec, cryptography, transactions, validator } from 'lisk-sdk';
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 import { flags as commonFlags } from '../../../utils/flags';
 import { getAssetFromPrompt, getPassphraseFromPrompt } from '../../../utils/reader';
 import { DEFAULT_NETWORK } from '../../../constants';

--- a/commander/src/bootstrapping/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/commands/transaction/create.ts
@@ -15,7 +15,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { flags as flagParser } from '@oclif/command';
-import { codec, cryptography, transactions, validator } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as validator from '@liskhq/lisk-validator';
+import * as transactions from '@liskhq/lisk-transactions';
+import { codec } from '@liskhq/lisk-codec';
 import { BaseIPCCommand } from '../base_ipc';
 import { flags as commonFlags } from '../../../utils/flags';
 import { getAssetFromPrompt, getPassphraseFromPrompt } from '../../../utils/reader';

--- a/commander/src/bootstrapping/commands/transaction/get.ts
+++ b/commander/src/bootstrapping/commands/transaction/get.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import BaseIPCCommand from '../base_ipc';
+
+interface Args {
+	readonly id: string;
+}
+
+export abstract class GetCommand extends BaseIPCCommand {
+	static description = 'Get transaction from local node by ID.';
+
+	static args = [
+		{
+			name: 'id',
+			required: true,
+			description: 'Transaction ID in hex format.',
+		},
+	];
+
+	static examples = [
+		'transaction:get eab06c6a22e88bca7150e0347a7d976acd070cb9284423e6eabecd657acc1263',
+	];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+	};
+
+	async run(): Promise<void> {
+		const { args } = this.parse(GetCommand);
+		const { id: transactionId } = args as Args;
+		if (!this._client) {
+			this.error('APIClient is not initialized.');
+		}
+
+		try {
+			const transaction = await this._client.transaction.get(Buffer.from(transactionId, 'hex'));
+			this.printJSON(this._client.transaction.toJSON(transaction));
+		} catch (errors) {
+			const errorMessage = Array.isArray(errors)
+				? errors.map(err => (err as Error).message).join(',')
+				: errors;
+
+			if (/^Specified key transactions:id:(.*)does not exist/.test((errors as Error).message)) {
+				this.error(`Transaction with id '${transactionId}' was not found.`);
+			} else {
+				this.error(errorMessage);
+			}
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/transaction/get.ts
+++ b/commander/src/bootstrapping/commands/transaction/get.ts
@@ -14,7 +14,7 @@
  */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 
 interface Args {
 	readonly id: string;

--- a/commander/src/bootstrapping/commands/transaction/index.ts
+++ b/commander/src/bootstrapping/commands/transaction/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { CreateCommand as TransactionCreateCommand } from './create';
+export { GetCommand as TransactionGetCommand } from './get';
+export { SendCommand as TransactionSendCommand } from './send';
+export { SignCommand as TransactionSignCommand } from './sign';

--- a/commander/src/bootstrapping/commands/transaction/send.ts
+++ b/commander/src/bootstrapping/commands/transaction/send.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { validator } from 'lisk-sdk';
+import BaseIPCCommand from '../base_ipc';
+
+interface Args {
+	readonly transaction: string;
+}
+
+export abstract class SendCommand extends BaseIPCCommand {
+	static description = 'Send transaction to the local node.';
+
+	static flags = {
+		...BaseIPCCommand.flags,
+	};
+
+	static args = [
+		{
+			name: 'transaction',
+			required: true,
+			description: 'A transaction to be sent to the node encoded as hex string',
+		},
+	];
+
+	static examples = [
+		'transaction:send 080810011880cab5ee012220fd061b9146691f3c56504be051175d5b76d1b1d0179c5c4370e18534c58821222a2408641214ab0041a7d3f7b2c290b5b834d46bdc7b7eb858151a0a73656e6420746f6b656e324028edd3601cdc35a41bb23415a0d9f3c3e9cf188d9971adf18742cea39d58aa84809aa87bcfe6feaac46211c80472ad9297fd87727709f5d7e7b4134caf106b02',
+	];
+
+	async run(): Promise<void> {
+		const { args } = this.parse(SendCommand);
+		const { transaction } = args as Args;
+		if (!validator.isHexString(transaction)) {
+			throw new Error('The transaction must be provided as a encoded hex string.');
+		}
+		if (!this._client) {
+			this.error('APIClient is not initialized.');
+		}
+
+		const { transactionId } = await this._client.invoke<{ transactionId: string }>(
+			'app:postTransaction',
+			{ transaction },
+		);
+		this.log(`Transaction with id: '${transactionId}' received by node.`);
+	}
+}

--- a/commander/src/bootstrapping/commands/transaction/send.ts
+++ b/commander/src/bootstrapping/commands/transaction/send.ts
@@ -13,7 +13,7 @@
  *
  */
 import { validator } from 'lisk-sdk';
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 
 interface Args {
 	readonly transaction: string;

--- a/commander/src/bootstrapping/commands/transaction/send.ts
+++ b/commander/src/bootstrapping/commands/transaction/send.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { validator } from 'lisk-sdk';
+import * as validator from '@liskhq/lisk-validator';
 import { BaseIPCCommand } from '../base_ipc';
 
 interface Args {

--- a/commander/src/bootstrapping/commands/transaction/sign.ts
+++ b/commander/src/bootstrapping/commands/transaction/sign.ts
@@ -15,7 +15,7 @@
 
 import { flags as flagParser } from '@oclif/command';
 import { transactions, cryptography } from 'lisk-sdk';
-import BaseIPCCommand from '../base_ipc';
+import { BaseIPCCommand } from '../base_ipc';
 import { flags as commonFlags } from '../../../utils/flags';
 import { getPassphraseFromPrompt } from '../../../utils/reader';
 import { DEFAULT_NETWORK } from '../../../constants';

--- a/commander/src/bootstrapping/commands/transaction/sign.ts
+++ b/commander/src/bootstrapping/commands/transaction/sign.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { flags as flagParser } from '@oclif/command';
+import { transactions, cryptography } from 'lisk-sdk';
+import BaseIPCCommand from '../base_ipc';
+import { flags as commonFlags } from '../../../utils/flags';
+import { getPassphraseFromPrompt } from '../../../utils/reader';
+import { DEFAULT_NETWORK } from '../../../constants';
+
+interface KeysAsset {
+	mandatoryKeys: Array<Readonly<string>>;
+	optionalKeys: Array<Readonly<string>>;
+}
+export abstract class SignCommand extends BaseIPCCommand {
+	static description = 'Sign encoded transaction.';
+
+	static args = [
+		{
+			name: 'transaction',
+			required: true,
+			description: 'The transaction to be signed encoded as hex string',
+		},
+	];
+
+	static flags = {
+		...BaseIPCCommand.flags,
+		passphrase: flagParser.string(commonFlags.passphrase),
+		'include-sender': flagParser.boolean({
+			description: 'Include sender signature in transaction.',
+			default: false,
+		}),
+		'mandatory-keys': flagParser.string({
+			multiple: true,
+			description: 'Mandatory publicKey string in hex format.',
+		}),
+		'optional-keys': flagParser.string({
+			multiple: true,
+			description: 'Optional publicKey string in hex format.',
+		}),
+		'network-identifier': flagParser.string(commonFlags.networkIdentifier),
+		json: flagParser.boolean({
+			char: 'j',
+			description: 'Print the transaction in JSON format.',
+		}),
+		'sender-public-key': flagParser.string({
+			char: 's',
+			description:
+				'Sign the transaction with provided sender public key, when passphrase is not provided',
+		}),
+		offline: flagParser.boolean({
+			...commonFlags.offline,
+			hidden: false,
+			default: false,
+		}),
+		network: flagParser.string({
+			...commonFlags.network,
+			default: DEFAULT_NETWORK,
+			hidden: false,
+		}),
+	};
+
+	static examples = [
+		'transaction:sign <hex-encoded-binary-transaction>',
+		'transaction:sign <hex-encoded-binary-transaction> --network testnet',
+	];
+
+	async run(): Promise<void> {
+		const {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			args: { transaction },
+			flags: {
+				'data-path': dataPath,
+				'include-sender': includeSender,
+				'sender-public-key': senderPublicKey,
+				'mandatory-keys': mandatoryKeys,
+				'optional-keys': optionalKeys,
+				json,
+				passphrase: passphraseSource,
+				offline,
+				'network-identifier': networkIdentifierSource,
+			},
+		} = this.parse(SignCommand);
+
+		if (offline && dataPath) {
+			throw new Error('Flag: --data-path should not be specified while signing offline.');
+		}
+
+		if (offline && !networkIdentifierSource) {
+			throw new Error('Flag: --network-identifier must be specified while signing offline.');
+		}
+
+		let networkIdentifier = networkIdentifierSource as string;
+		if (!offline) {
+			if (!this._client) {
+				this.error('APIClient is not initialized.');
+			}
+			const nodeInfo = await this._client.node.getNodeInfo();
+			networkIdentifier = nodeInfo.networkIdentifier;
+		}
+
+		if (!offline && networkIdentifierSource && networkIdentifier !== networkIdentifierSource) {
+			throw new Error(
+				`Invalid networkIdentifier specified, actual: ${networkIdentifierSource}, expected: ${networkIdentifier}.`,
+			);
+		}
+
+		const passphrase = passphraseSource ?? (await getPassphraseFromPrompt('passphrase', true));
+		const networkIdentifierBuffer = Buffer.from(networkIdentifier, 'hex');
+		const transactionObject = this.decodeTransaction(transaction);
+		const assetSchema = this.getAssetSchema(
+			transactionObject.moduleID as number,
+			transactionObject.assetID as number,
+		);
+		let signedTransaction: Record<string, unknown>;
+
+		// sign from multi sig account offline using input keys
+		if (!includeSender && !senderPublicKey) {
+			signedTransaction = transactions.signTransaction(
+				assetSchema.schema,
+				transactionObject,
+				networkIdentifierBuffer,
+				passphrase,
+			);
+		} else if (offline) {
+			if (!mandatoryKeys.length && !optionalKeys.length) {
+				throw new Error(
+					'--mandatory-keys or --optional-keys flag must be specified to sign transaction from multi signature account.',
+				);
+			}
+			const keys = {
+				mandatoryKeys: mandatoryKeys ? mandatoryKeys.map(k => Buffer.from(k, 'hex')) : [],
+				optionalKeys: optionalKeys ? optionalKeys.map(k => Buffer.from(k, 'hex')) : [],
+			};
+
+			signedTransaction = transactions.signMultiSignatureTransaction(
+				assetSchema.schema,
+				transactionObject,
+				networkIdentifierBuffer,
+				passphrase,
+				keys,
+				includeSender,
+			);
+		} else {
+			// sign from multi sig account online using account keys
+			if (!senderPublicKey) {
+				throw new Error(
+					'Sender publickey must be specified for signing transactions from multi signature account.',
+				);
+			}
+			const address = cryptography.getAddressFromPublicKey(Buffer.from(senderPublicKey, 'hex'));
+			const account = (await this._client?.account.get(address)) as { keys: KeysAsset };
+			let keysAsset: KeysAsset;
+			if (account.keys?.mandatoryKeys.length === 0 && account.keys?.optionalKeys.length === 0) {
+				keysAsset = transactionObject.asset as KeysAsset;
+			} else {
+				keysAsset = account.keys;
+			}
+			const keys = {
+				mandatoryKeys: keysAsset.mandatoryKeys.map(k => Buffer.from(k, 'hex')),
+				optionalKeys: keysAsset.optionalKeys.map(k => Buffer.from(k, 'hex')),
+			};
+
+			signedTransaction = transactions.signMultiSignatureTransaction(
+				assetSchema.schema,
+				transactionObject,
+				networkIdentifierBuffer,
+				passphrase,
+				keys,
+				includeSender,
+			);
+		}
+
+		if (json) {
+			this.printJSON({
+				transaction: this.encodeTransaction(signedTransaction).toString('hex'),
+			});
+			this.printJSON({
+				transaction: this.transactionToJSON(signedTransaction),
+			});
+		} else {
+			this.printJSON({
+				transaction: this.encodeTransaction(signedTransaction).toString('hex'),
+			});
+		}
+	}
+}

--- a/commander/src/bootstrapping/commands/transaction/sign.ts
+++ b/commander/src/bootstrapping/commands/transaction/sign.ts
@@ -14,7 +14,9 @@
  */
 
 import { flags as flagParser } from '@oclif/command';
-import { transactions, cryptography } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as transactions from '@liskhq/lisk-transactions';
+
 import { BaseIPCCommand } from '../base_ipc';
 import { flags as commonFlags } from '../../../utils/flags';
 import { getPassphraseFromPrompt } from '../../../utils/reader';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -29,7 +29,7 @@ interface InitPrompts {
 export default class InitGenerator extends Generator {
 	private answers!: InitPrompts;
 
-	async prompting() {
+	async prompting(): Promise<void> {
 		this.answers = (await this.prompt([
 			{
 				type: 'input',

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
@@ -35,13 +35,48 @@
 	"bin": {
 		"<%= appName %>": "./bin/run"
 	},
+	"lisk": {
+		"addressPrefix": "lsk"
+	},
 	"oclif": {
 		"bin": "<%= appName %>",
 		"commands": "./dist/commands",
 		"plugins": [
 			"@oclif/plugin-autocomplete",
 			"@oclif/plugin-help"
-		]
+		],
+		"topics": {
+			"account": {
+				"description": "Commands relating to Lisk Core accounts."
+			},
+			"block": {
+				"description": "Commands relating to Lisk Core blocks."
+			},
+			"blockchain": {
+				"description": "Commands relating to Lisk Core blockchain data."
+			},
+			"forger-info": {
+				"description": "Commands relating to Lisk Core forger-info data."
+			},
+			"forging": {
+				"description": "Commands relating to Lisk Core forging."
+			},
+			"node": {
+				"description": "Commands relating to Lisk Core node."
+			},
+			"config": {
+				"description": "Commands relating to Lisk Core node configuration."
+			},
+			"passphrase": {
+				"description": "Commands relating to Lisk Core passphrases."
+			},
+			"sdk": {
+				"description": "Commands relating to Lisk SDK development."
+			},
+			"transaction": {
+				"description": "Commands relating to Lisk Core transactions."
+			}
+		}
 	},
 	"files": [
 		"/bin",
@@ -58,7 +93,7 @@
 	},
 	"dependencies": {
 		"@oclif/command": "1.6.1",
-		"@oclif/config": "1.15.1",
+		"@oclif/plugin-autocomplete": "0.2.1",
 		"@oclif/plugin-help": "3.1.0",
 		"fs-extra": "9.0.1",
 		"inquirer": "7.3.2",
@@ -70,6 +105,7 @@
 	},
 	"devDependencies": {
 		"@oclif/dev-cli": "1.22.2",
+		"@oclif/config": "1.15.1",
 		"@types/fs-extra": "9.0.1",
 		"@types/node": "12.12.11",
 		"@types/tar": "4.0.3",

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
@@ -63,6 +63,7 @@
 		"fs-extra": "9.0.1",
 		"inquirer": "7.3.2",
 		"lisk-sdk": "5.0.3",
+		"lisk-commander": "5.0.0",
 		"tar": "6.0.2",
 		"tslib": "1.13.0",
 		"axios": "0.21.1"

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
@@ -47,34 +47,34 @@
 		],
 		"topics": {
 			"account": {
-				"description": "Commands relating to Lisk Core accounts."
+				"description": "Commands relating to <%= appName %> accounts."
 			},
 			"block": {
-				"description": "Commands relating to Lisk Core blocks."
+				"description": "Commands relating to <%= appName %> blocks."
 			},
 			"blockchain": {
-				"description": "Commands relating to Lisk Core blockchain data."
+				"description": "Commands relating to <%= appName %> blockchain data."
 			},
 			"forger-info": {
-				"description": "Commands relating to Lisk Core forger-info data."
+				"description": "Commands relating to <%= appName %> forger-info data."
 			},
 			"forging": {
-				"description": "Commands relating to Lisk Core forging."
+				"description": "Commands relating to <%= appName %> forging."
 			},
 			"node": {
-				"description": "Commands relating to Lisk Core node."
+				"description": "Commands relating to <%= appName %> node."
 			},
 			"config": {
-				"description": "Commands relating to Lisk Core node configuration."
+				"description": "Commands relating to <%= appName %> node configuration."
 			},
 			"passphrase": {
-				"description": "Commands relating to Lisk Core passphrases."
+				"description": "Commands relating to <%= appName %> passphrases."
 			},
 			"sdk": {
 				"description": "Commands relating to Lisk SDK development."
 			},
 			"transaction": {
-				"description": "Commands relating to Lisk Core transactions."
+				"description": "Commands relating to <%= appName %> transactions."
 			}
 		}
 	},

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/app/index.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/app/index.ts
@@ -1,17 +1,1 @@
-import { genesisBlockDevnet, configDevnet } from 'lisk-sdk';
-import { getApplication } from './app';
-import { registerPlugins } from './plugins';
-import { registerModules } from './modules';
-
-// TODO: This needed to be removed when start command is implemented
-const app = getApplication(genesisBlockDevnet, configDevnet as any);
-
-// Register all modules
-registerModules(app);
-
-// Register all plugins
-registerPlugins(app);
-
-app.run().catch(error => {
-	console.error('Application cause error: ', error);
-});
+export default {};

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/create.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/create.ts
@@ -1,0 +1,1 @@
+export { AccountCreateCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/get.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { AccountGetCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class GetCommand extends AccountGetCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/get.ts
@@ -4,6 +4,11 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class GetCommand extends AccountGetCommand {
+	static flags = {
+		...AccountGetCommand.flags,
+	};
+
+	static args = [...AccountGetCommand.args];
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/get.ts
@@ -3,7 +3,7 @@ import { AccountGetCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class GetCommand extends AccountGetCommand {
+export class GetCommand extends AccountGetCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/show.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/show.ts
@@ -1,0 +1,1 @@
+export { AccountShowCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/validate.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/account/validate.ts
@@ -1,0 +1,1 @@
+export { AccountValidateCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/block/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/block/get.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { BlockGetCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class GetCommand extends BlockGetCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/block/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/block/get.ts
@@ -3,7 +3,7 @@ import { BlockGetCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class GetCommand extends BlockGetCommand {
+export class GetCommand extends BlockGetCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/block/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/block/get.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class GetCommand extends BlockGetCommand {
+	static flags = {
+		...BlockGetCommand.flags,
+	};
+
+	static args = [...BlockGetCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/download.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/download.ts
@@ -1,0 +1,1 @@
+export { BlockchainDownloadCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/export.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/export.ts
@@ -1,0 +1,1 @@
+export { BlockchainExportCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/hash.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/hash.ts
@@ -1,0 +1,1 @@
+export { BlockchainHashCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/import.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/import.ts
@@ -1,1 +1,1 @@
-import { BlockchainImportCommand } from 'lisk-commander';
+export { BlockchainImportCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/import.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/import.ts
@@ -1,0 +1,1 @@
+import { BlockchainImportCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/reset.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/blockchain/reset.ts
@@ -1,0 +1,1 @@
+export { BlockchainResetCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/config/show.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/config/show.ts
@@ -1,0 +1,1 @@
+export { ConfigShowCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/export.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/export.ts
@@ -3,7 +3,7 @@ import { ForgerInfoExportCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class ExportCommand extends ForgerInfoExportCommand {
+export class ExportCommand extends ForgerInfoExportCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/export.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/export.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { ForgerInfoExportCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class ExportCommand extends ForgerInfoExportCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/export.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/export.ts
@@ -4,6 +4,10 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class ExportCommand extends ForgerInfoExportCommand {
+	static flags = {
+		...ForgerInfoExportCommand.flags,
+	};
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/import.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/import.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { ForgerInfoImportCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class ImportCommand extends ForgerInfoImportCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/import.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/import.ts
@@ -4,6 +4,10 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class ImportCommand extends ForgerInfoImportCommand {
+	static flags = {
+		...ForgerInfoImportCommand.flags,
+	};
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/import.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forger-info/import.ts
@@ -3,7 +3,7 @@ import { ForgerInfoImportCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class ImportCommand extends ForgerInfoImportCommand {
+export class ImportCommand extends ForgerInfoImportCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/config.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/config.ts
@@ -1,0 +1,1 @@
+export { ForgingConfigCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/disable.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/disable.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class DisableCommand extends ForgingDisableCommand {
+	static flags = {
+		...ForgingDisableCommand.flags,
+	};
+
+	static args = [...ForgingDisableCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/disable.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/disable.ts
@@ -3,7 +3,7 @@ import { ForgingDisableCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class DisableCommand extends ForgingDisableCommand {
+export class DisableCommand extends ForgingDisableCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/disable.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/disable.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { ForgingDisableCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class DisableCommand extends ForgingDisableCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/enable.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/enable.ts
@@ -3,7 +3,7 @@ import { ForgingEnableCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class EnableCommand extends ForgingEnableCommand {
+export class EnableCommand extends ForgingEnableCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/enable.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/enable.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class EnableCommand extends ForgingEnableCommand {
+	static flags = {
+		...ForgingEnableCommand.flags,
+	};
+
+	static args = [...ForgingEnableCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/enable.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/enable.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { ForgingEnableCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class EnableCommand extends ForgingEnableCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/status.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/status.ts
@@ -3,7 +3,7 @@ import { ForgingStatusCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class StatusCommand extends ForgingStatusCommand {
+export class StatusCommand extends ForgingStatusCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/status.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/status.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { ForgingStatusCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class StatusCommand extends ForgingStatusCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/status.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/forging/status.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class StatusCommand extends ForgingStatusCommand {
+	static flags = {
+		...ForgingStatusCommand.flags,
+	};
+
+	static args = [...ForgingStatusCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/hash-onion.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/hash-onion.ts
@@ -1,0 +1,1 @@
+export { HashOnionCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/node/info.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/node/info.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { NodeInfoCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class InfoCommand extends NodeInfoCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/node/info.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/node/info.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class InfoCommand extends NodeInfoCommand {
+	static flags = {
+		...NodeInfoCommand.flags,
+	};
+
+	static args = [...NodeInfoCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/node/info.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/node/info.ts
@@ -3,7 +3,7 @@ import { NodeInfoCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class InfoCommand extends NodeInfoCommand {
+export class InfoCommand extends NodeInfoCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/passphrase/decrypt.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/passphrase/decrypt.ts
@@ -1,0 +1,1 @@
+export { PassphraseDecryptCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/passphrase/encrypt.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/passphrase/encrypt.ts
@@ -1,0 +1,1 @@
+export { PassphraseEncryptCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/sdk/link.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/sdk/link.ts
@@ -1,0 +1,1 @@
+export { SDKLinkCommand } from 'lisk-commander';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/start.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/start.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { flags as flagParser } from '@oclif/command';
-import { StartCommand as BaseStartCommand } from 'lisk-commander';
+import { BaseStartCommand } from 'lisk-commander';
 import {
 	Application,
 	ApplicationConfig,
@@ -51,7 +51,7 @@ const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
 	}
 };
 
-export default class StartCommand extends BaseStartCommand {
+export class StartCommand extends BaseStartCommand {
 	static flags = {
 		...BaseStartCommand.flags,
 		'enable-http-api-plugin': flagParser.boolean({

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/start.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/start.ts
@@ -1,0 +1,132 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { flags as flagParser } from '@oclif/command';
+import { StartCommand as BaseStartCommand } from 'lisk-commander';
+import {
+	Application,
+	ApplicationConfig,
+	PartialApplicationConfig,
+	HTTPAPIPlugin,
+	ForgerPlugin,
+	MonitorPlugin,
+	ReportMisbehaviorPlugin,
+} from 'lisk-sdk';
+import { getApplication } from '../app/app';
+
+interface Flags {
+	[key: string]: string | number | boolean | undefined;
+}
+
+const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
+	if (flags['http-api-plugin-port'] !== undefined) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
+		config.plugins[HTTPAPIPlugin.alias].port = flags['http-api-plugin-port'];
+	}
+	if (
+		flags['http-api-plugin-whitelist'] !== undefined &&
+		typeof flags['http-api-plugin-whitelist'] === 'string'
+	) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[HTTPAPIPlugin.alias] = config.plugins[HTTPAPIPlugin.alias] ?? {};
+		config.plugins[HTTPAPIPlugin.alias].whiteList = flags['http-api-plugin-whitelist']
+			.split(',')
+			.filter(Boolean);
+	}
+	if (flags['monitor-plugin-port'] !== undefined) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[MonitorPlugin.alias] = config.plugins[MonitorPlugin.alias] ?? {};
+		config.plugins[MonitorPlugin.alias].port = flags['monitor-plugin-port'];
+	}
+	if (
+		flags['monitor-plugin-whitelist'] !== undefined &&
+		typeof flags['monitor-plugin-whitelist'] === 'string'
+	) {
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		config.plugins[MonitorPlugin.alias] = config.plugins[MonitorPlugin.alias] ?? {};
+		config.plugins[MonitorPlugin.alias].whiteList = flags['monitor-plugin-whitelist']
+			.split(',')
+			.filter(Boolean);
+	}
+};
+
+export default class StartCommand extends BaseStartCommand {
+	static flags = {
+		...BaseStartCommand.flags,
+		'enable-http-api-plugin': flagParser.boolean({
+			description:
+				'Enable HTTP API Plugin. Environment variable "LISK_ENABLE_HTTP_API_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_HTTP_API_PLUGIN',
+			default: false,
+		}),
+		'http-api-plugin-port': flagParser.integer({
+			description:
+				'Port to be used for HTTP API Plugin. Environment variable "LISK_HTTP_API_PLUGIN_PORT" can also be used.',
+			env: 'LISK_HTTP_API_PLUGIN_PORT',
+			dependsOn: ['enable-http-api-plugin'],
+		}),
+		'http-api-plugin-whitelist': flagParser.string({
+			description:
+				'List of IPs in comma separated value to allow the connection. Environment variable "LISK_HTTP_API_PLUGIN_WHITELIST" can also be used.',
+			env: 'LISK_HTTP_API_PLUGIN_WHITELIST',
+			dependsOn: ['enable-http-api-plugin'],
+		}),
+		'enable-forger-plugin': flagParser.boolean({
+			description:
+				'Enable Forger Plugin. Environment variable "LISK_ENABLE_FORGER_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_FORGER_PLUGIN',
+			default: false,
+		}),
+		'enable-monitor-plugin': flagParser.boolean({
+			description:
+				'Enable Monitor Plugin. Environment variable "LISK_ENABLE_MONITOR_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_MONITOR_PLUGIN',
+			default: false,
+		}),
+		'monitor-plugin-port': flagParser.integer({
+			description:
+				'Port to be used for Monitor Plugin. Environment variable "LISK_MONITOR_PLUGIN_PORT" can also be used.',
+			env: 'LISK_MONITOR_PLUGIN_PORT',
+			dependsOn: ['enable-monitor-plugin'],
+		}),
+		'monitor-plugin-whitelist': flagParser.string({
+			description:
+				'List of IPs in comma separated value to allow the connection. Environment variable "LISK_MONITOR_PLUGIN_WHITELIST" can also be used.',
+			env: 'LISK_MONITOR_PLUGIN_WHITELIST',
+			dependsOn: ['enable-monitor-plugin'],
+		}),
+		'enable-report-misbehavior-plugin': flagParser.boolean({
+			description:
+				'Enable ReportMisbehavior Plugin. Environment variable "LISK_ENABLE_REPORT_MISBEHAVIOR_PLUGIN" can also be used.',
+			env: 'LISK_ENABLE_MONITOR_PLUGIN',
+			default: false,
+		}),
+	};
+
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		/* eslint-disable @typescript-eslint/no-unsafe-call */
+		const { flags } = this.parse(BaseStartCommand);
+		// Set Plugins Config
+		setPluginConfig(config as ApplicationConfig, flags);
+		const app = getApplication(genesisBlock, config);
+
+		if (flags['enable-http-api-plugin']) {
+			app.registerPlugin(HTTPAPIPlugin, { loadAsChildProcess: true });
+		}
+		if (flags['enable-forger-plugin']) {
+			app.registerPlugin(ForgerPlugin, { loadAsChildProcess: true });
+		}
+		if (flags['enable-monitor-plugin']) {
+			app.registerPlugin(MonitorPlugin, { loadAsChildProcess: true });
+		}
+		if (flags['enable-report-misbehavior-plugin']) {
+			app.registerPlugin(ReportMisbehaviorPlugin, { loadAsChildProcess: true });
+		}
+
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/start.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/start.ts
@@ -52,7 +52,7 @@ const setPluginConfig = (config: ApplicationConfig, flags: Flags): void => {
 };
 
 export class StartCommand extends BaseStartCommand {
-	static flags = {
+	static flags: any = {
 		...BaseStartCommand.flags,
 		'enable-http-api-plugin': flagParser.boolean({
 			description:

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/create.ts
@@ -3,7 +3,7 @@ import { TransactionCreateCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class CreateCommand extends TransactionCreateCommand {
+export class CreateCommand extends TransactionCreateCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/create.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class CreateCommand extends TransactionCreateCommand {
+	static flags = {
+		...TransactionCreateCommand.flags,
+	};
+
+	static args = [...TransactionCreateCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/create.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { TransactionCreateCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class CreateCommand extends TransactionCreateCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/get.ts
@@ -3,7 +3,7 @@ import { TransactionGetCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class GetCommand extends TransactionGetCommand {
+export class GetCommand extends TransactionGetCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/get.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { TransactionGetCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class GetCommand extends TransactionGetCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/get.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/get.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class GetCommand extends TransactionGetCommand {
+	static flags = {
+		...TransactionGetCommand.flags,
+	};
+
+	static args = [...TransactionGetCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/send.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/send.ts
@@ -3,7 +3,7 @@ import { TransactionSendCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class SendCommand extends TransactionSendCommand {
+export class SendCommand extends TransactionSendCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/send.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/send.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class SendCommand extends TransactionSendCommand {
+	static flags = {
+		...TransactionSendCommand.flags,
+	};
+
+	static args = [...TransactionSendCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/send.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/send.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { TransactionSendCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class SendCommand extends TransactionSendCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/sign.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/sign.ts
@@ -4,6 +4,12 @@ import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
 export class SignCommand extends TransactionSignCommand {
+	static flags = {
+		...TransactionSignCommand.flags,
+	};
+
+	static args = [...TransactionSignCommand.args];
+
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/sign.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/sign.ts
@@ -1,0 +1,14 @@
+/* eslint-disable class-methods-use-this */
+import { TransactionSignCommand } from 'lisk-commander';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
+import { getApplication } from '../../app/app';
+
+export default class SignCommand extends TransactionSignCommand {
+	public getApplication(
+		genesisBlock: Record<string, unknown>,
+		config: PartialApplicationConfig,
+	): Application {
+		const app = getApplication(genesisBlock, config);
+		return app;
+	}
+}

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/sign.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/src/commands/transaction/sign.ts
@@ -3,7 +3,7 @@ import { TransactionSignCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
 
-export default class SignCommand extends TransactionSignCommand {
+export class SignCommand extends TransactionSignCommand {
 	public getApplication(
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/commands/account/create.spec.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/commands/account/create.spec.ts
@@ -1,24 +1,14 @@
-import { cryptography, passphrase } from 'lisk-sdk';
 import * as Config from '@oclif/config';
 import { AccountCreateCommand } from '../../../src/commands/account/create';
 import { getConfig } from '../../utils/config';
 
 describe('account:create', () => {
-	const defaultMnemonic =
-		'lab mirror fetch tuna village sell sphere truly excite manual planet capable';
-	const secondDefaultMnemonic =
-		'alone cabin buffalo blast region upper jealous basket brush put answer twice';
-	let results: any;
 	let config: Config.IConfig;
-
+	let results: any;
 	beforeEach(async () => {
 		results = [];
-		jest
-			.spyOn(passphrase.Mnemonic, 'generateMnemonic')
-			.mockReturnValueOnce(defaultMnemonic)
-			.mockReturnValueOnce(secondDefaultMnemonic);
-		jest.spyOn(process.stdout, 'write').mockImplementation(val => results.push(val));
 		config = await getConfig();
+		jest.spyOn(process.stdout, 'write').mockImplementation(val => results.push(val));
 	});
 
 	it('should throw an error if the flag is invalid number', async () => {
@@ -42,17 +32,12 @@ describe('account:create', () => {
 	describe('account:create', () => {
 		it('should create an account', async () => {
 			await AccountCreateCommand.run([], config);
-			expect(JSON.parse(results[0])).toEqual([
-				{
-					publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
-					privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
-						cryptography.getKeys(defaultMnemonic).publicKey,
-						'lsk',
-					),
-					binaryAddress: cryptography.getAddressFromPassphrase(defaultMnemonic).toString('hex'),
-					passphrase: defaultMnemonic,
-				},
+			expect(Object.keys(JSON.parse(results[0])[0])).toEqual([
+				'passphrase',
+				'privateKey',
+				'publicKey',
+				'binaryAddress',
+				'address',
 			]);
 		});
 	});
@@ -61,31 +46,7 @@ describe('account:create', () => {
 		const defaultNumber = 2;
 		it('should create multiple accounts', async () => {
 			await AccountCreateCommand.run(['--count', defaultNumber.toString()], config);
-			const result = [
-				{
-					publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
-					privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
-						cryptography.getKeys(defaultMnemonic).publicKey,
-						'lsk',
-					),
-					binaryAddress: cryptography.getAddressFromPassphrase(defaultMnemonic).toString('hex'),
-					passphrase: defaultMnemonic,
-				},
-				{
-					publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
-					privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
-						cryptography.getKeys(secondDefaultMnemonic).publicKey,
-						'lsk',
-					),
-					binaryAddress: cryptography
-						.getAddressFromPassphrase(secondDefaultMnemonic)
-						.toString('hex'),
-					passphrase: secondDefaultMnemonic,
-				},
-			];
-			expect(JSON.parse(results[0])).toEqual(result);
+			expect(JSON.parse(results[0])).toHaveLength(defaultNumber);
 		});
 	});
 });

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/commands/account/create.spec.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/commands/account/create.spec.ts
@@ -1,0 +1,106 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { cryptography, passphrase } from 'lisk-sdk';
+import * as Config from '@oclif/config';
+import { AccountCreateCommand } from '../../../src/commands/account/create';
+import { getConfig } from '../../utils/config';
+
+describe('account:create', () => {
+	const defaultMnemonic =
+		'lab mirror fetch tuna village sell sphere truly excite manual planet capable';
+	const secondDefaultMnemonic =
+		'alone cabin buffalo blast region upper jealous basket brush put answer twice';
+	let results: any;
+	let config: Config.IConfig;
+
+	beforeEach(async () => {
+		results = [];
+		jest
+			.spyOn(passphrase.Mnemonic, 'generateMnemonic')
+			.mockReturnValueOnce(defaultMnemonic)
+			.mockReturnValueOnce(secondDefaultMnemonic);
+		jest.spyOn(process.stdout, 'write').mockImplementation(val => results.push(val));
+		config = await getConfig();
+	});
+
+	it('should throw an error if the flag is invalid number', async () => {
+		await expect(AccountCreateCommand.run(['--count=NaN'], config)).rejects.toThrow(
+			'Count flag must be an integer and greater than 0',
+		);
+	});
+
+	it('should throw an error if the Count flag is less than 1', async () => {
+		await expect(AccountCreateCommand.run(['--count=0'], config)).rejects.toThrow(
+			'Count flag must be an integer and greater than 0',
+		);
+	});
+
+	it('should throw an error if the Count flag contains non-number characters', async () => {
+		await expect(AccountCreateCommand.run(['--count=10sk24'], config)).rejects.toThrow(
+			'Count flag must be an integer and greater than 0',
+		);
+	});
+
+	describe('account:create', () => {
+		it('should create an account', async () => {
+			await AccountCreateCommand.run([], config);
+			expect(JSON.parse(results[0])).toEqual([
+				{
+					publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
+					privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
+					address: cryptography.getBase32AddressFromPublicKey(
+						cryptography.getKeys(defaultMnemonic).publicKey,
+						'lsk',
+					),
+					binaryAddress: cryptography.getAddressFromPassphrase(defaultMnemonic).toString('hex'),
+					passphrase: defaultMnemonic,
+				},
+			]);
+		});
+	});
+
+	describe('account:create --count=x', () => {
+		const defaultNumber = 2;
+		it('should create multiple accounts', async () => {
+			await AccountCreateCommand.run(['--count', defaultNumber.toString()], config);
+			const result = [
+				{
+					publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
+					privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
+					address: cryptography.getBase32AddressFromPublicKey(
+						cryptography.getKeys(defaultMnemonic).publicKey,
+						'lsk',
+					),
+					binaryAddress: cryptography.getAddressFromPassphrase(defaultMnemonic).toString('hex'),
+					passphrase: defaultMnemonic,
+				},
+				{
+					publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
+					privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
+					address: cryptography.getBase32AddressFromPublicKey(
+						cryptography.getKeys(secondDefaultMnemonic).publicKey,
+						'lsk',
+					),
+					binaryAddress: cryptography
+						.getAddressFromPassphrase(secondDefaultMnemonic)
+						.toString('hex'),
+					passphrase: secondDefaultMnemonic,
+				},
+			];
+			expect(JSON.parse(results[0])).toEqual(result);
+		});
+	});
+});

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/commands/account/create.spec.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/commands/account/create.spec.ts
@@ -1,18 +1,3 @@
-/*
- * LiskHQ/lisk-commander
- * Copyright © 2021 Lisk Foundation
- *
- * See the LICENSE file at the top-level directory of this distribution
- * for licensing information.
- *
- * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
- * no part of this software, including this file, may be copied, modified,
- * propagated, or distributed except according to the terms contained in the
- * LICENSE file.
- *
- * Removal or modification of this copyright notice is prohibited.
- *
- */
 import { cryptography, passphrase } from 'lisk-sdk';
 import * as Config from '@oclif/config';
 import { AccountCreateCommand } from '../../../src/commands/account/create';

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/utils/config.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/utils/config.ts
@@ -1,0 +1,25 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import * as Config from '@oclif/config';
+
+import pJSON = require('../../package.json');
+
+export const getConfig = async () => {
+	const config = await Config.load();
+	config.pjson.lisk = { addressPrefix: 'lsk' };
+	config.pjson.version = pJSON.version;
+	return config;
+};

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/utils/config.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/test/utils/config.ts
@@ -1,18 +1,3 @@
-/*
- * LiskHQ/lisk-commander
- * Copyright © 2020 Lisk Foundation
- *
- * See the LICENSE file at the top-level directory of this distribution
- * for licensing information.
- *
- * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
- * no part of this software, including this file, may be copied, modified,
- * propagated, or distributed except according to the terms contained in the
- * LICENSE file.
- *
- * Removal or modification of this copyright notice is prohibited.
- *
- */
 import * as Config from '@oclif/config';
 
 import pJSON = require('../../package.json');

--- a/commander/src/constants.ts
+++ b/commander/src/constants.ts
@@ -1,0 +1,25 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+export enum NETWORK {
+	MAINNET = 'mainnet',
+	TESTNET = 'testnet',
+	BETANET = 'betanet',
+	ALPHANET = 'alphanet',
+	DEVNET = 'devnet',
+}
+export const DEFAULT_NETWORK = NETWORK.MAINNET;
+export const RELEASE_URL = 'https://downloads.lisk.io/lisk';

--- a/commander/src/constants.ts
+++ b/commander/src/constants.ts
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-commander
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/commander/src/index.ts
+++ b/commander/src/index.ts
@@ -1,1 +1,52 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
 export { run } from '@oclif/command';
+export {
+	AccountCreateCommand,
+	AccountGetCommand,
+	AccountShowCommand,
+	AccountValidateCommand,
+} from './bootstrapping/commands/account';
+export { BlockGetCommand } from './bootstrapping/commands/block';
+export {
+	BlockchainDownloadCommand,
+	BlockchainExportCommand,
+	BlockchainHashCommand,
+	BlockchainImportCommand,
+	BlockchainResetCommand,
+} from './bootstrapping/commands/blockchain';
+export { ConfigShowCommand } from './bootstrapping/commands/config';
+export {
+	ForgerInfoExportCommand,
+	ForgerInfoImportCommand,
+} from './bootstrapping/commands/forger-info';
+export {
+	ForgingConfigCommand,
+	ForgingDisableCommand,
+	ForgingEnableCommand,
+	ForgingStatusCommand,
+} from './bootstrapping/commands/forging';
+export { NodeInfoCommand } from './bootstrapping/commands/node';
+export {
+	PassphraseDecryptCommand,
+	PassphraseEncryptCommand,
+} from './bootstrapping/commands/passphrase';
+export { SDKLinkCommand } from './bootstrapping/commands/sdk';
+export {
+	TransactionCreateCommand,
+	TransactionGetCommand,
+	TransactionSendCommand,
+	TransactionSignCommand,
+} from './bootstrapping/commands/transaction';

--- a/commander/src/index.ts
+++ b/commander/src/index.ts
@@ -51,5 +51,4 @@ export {
 	TransactionSignCommand,
 } from './bootstrapping/commands/transaction';
 export { HashOnionCommand } from './bootstrapping/commands/hash-onion';
-export {} from './bootstrapping/commands/base_ipc';
 export { StartCommand as BaseStartCommand } from './bootstrapping/commands/start';

--- a/commander/src/index.ts
+++ b/commander/src/index.ts
@@ -50,3 +50,6 @@ export {
 	TransactionSendCommand,
 	TransactionSignCommand,
 } from './bootstrapping/commands/transaction';
+export { HashOnionCommand } from './bootstrapping/commands/hash-onion';
+export {} from './bootstrapping/commands/base_ipc';
+export { StartCommand as BaseStartCommand } from './bootstrapping/commands/start';

--- a/commander/src/types.ts
+++ b/commander/src/types.ts
@@ -38,3 +38,7 @@ export interface Schema {
 	readonly type: string;
 	readonly properties: Record<string, unknown>;
 }
+
+export type RecursivePartial<T> = {
+	[P in keyof T]?: RecursivePartial<T[P]>;
+};

--- a/commander/src/types.ts
+++ b/commander/src/types.ts
@@ -1,3 +1,19 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
 import { GeneratorConstructor, GeneratorOptions } from 'yeoman-generator';
 
 export interface BootstrapGeneratorOptions extends GeneratorOptions {
@@ -13,4 +29,12 @@ export interface LiskTemplate {
 		asset: GeneratorConstructor;
 		plugin: GeneratorConstructor;
 	};
+}
+
+export type PromiseResolvedType<T> = T extends Promise<infer R> ? R : never;
+
+export interface Schema {
+	readonly $id: string;
+	readonly type: string;
+	readonly properties: Record<string, unknown>;
 }

--- a/commander/src/utils/application.ts
+++ b/commander/src/utils/application.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { pathExistsSync, readFileSync } from 'fs-extra';
+import { getPidPath } from './path';
+
+interface ErrorWithCode extends Error {
+	readonly code?: string;
+}
+
+export const getPid = (dataPath: string): number =>
+	parseInt(readFileSync(getPidPath(dataPath), { encoding: 'utf8' }), 10);
+
+export const isApplicationRunning = (dataPath: string): boolean => {
+	const pidPath = getPidPath(dataPath);
+
+	if (!pathExistsSync(pidPath)) {
+		return false;
+	}
+
+	const pid = getPid(dataPath);
+
+	try {
+		process.kill(pid, 0);
+	} catch (e) {
+		if ((e as ErrorWithCode).code) {
+			return (e as ErrorWithCode).code === 'EPERM';
+		}
+
+		return false;
+	}
+
+	return true;
+};

--- a/commander/src/utils/application.ts
+++ b/commander/src/utils/application.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/commander/src/utils/commons.ts
+++ b/commander/src/utils/commons.ts
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-commander
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/commander/src/utils/commons.ts
+++ b/commander/src/utils/commons.ts
@@ -1,0 +1,46 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { cryptography } from 'lisk-sdk';
+import { NETWORK, RELEASE_URL } from '../constants';
+
+export const liskSnapshotUrl = (url: string, network: NETWORK): string => {
+	if (!['testnet', 'mainnet', 'betanet'].includes(network.toLowerCase())) {
+		return '';
+	}
+	if (url && url.search(RELEASE_URL) >= 0) {
+		return `${RELEASE_URL}/${network}/blockchain.db.tar.gz`;
+	}
+	return url;
+};
+
+export const encryptPassphrase = (
+	passphrase: string,
+	password: string,
+	outputPublicKey: boolean,
+): Record<string, unknown> => {
+	const encryptedPassphraseObject = cryptography.encryptPassphraseWithPassword(
+		passphrase,
+		password,
+	);
+	const encryptedPassphrase = cryptography.stringifyEncryptedPassphrase(encryptedPassphraseObject);
+
+	return outputPublicKey
+		? {
+				encryptedPassphrase,
+				publicKey: cryptography.getKeys(passphrase).publicKey.toString('hex'),
+		  }
+		: { encryptedPassphrase };
+};

--- a/commander/src/utils/commons.ts
+++ b/commander/src/utils/commons.ts
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { cryptography } from 'lisk-sdk';
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { NETWORK, RELEASE_URL } from '../constants';
 
 export const liskSnapshotUrl = (url: string, network: NETWORK): string => {

--- a/commander/src/utils/db.ts
+++ b/commander/src/utils/db.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { db } from 'lisk-sdk';
+import { getBlockchainDBPath } from './path';
+
+export const getBlockchainDB = (dataPath: string): db.KVStore =>
+	new db.KVStore(getBlockchainDBPath(dataPath));

--- a/commander/src/utils/db.ts
+++ b/commander/src/utils/db.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/commander/src/utils/db.ts
+++ b/commander/src/utils/db.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { db } from 'lisk-sdk';
+import * as db from '@liskhq/lisk-db';
 import { getBlockchainDBPath } from './path';
 
 export const getBlockchainDB = (dataPath: string): db.KVStore =>

--- a/commander/src/utils/download.ts
+++ b/commander/src/utils/download.ts
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-commander
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/commander/src/utils/download.ts
+++ b/commander/src/utils/download.ts
@@ -1,0 +1,112 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import * as crypto from 'crypto';
+import * as axios from 'axios';
+import * as fs from 'fs-extra';
+import * as tar from 'tar';
+import * as path from 'path';
+
+export interface FileInfo {
+	readonly fileName: string;
+	readonly fileDir: string;
+	readonly filePath: string;
+}
+
+export const getDownloadedFileInfo = (url: string, downloadDir: string): FileInfo => {
+	const pathWithoutProtocol = url.replace(/(^\w+:|^)\/\//, '').split('/');
+	const fileName = pathWithoutProtocol.pop() as string;
+	const filePath = path.join(downloadDir, fileName);
+
+	return {
+		fileName,
+		fileDir: downloadDir,
+		filePath,
+	};
+};
+
+export const download = async (url: string, dir: string): Promise<void> => {
+	const { filePath, fileDir } = getDownloadedFileInfo(url, dir);
+
+	if (fs.existsSync(filePath)) {
+		fs.unlinkSync(filePath);
+	}
+
+	fs.ensureDirSync(fileDir);
+	const writeStream = fs.createWriteStream(filePath);
+	const response = await axios.default({
+		url,
+		method: 'GET',
+		responseType: 'stream',
+		maxContentLength: 5000,
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+	response.data.pipe(writeStream);
+
+	return new Promise<void>((resolve, reject) => {
+		writeStream.on('finish', resolve);
+		writeStream.on('error', reject);
+	});
+};
+
+export const verifyChecksum = async (filePath: string, expectedChecksum: string): Promise<void> => {
+	const fileStream = fs.createReadStream(filePath);
+	const dataHash = crypto.createHash('sha256');
+	const fileHash = await new Promise<Buffer>((resolve, reject) => {
+		fileStream.on('data', (datum: Buffer) => {
+			dataHash.update(datum);
+		});
+		fileStream.on('error', error => {
+			reject(error);
+		});
+		fileStream.on('end', () => {
+			resolve(dataHash.digest());
+		});
+	});
+
+	const fileChecksum = fileHash.toString('hex');
+	if (fileChecksum !== expectedChecksum) {
+		throw new Error(
+			`File checksum: ${fileChecksum} mismatched with expected checksum: ${expectedChecksum}`,
+		);
+	}
+};
+
+export const getChecksum = (url: string, dir: string): string => {
+	const { filePath } = getDownloadedFileInfo(url, dir);
+	const content = fs.readFileSync(`${filePath}.SHA256`, 'utf8');
+
+	if (!content) {
+		throw new Error(`Invalid filepath: ${filePath}`);
+	}
+
+	return content.split(' ')[0];
+};
+
+export const downloadAndValidate = async (url: string, dir: string): Promise<void> => {
+	await download(url, dir);
+	await download(`${url}.SHA256`, dir);
+	const { filePath } = getDownloadedFileInfo(url, dir);
+	const checksum = getChecksum(url, dir);
+	await verifyChecksum(filePath, checksum);
+};
+
+export const extract = async (filePath: string, fileName: string, outDir: string): Promise<void> =>
+	tar.x({
+		file: path.join(filePath, fileName),
+		cwd: outDir,
+		strip: 1,
+	});

--- a/commander/src/utils/flags.ts
+++ b/commander/src/utils/flags.ts
@@ -21,12 +21,12 @@ const messageDescription = `Specifies a source for providing a message to the co
 	- --message="hello world"
 `;
 
-const passphraseDescription = `Specifies a source for your secret passphrase. Lisk Commander will prompt you for input if this option is not set.
+const passphraseDescription = `Specifies a source for your secret passphrase. Command will prompt you for input if this option is not set.
 	Examples:
 	- --passphrase='my secret passphrase' (should only be used where security is not important)
 `;
 
-const passwordDescription = `Specifies a source for your secret password. Lisk Commander will prompt you for input if this option is not set.
+const passwordDescription = `Specifies a source for your secret password. Command will prompt you for input if this option is not set.
 	Examples:
 	- --password=pass:password123 (should only be used where security is not important)
 `;
@@ -86,5 +86,18 @@ export const flags: FlagMap = {
 	},
 	communityIdentifier: {
 		description: communityIdentifierDescription,
+	},
+	dataPath: {
+		char: 'd',
+		description:
+			'Directory path to specify where node data is stored. Environment variable "LISK_DATA_PATH" can also be used.',
+	},
+	offline: {
+		description: 'Specify whether to connect to a local node or not.',
+	},
+	network: {
+		char: 'n',
+		description:
+			'Default network config to use. Environment variable "LISK_NETWORK" can also be used.',
 	},
 };

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -16,7 +16,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import { PartialApplicationConfig } from 'lisk-sdk';
+import { PartialApplicationConfig } from 'lisk-framework';
 
 const defaultDir = '.lisk';
 const getConfigPath = (dataPath: string): string => path.join(dataPath, 'config');

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -16,13 +16,12 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import { PartialApplicationConfig, systemDirs } from 'lisk-sdk';
+import { PartialApplicationConfig } from 'lisk-sdk';
 
 const defaultDir = '.lisk';
-const defaultFolder = 'lisk-core';
 const getConfigPath = (dataPath: string): string => path.join(dataPath, 'config');
 
-export const getDefaultPath = (): string => path.join(os.homedir(), defaultDir, defaultFolder);
+export const getDefaultPath = (name: string): string => path.join(os.homedir(), defaultDir, name);
 
 export const getFullPath = (dataPath: string): string => path.resolve(dataPath);
 
@@ -99,20 +98,3 @@ export const getForgerDBPath = (dataPath: string): string =>
 
 export const getPidPath = (dataPath: string): string =>
 	path.join(dataPath, 'tmp', 'pids', 'controller.pid');
-
-export interface SocketPaths {
-	readonly pub: string;
-	readonly sub: string;
-	readonly rpc: string;
-	readonly root: string;
-}
-
-export const getSocketsPath = (dataPath: string, network = defaultFolder): SocketPaths => {
-	const dirs = systemDirs(network, dataPath);
-	return {
-		root: `unix://${dirs.sockets}`,
-		pub: `unix://${dirs.sockets}/lisk_pub.sock`,
-		sub: `unix://${dirs.sockets}/lisk_sub.sock`,
-		rpc: `unix://${dirs.sockets}/bus_rpc_socket.sock`,
-	};
-};

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import { PartialApplicationConfig, systemDirs } from 'lisk-sdk';
+
+const defaultDir = '.lisk';
+const defaultFolder = 'lisk-core';
+const getConfigPath = (dataPath: string): string => path.join(dataPath, 'config');
+
+export const getDefaultPath = (): string => path.join(os.homedir(), defaultDir, defaultFolder);
+
+export const getFullPath = (dataPath: string): string => path.resolve(dataPath);
+
+export const splitPath = (dataPath: string): { rootPath: string; label: string } => {
+	const rootPath = path.resolve(path.join(dataPath, '../'));
+	const label = path.parse(dataPath).name;
+	return {
+		rootPath,
+		label,
+	};
+};
+
+export const getDefaultConfigDir = (): string => path.join(__dirname, '../..');
+
+export const getNetworkConfigFilesPath = (
+	dataPath: string,
+	network: string,
+): { genesisBlockFilePath: string; configFilePath: string } => {
+	const basePath = path.join(dataPath, 'config', network);
+	return {
+		genesisBlockFilePath: path.join(basePath, 'genesis_block.json'),
+		configFilePath: path.join(basePath, 'config.json'),
+	};
+};
+
+export const getDefaultNetworkConfigFilesPath = (
+	network: string,
+): { genesisBlockFilePath: string; configFilePath: string } => {
+	const basePath = path.join(getDefaultConfigDir(), 'config', network);
+	return {
+		genesisBlockFilePath: path.join(basePath, 'genesis_block.json'),
+		configFilePath: path.join(basePath, 'config.json'),
+	};
+};
+
+export const getConfigDirs = (dataPath: string): string[] => {
+	const configPath = getConfigPath(dataPath);
+	fs.ensureDirSync(configPath);
+	const files = fs.readdirSync(configPath);
+	return files.filter(file => fs.statSync(path.join(configPath, file)).isDirectory());
+};
+
+export const getGenesisBlockAndConfig = async (
+	network: string,
+): Promise<{
+	genesisBlock: Record<string, unknown>;
+	config: PartialApplicationConfig;
+}> => {
+	const {
+		genesisBlockFilePath: defaultGenesisBlockFilePath,
+		configFilePath: defaultConfigFilepath,
+	} = getDefaultNetworkConfigFilesPath(network);
+
+	// Get config from network config or config specified
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const genesisBlock: Record<string, unknown> = await fs.readJSON(defaultGenesisBlockFilePath);
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const config: PartialApplicationConfig = await fs.readJSON(defaultConfigFilepath);
+
+	return { genesisBlock, config };
+};
+
+export const removeConfigDir = (dataPath: string, network: string): void =>
+	fs.removeSync(path.join(dataPath, 'config', network));
+
+export const ensureConfigDir = (dataPath: string, network: string): void =>
+	fs.ensureDirSync(path.join(dataPath, 'config', network));
+
+export const getBlockchainDBPath = (dataPath: string): string =>
+	path.join(dataPath, 'data', 'blockchain.db');
+
+export const getForgerDBPath = (dataPath: string): string =>
+	path.join(dataPath, 'data', 'forger.db');
+
+export const getPidPath = (dataPath: string): string =>
+	path.join(dataPath, 'tmp', 'pids', 'controller.pid');
+
+export interface SocketPaths {
+	readonly pub: string;
+	readonly sub: string;
+	readonly rpc: string;
+	readonly root: string;
+}
+
+export const getSocketsPath = (dataPath: string, network = defaultFolder): SocketPaths => {
+	const dirs = systemDirs(network, dataPath);
+	return {
+		root: `unix://${dirs.sockets}`,
+		pub: `unix://${dirs.sockets}/lisk_pub.sock`,
+		sub: `unix://${dirs.sockets}/lisk_sub.sock`,
+		rpc: `unix://${dirs.sockets}/bus_rpc_socket.sock`,
+	};
+};

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -35,7 +35,7 @@ export const splitPath = (dataPath: string): { rootPath: string; label: string }
 	};
 };
 
-export const getDefaultConfigDir = (): string => path.join(__dirname, '../..');
+export const getDefaultConfigDir = (): string => path.join(__dirname, '../../../');
 
 export const getNetworkConfigFilesPath = (
 	dataPath: string,

--- a/commander/src/utils/reader.ts
+++ b/commander/src/utils/reader.ts
@@ -13,7 +13,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { passphrase as liskPassphrase, Schema } from 'lisk-sdk';
+import { Schema } from '@liskhq/lisk-codec';
+import * as liskPassphrase from '@liskhq/lisk-passphrase';
+
 import fs from 'fs';
 import inquirer from 'inquirer';
 import readline from 'readline';

--- a/commander/src/utils/reader.ts
+++ b/commander/src/utils/reader.ts
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import * as liskPassphrase from '@liskhq/lisk-passphrase';
+import { passphrase as liskPassphrase, Schema } from 'lisk-sdk';
 import fs from 'fs';
 import inquirer from 'inquirer';
 import readline from 'readline';
@@ -25,15 +25,33 @@ interface MnemonicError {
 	readonly message: string;
 }
 
-const capitalise = (text: string): string => `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+interface PropertyValue {
+	readonly dataType: string;
+	readonly type: string;
+	readonly items: { type: string; properties: Record<string, unknown> };
+}
 
-const getPassphraseVerificationFailError = (displayName: string): string =>
-	`${capitalise(displayName)} was not successfully repeated.`;
+interface Question {
+	readonly [key: string]: unknown;
+}
+
+interface NestedPropertyTemplate {
+	[key: string]: string[];
+}
+
+interface NestedAsset {
+	[key: string]: Array<Record<string, unknown>>;
+}
 
 interface SplitSource {
 	readonly sourceIdentifier: string;
 	readonly sourceType: string;
 }
+
+const capitalise = (text: string): string => `${text.charAt(0).toUpperCase()}${text.slice(1)}`;
+
+const getPromptVerificationFailError = (displayName: string): string =>
+	`${capitalise(displayName)} was not successfully repeated.`;
 
 const splitSource = (source: string): SplitSource => {
 	const delimiter = ':';
@@ -68,7 +86,7 @@ export const getPassphraseFromPrompt = async (
 	const { passphrase, passphraseRepeat } = await inquirer.prompt(questions);
 
 	if (!passphrase || (shouldConfirm && passphrase !== passphraseRepeat)) {
-		throw new ValidationError(getPassphraseVerificationFailError(displayName));
+		throw new ValidationError(getPromptVerificationFailError(displayName));
 	}
 
 	const passphraseErrors = [passphrase]
@@ -94,6 +112,35 @@ export const getPassphraseFromPrompt = async (
 
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return passphrase;
+};
+
+export const getPasswordFromPrompt = async (
+	displayName = 'password',
+	shouldConfirm = false,
+): Promise<string> => {
+	const questions = [
+		{
+			type: 'password',
+			name: 'password',
+			message: `Please enter ${displayName}: `,
+		},
+	];
+	if (shouldConfirm) {
+		questions.push({
+			type: 'password',
+			name: 'passwordRepeat',
+			message: `Please re-enter ${displayName}: `,
+		});
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const { password, passwordRepeat } = await inquirer.prompt(questions);
+	if (!password || (shouldConfirm && password !== passwordRepeat)) {
+		throw new ValidationError(getPromptVerificationFailError(displayName));
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	return password;
 };
 
 const getFileDoesNotExistError = (path: string): string => `File at ${path} does not exist.`;
@@ -165,4 +212,131 @@ export const readStdIn = async (): Promise<string[]> => {
 	});
 
 	return readFromStd;
+};
+
+const getNestedPropertyTemplate = (schema: Schema): NestedPropertyTemplate => {
+	const keyValEntries = Object.entries(schema.properties);
+	const template: NestedPropertyTemplate = {};
+
+	// eslint-disable-next-line @typescript-eslint/prefer-for-of
+	for (let i = 0; i < keyValEntries.length; i += 1) {
+		const [schemaPropertyName, schemaPropertyValue] = keyValEntries[i];
+		if ((schemaPropertyValue as PropertyValue).type === 'array') {
+			// nested items properties
+			if ((schemaPropertyValue as PropertyValue).items.type === 'object') {
+				template[schemaPropertyName] = Object.keys(
+					(schemaPropertyValue as PropertyValue).items.properties,
+				);
+			}
+		}
+	}
+	return template;
+};
+
+const castValue = (
+	strVal: string,
+	schemaType: string,
+): number | string | Record<string, unknown> => {
+	if (schemaType === 'object') {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+		return JSON.parse(strVal);
+	}
+	return Number.isInteger(Number(strVal)) ? Number(strVal) : strVal;
+};
+
+export const transformAsset = (
+	schema: Schema,
+	data: Record<string, string>,
+): Record<string, unknown> => {
+	const propertySchema = Object.values(schema.properties);
+	const assetData = {} as Record<string, unknown>;
+	return Object.entries(data).reduce((acc, curr, index) => {
+		const schemaType = (propertySchema[index] as { type: string }).type;
+		acc[curr[0]] = schemaType === 'array' ? curr[1].split(',') : castValue(curr[1], schemaType);
+		return acc;
+	}, assetData);
+};
+
+export const transformNestedAsset = (
+	schema: Schema,
+	data: Array<Record<string, string>>,
+): NestedAsset => {
+	const template = getNestedPropertyTemplate(schema);
+	const result = {} as NestedAsset;
+	const initData = {} as Record<string, unknown>;
+	const items: Array<Record<string, unknown>> = [];
+	for (const assetData of data) {
+		const [[key, val]] = Object.entries(assetData);
+		const templateValues = template[key];
+		const valObject = val.split(',').reduce((acc, curr, index) => {
+			acc[templateValues[index]] = Number.isInteger(Number(curr)) ? Number(curr) : curr;
+			return acc;
+		}, initData);
+		items.push(valObject);
+		result[key] = items;
+	}
+	return result;
+};
+
+export const prepareQuestions = (schema: Schema): Question[] => {
+	const keyValEntries = Object.entries(schema.properties);
+	const questions: Question[] = [];
+
+	for (const [schemaPropertyName, schemaPropertyValue] of keyValEntries) {
+		if ((schemaPropertyValue as PropertyValue).type === 'array') {
+			let commaSeparatedKeys: string[] = [];
+			// nested items properties
+			if ((schemaPropertyValue as PropertyValue).items.type === 'object') {
+				commaSeparatedKeys = Object.keys((schemaPropertyValue as PropertyValue).items.properties);
+			}
+			questions.push({
+				type: 'input',
+				name: schemaPropertyName,
+				message: `Please enter: ${schemaPropertyName}(${
+					commaSeparatedKeys.length ? commaSeparatedKeys.join(', ') : 'comma separated values (a,b)'
+				}): `,
+			});
+			if ((schemaPropertyValue as PropertyValue).items.type === 'object') {
+				questions.push({
+					type: 'confirm',
+					name: 'askAgain',
+					message: `Want to enter another ${schemaPropertyName}(${commaSeparatedKeys.join(', ')})`,
+				});
+			}
+		} else {
+			questions.push({
+				type: 'input',
+				name: schemaPropertyName,
+				message: `Please enter: ${schemaPropertyName}: `,
+			});
+		}
+	}
+	return questions;
+};
+
+export const getAssetFromPrompt = async (
+	assetSchema: Schema,
+	output: Array<{ [key: string]: string }> = [],
+): Promise<NestedAsset | Record<string, unknown>> => {
+	// prepare array of questions based on asset schema
+	const questions = prepareQuestions(assetSchema);
+	let isTypeConfirm = false;
+	// Prompt user with prepared questions
+	const result = await inquirer.prompt(questions).then(async answer => {
+		const inquirerResult = answer as { [key: string]: string };
+		isTypeConfirm = typeof inquirerResult.askAgain === 'boolean';
+		// if its a multiple questions prompt user again
+		if (inquirerResult.askAgain) {
+			output.push(inquirerResult);
+			return getAssetFromPrompt(assetSchema, output);
+		}
+		output.push(inquirerResult);
+		return Promise.resolve(answer);
+	});
+	const filteredResult = output.map(({ askAgain, ...assetProps }) => assetProps);
+
+	// transform asset prompt result according to asset schema
+	return isTypeConfirm
+		? transformNestedAsset(assetSchema, filteredResult)
+		: transformAsset(assetSchema, result as Record<string, string>);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,6 +1544,16 @@
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
+"@oclif/parser@3.8.5":
+  version "3.8.5"
+  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.5.tgz#c5161766a1efca7343e1f25d769efbefe09f639b"
+  integrity sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==
+  dependencies:
+    "@oclif/errors" "^1.2.2"
+    "@oclif/linewrap" "^1.0.0"
+    chalk "^2.4.2"
+    tslib "^1.9.3"
+
 "@oclif/parser@^3.8.0", "@oclif/parser@^3.8.3":
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.4.tgz#1a90fc770a42792e574fb896325618aebbe8c9e4"


### PR DESCRIPTION
### What was the problem?

This PR resolves #6075 

### How was it solved?

- Add base commands to commander
- Add commands to `lisk-ts` template

### How was it tested?

1. `cd lisk-sdk`; `yarn; yarn build`
2. `cd commander; yarn link`
3. `mkdir /tmp/test_lisk; cd /tmp/test_lisk`
4. `../lisk-sdk/commander/bin/run init`
5. `yarn link lisk-commander`
6. `./bin/run`
7, `npm run test`