### PR TITLE
Generate initial genesis block and config with init command - Closes #6095

### DIFF
--- a/commander/src/bootstrapping/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/commands/genesis-block/create.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs-extra';
 import { join, resolve } from 'path';
 import * as inquirer from 'inquirer';
 import * as ProgressBar from 'progress';
-import { createMnemonicPassphrase } from '../../../utils/mnemonic';
+import { generateGenesisBlock } from '../../../utils/genesis_creation';
 
 interface AccountInfo {
 	readonly address: string;

--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -28,9 +28,7 @@ import {
 	getConfigDirs,
 	removeConfigDir,
 	ensureConfigDir,
-	getDefaultConfigDir,
 	getNetworkConfigFilesPath,
-	getDefaultNetworkConfigFilesPath,
 } from '../../utils/path';
 
 const LOG_OPTIONS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
@@ -105,8 +103,7 @@ export abstract class StartCommand extends Command {
 		this.log(`Starting Lisk ${this.config.pjson.name} at ${getFullPath(dataPath)}.`);
 		const pathConfig = splitPath(dataPath);
 
-		const defaultNetworkConfigs = getDefaultConfigDir();
-		const defaultNetworkConfigDir = getConfigDirs(defaultNetworkConfigs);
+		const defaultNetworkConfigDir = getConfigDirs(process.cwd());
 		if (!defaultNetworkConfigDir.includes(flags.network)) {
 			this.error(
 				`Network must be one of ${defaultNetworkConfigDir.join(',')} but received ${
@@ -144,7 +141,8 @@ export abstract class StartCommand extends Command {
 		const {
 			genesisBlockFilePath: defaultGenesisBlockFilePath,
 			configFilePath: defaultConfigFilepath,
-		} = getDefaultNetworkConfigFilesPath(flags.network);
+		} = getNetworkConfigFilesPath(process.cwd(), flags.network);
+
 		if (
 			!fs.existsSync(genesisBlockFilePath) ||
 			(fs.existsSync(genesisBlockFilePath) && flags['overwrite-config'])

--- a/commander/src/bootstrapping/generators/init_generator.ts
+++ b/commander/src/bootstrapping/generators/init_generator.ts
@@ -39,13 +39,34 @@ export default class InitGenerator extends BootstrapGenerator {
 
 	public install(): void {
 		this.log('\n');
-		this.log(
-			'After completion of npm installation run below command to start your blockchain app.\n',
-		);
-		this.log(`cd ${this.destinationRoot()}; npm start`);
+		this.installDependencies({ npm: true, bower: false, yarn: false, skipMessage: false });
 	}
 
 	public end(): void {
-		this.installDependencies({ npm: true, bower: false, yarn: false, skipMessage: false });
+		this.log('\n Generating genesis block and config.');
+
+		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
+			'genesis-block:create',
+			'--output',
+			'config/mainnet',
+		]);
+		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
+			'config:create',
+			'--output',
+			'config/mainnet',
+		]);
+		this.fs.move(
+			`${this.destinationRoot()}/config/mainnet/accounts.json`,
+			`${this.destinationRoot()}/.secrets/mainnet/accounts.json`,
+			{ globOptions: { dot: true, ignore: ['.DS_Store'] } },
+		);
+		this.fs.move(
+			`${this.destinationRoot()}/config/mainnet/forging_info.json`,
+			`${this.destinationRoot()}/.secrets/mainnet/forging_info.json`,
+			{ globOptions: { dot: true, ignore: ['.DS_Store'] } },
+		);
+
+		this.log('Run below command to start your blockchain app.\n');
+		this.log(`cd ${this.destinationRoot()}; npm start`);
 	}
 }

--- a/commander/src/bootstrapping/generators/init_generator.ts
+++ b/commander/src/bootstrapping/generators/init_generator.ts
@@ -41,32 +41,4 @@ export default class InitGenerator extends BootstrapGenerator {
 		this.log('\n');
 		this.installDependencies({ npm: true, bower: false, yarn: false, skipMessage: false });
 	}
-
-	public end(): void {
-		this.log('\n Generating genesis block and config.');
-
-		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
-			'genesis-block:create',
-			'--output',
-			'config/mainnet',
-		]);
-		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
-			'config:create',
-			'--output',
-			'config/mainnet',
-		]);
-		this.fs.move(
-			`${this.destinationRoot()}/config/mainnet/accounts.json`,
-			`${this.destinationRoot()}/.secrets/mainnet/accounts.json`,
-			{ globOptions: { dot: true, ignore: ['.DS_Store'] } },
-		);
-		this.fs.move(
-			`${this.destinationRoot()}/config/mainnet/forging_info.json`,
-			`${this.destinationRoot()}/.secrets/mainnet/forging_info.json`,
-			{ globOptions: { dot: true, ignore: ['.DS_Store'] } },
-		);
-
-		this.log('Run below command to start your blockchain app.\n');
-		this.log(`cd ${this.destinationRoot()}; npm start`);
-	}
 }

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -16,6 +16,7 @@
 
 import { userInfo } from 'os';
 import { basename, join } from 'path';
+import fs from 'fs';
 
 import * as Generator from 'yeoman-generator';
 
@@ -72,5 +73,34 @@ export default class InitGenerator extends Generator {
 			{},
 			{ globOptions: { dot: true, ignore: ['.DS_Store'] } },
 		);
+	}
+
+	public end(): void {
+		this.log('Generating genesis block and config.');
+		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
+			'genesis-block:create',
+			'--output',
+			'config/mainnet',
+		]);
+		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
+			'config:create',
+			'--output',
+			'config/mainnet',
+		]);
+
+		fs.mkdirSync(`${this.destinationRoot()}/.secrets/mainnet`, { recursive: true });
+
+		fs.renameSync(
+			`${this.destinationRoot()}/config/mainnet/accounts.json`,
+			`${this.destinationRoot()}/.secrets/mainnet/accounts.json`,
+		);
+
+		fs.renameSync(
+			`${this.destinationRoot()}/config/mainnet/forging_info.json`,
+			`${this.destinationRoot()}/.secrets/mainnet/forging_info.json`,
+		);
+
+		this.log('\nRun below command to start your blockchain app.\n');
+		this.log(`cd ${this.destinationRoot()}; npm start`);
 	}
 }

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -16,7 +16,7 @@
 
 import { userInfo } from 'os';
 import { basename, join } from 'path';
-import fs from 'fs';
+import * as fs from 'fs';
 
 import * as Generator from 'yeoman-generator';
 
@@ -100,7 +100,7 @@ export default class InitGenerator extends Generator {
 			`${this.destinationPath('.secrets/mainnet/forging_info.json')}`,
 		);
 		this.log(
-			`  The files, "forging_info.json" and "accounts.json" have been moved to "./.secrets/mainnet"`,
+			'  The files, "forging_info.json" and "accounts.json" have been moved to "./.secrets/mainnet"',
 		);
 
 		this.log('\nRun below command to start your blockchain app.\n');

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -99,8 +99,11 @@ export default class InitGenerator extends Generator {
 			`${this.destinationPath('config/mainnet/forging_info.json')}`,
 			`${this.destinationPath('.secrets/mainnet/forging_info.json')}`,
 		);
+		this.log(
+			`  The files, "forging_info.json" and "accounts.json" have been moved to "./.secrets/mainnet"`,
+		);
 
 		this.log('\nRun below command to start your blockchain app.\n');
-		this.log(`cd ${this.destinationRoot()}; npm start`);
+		this.log(`cd ${this.destinationRoot()}; ./bin/run start`);
 	}
 }

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -77,27 +77,27 @@ export default class InitGenerator extends Generator {
 
 	public end(): void {
 		this.log('Generating genesis block and config.');
-		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
+		this.spawnCommandSync(`${this.destinationPath('bin/run')}`, [
 			'genesis-block:create',
 			'--output',
 			'config/mainnet',
 		]);
-		this.spawnCommandSync(`${this.destinationRoot()}/bin/run`, [
+		this.spawnCommandSync(`${this.destinationPath('bin/run')}`, [
 			'config:create',
 			'--output',
 			'config/mainnet',
 		]);
 
-		fs.mkdirSync(`${this.destinationRoot()}/.secrets/mainnet`, { recursive: true });
+		fs.mkdirSync(`${this.destinationPath('.secrets/mainnet')}`, { recursive: true });
 
 		fs.renameSync(
-			`${this.destinationRoot()}/config/mainnet/accounts.json`,
-			`${this.destinationRoot()}/.secrets/mainnet/accounts.json`,
+			`${this.destinationPath('config/mainnet/accounts.json')}`,
+			`${this.destinationPath('.secrets/mainnet/accounts.json')}`,
 		);
 
 		fs.renameSync(
-			`${this.destinationRoot()}/config/mainnet/forging_info.json`,
-			`${this.destinationRoot()}/.secrets/mainnet/forging_info.json`,
+			`${this.destinationPath('config/mainnet/forging_info.json')}`,
+			`${this.destinationPath('.secrets/mainnet/forging_info.json')}`,
 		);
 
 		this.log('\nRun below command to start your blockchain app.\n');

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/.gitignore
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/.gitignore
@@ -39,6 +39,7 @@ sftp-config.json
 framework/test/mocha/network/pm2.network.json
 framework/test/mocha/network/configs/
 framework/test/mocha/network/networkTestsLogger.logs
+.secrets
 
 # Coverage directory used by tools like istanbul
 .coverage-unit/

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
@@ -24,7 +24,7 @@
 		"format": "prettier --write '**/*'",
 		"prepack": "oclif-dev manifest && oclif-dev readme --multi --dir=docs/commands && npm shrinkwrap && npm prune --production && npm shrinkwrap",
 		"prebuild": "if test -d dist; then rm -r dist; fi; rm -f tsconfig.tsbuildinfo; rm -f npm-shrinkwrap.json",
-		"start": "npx ts-node src/app",
+		"start": "echo Run \"./bin/run start\" to start the app",
 		"build": "tsc",
 		"test": "jest --passWithNoTests",
 		"test:coverage": "jest --passWithNoTests --coverage=true --coverage-reporters=text",

--- a/commander/src/utils/genesis_creation.ts
+++ b/commander/src/utils/genesis_creation.ts
@@ -1,0 +1,123 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { Account } from '@liskhq/lisk-chain';
+import { createGenesisBlock, getGenesisBlockJSON, accountAssetSchemas } from '@liskhq/lisk-genesis';
+import { RegisteredSchema } from 'lisk-framework';
+import { objects } from '@liskhq/lisk-utils';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import { createMnemonicPassphrase } from './mnemonic';
+
+interface generateGenesisBlockInput {
+	readonly schema: RegisteredSchema;
+	readonly defaultAccount: Record<string, unknown>;
+	readonly numOfAccounts: number;
+	readonly numOfValidators: number;
+	readonly tokenDistribution: number;
+}
+
+interface generateGenesisBlockOutput {
+	readonly genesisBlock: Record<string, unknown>;
+	readonly accountList: AccountInfo[];
+	readonly delegateList: {
+		readonly password: string;
+		readonly address: string;
+		readonly passphrase: string;
+		readonly username: string;
+	}[];
+}
+
+interface AccountInfo {
+	readonly address: string;
+	readonly passphrase: string;
+}
+const createAccount = (): AccountInfo => {
+	const passphrase = createMnemonicPassphrase();
+	const address = cryptography.getAddressFromPassphrase(passphrase).toString('hex');
+	return {
+		passphrase,
+		address,
+	};
+};
+
+const prepareNormalAccounts = (
+	data: {
+		address: string;
+	}[],
+	tokenBalance: number,
+): Account[] =>
+	data.map(acc => ({
+		address: Buffer.from(acc.address, 'hex'),
+		token: { balance: BigInt(tokenBalance) },
+	}));
+
+const prepareValidatorAccounts = (
+	data: {
+		username: string;
+		address: string;
+	}[],
+	tokenBalance: number,
+): Account[] =>
+	data.map(acc => ({
+		address: Buffer.from(acc.address, 'hex'),
+		token: { balance: BigInt(tokenBalance) },
+		dpos: {
+			delegate: {
+				username: acc.username,
+			},
+		},
+	}));
+
+export const generateGenesisBlock = ({
+	defaultAccount,
+	numOfAccounts = 10,
+	numOfValidators = 103,
+	schema,
+	tokenDistribution = 10000000,
+}: generateGenesisBlockInput): generateGenesisBlockOutput => {
+	const accountSchemas = schema.account.properties;
+	const defaultAccountAssetSchema = Object.fromEntries(
+		Object.entries(defaultAccount).map(([k, v]) => [k, { default: v }]),
+	);
+	const accountSchemasWithDefaults = objects.mergeDeep(
+		{},
+		accountSchemas,
+		defaultAccountAssetSchema,
+	);
+	const accountList = new Array(numOfAccounts).fill(0).map(_x => createAccount());
+	const delegateList = new Array(numOfValidators).fill(0).map((_x, index) => ({
+		...{ username: `delegate_${index}` },
+		...createAccount(),
+		...{ password: createMnemonicPassphrase() },
+	}));
+	const validAccounts = prepareNormalAccounts(accountList, tokenDistribution);
+	const validDelegateAccounts = prepareValidatorAccounts(delegateList, tokenDistribution);
+
+	const updatedGenesisBlock = createGenesisBlock({
+		initDelegates: validDelegateAccounts.map(a => a.address),
+		accounts: [...validAccounts, ...validDelegateAccounts] as Account[],
+		accountAssetSchemas: accountSchemasWithDefaults as accountAssetSchemas,
+	});
+	const genesisBlock = getGenesisBlockJSON({
+		genesisBlock: updatedGenesisBlock,
+		accountAssetSchemas: accountSchemasWithDefaults as accountAssetSchemas,
+	});
+
+	return {
+		genesisBlock,
+		delegateList,
+		accountList,
+	};
+};


### PR DESCRIPTION
### What was the problem?

This PR resolves #6095 

### How was it solved?

- ♻️ Extract genesis creation logic out of create command 80b8447
- ♻️ Generate genesis block and config on running init 362aa80

### How was it tested?

- Generate your app using `./bin/run init /User/xyz/myapp`
- `cd /User/xyz/myapp`
- `<path_to_lisk_commander>/bin/run init`

**Note:** In order to link local repos, add below code to `init_generator.ts` in beginning of `end()` method,

```
this.spawnCommandSync(`yarn`, [
			'link',
			'lisk-commander',
		]);
this.spawnCommandSync(`yarn`, [
			'link',
			'lisk-framework',
		]);
```