### PR TITLE
Add fieldNumber to options prop of nodeInfo - Closes #6190

### DIFF
--- a/elements/lisk-p2p/src/schema.ts
+++ b/elements/lisk-p2p/src/schema.ts
@@ -28,11 +28,11 @@ export const nodeInfoSchema = {
 		},
 		nonce: {
 			dataType: 'string',
-			fieldNumber: 4,
+			fieldNumber: 3,
 		},
 		advertiseAddress: {
 			dataType: 'boolean',
-			fieldNumber: 5,
+			fieldNumber: 4,
 		},
 	},
 	required: ['networkIdentifier', 'networkVersion', 'nonce'],
@@ -65,6 +65,7 @@ export const mergeCustomSchema = (baseSchema: Schema, customSchema: Schema): Sch
 		...baseSchema.properties,
 		options: {
 			type: 'object',
+			fieldNumber: 5,
 			properties: { ...customSchema.properties },
 		},
 	},


### PR DESCRIPTION
### What was the problem?

This PR resolves #6190

### How was it solved?

- Added `fieldNumber` to `options` property of `nodeInfoSchema`

### How was it tested?

Run all the tests in `lisk-p2p` and `lisk-framework`
