### PR TITLE
Failure in package installation during bootstrapping is not detected - Closes #6083

### DIFF
--- a/commander/src/bootstrapping/env.ts
+++ b/commander/src/bootstrapping/env.ts
@@ -18,6 +18,6 @@ import yeoman from 'yeoman-environment';
 
 const env = yeoman.createEnv();
 
-env.register(require.resolve('./generators/init'), 'lisk:init');
+env.register(require.resolve('./generators/init_generator'), 'lisk:init');
 
 export { env };

--- a/commander/src/bootstrapping/generators/init_generator.ts
+++ b/commander/src/bootstrapping/generators/init_generator.ts
@@ -35,16 +35,18 @@ export default class InitGenerator extends BootstrapGenerator {
 	}
 
 	public install(): void {
+		this.log('\n');
 		this.log('Initializing git repository');
 		this.composeWith(require.resolve('generator-git-init'));
 
-		this.log('Installing npm packages');
-		this.npmInstall();
+		this.log('\n');
+		this.log(
+			'After completion of npm installation run below command to start your blockchain app.\n',
+		);
+		this.log(`cd ${this.destinationRoot()}; npm start`);
 	}
 
 	public end(): void {
-		this.log('\n\n');
-		this.log('All set! Run below command to start your blockchain app.\n');
-		this.log(`cd ${this.destinationRoot()}; npm start`);
+		this.installDependencies({ npm: true, bower: false, yarn: false, skipMessage: false });
 	}
 }

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/app/package.json
@@ -14,8 +14,8 @@
 	"homepage": "",
 	"repository": {},
 	"engines": {
-		"node": ">=12.20.1",
-		"npm": ">=6.14.10"
+		"node": ">=12.13.0 <=12",
+		"npm": ">=6.12.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6083

### How was it solved?

- Show the log message before installing npm 
- If npm installation fails, tell use to run `npm install` himself. 

### How was it tested?

- Change some package name in template package.json to invalid 
- Run the `lisk init` to generate the app and notice the error message. 
