### PR TITLE
P2P communication in binary cannot be decoded in other client - Closes #6265

### DIFF
--- a/elements/lisk-p2p/src/constants.ts
+++ b/elements/lisk-p2p/src/constants.ts
@@ -15,6 +15,7 @@
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
 
 // General P2P constants
+export const DEFAULT_MESSAGE_ENCODING_FORMAT = 'base64';
 export const DEFAULT_NODE_HOST_IP = '0.0.0.0';
 export const DEFAULT_LOCALHOST_IP = '127.0.0.1';
 export const DEFAULT_BAN_TIME = 86400000; // Milliseconds in a day -> hours*minutes*seconds*milliseconds

--- a/elements/lisk-p2p/src/p2p_request.ts
+++ b/elements/lisk-p2p/src/p2p_request.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { DEFAULT_MESSAGE_ENCODING_FORMAT } from './constants';
 import { RPCResponseAlreadySentError } from './errors';
 import { P2PResponsePacket, RequestOptions } from './types';
 
@@ -80,7 +81,7 @@ export class P2PRequest {
 	}
 
 	public end(responseData?: unknown): void {
-		const data = this._getBinaryData(responseData);
+		const data = this._getBase64Data(responseData);
 		const responsePacket: P2PResponsePacket = {
 			data,
 			peerId: this.peerId,
@@ -93,20 +94,22 @@ export class P2PRequest {
 	}
 
 	// eslint-disable-next-line class-methods-use-this
-	private _getBinaryData(data: unknown): string | undefined {
+	private _getBase64Data(data: unknown): string | undefined {
 		if (!data) {
 			return undefined;
 		}
 
 		if (Buffer.isBuffer(data)) {
-			return data.toString('binary');
+			return data.toString(DEFAULT_MESSAGE_ENCODING_FORMAT);
 		}
 
-		return Buffer.from(JSON.stringify(data), 'utf8').toString('binary');
+		return Buffer.from(JSON.stringify(data), 'utf8').toString(DEFAULT_MESSAGE_ENCODING_FORMAT);
 	}
 
 	// eslint-disable-next-line class-methods-use-this
 	private _getBufferData(options: RequestOptions): Buffer | undefined {
-		return typeof options.data === 'string' ? Buffer.from(options.data, 'binary') : undefined;
+		return typeof options.data === 'string'
+			? Buffer.from(options.data, DEFAULT_MESSAGE_ENCODING_FORMAT)
+			: undefined;
 	}
 }

--- a/elements/lisk-p2p/src/peer/base.ts
+++ b/elements/lisk-p2p/src/peer/base.ts
@@ -26,6 +26,7 @@ import {
 	INVALID_PEER_INFO_PENALTY,
 	INVALID_PEER_LIST_PENALTY,
 	INVALID_PEER_INFO_LIST_REASON,
+	DEFAULT_MESSAGE_ENCODING_FORMAT,
 } from '../constants';
 import {
 	InvalidPeerInfoError,
@@ -342,7 +343,7 @@ export class Peer extends EventEmitter {
 			throw new Error('Peer socket does not exist');
 		}
 
-		const data = this._getBinaryData(packet.data);
+		const data = this._getBase64Data(packet.data);
 		this._socket.emit(REMOTE_SC_EVENT_MESSAGE, {
 			event: packet.event,
 			data,
@@ -359,7 +360,7 @@ export class Peer extends EventEmitter {
 					throw new Error('Peer socket does not exist');
 				}
 
-				const data = this._getBinaryData(packet.data);
+				const data = this._getBase64Data(packet.data);
 				this._socket.emit(
 					REMOTE_SC_EVENT_RPC_REQUEST,
 					{
@@ -646,15 +647,15 @@ export class Peer extends EventEmitter {
 	}
 
 	// All the inbound and outbound messages communication to socket
-	// Should be converted to binary string
+	// Should be converted to base64 string
 	// eslint-disable-next-line class-methods-use-this
-	private _getBinaryData(data?: Buffer): string | undefined {
+	private _getBase64Data(data?: Buffer): string | undefined {
 		if (data === undefined) {
 			return undefined;
 		}
 
 		if (Buffer.isBuffer(data)) {
-			return data.toString('binary');
+			return data.toString(DEFAULT_MESSAGE_ENCODING_FORMAT);
 		}
 
 		return data;
@@ -666,6 +667,6 @@ export class Peer extends EventEmitter {
 			return undefined;
 		}
 
-		return Buffer.from(data, 'binary');
+		return Buffer.from(data, DEFAULT_MESSAGE_ENCODING_FORMAT);
 	}
 }

--- a/elements/lisk-p2p/test/functional/actions/request.ts
+++ b/elements/lisk-p2p/test/functional/actions/request.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { DEFAULT_MESSAGE_ENCODING_FORMAT } from '../../../src/constants';
 import { P2P, events } from '../../../src/index';
 import { createNetwork, destroyNetwork, NETWORK_PEER_COUNT } from '../../utils/network_setup';
 
@@ -28,7 +29,7 @@ describe('P2P.request', () => {
 					request.end({
 						nodePort: p2p.config.port,
 						requestProcedure: request.procedure,
-						requestData: request.data,
+						requestData: request.data.toString(DEFAULT_MESSAGE_ENCODING_FORMAT),
 						requestPeerId: request.peerId,
 					});
 				}
@@ -43,26 +44,21 @@ describe('P2P.request', () => {
 	it('should make request to the network; it should reach a single peer', async () => {
 		// Arrange
 		const secondP2PNode = p2pNodeList[1];
-		const data = Buffer.from(JSON.stringify('bar'), 'utf8');
+		const data = Buffer.from('bar');
 
 		// Act
 		const response = await secondP2PNode.request({
 			procedure: 'foo',
 			data,
 		});
-		const parsedData = JSON.parse((response.data as Buffer).toString('utf-8'));
-		const result = {
-			...parsedData,
-			requestData: JSON.parse(Buffer.from(parsedData.requestData.data).toString('utf-8')),
-		};
+		const parsedData = JSON.parse((response.data as Buffer).toString('utf8'));
 
 		// Assert
-		expect(response).toHaveProperty('data');
 		expect(response.data).toBeInstanceOf(Buffer);
 		expect(response.peerId).toEqual('127.0.0.1:5001');
-		expect(result).toMatchObject({
+		expect(parsedData).toMatchObject({
 			nodePort: 5000,
-			requestData: 'bar',
+			requestData: data.toString(DEFAULT_MESSAGE_ENCODING_FORMAT),
 			requestPeerId: '127.0.0.1:5001',
 			requestProcedure: 'foo',
 		});
@@ -86,7 +82,7 @@ describe('P2P.request', () => {
 				procedure: 'foo',
 				data: i,
 			});
-			const parsedData = JSON.parse((response.data as Buffer).toString('utf-8'));
+			const parsedData = JSON.parse((response.data as Buffer).toString('utf8'));
 			if (!nodePortToResponsesMap[parsedData.nodePort]) {
 				nodePortToResponsesMap[parsedData.nodePort] = [];
 			}

--- a/elements/lisk-p2p/test/functional/actions/request.ts
+++ b/elements/lisk-p2p/test/functional/actions/request.ts
@@ -50,10 +50,10 @@ describe('P2P.request', () => {
 			procedure: 'foo',
 			data,
 		});
-		const parsedData = JSON.parse((response.data as Buffer).toString('binary'));
+		const parsedData = JSON.parse((response.data as Buffer).toString('utf-8'));
 		const result = {
 			...parsedData,
-			requestData: JSON.parse(Buffer.from(parsedData.requestData.data).toString('binary')),
+			requestData: JSON.parse(Buffer.from(parsedData.requestData.data).toString('utf-8')),
 		};
 
 		// Assert
@@ -86,7 +86,7 @@ describe('P2P.request', () => {
 				procedure: 'foo',
 				data: i,
 			});
-			const parsedData = JSON.parse((response.data as Buffer).toString('binary'));
+			const parsedData = JSON.parse((response.data as Buffer).toString('utf-8'));
 			if (!nodePortToResponsesMap[parsedData.nodePort]) {
 				nodePortToResponsesMap[parsedData.nodePort] = [];
 			}

--- a/elements/lisk-p2p/test/functional/actions/request_from_peer.ts
+++ b/elements/lisk-p2p/test/functional/actions/request_from_peer.ts
@@ -64,7 +64,7 @@ describe('P2P.requestFromPeer', () => {
 		expect(collectedMessages).toHaveLength(1);
 		expect(collectedMessages[0]).toHaveProperty('request');
 		expect(collectedMessages[0].request.procedure).toBe('foo');
-		expect(collectedMessages[0].request.data).toEqual(Buffer.from('123456', 'utf-8'));
+		expect(collectedMessages[0].request.data).toEqual(Buffer.from('123456', 'utf8'));
 	});
 
 	it('should receive response from a specific peer within the network', async () => {

--- a/elements/lisk-p2p/test/functional/custom_peer_selection.ts
+++ b/elements/lisk-p2p/test/functional/custom_peer_selection.ts
@@ -171,10 +171,10 @@ describe('Custom peer selection', () => {
 				procedure: 'foo',
 				data: 'bar',
 			});
-			const parsedData = JSON.parse((response.data as Buffer).toString('binary'));
+			const parsedData = JSON.parse((response.data as Buffer).toString('utf-8'));
 			const result = {
 				...parsedData,
-				requestData: JSON.parse(Buffer.from(parsedData.requestData.data).toString('binary')),
+				requestData: JSON.parse(Buffer.from(parsedData.requestData.data).toString('utf-8')),
 			};
 
 			expect(response).toHaveProperty('data');

--- a/elements/lisk-p2p/test/functional/custom_peer_selection.ts
+++ b/elements/lisk-p2p/test/functional/custom_peer_selection.ts
@@ -25,6 +25,7 @@ import {
 } from '../../src/types';
 
 import { createNetwork, destroyNetwork } from '../utils/network_setup';
+import { DEFAULT_MESSAGE_ENCODING_FORMAT } from '../../src/constants';
 
 const { ConnectionKind } = constants;
 
@@ -158,7 +159,7 @@ describe('Custom peer selection', () => {
 						request.end({
 							nodePort: p2p.config.port,
 							requestProcedure: request.procedure,
-							requestData: request.data,
+							requestData: request.data.toString(DEFAULT_MESSAGE_ENCODING_FORMAT),
 						});
 					}
 				});
@@ -167,22 +168,20 @@ describe('Custom peer selection', () => {
 
 		it('should make a request to the network; it should reach a single peer based on custom selection function', async () => {
 			const middleP2PNode = p2pNodeList[networkSize / 2];
+			const data = Buffer.from('bar');
+
 			const response = await middleP2PNode.request({
 				procedure: 'foo',
-				data: 'bar',
+				data,
 			});
-			const parsedData = JSON.parse((response.data as Buffer).toString('utf-8'));
-			const result = {
-				...parsedData,
-				requestData: JSON.parse(Buffer.from(parsedData.requestData.data).toString('utf-8')),
-			};
+			const parsedData = JSON.parse((response.data as Buffer).toString('utf8'));
 
 			expect(response).toHaveProperty('data');
 			expect(response.data).toBeInstanceOf(Buffer);
-			expect(result).toMatchObject({
+			expect(parsedData).toMatchObject({
 				nodePort: expect.any(Number),
 				requestProcedure: expect.any(String),
-				requestData: 'bar',
+				requestData: data.toString(DEFAULT_MESSAGE_ENCODING_FORMAT),
 			});
 		});
 	});

--- a/elements/lisk-p2p/test/unit/p2p_request.ts
+++ b/elements/lisk-p2p/test/unit/p2p_request.ts
@@ -15,6 +15,7 @@
 import { P2PRequest } from '../../src/p2p_request';
 import { RPCResponseAlreadySentError } from '../../src/errors';
 import { RequestOptions } from '../../src/types';
+import { DEFAULT_MESSAGE_ENCODING_FORMAT } from '../../src/constants';
 
 describe('p2pRequest', () => {
 	let requestOptions: RequestOptions;
@@ -60,7 +61,7 @@ describe('p2pRequest', () => {
 
 	describe('#data', () => {
 		it('should have a data property which is set to the value specified in the constructor', () =>
-			expect(request.data).toEqual(Buffer.from('bar', 'binary')));
+			expect(request.data).toEqual(Buffer.from('bar', DEFAULT_MESSAGE_ENCODING_FORMAT)));
 	});
 
 	describe('#rate', () => {
@@ -88,7 +89,7 @@ describe('p2pRequest', () => {
 		it('should send data back to callback in correct format', () => {
 			expect(respondCallback).toHaveBeenCalledTimes(1);
 			expect(respondCallback).toHaveBeenCalledWith(undefined, {
-				data: request['_getBinaryData']('hello'),
+				data: request['_getBase64Data']('hello'),
 				peerId: requestOptions.id,
 			});
 		});
@@ -114,7 +115,7 @@ describe('p2pRequest', () => {
 
 		it('should set wasResponseSent property to true', () => {
 			expect(request).toMatchObject({
-				_data: Buffer.from('bar', 'binary'),
+				_data: Buffer.from('bar', DEFAULT_MESSAGE_ENCODING_FORMAT),
 				_peerId: 'abc123',
 				_procedure: 'foo',
 				_rate: 0,

--- a/elements/lisk-p2p/test/unit/peer/base.ts
+++ b/elements/lisk-p2p/test/unit/peer/base.ts
@@ -24,6 +24,7 @@ import {
 	DEFAULT_WS_MAX_MESSAGE_RATE_PENALTY,
 	DEFAULT_WS_MAX_MESSAGE_RATE,
 	DEFAULT_RATE_CALCULATION_INTERVAL,
+	DEFAULT_MESSAGE_ENCODING_FORMAT,
 } from '../../../src/constants';
 import {
 	EVENT_BAN_PEER,
@@ -272,7 +273,7 @@ describe('peer/base', () => {
 			// Assert
 			expect((defaultPeer as any)._socket.emit).toHaveBeenCalledWith(REMOTE_SC_EVENT_MESSAGE, {
 				event: p2pPacket.event,
-				data: p2pPacket.data?.toString('binary'),
+				data: p2pPacket.data?.toString(DEFAULT_MESSAGE_ENCODING_FORMAT),
 			});
 		});
 	});
@@ -304,7 +305,7 @@ describe('peer/base', () => {
 				REMOTE_SC_EVENT_RPC_REQUEST,
 				{
 					procedure: p2pPacket.procedure,
-					data: p2pPacket.data?.toString('binary'),
+					data: p2pPacket.data?.toString(DEFAULT_MESSAGE_ENCODING_FORMAT),
 				},
 				expect.any(Function),
 			);

--- a/elements/lisk-p2p/test/unit/peer/outbound.ts
+++ b/elements/lisk-p2p/test/unit/peer/outbound.ts
@@ -23,6 +23,7 @@ import {
 	DEFAULT_ACK_TIMEOUT,
 	DEFAULT_WS_MAX_MESSAGE_RATE,
 	DEFAULT_HTTP_PATH,
+	DEFAULT_MESSAGE_ENCODING_FORMAT,
 } from '../../../src/constants';
 import {
 	P2PPeerInfo,
@@ -265,9 +266,10 @@ describe('peer/outbound', () => {
 	describe('#send', () => {
 		// Arrange
 		let p2pPacket: P2PMessagePacketBufferData;
+		const data = Buffer.from('myData', DEFAULT_MESSAGE_ENCODING_FORMAT);
 		beforeEach(() => {
 			p2pPacket = {
-				data: Buffer.from('myData'),
+				data,
 				event: 'myEvent',
 			};
 		});
@@ -297,7 +299,7 @@ describe('peer/outbound', () => {
 
 			expect(outboundSocket.emit).toHaveBeenCalledTimes(1);
 			expect(outboundSocket.emit).toHaveBeenCalledWith(REMOTE_SC_EVENT_MESSAGE, {
-				data: 'myData',
+				data: data.toString(DEFAULT_MESSAGE_ENCODING_FORMAT),
 				event: 'myEvent',
 			});
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6265 

### How was it solved?

- use base64 instead of binary encoding format
- update p2p tests

### How was it tested?

- Update p2p tests