### PR TITLE
Update monitor plugin to use lisk-framework - Closes #6131

### DIFF
--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/blocks.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/blocks.spec.ts
@@ -13,6 +13,7 @@
  */
 import { blockHeaderSchema, blockSchema } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
+import { testing } from 'lisk-framework';
 import { when } from 'jest-when';
 import { MonitorPlugin } from '../../src';
 
@@ -20,31 +21,24 @@ describe('_handlePostBlock', () => {
 	let monitorPlugin: MonitorPlugin;
 	let blockHeaderString: string;
 	let encodedBlock: string;
-	const channelMock = {
-		registerToBus: jest.fn(),
-		once: jest.fn(),
-		publish: jest.fn(),
-		subscribe: jest.fn(),
-		isValidEventName: jest.fn(),
-		isValidActionName: jest.fn(),
-		invoke: jest.fn(),
-		eventsList: [],
-		actionsList: [],
-		actions: {},
-		moduleAlias: '',
-		options: {},
-	} as any;
+	let channelInvokeMock;
+	const {
+		mocks: { channelMock },
+	} = testing;
 
 	beforeEach(async () => {
 		monitorPlugin = new (MonitorPlugin as any)();
-		await monitorPlugin.load(channelMock);
+		await monitorPlugin.load(channelMock as any);
 		monitorPlugin.schemas = { block: blockSchema, blockHeader: blockHeaderSchema } as any;
 		blockHeaderString =
 			'080210c08db7011880ea3022209696342ed355848b4cd6d7c77093121ae3fc10f449447f41044972174e75bc2b2a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8553220addb0e15a44b0fdc6ff291be28d8c98f5551d0cd9218d749e30ddb87c6e31ca93880c8afa025421a08e0dc2a10e0dc2a1a10c8c557b5dba8527c0e760124128fd15c4a40d90764813046127a50acf4b449fccad057944e7665ab065d7057e56983e42abe55a3cbc1eb35a8c126f54597d0a0b426f2ad9a2d62769185ad8e3b4a5b3af909';
 		encodedBlock = codec
 			.encode(blockSchema, { header: Buffer.from(blockHeaderString, 'hex'), payload: [] })
 			.toString('hex');
-		when(channelMock.invoke)
+
+		channelInvokeMock = jest.fn();
+		channelMock.invoke = channelInvokeMock;
+		when(channelInvokeMock)
 			.calledWith('app:getConnectedPeers')
 			.mockResolvedValue([] as never);
 	});

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/forks.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/forks.spec.ts
@@ -12,33 +12,22 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { blockHeaderSchema, blockSchema } from '@liskhq/lisk-chain';
+import { blockHeaderSchema, blockSchema, RawBlock } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { hash } from '@liskhq/lisk-cryptography';
-import { RawBlock } from '@liskhq/lisk-chain';
+import { testing } from 'lisk-framework';
 import { MonitorPlugin } from '../../src/monitor_plugin';
 
 describe('_handleFork', () => {
 	let monitorPluginInstance: MonitorPlugin;
 	let encodedBlock: string;
-	const channelMock = {
-		registerToBus: jest.fn(),
-		once: jest.fn(),
-		publish: jest.fn(),
-		subscribe: jest.fn(),
-		isValidEventName: jest.fn(),
-		isValidActionName: jest.fn(),
-		invoke: jest.fn(),
-		eventsList: [],
-		actionsList: [],
-		actions: {},
-		moduleAlias: '',
-		options: {},
-	} as any;
+	const {
+		mocks: { channelMock },
+	} = testing;
 
 	beforeEach(async () => {
 		monitorPluginInstance = new (MonitorPlugin as any)();
-		await monitorPluginInstance.load(channelMock);
+		await monitorPluginInstance.load(channelMock as any);
 		monitorPluginInstance.schemas = { block: blockSchema, blockHeader: blockHeaderSchema } as any;
 		encodedBlock =
 			'0acd01080210c38ec1fc0518a2012220c736b8cfb669ff453118230c71d7dc433797b5b30da6b9d89a14457f1b56faa12a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85532209bcf519c9e0a8e66b3939f9d592b5a1728141ea3253b7d3a2424a44575c5f4e738004216087410001a1060fce85c0ca51ca1c72c589c9f651f574a40396edc8e940c5f5829d382c10cae3c2f7f24a5a9bb42ef8c545439e1a2e83951f87bc894816d7b90958b411a37b816c9e2d597dd52d7847d5a73f411ded65303';

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/subscribe_event.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/subscribe_event.spec.ts
@@ -11,16 +11,19 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import { testing } from 'lisk-framework';
 import { MonitorPlugin } from '../../src';
 
 describe('subscribe to event', () => {
 	let monitorPlugin: MonitorPlugin;
 	let subscribeMock: jest.Mock;
+	const {
+		mocks: { channelMock },
+	} = testing;
+
 	beforeEach(() => {
 		subscribeMock = jest.fn();
-		const channelMock = {
-			subscribe: subscribeMock,
-		};
+		channelMock.subscribe = subscribeMock;
 		monitorPlugin = new (MonitorPlugin as any)();
 		(monitorPlugin as any)._channel = channelMock;
 	});

--- a/framework-plugins/lisk-framework-monitor-plugin/test/unit/transaction.spec.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/test/unit/transaction.spec.ts
@@ -13,28 +13,18 @@
  */
 
 import { randomBytes } from 'crypto';
+import { testing } from 'lisk-framework';
 import { MonitorPlugin } from '../../src/monitor_plugin';
 
 describe('_handlePostTransactionAnnounce', () => {
 	let monitorPluginInstance: MonitorPlugin;
-	const channelMock = {
-		registerToBus: jest.fn(),
-		once: jest.fn(),
-		publish: jest.fn(),
-		subscribe: jest.fn(),
-		isValidEventName: jest.fn(),
-		isValidActionName: jest.fn(),
-		invoke: jest.fn(),
-		eventsList: [],
-		actionsList: [],
-		actions: {},
-		moduleAlias: '',
-		options: {},
-	} as any;
+	const {
+		mocks: { channelMock },
+	} = testing;
 
 	beforeEach(async () => {
 		monitorPluginInstance = new (MonitorPlugin as any)();
-		await monitorPluginInstance.load(channelMock);
+		await monitorPluginInstance.load(channelMock as any);
 	});
 
 	it('should add new transactions to state', () => {
@@ -61,24 +51,13 @@ describe('_handlePostTransactionAnnounce', () => {
 
 describe('_cleanUpTransactionStats', () => {
 	let monitorPluginInstance: MonitorPlugin;
-	const channelMock = {
-		registerToBus: jest.fn(),
-		once: jest.fn(),
-		publish: jest.fn(),
-		subscribe: jest.fn(),
-		isValidEventName: jest.fn(),
-		isValidActionName: jest.fn(),
-		invoke: jest.fn(),
-		eventsList: [],
-		actionsList: [],
-		actions: {},
-		moduleAlias: '',
-		options: {},
-	} as any;
+	const {
+		mocks: { channelMock },
+	} = testing;
 
 	beforeEach(async () => {
 		monitorPluginInstance = new (MonitorPlugin as any)();
-		await monitorPluginInstance.load(channelMock);
+		await monitorPluginInstance.load(channelMock as any);
 	});
 
 	it('should remove transaction stats that are more than 10 minutes old', () => {

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -22,7 +22,6 @@ export {
 	getAccountSchemaWithDefault,
 	getGenesisBlockHeaderAssetSchema,
 	blockHeaderAssetSchema,
-	testing,
 } from '@liskhq/lisk-chain';
 export {
 	BaseModule,
@@ -45,4 +44,6 @@ export { IPCChannel } from './controller/channels';
 export type { BaseChannel } from './controller/channels';
 export type { EventsDefinition, EventCallback } from './controller/event';
 export type { ActionsDefinition, ActionHandler } from './controller/action';
+// eslint-disable-next-line import/no-cycle
+export * from './testing';
 export * from './types';

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -44,6 +44,5 @@ export { IPCChannel } from './controller/channels';
 export type { BaseChannel } from './controller/channels';
 export type { EventsDefinition, EventCallback } from './controller/event';
 export type { ActionsDefinition, ActionHandler } from './controller/action';
-// eslint-disable-next-line import/no-cycle
-export * from './testing';
+export * as testing from './testing';
 export * from './types';

--- a/framework/src/testing/app_env.ts
+++ b/framework/src/testing/app_env.ts
@@ -17,10 +17,12 @@ import { APIClient, createIPCClient } from '@liskhq/lisk-api-client';
 import { codec } from '@liskhq/lisk-codec';
 import { homedir } from 'os';
 import { resolve as pathResolve } from 'path';
-import { Application, DPoSModule, PartialApplicationConfig } from '..';
 import { ModuleClass, PluginClass } from './types';
 import { defaultConfig } from './fixtures';
 import { createGenesisBlockWithAccounts } from './fixtures/genesis_block';
+import { PartialApplicationConfig } from '../types';
+import { Application } from '../application';
+import { DPoSModule } from '../modules/dpos';
 
 interface GetApplicationEnv {
 	modules: ModuleClass[];

--- a/framework/src/testing/block_processing_env.ts
+++ b/framework/src/testing/block_processing_env.ts
@@ -22,7 +22,7 @@ import { objects } from '@liskhq/lisk-utils';
 
 import { Processor } from '../node/processor';
 import { InMemoryChannel } from '../controller';
-import { loggerMock, moduleChannelMock } from './mocks';
+import { loggerMock, channelMock } from './mocks';
 import { createBlock } from './create_block';
 import { defaultAccount, defaultConfig, createGenesisBlockWithAccounts } from './fixtures';
 import { createDB, removeDB, getAccountSchemaFromModules } from './utils';
@@ -71,7 +71,7 @@ const getProcessor = (
 	networkIdentifier: Buffer,
 	params: BlockProcessingParams,
 ): Processor => {
-	const channel = (moduleChannelMock as unknown) as InMemoryChannel;
+	const channel = (channelMock as unknown) as InMemoryChannel;
 
 	const chainModule = new Chain({
 		db,

--- a/framework/src/testing/create_genesis_block.ts
+++ b/framework/src/testing/create_genesis_block.ts
@@ -15,7 +15,7 @@
 
 import { AccountDefaultProps, GenesisBlock } from '@liskhq/lisk-chain';
 import { createGenesisBlock as createGenesis } from '@liskhq/lisk-genesis';
-import { GenesisConfig } from '..';
+import { GenesisConfig } from '../types';
 import { ModuleClass, PartialAccount } from './types';
 import { getAccountSchemaFromModules } from './utils';
 

--- a/framework/src/testing/fixtures/genesis_block.ts
+++ b/framework/src/testing/fixtures/genesis_block.ts
@@ -39,7 +39,7 @@ export const createGenesisBlockWithAccounts = <T = AccountDefaultProps>(
 			} as unknown) as PartialAccount<T>),
 	);
 	// Set genesis block timestamp to 1 day in past relative to current date
-	const timestamp = Math.floor(new Date().setMonth(new Date().getDay() - 1) / 1000);
+	const timestamp = Math.floor(new Date().setDate(new Date().getDay() - 1) / 1000);
 
 	const genesisBlock = createGenesisBlock<T>({
 		modules,

--- a/framework/src/testing/index.ts
+++ b/framework/src/testing/index.ts
@@ -12,16 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-// eslint-disable-next-line import/no-cycle
 import * as fixtures from './fixtures';
 import * as mocks from './mocks';
 
-export { createBlock } from './create_block';
-// eslint-disable-next-line import/no-cycle
 export { createTransaction } from './create_transaction';
-// eslint-disable-next-line import/no-cycle
 export { createGenesisBlock } from './create_genesis_block';
-// eslint-disable-next-line import/no-cycle
 export { getModuleInstance, getAccountSchemaFromModules } from './utils';
 export * from './create_block';
 export * from './app_env';

--- a/framework/src/testing/index.ts
+++ b/framework/src/testing/index.ts
@@ -12,12 +12,16 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-
+// eslint-disable-next-line import/no-cycle
 import * as fixtures from './fixtures';
 import * as mocks from './mocks';
 
+export { createBlock } from './create_block';
+// eslint-disable-next-line import/no-cycle
 export { createTransaction } from './create_transaction';
+// eslint-disable-next-line import/no-cycle
 export { createGenesisBlock } from './create_genesis_block';
+// eslint-disable-next-line import/no-cycle
 export { getModuleInstance, getAccountSchemaFromModules } from './utils';
 export * from './create_block';
 export * from './app_env';

--- a/framework/src/testing/mocks/channel_mock.ts
+++ b/framework/src/testing/mocks/channel_mock.ts
@@ -12,10 +12,22 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-/* eslint-disable @typescript-eslint/no-empty-function */
-export const moduleChannelMock = {
+export const channelMock = {
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	publish: (_name: string, _data?: Record<string, unknown>): void => {},
-	subscribe: (_name: string, _data?: Record<string, unknown>): void => {},
-	once: (_name: string, _data?: Record<string, unknown>): void => {},
-	invoke: (_name: string, _data?: Record<string, unknown>): void => {},
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	registerToBus: async (_arg: unknown): Promise<void> => Promise.resolve(),
+	isValidEventName: (_name: string, _throwError = true): boolean | never => true,
+	isValidActionName: (_name: string, _throwError = true): boolean | never => true,
+	eventsList: [],
+	actionsList: [],
+	actions: {},
+	moduleAlias: '',
+	options: {},
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	once: (_event: string): void => {},
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	subscribe: (_event: string): void => {},
+	invoke: async <T = unknown>(_name: string, _params?: Record<string, unknown>): Promise<T> =>
+		Promise.resolve(({} as unknown) as T),
 };

--- a/framework/src/testing/mocks/index.ts
+++ b/framework/src/testing/mocks/index.ts
@@ -11,7 +11,6 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-
 export * from './channel_mock';
 export * from './consensus_mock';
 export * from './data_access_mock';

--- a/framework/src/testing/types.ts
+++ b/framework/src/testing/types.ts
@@ -14,9 +14,9 @@
  */
 import { APIClient } from '@liskhq/lisk-api-client';
 import { Account, AccountDefaultProps } from '@liskhq/lisk-chain';
-import { GenesisConfig } from '..';
 import { BaseAsset, BaseModule } from '../modules';
 import { BasePlugin } from '../plugins/base_plugin';
+import { GenesisConfig } from '../types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AssetClass<T = any> = new (args?: T) => BaseAsset;

--- a/framework/src/testing/utils.ts
+++ b/framework/src/testing/utils.ts
@@ -21,10 +21,11 @@ import { BaseModule, GenesisConfig } from '..';
 import { Logger } from '../logger';
 import { BaseModuleChannel } from '../modules';
 import { BaseModuleDataAccess } from '../types';
-import { moduleChannelMock } from './mocks/channel_mock';
+import { channelMock } from './mocks/channel_mock';
 import { DataAccessMock } from './mocks/data_access_mock';
 import { loggerMock } from './mocks/logger_mock';
 import { APP_EVENT_BLOCK_NEW } from '../constants';
+// eslint-disable-next-line import/no-cycle
 import { Data, ModuleClass, WaitUntilBlockHeightOptions } from './types';
 
 export const getAccountSchemaFromModules = (
@@ -59,7 +60,7 @@ export const getModuleInstance = <
 	const module = new Module(opts?.genesisConfig ?? ({} as never));
 
 	module.init({
-		channel: opts?.channel ?? moduleChannelMock,
+		channel: opts?.channel ?? channelMock,
 		logger: opts?.logger ?? loggerMock,
 		dataAccess: opts?.dataAccess ?? (new DataAccessMock<T2, T3>() as never),
 	});

--- a/framework/src/testing/utils.ts
+++ b/framework/src/testing/utils.ts
@@ -17,15 +17,13 @@ import * as fs from 'fs-extra';
 import { AccountDefaultProps, AccountSchema, Block, BlockHeaderAsset } from '@liskhq/lisk-chain';
 import { KVStore } from '@liskhq/lisk-db';
 
-import { BaseModule, GenesisConfig } from '..';
 import { Logger } from '../logger';
-import { BaseModuleChannel } from '../modules';
-import { BaseModuleDataAccess } from '../types';
+import { BaseModule, BaseModuleChannel } from '../modules';
+import { BaseModuleDataAccess, GenesisConfig } from '../types';
 import { channelMock } from './mocks/channel_mock';
 import { DataAccessMock } from './mocks/data_access_mock';
 import { loggerMock } from './mocks/logger_mock';
 import { APP_EVENT_BLOCK_NEW } from '../constants';
-// eslint-disable-next-line import/no-cycle
 import { Data, ModuleClass, WaitUntilBlockHeightOptions } from './types';
 
 export const getAccountSchemaFromModules = (

--- a/framework/test/unit/modules/dpos/dpos_module.spec.ts
+++ b/framework/test/unit/modules/dpos/dpos_module.spec.ts
@@ -33,7 +33,7 @@ jest.mock('../../../../src/modules/dpos/delegates');
 jest.mock('../../../../src/modules/dpos/random_seed');
 
 describe('DPoSModule', () => {
-	const { StateStoreMock, loggerMock, moduleChannelMock, DataAccessMock } = testing.mocks;
+	const { StateStoreMock, loggerMock, channelMock, DataAccessMock } = testing.mocks;
 
 	let dposModule!: DPoSModule;
 	let genesisConfig: GenesisConfig;
@@ -221,7 +221,7 @@ describe('DPoSModule', () => {
 
 			dposModule.init({
 				logger: loggerMock,
-				channel: moduleChannelMock,
+				channel: channelMock,
 				dataAccess: new DataAccessMock<DPOSAccountProps>(),
 			});
 		});
@@ -323,7 +323,7 @@ describe('DPoSModule', () => {
 			});
 
 			dposModule.init({
-				channel: moduleChannelMock,
+				channel: channelMock,
 				dataAccess: new DataAccessMock<DPOSAccountProps>({ accounts: [account, delegate] }),
 				logger: loggerMock as any,
 			});

--- a/framework/test/utils/node/state_store_mock.ts
+++ b/framework/test/utils/node/state_store_mock.ts
@@ -71,9 +71,9 @@ export class StateStoreMock {
 				const index = this.accountData.findIndex(acc => acc.address.equals(address));
 				if (index > -1) {
 					this.accountData[index] = account;
+					return;
 				}
 				this.accountData.push(account);
-				return Promise.resolve();
 			},
 		};
 
@@ -85,7 +85,6 @@ export class StateStoreMock {
 			// eslint-disable-next-line @typescript-eslint/require-await
 			set: async (key: string, value: Buffer): Promise<void> => {
 				this.chainData[key] = value;
-				return Promise.resolve();
 			},
 		};
 	}

--- a/framework/test/utils/node/state_store_mock.ts
+++ b/framework/test/utils/node/state_store_mock.ts
@@ -71,9 +71,9 @@ export class StateStoreMock {
 				const index = this.accountData.findIndex(acc => acc.address.equals(address));
 				if (index > -1) {
 					this.accountData[index] = account;
-					return;
 				}
 				this.accountData.push(account);
+				return Promise.resolve();
 			},
 		};
 
@@ -85,6 +85,7 @@ export class StateStoreMock {
 			// eslint-disable-next-line @typescript-eslint/require-await
 			set: async (key: string, value: Buffer): Promise<void> => {
 				this.chainData[key] = value;
+				return Promise.resolve();
 			},
 		};
 	}


### PR DESCRIPTION
### What was the problem?

This PR resolves #6131

### How was it solved?

♻️ Use testing in monitor plugin from framework #6131 9b10acc

### How was it tested?

`npm run test`
