### PR TITLE
Add getModuleInstance in lisk-framework - Closes #6118

### DIFF
--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -27,7 +27,7 @@ import {
 import { BaseAsset } from './base_asset';
 import { Logger } from '../logger/logger';
 
-interface BaseModuleChannel {
+export interface BaseModuleChannel {
 	publish(name: string, data?: Record<string, unknown>): void;
 }
 

--- a/framework/src/testing/mocks/channel_mock.ts
+++ b/framework/src/testing/mocks/channel_mock.ts
@@ -13,7 +13,7 @@
  *
  */
 
-export { createBlock } from './create_block';
-export { createTransaction } from './create_transaction';
-export { createGenesisBlock } from './create_genesis_block';
-export { getModuleInstance, getAccountSchemaFromModules } from './utils';
+export const moduleChannelMock = {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	publish: (_name: string, _data?: Record<string, unknown>): void => {},
+};

--- a/framework/src/testing/mocks/data_access_mock.ts
+++ b/framework/src/testing/mocks/data_access_mock.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { dataStructures } from '@liskhq/lisk-utils';
+import { BlockHeader, Account } from '@liskhq/lisk-chain';
+
+export class DataAccessMock<T1, T2> {
+	protected _blockHeaders: BlockHeader<T2>[];
+	protected _accounts: dataStructures.BufferMap<Account<T1>>;
+	protected _chainState: Record<string, Buffer>;
+
+	public constructor(opts?: {
+		blockHeaders?: BlockHeader<T2>[];
+		accounts?: Account<T1>[];
+		chainState?: Record<string, Buffer>;
+	}) {
+		this._blockHeaders = opts?.blockHeaders ?? [];
+		this._chainState = opts?.chainState ?? {};
+		this._accounts = new dataStructures.BufferMap<Account<T1>>();
+
+		for (const account of opts?.accounts ?? []) {
+			this._accounts.set(account.address, account);
+		}
+	}
+
+	public async getChainState(key: string): Promise<Buffer | undefined> {
+		return Promise.resolve(this._chainState[key]);
+	}
+
+	public async getAccountByAddress(address: Buffer): Promise<Account<T1>> {
+		if (!this._accounts.has(address)) {
+			throw new Error(`Account with address ${address.toString('hex')} does not exists`);
+		}
+
+		return Promise.resolve(this._accounts.get(address) as Account<T1>);
+	}
+
+	public async getLastBlockHeader(): Promise<BlockHeader<T2>> {
+		return Promise.resolve(this._blockHeaders[this._blockHeaders.length - 1]);
+	}
+}

--- a/framework/src/testing/mocks/logger_mock.ts
+++ b/framework/src/testing/mocks/logger_mock.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+export const loggerMock = {
+	trace: (_data?: object | unknown, _message?: string): void => {},
+	debug: (_data?: object | unknown, _message?: string): void => {},
+	info: (_data?: object | unknown, _message?: string): void => {},
+	warn: (_data?: object | unknown, _message?: string): void => {},
+	error: (_data?: object | unknown, _message?: string): void => {},
+	fatal: (_data?: object | unknown, _message?: string): void => {},
+	level: (): number => 2,
+};

--- a/framework/src/testing/utils.ts
+++ b/framework/src/testing/utils.ts
@@ -13,8 +13,14 @@
  *
  */
 
-import { AccountSchema } from '@liskhq/lisk-chain';
-import { GenesisConfig } from '..';
+import { AccountDefaultProps, AccountSchema, BlockHeaderAsset } from '@liskhq/lisk-chain';
+import { BaseModule, GenesisConfig } from '..';
+import { Logger } from '../logger';
+import { BaseModuleChannel } from '../modules';
+import { BaseModuleDataAccess } from '../types';
+import { moduleChannelMock } from './mocks/channel_mock';
+import { DataAccessMock } from './mocks/data_access_mock';
+import { loggerMock } from './mocks/logger_mock';
 import { ModuleClass } from './types';
 
 export const getAccountSchemaFromModules = (
@@ -31,4 +37,29 @@ export const getAccountSchemaFromModules = (
 	}
 
 	return accountSchemas;
+};
+
+export const getModuleInstance = <T1 = AccountDefaultProps, T2 = BlockHeaderAsset>(
+	Module: ModuleClass,
+	{
+		genesisConfig,
+		dataAccess,
+		channel,
+		logger,
+	}: {
+		genesisConfig?: GenesisConfig;
+		dataAccess?: BaseModuleDataAccess;
+		channel?: BaseModuleChannel;
+		logger?: Logger;
+	},
+): BaseModule => {
+	const module = new Module(genesisConfig ?? ({} as never));
+
+	module.init({
+		channel: channel ?? moduleChannelMock,
+		logger: logger ?? loggerMock,
+		dataAccess: dataAccess ?? (new DataAccessMock<T1, T2>() as never),
+	});
+
+	return module;
 };

--- a/framework/src/testing/utils.ts
+++ b/framework/src/testing/utils.ts
@@ -41,24 +41,19 @@ export const getAccountSchemaFromModules = (
 
 export const getModuleInstance = <T1 = AccountDefaultProps, T2 = BlockHeaderAsset>(
 	Module: ModuleClass,
-	{
-		genesisConfig,
-		dataAccess,
-		channel,
-		logger,
-	}: {
+	opts?: {
 		genesisConfig?: GenesisConfig;
 		dataAccess?: BaseModuleDataAccess;
 		channel?: BaseModuleChannel;
 		logger?: Logger;
 	},
 ): BaseModule => {
-	const module = new Module(genesisConfig ?? ({} as never));
+	const module = new Module(opts?.genesisConfig ?? ({} as never));
 
 	module.init({
-		channel: channel ?? moduleChannelMock,
-		logger: logger ?? loggerMock,
-		dataAccess: dataAccess ?? (new DataAccessMock<T1, T2>() as never),
+		channel: opts?.channel ?? moduleChannelMock,
+		logger: opts?.logger ?? loggerMock,
+		dataAccess: opts?.dataAccess ?? (new DataAccessMock<T1, T2>() as never),
 	});
 
 	return module;

--- a/framework/test/unit/testing/__snapshots__/utils.spec.ts.snap
+++ b/framework/test/unit/testing/__snapshots__/utils.spec.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`utils getAccountSchemaFromModules() should get schema object for modules 1`] = `
+Object {
+  "sequence": Object {
+    "default": Object {
+      "nonce": 0n,
+    },
+    "properties": Object {
+      "nonce": Object {
+        "dataType": "uint64",
+        "fieldNumber": 1,
+      },
+    },
+    "type": "object",
+  },
+  "token": Object {
+    "default": Object {
+      "balance": 0n,
+    },
+    "properties": Object {
+      "balance": Object {
+        "dataType": "uint64",
+        "fieldNumber": 1,
+      },
+    },
+    "type": "object",
+  },
+}
+`;

--- a/framework/test/unit/testing/utils.spec.ts
+++ b/framework/test/unit/testing/utils.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { SequenceModule, TokenModule } from '../../../src';
+import { getAccountSchemaFromModules, getModuleInstance } from '../../../src/testing/utils';
+
+describe('utils', () => {
+	describe('getAccountSchemaFromModules()', () => {
+		it('should get schema object for modules', () => {
+			expect(getAccountSchemaFromModules([TokenModule, SequenceModule])).toMatchSnapshot();
+		});
+	});
+
+	describe('getModuleInstance()', () => {
+		it('should create module instance with default mocks', () => {
+			const module = getModuleInstance(TokenModule);
+
+			expect(module).toBeInstanceOf(TokenModule);
+		});
+
+		it('should create module instance with custom data access', () => {
+			const dataAccess = {
+				getChainState: jest.fn(),
+				getAccountByAddress: jest.fn(),
+				getLastBlockHeader: jest.fn(),
+			};
+			const module = getModuleInstance(TokenModule, { dataAccess });
+
+			expect(module).toBeInstanceOf(TokenModule);
+			expect(module['_dataAccess']).toBe(dataAccess);
+		});
+
+		it('should create module instance with custom logger', () => {
+			const logger = {
+				trace: jest.fn(),
+				debug: jest.fn(),
+				info: jest.fn(),
+				warn: jest.fn(),
+				error: jest.fn(),
+				fatal: jest.fn(),
+				level: jest.fn(),
+			};
+			const module = getModuleInstance(TokenModule, { logger });
+
+			expect(module).toBeInstanceOf(TokenModule);
+			expect(module['_logger']).toBe(logger);
+		});
+
+		it('should create module instance with custom channel', () => {
+			const channel = {
+				publish: jest.fn(),
+			};
+			const module = getModuleInstance(TokenModule, { channel });
+
+			expect(module).toBeInstanceOf(TokenModule);
+			expect(module['_channel']).toBe(channel);
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6118

### How was it solved?

- Created utility function to create module instance 
- Created mocks for data access, logger and channel

### How was it tested?

- Run unit tests for framework
