### PR TITLE
Transaction create command with no signature failed - Closes #6160, #6161, #6162

### DIFF
--- a/commander/src/bootstrapping/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/commands/transaction/create.ts
@@ -31,7 +31,7 @@ import {
 	getAssetSchema,
 	transactionToJSON,
 } from '../../../utils/transaction';
-import { getDefaultPath, getGenesisBlockAndConfig } from '../../../utils/path';
+import { getDefaultPath } from '../../../utils/path';
 import { isApplicationRunning } from '../../../utils/application';
 import { PromiseResolvedType } from '../../../types';
 
@@ -42,7 +42,6 @@ interface Args {
 }
 
 interface CreateFlags {
-	network: string;
 	'network-identifier'?: string;
 	passphrase?: string;
 	asset?: string;
@@ -241,7 +240,6 @@ export abstract class CreateCommand extends Command {
 	];
 
 	static flags = {
-		network: flagsWithParser.network,
 		passphrase: flagsWithParser.passphrase,
 		asset: flagParser.string({
 			char: 'a',
@@ -293,8 +291,7 @@ export abstract class CreateCommand extends Command {
 		this._dataPath = flags['data-path'] ?? getDefaultPath(this.config.pjson.name);
 
 		if (flags.offline) {
-			const { genesisBlock, config } = await getGenesisBlockAndConfig(flags.network);
-			const app = this.getApplication(genesisBlock, config);
+			const app = this.getApplication({}, {});
 			this._schema = app.getSchema();
 
 			transactionObject = await createTransactionOffline(

--- a/commander/src/bootstrapping/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/commands/transaction/create.ts
@@ -15,15 +15,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable no-param-reassign */
-import Command, { flags as flagParser } from '@oclif/command';
 import * as apiClient from '@liskhq/lisk-api-client';
 import { codec, Schema } from '@liskhq/lisk-codec';
 import * as cryptography from '@liskhq/lisk-cryptography';
-import { Application, PartialApplicationConfig, RegisteredSchema } from 'lisk-framework';
 import * as transactions from '@liskhq/lisk-transactions';
 import * as validator from '@liskhq/lisk-validator';
-
+import Command, { flags as flagParser } from '@oclif/command';
+import { Application, PartialApplicationConfig, RegisteredSchema } from 'lisk-framework';
+import { PromiseResolvedType } from '../../../types';
 import { flagsWithParser } from '../../../utils/flags';
+import { getDefaultPath } from '../../../utils/path';
 import { getAssetFromPrompt, getPassphraseFromPrompt } from '../../../utils/reader';
 import {
 	encodeTransaction,
@@ -31,9 +32,6 @@ import {
 	getAssetSchema,
 	transactionToJSON,
 } from '../../../utils/transaction';
-import { getDefaultPath } from '../../../utils/path';
-import { isApplicationRunning } from '../../../utils/application';
-import { PromiseResolvedType } from '../../../types';
 
 interface Args {
 	readonly moduleID: number;
@@ -301,10 +299,6 @@ export abstract class CreateCommand extends Command {
 				incompleteTransaction,
 			);
 		} else {
-			if (!isApplicationRunning(this._dataPath)) {
-				throw new Error(`Application at data path ${this._dataPath} is not running.`);
-			}
-
 			this._client = await getApiClient(this._dataPath, this.config.pjson.name);
 			this._schema = this._client.schemas;
 

--- a/commander/src/utils/flags.ts
+++ b/commander/src/utils/flags.ts
@@ -160,7 +160,6 @@ export const flagsWithParser = {
 	password: flagParser.string(flags.password),
 	offline: flagParser.boolean({
 		...flags.offline,
-		default: false,
 	}),
 	json: flagParser.boolean(flags.json),
 	senderPublicKey: flagParser.string(flags.senderPublicKey),

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -16,7 +16,6 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as os from 'os';
-import { PartialApplicationConfig } from 'lisk-framework';
 
 const defaultDir = '.lisk';
 const getConfigPath = (dataPath: string): string => path.join(dataPath, 'config');
@@ -34,8 +33,6 @@ export const splitPath = (dataPath: string): { rootPath: string; label: string }
 	};
 };
 
-export const getDefaultConfigDir = (): string => process.cwd();
-
 export const getNetworkConfigFilesPath = (
 	dataPath: string,
 	network: string,
@@ -47,41 +44,11 @@ export const getNetworkConfigFilesPath = (
 	};
 };
 
-export const getDefaultNetworkConfigFilesPath = (
-	network: string,
-): { genesisBlockFilePath: string; configFilePath: string } => {
-	const basePath = path.join(getDefaultConfigDir(), 'config', network);
-	return {
-		genesisBlockFilePath: path.join(basePath, 'genesis_block.json'),
-		configFilePath: path.join(basePath, 'config.json'),
-	};
-};
-
 export const getConfigDirs = (dataPath: string): string[] => {
 	const configPath = getConfigPath(dataPath);
 	fs.ensureDirSync(configPath);
 	const files = fs.readdirSync(configPath);
 	return files.filter(file => fs.statSync(path.join(configPath, file)).isDirectory());
-};
-
-export const getGenesisBlockAndConfig = async (
-	network: string,
-): Promise<{
-	genesisBlock: Record<string, unknown>;
-	config: PartialApplicationConfig;
-}> => {
-	const {
-		genesisBlockFilePath: defaultGenesisBlockFilePath,
-		configFilePath: defaultConfigFilepath,
-	} = getDefaultNetworkConfigFilesPath(network);
-
-	// Get config from network config or config specified
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const genesisBlock: Record<string, unknown> = await fs.readJSON(defaultGenesisBlockFilePath);
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-	const config: PartialApplicationConfig = await fs.readJSON(defaultConfigFilepath);
-
-	return { genesisBlock, config };
 };
 
 export const removeConfigDir = (dataPath: string, network: string): void =>

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -34,7 +34,7 @@ export const splitPath = (dataPath: string): { rootPath: string; label: string }
 	};
 };
 
-export const getDefaultConfigDir = (): string => path.join(__dirname, '../../../');
+export const getDefaultConfigDir = (): string => process.cwd();
 
 export const getNetworkConfigFilesPath = (
 	dataPath: string,

--- a/commander/test/bootstrapping/commands/transaction/create.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/create.spec.ts
@@ -180,14 +180,13 @@ describe('transaction:create command', () => {
 								'--asset={"amount": "abc"}',
 								`--passphrase=${passphrase}`,
 								'--offline',
+								'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+								'--nonce=1',
 								'--data-path=/tmp',
-								'--network=devnet',
 							],
 							config,
 						),
-					).rejects.toThrow(
-						'Flag: --data-path should not be specified while creating transaction offline',
-					);
+					).rejects.toThrow('--data-path= cannot also be provided when using --offline=');
 				});
 			});
 
@@ -202,13 +201,10 @@ describe('transaction:create command', () => {
 								'--asset={"amount": "abc"}',
 								`--passphrase=${passphrase}`,
 								'--offline',
-								'--network=devnet',
 							],
 							config,
 						),
-					).rejects.toThrow(
-						'Flag: --network-identifier must be specified while creating transaction offline',
-					);
+					).rejects.toThrow('--network-identifier= must also be provided when using --offline=');
 				});
 			});
 
@@ -223,12 +219,11 @@ describe('transaction:create command', () => {
 								'--asset={"amount": "abc"}',
 								`--passphrase=${passphrase}`,
 								'--offline',
-								'--network=devnet',
 								'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							],
 							config,
 						),
-					).rejects.toThrow('Flag: --nonce must be specified while creating transaction offline');
+					).rejects.toThrow('--nonce= must also be provided when using --offline=');
 				});
 			});
 
@@ -245,11 +240,12 @@ describe('transaction:create command', () => {
 								'--offline',
 								'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 								'--nonce=1',
-								'--network=devnet',
 							],
 							config,
 						),
-					).rejects.toThrow('Sender public key must be specified when no-signature flags is used');
+					).rejects.toThrow(
+						'--sender-public-key= must also be provided when using --no-signature=',
+					);
 				});
 			});
 
@@ -265,7 +261,6 @@ describe('transaction:create command', () => {
 							`--passphrase=${passphrase}`,
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
-							'--network=devnet',
 						],
 						config,
 					);
@@ -290,7 +285,6 @@ describe('transaction:create command', () => {
 							`--sender-public-key=${senderPublicKey}`,
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
-							'--network=devnet',
 						],
 						config,
 					);
@@ -314,7 +308,6 @@ describe('transaction:create command', () => {
 							`--passphrase=${passphrase}`,
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
-							'--network=devnet',
 						],
 						config,
 					);
@@ -338,7 +331,6 @@ describe('transaction:create command', () => {
 							`--passphrase=${passphrase}`,
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
-							'--network=devnet',
 						],
 						config,
 					);
@@ -361,7 +353,6 @@ describe('transaction:create command', () => {
 							'100000000',
 							`--passphrase=${passphrase}`,
 							'--offline',
-							'--network=devnet',
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
 						],
@@ -393,7 +384,6 @@ describe('transaction:create command', () => {
 							'0',
 							'100000000',
 							'--offline',
-							'--network=devnet',
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
 						],
@@ -430,7 +420,6 @@ describe('transaction:create command', () => {
 							`--sender-public-key=${senderPublicKey}`,
 							'--json',
 							'--offline',
-							'--network=devnet',
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
 						],
@@ -470,7 +459,6 @@ describe('transaction:create command', () => {
 							`--passphrase=${passphrase}`,
 							'--json',
 							'--offline',
-							'--network=devnet',
 							'--network-identifier=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
 							'--nonce=1',
 						],

--- a/commander/test/bootstrapping/commands/transaction/sign.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/sign.spec.ts
@@ -100,7 +100,6 @@ describe('transaction:sign command', () => {
 			`--optional-keys=${optionalKeys[1]}`,
 			`--network-identifier=${networkIdentifierStr}`,
 			'--offline',
-			'--network=devnet',
 			'--sender-public-key=f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
 		];
 	};
@@ -207,13 +206,12 @@ describe('transaction:sign command', () => {
 							unsignedTransaction,
 							`--passphrase=${senderPassphrase}`,
 							`--network-identifier=${networkIdentifierStr}`,
-							'--network=devnet',
 							'--offline',
 							'--data-path=/tmp',
 						],
 						config,
 					),
-				).rejects.toThrow('Flag: --data-path should not be specified while signing offline.');
+				).rejects.toThrow('--data-path= cannot also be provided when using --offline=');
 			});
 		});
 
@@ -221,15 +219,10 @@ describe('transaction:sign command', () => {
 			it('should throw an error when missing network identifier flag.', async () => {
 				await expect(
 					SignCommandExtended.run(
-						[
-							unsignedTransaction,
-							`--passphrase=${senderPassphrase}`,
-							'--network=devnet',
-							'--offline',
-						],
+						[unsignedTransaction, `--passphrase=${senderPassphrase}`, '--offline'],
 						config,
 					),
-				).rejects.toThrow('Flag: --network-identifier must be specified while signing offline.');
+				).rejects.toThrow('--network-identifier= must also be provided when using --offline=');
 			});
 		});
 
@@ -241,7 +234,6 @@ describe('transaction:sign command', () => {
 						`--passphrase=${senderPassphrase}`,
 						`--network-identifier=${networkIdentifierStr}`,
 						'--offline',
-						'--network=devnet',
 					],
 					config,
 				);
@@ -260,7 +252,6 @@ describe('transaction:sign command', () => {
 						`--network-identifier=${networkIdentifierStr}`,
 						'--json',
 						'--offline',
-						'--network=devnet',
 					],
 					config,
 				);


### PR DESCRIPTION
### What was the problem?

This PR resolves  #6160, #6161, #6162

### How was it solved?

- Refactored transaction creation to use oclif flag dependencies 
- When no-signature is specified use the public key to get the address

### How was it tested?

- Run unit tests
- Follow the steps defined in the issue
