### PR TITLE
The prefix parameter of getAddressFromBase32Address does not work - Closes #6185

### DIFF
--- a/elements/lisk-client/test/lisk-cryptography/keys.spec.ts
+++ b/elements/lisk-client/test/lisk-cryptography/keys.spec.ts
@@ -157,7 +157,7 @@ describe('keys', () => {
 			const address = 'LSK24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 			it('should throw an error', () => {
 				return expect(validateBase32Address.bind(null, address)).toThrow(
-					'Invalid prefix. Expected prefix: lsk',
+					'Invalid address prefix. Actual prefix: LSK, Expected prefix: lsk',
 				);
 			});
 		});

--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -135,7 +135,9 @@ export const validateBase32Address = (
 	const addressPrefix = address.substring(0, 3);
 
 	if (addressPrefix !== prefix) {
-		throw new Error(`Invalid prefix. Expected prefix: ${prefix}`);
+		throw new Error(
+			`Invalid address prefix. Actual prefix: ${addressPrefix}, Expected prefix: ${prefix}`,
+		);
 	}
 
 	const addressSubstringArray = address.substring(3).split('');
@@ -159,7 +161,7 @@ export const getAddressFromBase32Address = (
 	base32Address: string,
 	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
 ): Buffer => {
-	validateBase32Address(base32Address);
+	validateBase32Address(base32Address, prefix);
 	// Ignore lsk prefix and checksum
 	const base32AddressNoPrefixNoChecksum = base32Address.substring(
 		prefix.length,

--- a/elements/lisk-cryptography/test/keys.spec.ts
+++ b/elements/lisk-cryptography/test/keys.spec.ts
@@ -182,7 +182,7 @@ describe('keys', () => {
 			const address = 'LSK24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 			it('should throw an error', () => {
 				return expect(validateBase32Address.bind(null, address)).toThrow(
-					'Invalid prefix. Expected prefix: lsk',
+					'Invalid address prefix. Actual prefix: LSK, Expected prefix: lsk',
 				);
 			});
 		});
@@ -221,10 +221,24 @@ describe('keys', () => {
 			return expect(getAddressFromBase32Address.bind(null, 'invalid')).toThrow();
 		});
 
-		it('should return an address given a base32 address', () => {
+		it('should throw error for invalid prefix', () => {
+			expect(() =>
+				getAddressFromBase32Address('abcvtr2zq9v36vyefjdvhxas92nf438z9ap8wnzav').toString('hex'),
+			).toThrow('Invalid address prefix. Actual prefix: abc, Expected prefix: lsk');
+		});
+
+		it('should return an address given a base32 address with default prefix', () => {
 			expect(getAddressFromBase32Address(account.address).toString('hex')).toBe(
 				account.binaryAddress,
 			);
+		});
+
+		it('should return an address given a base32 address with custom prefix', () => {
+			expect(
+				getAddressFromBase32Address('abcvtr2zq9v36vyefjdvhxas92nf438z9ap8wnzav', 'abc').toString(
+					'hex',
+				),
+			).toBe('14e58055a242851b7b9a17439db707f250f03724');
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6185 

### How was it solved?

- Fixed custom prefix validation

### How was it tested?

- Added unit tests