### PR TITLE
Start command with custom data path does not work - Closes #6172

### DIFF
--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -103,7 +103,7 @@ export abstract class StartCommand extends Command {
 		this.log(`Starting Lisk ${this.config.pjson.name} at ${getFullPath(dataPath)}.`);
 		const pathConfig = splitPath(dataPath);
 
-		const defaultNetworkConfigDir = getConfigDirs(process.cwd());
+		const defaultNetworkConfigDir = getConfigDirs(this.getApplicationConfigDir(), true);
 		if (!defaultNetworkConfigDir.includes(flags.network)) {
 			this.error(
 				`Network must be one of ${defaultNetworkConfigDir.join(',')} but received ${
@@ -141,7 +141,7 @@ export abstract class StartCommand extends Command {
 		const {
 			genesisBlockFilePath: defaultGenesisBlockFilePath,
 			configFilePath: defaultConfigFilepath,
-		} = getNetworkConfigFilesPath(process.cwd(), flags.network);
+		} = getNetworkConfigFilesPath(this.getApplicationConfigDir(), flags.network, true);
 
 		if (
 			!fs.existsSync(genesisBlockFilePath) ||
@@ -228,4 +228,6 @@ export abstract class StartCommand extends Command {
 		genesisBlock: Record<string, unknown>,
 		config: PartialApplicationConfig,
 	): Application;
+
+	abstract getApplicationConfigDir(): string;
 }

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/app.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Application, PartialApplicationConfig, utils } from 'lisk-sdk';
+import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { registerModules } from './modules';
 import { registerPlugins } from './plugins';
 
@@ -6,10 +6,7 @@ export const getApplication = (
 	genesisBlock: Record<string, unknown>,
 	config: PartialApplicationConfig,
 ): Application => {
-	const app = Application.defaultApplication(
-		genesisBlock,
-		utils.objects.mergeDeep(config, { label: '<%= appName %>' }),
-	);
+	const app = Application.defaultApplication(genesisBlock, config);
 
 	registerModules(app);
 	registerPlugins(app);

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/commands/start.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/commands/start.ts
@@ -12,6 +12,7 @@ import {
 	MonitorPlugin,
 	ReportMisbehaviorPlugin,
 } from 'lisk-sdk';
+import { join } from 'path';
 import { getApplication } from '../app/app';
 
 interface Flags {
@@ -130,5 +131,9 @@ export class StartCommand extends BaseStartCommand {
 		}
 
 		return app;
+	}
+
+	public getApplicationConfigDir(): string {
+		return join(__dirname, '../../config');
 	}
 }

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -36,16 +36,19 @@ export const splitPath = (dataPath: string): { rootPath: string; label: string }
 export const getNetworkConfigFilesPath = (
 	dataPath: string,
 	network: string,
+	configDirIncluded = false,
 ): { genesisBlockFilePath: string; configFilePath: string } => {
-	const basePath = path.join(dataPath, 'config', network);
+	const basePath = configDirIncluded
+		? path.join(dataPath, network)
+		: path.join(dataPath, 'config', network);
 	return {
 		genesisBlockFilePath: path.join(basePath, 'genesis_block.json'),
 		configFilePath: path.join(basePath, 'config.json'),
 	};
 };
 
-export const getConfigDirs = (dataPath: string): string[] => {
-	const configPath = getConfigPath(dataPath);
+export const getConfigDirs = (dataPath: string, configDirIncluded = false): string[] => {
+	const configPath = configDirIncluded ? dataPath : getConfigPath(dataPath);
 	fs.ensureDirSync(configPath);
 	const files = fs.readdirSync(configPath);
 	return files.filter(file => fs.statSync(path.join(configPath, file)).isDirectory());

--- a/commander/test/bootstrapping/commands/start.spec.ts
+++ b/commander/test/bootstrapping/commands/start.spec.ts
@@ -34,6 +34,11 @@ class StartCommandExtended extends StartCommand {
 		jest.spyOn(app, 'run').mockResolvedValue();
 		return app;
 	}
+
+	// eslint-disable-next-line class-methods-use-this
+	public getApplicationConfigDir(): string {
+		return '/my/custom/app';
+	}
 }
 
 describe('start', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6172

### How was it solved?

- Added support for getting config dir from the extended start command 
- Fixed `getApplication`  to not override the label 

### How was it tested?

- Updated unit tests
- Verified it by manual testing the command
