### PR TITLE
Add ip address binding option for private port - Closes #6084

### DIFF
--- a/framework-plugins/lisk-framework-http-api-plugin/src/defaults/default_config.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/defaults/default_config.ts
@@ -20,6 +20,10 @@ export const defaultConfig = {
 			minimum: 1,
 			maximum: 65535,
 		},
+		host: {
+			type: 'string',
+			format: 'ip',
+		},
 		whiteList: {
 			type: 'array',
 			items: {
@@ -70,6 +74,7 @@ export const defaultConfig = {
 	required: ['port', 'whiteList', 'cors', 'limits'],
 	default: {
 		port: 4000,
+		host: '127.0.0.1',
 		whiteList: ['127.0.0.1'],
 		cors: {
 			origin: '*',

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -74,7 +74,8 @@ export class HTTPAPIPlugin extends BasePlugin {
 			this._registerMiddlewares(options);
 			this._registerControllers();
 			this._registerAfterMiddlewares(options);
-			this._server = this._app.listen(options.port, '0.0.0.0');
+			// default bind to port only at localhost instead of INADDR_ANY
+			this._server = this._app.listen(options.port, options.host ?? '127.0.0.1');
 		});
 	}
 

--- a/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/http_api_plugin.ts
@@ -74,8 +74,7 @@ export class HTTPAPIPlugin extends BasePlugin {
 			this._registerMiddlewares(options);
 			this._registerControllers();
 			this._registerAfterMiddlewares(options);
-			// default bind to port only at localhost instead of INADDR_ANY
-			this._server = this._app.listen(options.port, options.host ?? '127.0.0.1');
+			this._server = this._app.listen(options.port, options.host);
 		});
 	}
 

--- a/framework-plugins/lisk-framework-http-api-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/types.ts
@@ -14,7 +14,7 @@
 
 export interface Options {
 	readonly port: number;
-	readonly host?: string;
+	readonly host: string;
 	readonly whiteList: ReadonlyArray<string>;
 	readonly cors: {
 		readonly origin: string;

--- a/framework-plugins/lisk-framework-http-api-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/src/types.ts
@@ -14,6 +14,7 @@
 
 export interface Options {
 	readonly port: number;
+	readonly host?: string;
 	readonly whiteList: ReadonlyArray<string>;
 	readonly cors: {
 		readonly origin: string;

--- a/framework-plugins/lisk-framework-monitor-plugin/src/defaults/default_config.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/defaults/default_config.ts
@@ -20,6 +20,10 @@ export const defaultConfig = {
 			minimum: 1,
 			maximum: 65535,
 		},
+		host: {
+			type: 'string',
+			format: 'ip',
+		},
 		whiteList: {
 			type: 'array',
 			items: {
@@ -70,6 +74,7 @@ export const defaultConfig = {
 	required: ['port', 'whiteList', 'cors', 'limits'],
 	default: {
 		port: 4003,
+		host: '127.0.0.1',
 		whiteList: ['127.0.0.1'],
 		cors: {
 			origin: '*',

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -106,7 +106,7 @@ export class MonitorPlugin extends BasePlugin {
 			this._registerControllers();
 			this._registerAfterMiddlewares(options);
 			this._subscribeToEvents();
-			this._server = this._app.listen(options.port, options.host ?? '127.0.0.1');
+			this._server = this._app.listen(options.port, options.host);
 		});
 	}
 

--- a/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/monitor_plugin.ts
@@ -106,7 +106,7 @@ export class MonitorPlugin extends BasePlugin {
 			this._registerControllers();
 			this._registerAfterMiddlewares(options);
 			this._subscribeToEvents();
-			this._server = this._app.listen(options.port, '0.0.0.0');
+			this._server = this._app.listen(options.port, options.host ?? '127.0.0.1');
 		});
 	}
 

--- a/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
@@ -14,7 +14,7 @@
 
 export interface Options {
 	readonly port: number;
-	readonly host?: string;
+	readonly host: string;
 	readonly whiteList: ReadonlyArray<string>;
 	readonly cors: {
 		readonly origin: string;

--- a/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/types.ts
@@ -14,6 +14,7 @@
 
 export interface Options {
 	readonly port: number;
+	readonly host?: string;
 	readonly whiteList: ReadonlyArray<string>;
 	readonly cors: {
 		readonly origin: string;

--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -32,6 +32,7 @@ interface BusConfiguration {
 		readonly enable: boolean;
 		readonly mode: string;
 		readonly port: number;
+		readonly host?: string;
 	};
 }
 
@@ -115,6 +116,7 @@ export class Bus {
 			this._wsServer = new WSServer({
 				path: '/ws',
 				port: config.rpc.port,
+				host: config.rpc.host,
 				logger: this.logger,
 			});
 		}

--- a/framework/src/controller/ws/ws_server.ts
+++ b/framework/src/controller/ws/ws_server.ts
@@ -24,17 +24,24 @@ export class WSServer {
 	public server!: WebSocket.Server;
 	private pingTimer!: NodeJS.Timeout;
 	private readonly port: number;
+	private readonly host?: string;
 	private readonly path: string;
 	private readonly logger: Logger;
 
-	public constructor(options: { port: number; path: string; logger: Logger }) {
+	public constructor(options: { port: number; host?: string; path: string; logger: Logger }) {
 		this.port = options.port;
+		this.host = options.host;
 		this.path = options.path;
 		this.logger = options.logger;
 	}
 
 	public start(messageHandler: WSMessageHandler): WebSocket.Server {
-		this.server = new WebSocket.Server({ path: this.path, port: this.port, clientTracking: true });
+		this.server = new WebSocket.Server({
+			path: this.path,
+			port: this.port,
+			host: this.host,
+			clientTracking: true,
+		});
 		this.server.on('connection', socket => this._handleConnection(socket, messageHandler));
 		this.server.on('error', error => {
 			this.logger.error(error);

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -351,6 +351,10 @@ export const applicationConfigSchema = {
 					minimum: 1024,
 					maximum: 65535,
 				},
+				host: {
+					type: 'string',
+					format: 'ip',
+				},
 			},
 		},
 	},
@@ -369,6 +373,7 @@ export const applicationConfigSchema = {
 			enable: false,
 			mode: 'ipc',
 			port: 8080,
+			host: '127.0.0.1',
 		},
 		genesisConfig: {
 			blockTime: 10,

--- a/framework/test/unit/__snapshots__/application.spec.ts.snap
+++ b/framework/test/unit/__snapshots__/application.spec.ts.snap
@@ -2221,6 +2221,7 @@ Object {
   "rootPath": "~/.lisk",
   "rpc": Object {
     "enable": false,
+    "host": "127.0.0.1",
     "mode": "ipc",
     "port": 8080,
   },

--- a/framework/test/unit/schema/__snapshots__/application_schema.spec.ts.snap
+++ b/framework/test/unit/schema/__snapshots__/application_schema.spec.ts.snap
@@ -44,6 +44,7 @@ Object {
       "rootPath": "~/.lisk",
       "rpc": Object {
         "enable": false,
+        "host": "127.0.0.1",
         "mode": "ipc",
         "port": 8080,
       },
@@ -388,6 +389,10 @@ Object {
         "properties": Object {
           "enable": Object {
             "type": "boolean",
+          },
+          "host": Object {
+            "format": "ip",
+            "type": "string",
           },
           "mode": Object {
             "enum": Array [


### PR DESCRIPTION
### What was the problem?

This PR resolves #6084 

### How was it solved?

*  Add option for reading`host` from application config which defaults to `localhost`
*  Add option for reading`host` from HTTP API plugin config which defaults to `localhost`
*  Add option for reading`host` from Monitor plugin config which defaults to `localhost`
### How was it tested?
Tested manually by starting a node with custom config containing host address & sending requests from host address
