### PR TITLE
Inject config from server to UI - Closes #6140

### DIFF
--- a/framework-plugins/lisk-framework-faucet-plugin/public/index.html
+++ b/framework-plugins/lisk-framework-faucet-plugin/public/index.html
@@ -28,6 +28,7 @@
     <title>React App</title>
   </head>
   <body>
+		<script src="./config.js"></script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/framework-plugins/lisk-framework-faucet-plugin/public/index.html
+++ b/framework-plugins/lisk-framework-faucet-plugin/public/index.html
@@ -1,22 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -25,13 +23,14 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-		<script src="%PUBLIC_URL%/config.js"></script>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>React App</title>
+</head>
+
+<body>
+  <script src="%PUBLIC_URL%/config.js"></script>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -41,5 +40,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/framework-plugins/lisk-framework-faucet-plugin/public/index.html
+++ b/framework-plugins/lisk-framework-faucet-plugin/public/index.html
@@ -28,7 +28,7 @@
     <title>React App</title>
   </head>
   <body>
-		<script src="./config.js"></script>
+		<script src="%PUBLIC_URL%/config.js"></script>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/framework-plugins/lisk-framework-faucet-plugin/src/plugin/defaults/config.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/plugin/defaults/config.ts
@@ -50,7 +50,7 @@ export const config = {
 	},
 	required: ['encryptedPassphrase'],
 	default: {
-		applicationUrl: 'ws://localhost:8080',
+		applicationUrl: 'ws://localhost:8080/ws',
 		fee: (10 ** 8 * 0.1).toString(), // 0.1 LSK,
 		amount: (10 ** 8 * 100).toString(), // 100 LSK,
 		tokenPrefix: 'lsk',

--- a/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
@@ -31,6 +31,7 @@ import {
 import * as express from 'express';
 import { join } from 'path';
 import { Server } from 'http';
+import { writeFileSync } from 'fs';
 import * as defaults from './defaults';
 import { FaucetPluginOptions, State } from './types';
 
@@ -171,6 +172,19 @@ export class FaucetPlugin extends BasePlugin {
 			defaults.config.default,
 			this._options,
 		) as FaucetPluginOptions;
+
+		const config = {
+			applicationUrl: this._options.applicationUrl,
+			amount: (BigInt(this._options.amount) / BigInt(10 ** 8)).toString(),
+			tokenPrefix: this._options.tokenPrefix,
+			captcha: this._options.captcha,
+			logoURL: this._options.logoURL,
+		};
+		// Write config file for faucet
+		writeFileSync(
+			join(__dirname, '../../build', 'config.js'),
+			`window.FAUCET_CONFIG = ${JSON.stringify(config)}`,
+		);
 		const app = express();
 		app.use(express.static(join(__dirname, '../../build')));
 		this._server = app.listen(3333, 'localhost');

--- a/framework-plugins/lisk-framework-faucet-plugin/src/plugin/types.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/plugin/types.ts
@@ -22,6 +22,7 @@ export interface FaucetPluginOptions extends PluginOptionsWithAppConfig {
 	tokenPrefix: string;
 	logoURL?: string;
 	captcha?: Record<string, unknown>;
+	amount?: string;
 }
 
 export interface State {

--- a/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
@@ -14,19 +14,31 @@ const validateAddress = (address: string, prefix: string): boolean => {
 		return false;
 	}
 };
+
+interface FaucetConfig {
+	amount: string;
+	applicationUrl: string;
+	tokenPrefix: string;
+	logoURL: string;
+	captcha: {
+		sitekey: string;
+	};
+}
+
 declare global {
 	interface Window {
 		grecaptcha: any;
+		config: any;
+		FAUCET_CONFIG: FaucetConfig;
 	}
 }
 
 const WarningIcon = () => <span className={`${styles.icon} ${styles.warning}`}>&#xE8B2;</span>;
 
 export const App: React.FC = () => {
-	const amount = '100';
-	const prefix = 'lsk';
+	const { amount, tokenPrefix: prefix, captcha, applicationUrl, logoURL } = window.FAUCET_CONFIG;
+	const recaptchaConfig = captcha ?? { sitekey: 'key' };
 	const faucetAddress = 'lskdwsyfmcko6mcd357446yatromr9vzgu7eb8y99';
-	const recaptchaKey = 'key';
 	const [input, updateInput] = React.useState('');
 	const [errorMsg, updateErrorMsg] = React.useState('');
 	const [recaptchaReady, updateRecaptchaReady] = React.useState(false);
@@ -47,7 +59,7 @@ export const App: React.FC = () => {
 					return;
 				}
 				// eslint-disable-next-line
-				window.grecaptcha.render('recapcha', { sitekey: recaptchaKey });
+				window.grecaptcha.render('recapcha', recaptchaConfig);
 				updateRecaptchaReady(true);
 			}
 		}, 1000);
@@ -66,8 +78,8 @@ export const App: React.FC = () => {
 	const onSubmit = async () => {
 		try {
 			// eslint-disable-next-line
-			const token = await window.grecaptcha.execute(recaptchaKey, { action: 'submit' });
-			const client = await apiClient.createWSClient('ws://localhost:8080/ws');
+			const token = await window.grecaptcha.execute(recaptchaConfig.sitekey, { action: 'submit' });
+			const client = await apiClient.createWSClient(applicationUrl);
 			await client.invoke('faucet:fundToken', {
 				address: getAddressFromBase32Address(input, prefix),
 				token,
@@ -80,7 +92,7 @@ export const App: React.FC = () => {
 	return (
 		<div className={styles.root}>
 			<header className={styles.header}>
-				<img src={logo} className={styles.logo} alt="logo" />
+				<img src={logoURL ?? logo} className={styles.logo} alt="logo" />
 			</header>
 			<section className={styles.content}>
 				<div className={styles.main}>

--- a/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
@@ -28,7 +28,6 @@ interface FaucetConfig {
 declare global {
 	interface Window {
 		grecaptcha: any;
-		config: any;
 		FAUCET_CONFIG: FaucetConfig;
 	}
 }

--- a/framework-plugins/lisk-framework-faucet-plugin/test/unit/plugin/__snapshots__/faucet_plugin.spec.ts.snap
+++ b/framework-plugins/lisk-framework-faucet-plugin/test/unit/plugin/__snapshots__/faucet_plugin.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`FaucetPlugin constructor should load default config 1`] = `
 Object {
   "amount": "10000000000",
-  "applicationUrl": "ws://localhost:8080",
+  "applicationUrl": "ws://localhost:8080/ws",
   "encryptedPassphrase": "salt=683425ca06c9ff88a5ab292bb5066dc5&cipherText=4ce151&iv=bfaeef79a466e370e210f3c6&tag=e84bf097b1ec5ae428dd7ed3b4cce522&version=1",
   "fee": "10000000",
   "tokenPrefix": "lsk",
@@ -15,7 +15,7 @@ Object {
   "$id": "#/plugins/lisk-faucet/config",
   "default": Object {
     "amount": "10000000000",
-    "applicationUrl": "ws://localhost:8080",
+    "applicationUrl": "ws://localhost:8080/ws",
     "captcha": undefined,
     "fee": "10000000",
     "logoURL": undefined,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6140 

### How was it solved?

- Create a config file and write it with all the config values under `FAUCET_CONFIG`
- Read config from `window.FAUCET_CONFIG` in the react app

### How was it tested?

Update `framework/test/test_app/app.js` to have `FaucetPlugin` and run 
`node framework/test/test_app`
