### PR TITLE
Fix incompatible channel type of `lisk-api-client` - Closes #6246

### DIFF
--- a/elements/lisk-api-client/src/api_client.ts
+++ b/elements/lisk-api-client/src/api_client.ts
@@ -51,7 +51,7 @@ export class APIClient {
 		return this._channel.invoke(actionName, params);
 	}
 
-	public subscribe<T = Record<string, unknown>>(eventName: string, cb: EventCallback<T>): void {
+	public subscribe(eventName: string, cb: EventCallback): void {
 		this._channel.subscribe(eventName, cb);
 	}
 

--- a/elements/lisk-api-client/src/types.ts
+++ b/elements/lisk-api-client/src/types.ts
@@ -45,7 +45,7 @@ export interface Channel {
 	connect: () => Promise<void>;
 	disconnect: () => Promise<void>;
 	invoke: <T>(actionName: string, params?: Record<string, unknown>) => Promise<T>;
-	subscribe: <T>(eventName: string, cb: EventCallback<T>) => void;
+	subscribe: (eventName: string, cb: EventCallback) => void;
 }
 
 export interface RegisteredSchemas {

--- a/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
@@ -182,9 +182,7 @@ export class FaucetPlugin extends BasePlugin {
 	// eslint-disable-next-line @typescript-eslint/require-await, class-methods-use-this
 	public async load(channel: BaseChannel): Promise<void> {
 		this._channel = channel;
-		// TODO: Channel type should be fixed. See issue #6246
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		this._client = await createClient((this._channel as unknown) as any);
+		this._client = await createClient(this._channel);
 		this._options = objects.mergeDeep(
 			{},
 			defaults.config.default,
@@ -210,7 +208,7 @@ export class FaucetPlugin extends BasePlugin {
 
 	// eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-empty-function
 	public async unload(): Promise<void> {
-		await new Promise((resolve, reject) => {
+		return new Promise((resolve, reject) => {
 			this._server.close(err => {
 				if (err) {
 					reject(err);


### PR DESCRIPTION
### What was the problem?

This PR resolves #6246 

### How was it solved?

- Update `channel.subscribe` type in `lisk-api-client`

### How was it tested?

`npm run test` in `lisk-api-client` and `lisk-framework-faucet-plugin`
