### PR TITLE
Add waitUntilHeight in lisk-framework - Closes #6124

### DIFF
--- a/framework/package.json
+++ b/framework/package.json
@@ -40,6 +40,7 @@
 		"test:functional": "jest --config=./test/functional/jest.config.js --runInBand"
 	},
 	"dependencies": {
+		"@liskhq/lisk-api-client": "^5.0.2",
 		"@liskhq/lisk-bft": "^0.2.1",
 		"@liskhq/lisk-chain": "^0.2.0",
 		"@liskhq/lisk-codec": "^0.1.0",
@@ -63,7 +64,6 @@
 		"ws": "7.3.1"
 	},
 	"devDependencies": {
-		"@liskhq/lisk-api-client": "^5.0.2",
 		"@liskhq/lisk-passphrase": "^3.0.1",
 		"@types/bunyan": "1.8.6",
 		"@types/jest": "26.0.13",

--- a/framework/src/testing/types.ts
+++ b/framework/src/testing/types.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { APIClient } from '@liskhq/lisk-api-client';
 import { Account, AccountDefaultProps } from '@liskhq/lisk-chain';
 import { GenesisConfig } from '..';
 import { BaseAsset, BaseModule } from '../modules';
@@ -20,3 +21,11 @@ import { BaseAsset, BaseModule } from '../modules';
 export type AssetClass<T = any> = new (args?: T) => BaseAsset;
 export type ModuleClass = new (genesisConfig: GenesisConfig) => BaseModule;
 export type PartialAccount<T = AccountDefaultProps> = Partial<Account<T>> & { address: Buffer };
+export interface Data {
+	readonly block: string;
+}
+export interface WaitOptions {
+	apiClient: APIClient;
+	height: number;
+	timeout?: number;
+}

--- a/framework/src/testing/types.ts
+++ b/framework/src/testing/types.ts
@@ -24,7 +24,7 @@ export type PartialAccount<T = AccountDefaultProps> = Partial<Account<T>> & { ad
 export interface Data {
 	readonly block: string;
 }
-export interface WaitOptions {
+export interface WaitUntilBlockHeightOptions {
 	apiClient: APIClient;
 	height: number;
 	timeout?: number;

--- a/framework/src/testing/utils.ts
+++ b/framework/src/testing/utils.ts
@@ -63,12 +63,14 @@ export const getModuleInstance = <T1 = AccountDefaultProps, T2 = BlockHeaderAsse
 export const waitUntilBlockHeight = async ({
 	apiClient,
 	height,
-	timeout = 15,
+	timeout,
 }: WaitOptions): Promise<void> =>
 	new Promise((resolve, reject) => {
-		setTimeout(() => {
-			reject(new Error(`'waitUntilBlockHeight' timed out after ${timeout} ms`));
-		}, timeout);
+		if (timeout) {
+			setTimeout(() => {
+				reject(new Error(`'waitUntilBlockHeight' timed out after ${timeout} ms`));
+			}, timeout);
+		}
 
 		// eslint-disable-next-line @typescript-eslint/require-await
 		apiClient.subscribe(APP_EVENT_BLOCK_NEW, async (data?: Data) => {

--- a/framework/src/testing/utils.ts
+++ b/framework/src/testing/utils.ts
@@ -71,7 +71,7 @@ export const waitUntilBlockHeight = async ({
 		}, timeout);
 
 		// eslint-disable-next-line @typescript-eslint/require-await
-		apiClient.subscribe(APP_EVENT_BLOCK_NEW, async (data?: Record<string, unknown>) => {
+		apiClient.subscribe(APP_EVENT_BLOCK_NEW, async (data?: Data) => {
 			const { block } = (data as unknown) as Data;
 			const { header } = apiClient.block.decode<Block>(block);
 

--- a/framework/src/testing/utils.ts
+++ b/framework/src/testing/utils.ts
@@ -22,7 +22,7 @@ import { moduleChannelMock } from './mocks/channel_mock';
 import { DataAccessMock } from './mocks/data_access_mock';
 import { loggerMock } from './mocks/logger_mock';
 import { APP_EVENT_BLOCK_NEW } from '../constants';
-import { Data, ModuleClass, WaitOptions } from './types';
+import { Data, ModuleClass, WaitUntilBlockHeightOptions } from './types';
 
 export const getAccountSchemaFromModules = (
 	modules: ModuleClass[],
@@ -64,7 +64,7 @@ export const waitUntilBlockHeight = async ({
 	apiClient,
 	height,
 	timeout,
-}: WaitOptions): Promise<void> =>
+}: WaitUntilBlockHeightOptions): Promise<void> =>
 	new Promise((resolve, reject) => {
 		if (timeout) {
 			setTimeout(() => {

--- a/framework/test/unit/testing/__snapshots__/utils.spec.ts.snap
+++ b/framework/test/unit/testing/__snapshots__/utils.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`utils getAccountSchemaFromModules() should get schema object for modules 1`] = `
+exports[`utils getAccountSchemaFromModules should get schema object for modules 1`] = `
 Object {
   "sequence": Object {
     "default": Object {

--- a/framework/test/unit/testing/utils.spec.ts
+++ b/framework/test/unit/testing/utils.spec.ts
@@ -11,6 +11,8 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+
+import { APIClient } from '@liskhq/lisk-api-client';
 import { SequenceModule, TokenModule } from '../../../src';
 import {
 	getAccountSchemaFromModules,
@@ -72,22 +74,27 @@ describe('utils', () => {
 	});
 
 	describe('waitUntilBlockHeight', () => {
-		const apiClient = {
-			// eslint-disable-next-line @typescript-eslint/require-await
-			subscribe: jest.fn(async (_, callback) => callback({ block: 'blockdata' })),
-			block: {
-				decode: jest.fn().mockReturnValue({ header: { height: 2 } }),
-			},
-		} as any;
+		let apiClient: APIClient;
+		beforeEach(() => {
+			apiClient = {
+				// eslint-disable-next-line @typescript-eslint/require-await
+				subscribe: jest.fn(async (_, callback) => callback({ block: 'blockdata' })),
+				block: {
+					decode: jest.fn().mockReturnValue({ header: { height: 2 } }),
+				},
+			} as any;
+		});
 
 		it('should resolve after input height', async () => {
 			await expect(waitUntilBlockHeight({ apiClient, height: 1 })).resolves.toBeUndefined();
 		});
 
 		it('should timeout', async () => {
-			await expect(
-				waitUntilBlockHeight({ apiClient, height: 1, timeout: 0 }),
-			).resolves.toBeUndefined();
+			// eslint-disable-next-line @typescript-eslint/require-await
+			apiClient.subscribe = jest.fn(async () => setTimeout(() => undefined, 2));
+			await expect(waitUntilBlockHeight({ apiClient, height: 1, timeout: 1 })).rejects.toThrow(
+				"'waitUntilBlockHeight' timed out after 1 ms",
+			);
 		});
 	});
 });

--- a/framework/test/unit/testing/utils.spec.ts
+++ b/framework/test/unit/testing/utils.spec.ts
@@ -21,7 +21,7 @@ import {
 } from '../../../src/testing/utils';
 
 describe('utils', () => {
-	describe('getAccountSchemaFromModules()', () => {
+	describe('getAccountSchemaFromModules', () => {
 		it('should get schema object for modules', () => {
 			expect(getAccountSchemaFromModules([TokenModule, SequenceModule])).toMatchSnapshot();
 		});

--- a/framework/test/unit/testing/utils.spec.ts
+++ b/framework/test/unit/testing/utils.spec.ts
@@ -11,9 +11,12 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-
 import { SequenceModule, TokenModule } from '../../../src';
-import { getAccountSchemaFromModules, getModuleInstance } from '../../../src/testing/utils';
+import {
+	getAccountSchemaFromModules,
+	getModuleInstance,
+	waitUntilBlockHeight,
+} from '../../../src/testing/utils';
 
 describe('utils', () => {
 	describe('getAccountSchemaFromModules()', () => {
@@ -22,7 +25,7 @@ describe('utils', () => {
 		});
 	});
 
-	describe('getModuleInstance()', () => {
+	describe('getModuleInstance', () => {
 		it('should create module instance with default mocks', () => {
 			const module = getModuleInstance(TokenModule);
 
@@ -65,6 +68,26 @@ describe('utils', () => {
 
 			expect(module).toBeInstanceOf(TokenModule);
 			expect(module['_channel']).toBe(channel);
+		});
+	});
+
+	describe('waitUntilBlockHeight', () => {
+		const apiClient = {
+			// eslint-disable-next-line @typescript-eslint/require-await
+			subscribe: jest.fn(async (_, callback) => callback({ block: 'blockdata' })),
+			block: {
+				decode: jest.fn().mockReturnValue({ header: { height: 2 } }),
+			},
+		} as any;
+
+		it('should resolve after input height', async () => {
+			await expect(waitUntilBlockHeight({ apiClient, height: 1 })).resolves.toBeUndefined();
+		});
+
+		it('should timeout', async () => {
+			await expect(
+				waitUntilBlockHeight({ apiClient, height: 1, timeout: 0 }),
+			).resolves.toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #6124 

### How was it solved?

- Moved `lisk-api` from dev-dependency to dependency. This is done for testing and type purposes. 
- Added util function `waitUntilHeight`

### How was it tested?

Run unit tests for `waitUntilHeight`


