### PR TITLE
Add access to logger to module and plugins - Closes #6097

### DIFF
--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/src/report_misbehavior_plugin.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/src/report_misbehavior_plugin.ts
@@ -30,7 +30,6 @@ import {
 	PluginInfo,
 } from 'lisk-framework';
 import { objects } from '@liskhq/lisk-utils';
-import * as createDebug from 'debug';
 import {
 	getDBInstance,
 	saveBlockHeaders,
@@ -44,7 +43,6 @@ import { postBlockEventSchema } from './schema';
 
 // eslint-disable-next-line
 const packageJSON = require('../package.json');
-const debug = createDebug('plugin:report-misbehavior');
 
 const actionParamsSchema = {
 	$id: 'lisk/report_misbehavior/auth',
@@ -151,7 +149,7 @@ export class ReportMisbehaviorPlugin extends BasePlugin {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		this._clearBlockHeadersIntervalId = setInterval(() => {
 			clearBlockHeaders(this._pluginDB, this.schemas, this._state.currentHeight).catch(error =>
-				debug(error),
+				this._logger.debug(error),
 			);
 		}, this._clearBlockHeadersInterval);
 	}
@@ -169,7 +167,7 @@ export class ReportMisbehaviorPlugin extends BasePlugin {
 			if (event === 'postBlock') {
 				const errors = validator.validate(postBlockEventSchema, data as Record<string, unknown>);
 				if (errors.length > 0) {
-					debug('Invalid block data', errors);
+					this._logger.debug(errors, 'Invalid block data');
 					return;
 				}
 				const blockData = data as { block: string };
@@ -204,10 +202,10 @@ export class ReportMisbehaviorPlugin extends BasePlugin {
 							transaction: encodedTransaction,
 						});
 
-						debug('Sent Report misbehavior transaction', result.transactionId);
+						this._logger.debug('Sent Report misbehavior transaction', result.transactionId);
 					}
 				} catch (error) {
-					debug(error);
+					this._logger.debug(error);
 				}
 			}
 		});

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/src/report_misbehavior_plugin.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/src/report_misbehavior_plugin.ts
@@ -149,7 +149,7 @@ export class ReportMisbehaviorPlugin extends BasePlugin {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		this._clearBlockHeadersIntervalId = setInterval(() => {
 			clearBlockHeaders(this._pluginDB, this.schemas, this._state.currentHeight).catch(error =>
-				this._logger.debug(error),
+				this._logger.error(error),
 			);
 		}, this._clearBlockHeadersInterval);
 	}
@@ -167,7 +167,7 @@ export class ReportMisbehaviorPlugin extends BasePlugin {
 			if (event === 'postBlock') {
 				const errors = validator.validate(postBlockEventSchema, data as Record<string, unknown>);
 				if (errors.length > 0) {
-					this._logger.debug(errors, 'Invalid block data');
+					this._logger.error(errors, 'Invalid block data');
 					return;
 				}
 				const blockData = data as { block: string };
@@ -205,7 +205,7 @@ export class ReportMisbehaviorPlugin extends BasePlugin {
 						this._logger.debug('Sent Report misbehavior transaction', result.transactionId);
 					}
 				} catch (error) {
-					this._logger.debug(error);
+					this._logger.error(error);
 				}
 			}
 		});

--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -334,7 +334,6 @@ export class Application {
 				consoleLogLevel: this.config.logger.consoleLogLevel,
 				fileLogLevel: this.config.logger.fileLogLevel,
 			},
-			dataPath: dirs.dataPath,
 			rootPath: this.config.rootPath,
 			label: this.config.label,
 		};

--- a/framework/src/controller/controller.ts
+++ b/framework/src/controller/controller.ts
@@ -15,10 +15,10 @@
 import * as childProcess from 'child_process';
 import { ChildProcess } from 'child_process';
 import * as path from 'path';
-import { getPluginExportPath, BasePlugin, InstantiablePlugin } from '../plugins/base_plugin';
 import { Logger } from '../logger';
+import { BasePlugin, getPluginExportPath, InstantiablePlugin } from '../plugins/base_plugin';
 import { systemDirs } from '../system_dirs';
-import { PluginOptions, PluginsOptions, SocketPaths } from '../types';
+import { PluginOptions, PluginOptionsWithAppConfig, SocketPaths } from '../types';
 import { Bus } from './bus';
 import { BaseChannel } from './channels';
 import { InMemoryChannel } from './channels/in_memory_channel';
@@ -100,14 +100,17 @@ export class Controller {
 		await this._setupBus();
 	}
 
-	public async loadPlugins(plugins: PluginsObject, pluginOptions: PluginsOptions): Promise<void> {
+	public async loadPlugins(
+		plugins: PluginsObject,
+		pluginOptions: { [key: string]: PluginOptionsWithAppConfig },
+	): Promise<void> {
 		if (!this.bus) {
 			throw new Error('Controller bus is not initialized. Plugins can not be loaded.');
 		}
 
 		for (const alias of Object.keys(plugins)) {
 			const klass = plugins[alias];
-			const options = { dataPath: this.config.dataPath, ...pluginOptions[alias] };
+			const options = pluginOptions[alias];
 
 			if (options.loadAsChildProcess && this.config.rpc.enable) {
 				await this._loadChildProcessPlugin(alias, klass, options);

--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -25,6 +25,7 @@ import {
 	BaseModuleDataAccess,
 } from '../types';
 import { BaseAsset } from './base_asset';
+import { Logger } from '../logger/logger';
 
 interface BaseModuleChannel {
 	publish(name: string, data?: Record<string, unknown>): void;
@@ -37,6 +38,7 @@ export abstract class BaseModule {
 	public actions: Actions = {};
 	public events: string[] = [];
 	public accountSchema?: AccountSchema;
+	protected _logger!: Logger;
 	protected _channel!: BaseModuleChannel;
 	protected _dataAccess!: BaseModuleDataAccess;
 	public abstract name: string;
@@ -46,9 +48,14 @@ export abstract class BaseModule {
 		this.config = genesisConfig;
 	}
 
-	public init(input: { channel: BaseModuleChannel; dataAccess: BaseModuleDataAccess }): void {
+	public init(input: {
+		channel: BaseModuleChannel;
+		dataAccess: BaseModuleDataAccess;
+		logger: Logger;
+	}): void {
 		this._channel = input.channel;
 		this._dataAccess = input.dataAccess;
+		this._logger = input.logger;
 	}
 
 	public async beforeTransactionApply?(context: TransactionApplyContext): Promise<void>;

--- a/framework/src/modules/dpos/delegates.ts
+++ b/framework/src/modules/dpos/delegates.ts
@@ -12,9 +12,9 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import * as createDebug from 'debug';
 import { getAddressFromPublicKey, hash } from '@liskhq/lisk-cryptography';
 import { Account } from '@liskhq/lisk-chain';
+import { Logger } from '../../logger/logger';
 import { Consensus, StateStore } from '../../types';
 import { DelegateWeight, DPOSAccountProps } from './types';
 import { getRegisteredDelegates, getVoteWeights, setVoteWeights } from './data_access';
@@ -27,8 +27,6 @@ import {
 	MAX_LAST_FORGED_HEIGHT_DIFF,
 } from './constants';
 import { isCurrentlyPunished } from './utils';
-
-const debug = createDebug('dpos:delegates');
 
 export const shuffleDelegateList = (
 	previousRoundSeed1: Buffer,
@@ -151,6 +149,7 @@ export const createVoteWeightsSnapshot = async ({
 	height,
 	stateStore,
 	round,
+	logger,
 	voteWeightCapRate = DEFAULT_VOTE_WEIGHT_CAP_RATE,
 	activeDelegates = DEFAULT_ACTIVE_DELEGATE,
 	standbyDelegates = DEFAULT_STANDBY_DELEGATE,
@@ -163,8 +162,9 @@ export const createVoteWeightsSnapshot = async ({
 	activeDelegates?: number;
 	standbyDelegates?: number;
 	standbyThreshold?: bigint;
+	logger: Logger;
 }): Promise<void> => {
-	debug(`Creating vote weight snapshot for round: ${round.toString()}`);
+	logger.debug(`Creating vote weight snapshot for round: ${round.toString()}`);
 
 	const delegateUserNames = await getRegisteredDelegates(stateStore);
 

--- a/framework/src/modules/dpos/dpos_module.ts
+++ b/framework/src/modules/dpos/dpos_module.ts
@@ -16,7 +16,6 @@ import { Account } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { objects as objectsUtils } from '@liskhq/lisk-utils';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
-import * as createDebug from 'debug';
 import { getMinWaitingHeight, getMinPunishedHeight } from './utils';
 import { AfterBlockApplyContext, AfterGenesisBlockApplyContext, GenesisConfig } from '../../types';
 import { BaseModule } from '../base_module';
@@ -47,8 +46,6 @@ const dposModuleParamsDefault = {
 	standbyDelegates: 2,
 	delegateListRoundOffset: 2,
 };
-
-const debug = createDebug('dpos');
 
 export class DPoSModule extends BaseModule {
 	public name = 'dpos';
@@ -166,8 +163,7 @@ export class DPoSModule extends BaseModule {
 			const finalizedBlockRound = this.rounds.calcRound(finalizedHeight);
 			const disposableDelegateListUntilRound =
 				finalizedBlockRound - this._delegateListRoundOffset - this._delegateActiveRoundLimit;
-
-			debug('Deleting voteWeights until round: ', disposableDelegateListUntilRound);
+			this._logger.debug(disposableDelegateListUntilRound, 'Deleting voteWeights until round');
 			await deleteVoteWeightsUntilRound(disposableDelegateListUntilRound, context.stateStore);
 		}
 
@@ -222,6 +218,7 @@ export class DPoSModule extends BaseModule {
 		) {
 			// Height is 1, but to create round 1-3, round offset should start from 0 - 2
 			await createVoteWeightsSnapshot({
+				logger: this._logger,
 				stateStore: context.stateStore,
 				height: context.genesisBlock.header.height,
 				round: i,
@@ -239,7 +236,7 @@ export class DPoSModule extends BaseModule {
 		} = context;
 
 		const round = this.rounds.calcRound(blockHeader.height);
-		debug('Updating delegates productivity for round', round);
+		this._logger.debug(round, 'Updating delegates productivity for round');
 		await updateDelegateProductivity({
 			height: blockHeader.height,
 			blockTime: this._blockTime,
@@ -253,11 +250,12 @@ export class DPoSModule extends BaseModule {
 	private async _createVoteWeightSnapshot(context: AfterBlockApplyContext): Promise<void> {
 		const round = this.rounds.calcRound(context.block.header.height);
 		// Calculate Vote Weights List
-		debug('Creating delegate list for round', round + this._delegateListRoundOffset);
+		this._logger.debug(round + this._delegateListRoundOffset, 'Creating delegate list for round');
 
 		const snapshotHeight = context.block.header.height + 1;
 		const snapshotRound = this.rounds.calcRound(snapshotHeight) + this._delegateListRoundOffset;
 		await createVoteWeightsSnapshot({
+			logger: this._logger,
 			stateStore: context.stateStore,
 			height: snapshotHeight,
 			round: snapshotRound,
@@ -270,13 +268,14 @@ export class DPoSModule extends BaseModule {
 		const round = this.rounds.calcRound(context.block.header.height);
 		const nextRound = round + 1;
 
-		debug('Updating delegate list for', nextRound);
+		this._logger.debug(nextRound, 'Updating delegate list for');
 		// Calculate Delegate List
-		const [randomSeed1, randomSeed2] = generateRandomSeeds(
+		const [randomSeed1, randomSeed2] = generateRandomSeeds({
 			round,
-			this.rounds,
-			context.stateStore.chain.lastBlockHeaders,
-		);
+			rounds: this.rounds,
+			headers: context.stateStore.chain.lastBlockHeaders,
+			logger: this._logger,
+		});
 		await updateDelegateList({
 			round: nextRound,
 			randomSeeds: [randomSeed1, randomSeed2],

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -264,6 +264,7 @@ export class Node {
 						this._chain.dataAccess.getAccountByAddress<T>(address),
 					getLastBlockHeader: async () => this._chain.dataAccess.getLastBlockHeader(),
 				},
+				logger: this._logger,
 			});
 		}
 		// Initialize callable P2P endpoints

--- a/framework/src/plugins/base_plugin.ts
+++ b/framework/src/plugins/base_plugin.ts
@@ -22,7 +22,7 @@ import { ActionsDefinition } from '../controller/action';
 import { BaseChannel } from '../controller/channels';
 import { EventsDefinition } from '../controller/event';
 import { ImplementationMissingError } from '../errors';
-import { createLogger, Logger } from '../logger/logger';
+import { createLogger, Logger } from '../logger';
 import { systemDirs } from '../system_dirs';
 import { PluginOptionsWithAppConfig, RegisteredSchema, TransactionJSON } from '../types';
 

--- a/framework/src/plugins/base_plugin.ts
+++ b/framework/src/plugins/base_plugin.ts
@@ -12,16 +12,19 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import * as assert from 'assert';
 import { RawBlock } from '@liskhq/lisk-chain';
 import { codec, Schema } from '@liskhq/lisk-codec';
 import { hash } from '@liskhq/lisk-cryptography';
+import * as assert from 'assert';
+import { join } from 'path';
 import { APP_EVENT_READY } from '../constants';
 import { ActionsDefinition } from '../controller/action';
 import { BaseChannel } from '../controller/channels';
 import { EventsDefinition } from '../controller/event';
 import { ImplementationMissingError } from '../errors';
-import { RegisteredSchema, TransactionJSON } from '../types';
+import { createLogger, Logger } from '../logger/logger';
+import { systemDirs } from '../system_dirs';
+import { PluginOptionsWithAppConfig, RegisteredSchema, TransactionJSON } from '../types';
 
 interface DefaultAccountJSON {
 	[name: string]: { [key: string]: unknown } | undefined;
@@ -187,12 +190,13 @@ export interface PluginCodec {
 }
 
 export abstract class BasePlugin {
-	public readonly options: object;
+	public readonly options: PluginOptionsWithAppConfig;
 	public schemas!: RegisteredSchema;
 
 	public codec: PluginCodec;
+	protected _logger!: Logger;
 
-	protected constructor(options: object) {
+	protected constructor(options: PluginOptionsWithAppConfig) {
 		this.options = options;
 
 		this.codec = {
@@ -231,6 +235,17 @@ export abstract class BasePlugin {
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async init(channel: BaseChannel): Promise<void> {
+		const dirs = systemDirs(this.options.appConfig?.label, this.options.appConfig?.rootPath);
+		this._logger = createLogger({
+			consoleLogLevel: this.options.appConfig?.logger.consoleLogLevel,
+			fileLogLevel: this.options.appConfig?.logger.fileLogLevel,
+			logFilePath: join(
+				dirs.logs,
+				`plugin-${((this.constructor as unknown) as typeof BasePlugin).alias}.log`,
+			),
+			module: `plugin:${((this.constructor as unknown) as typeof BasePlugin).alias}`,
+		});
+
 		channel.once(APP_EVENT_READY, async () => {
 			this.schemas = await channel.invoke('app:getSchema');
 		});

--- a/framework/src/plugins/base_plugin.ts
+++ b/framework/src/plugins/base_plugin.ts
@@ -235,10 +235,10 @@ export abstract class BasePlugin {
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async init(channel: BaseChannel): Promise<void> {
-		const dirs = systemDirs(this.options.appConfig?.label, this.options.appConfig?.rootPath);
+		const dirs = systemDirs(this.options.appConfig.label, this.options.appConfig.rootPath);
 		this._logger = createLogger({
-			consoleLogLevel: this.options.appConfig?.logger.consoleLogLevel,
-			fileLogLevel: this.options.appConfig?.logger.fileLogLevel,
+			consoleLogLevel: this.options.appConfig.logger.consoleLogLevel,
+			fileLogLevel: this.options.appConfig.logger.fileLogLevel,
 			logFilePath: join(
 				dirs.logs,
 				`plugin-${((this.constructor as unknown) as typeof BasePlugin).alias}.log`,

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -75,8 +75,23 @@ export interface PluginOptions extends Record<string, unknown> {
 	readonly alias?: string;
 }
 
-export interface PluginsOptions {
-	[key: string]: PluginOptions;
+export interface AppConfigForPlugin {
+	readonly dataPath: string;
+	readonly rootPath: string;
+	readonly version: string;
+	readonly networkVersion: string;
+	readonly genesisConfig: GenesisConfig;
+	readonly label: string;
+	readonly logger: {
+		readonly consoleLogLevel: string;
+		readonly fileLogLevel: string;
+	};
+}
+
+export interface PluginOptionsWithAppConfig extends PluginOptions {
+	// TODO: Remove data path from here and use from appConfig
+	readonly dataPath: string;
+	appConfig: AppConfigForPlugin;
 }
 
 export interface DelegateConfig {
@@ -164,7 +179,9 @@ export interface ApplicationConfig {
 		consoleLogLevel: string;
 	};
 	genesisConfig: GenesisConfig;
-	plugins: PluginsOptions;
+	plugins: {
+		[key: string]: PluginOptions;
+	};
 	transactionPool: TransactionPoolConfig;
 	rpc: RPCConfig;
 }

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -76,7 +76,6 @@ export interface PluginOptions extends Record<string, unknown> {
 }
 
 export interface AppConfigForPlugin {
-	readonly dataPath: string;
 	readonly rootPath: string;
 	readonly version: string;
 	readonly networkVersion: string;

--- a/framework/test/unit/modules/dpos/dpos_module.spec.ts
+++ b/framework/test/unit/modules/dpos/dpos_module.spec.ts
@@ -47,6 +47,9 @@ describe('DPoSModule', () => {
 	const channelMock = {
 		publish: jest.fn(),
 	};
+	const loggerMock = {
+		debug: jest.fn(),
+	};
 
 	beforeEach(() => {
 		genesisConfig = {
@@ -199,6 +202,11 @@ describe('DPoSModule', () => {
 			};
 
 			dposModule = new DPoSModule(genesisConfig);
+			dposModule.init({
+				channel: channelMock,
+				dataAccess: dataAccessMock as any,
+				logger: loggerMock as any,
+			});
 		});
 
 		describe('when finalized height changed', () => {
@@ -244,6 +252,7 @@ describe('DPoSModule', () => {
 					height: blockRound * 103 + 1,
 					stateStore: context.stateStore,
 					round: blockRound + (genesisConfig.delegateListRoundOffset as number) + 1,
+					logger: loggerMock,
 				});
 			});
 
@@ -281,7 +290,11 @@ describe('DPoSModule', () => {
 
 		beforeEach(() => {
 			dposModule = new DPoSModule(genesisConfig);
-			dposModule.init({ channel: channelMock, dataAccess: dataAccessMock as any });
+			dposModule.init({
+				channel: channelMock,
+				dataAccess: dataAccessMock as any,
+				logger: loggerMock as any,
+			});
 
 			unvoteHeight = 50059;
 			account = createFakeDefaultAccount({});

--- a/framework/test/unit/modules/dpos/random_seed.spec.ts
+++ b/framework/test/unit/modules/dpos/random_seed.spec.ts
@@ -40,6 +40,7 @@ const generateHeadersFromTest = (blocks: any): BlockHeader[] =>
 describe('random_seed', () => {
 	let rounds: Rounds;
 	let randomSeeds: Buffer[];
+	let logger: any;
 
 	const testCases = [
 		...randomSeedFirstRound.testCases,
@@ -47,6 +48,10 @@ describe('random_seed', () => {
 		...randomSeedsInvalidSeedReveal.testCases,
 		...randomSeedsNotForgedEarlier.testCases,
 	];
+
+	beforeEach(() => {
+		logger = { debug: jest.fn() };
+	});
 
 	describe('generateRandomSeeds', () => {
 		it('should throw error if called before middle of the round', () => {
@@ -59,7 +64,7 @@ describe('random_seed', () => {
 			const headers = generateHeadersFromTest(input.blocks);
 
 			// Act & Assert
-			expect(() => generateRandomSeeds(round, rounds, headers)).toThrow(
+			expect(() => generateRandomSeeds({ round, rounds, headers, logger })).toThrow(
 				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 				`Random seed can't be calculated earlier in a round. Wait till you pass middle of round. Current height: ${input.blocks.length}`,
 			);
@@ -79,7 +84,7 @@ describe('random_seed', () => {
 					const headers = generateHeadersFromTest(input.blocks);
 
 					// Act
-					randomSeeds = generateRandomSeeds(round, rounds, headers);
+					randomSeeds = generateRandomSeeds({ round, rounds, headers, logger });
 
 					// Assert
 					expect(randomSeeds[0].toString('hex')).toEqual(output.randomSeed1);

--- a/framework/test/unit/plugins/base_plugin.spec.ts
+++ b/framework/test/unit/plugins/base_plugin.spec.ts
@@ -13,15 +13,22 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { when } from 'jest-when';
 import { transactionSchema } from '@liskhq/lisk-chain';
-import { getPluginExportPath, PluginInfo } from '../../../src/plugins/base_plugin';
+import { when } from 'jest-when';
 import { BaseChannel, BasePlugin } from '../../../src';
+import * as loggerModule from '../../../src/logger';
 import { TransferAsset } from '../../../src/modules/token/transfer_asset';
+import { getPluginExportPath, PluginInfo } from '../../../src/plugins/base_plugin';
+
+const appConfigForPlugin = {
+	rootPath: '/my/path',
+	label: 'my-app',
+	logger: { consoleLogLevel: 'debug', fileLogLevel: '123' },
+};
 
 class MyPlugin extends BasePlugin {
-	public constructor(options: object = {}) {
-		super(options);
+	public constructor(options: object = { appConfig: appConfigForPlugin }) {
+		super(options as never);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/class-literal-property-style
@@ -63,6 +70,11 @@ const channelMock = {
 	once: jest.fn().mockImplementation((_eventName, cb) => cb()),
 };
 
+const loggerMock = {
+	debug: jest.fn(),
+	info: jest.fn(),
+};
+
 const schemas = {
 	accountSchema: {},
 	transactionSchema,
@@ -84,6 +96,7 @@ describe('base_plugin', () => {
 		beforeEach(() => {
 			plugin = new MyPlugin();
 
+			jest.spyOn(loggerModule, 'createLogger').mockReturnValue(loggerMock as never);
 			when(channelMock.invoke).calledWith('app:getSchema').mockResolvedValue(schemas);
 		});
 
@@ -98,6 +111,20 @@ describe('base_plugin', () => {
 		});
 
 		describe('init', () => {
+			it('should create logger instance', async () => {
+				// Act
+				await plugin.init((channelMock as unknown) as BaseChannel);
+
+				// Assert
+				expect(loggerModule.createLogger).toHaveBeenCalledTimes(1);
+				expect(loggerModule.createLogger).toHaveBeenCalledWith({
+					...appConfigForPlugin.logger,
+					logFilePath: `${appConfigForPlugin.rootPath}/${appConfigForPlugin.label}/logs/plugin-${MyPlugin.alias}.log`,
+					module: `plugin:${MyPlugin.alias}`,
+				});
+				expect(plugin['_logger']).toBe(loggerMock);
+			});
+
 			it('should fetch schemas and assign to instance', async () => {
 				// Act
 				await plugin.init((channelMock as unknown) as BaseChannel);


### PR DESCRIPTION
### What was the problem?

This PR resolves #6097

### How was it solved?

- Added logger support for module and plugin as protected member. 
- Logger will be available for both after `init` process 

### How was it tested?

- Unit tests for framework 
