### PR TITLE
Add functional test for faucet plugin - Closes #6247

### DIFF
--- a/framework-plugins/lisk-framework-faucet-plugin/package.json
+++ b/framework-plugins/lisk-framework-faucet-plugin/package.json
@@ -30,6 +30,7 @@
 		"test": "jest --config=./test/unit/jest.config.js ",
 		"test:coverage": "jest --config=./test/unit/jest.config.js  --coverage=true --coverage-reporters=text",
 		"test:watch": "npm test -- --watch",
+		"test:functional": "jest --config=./test/functional/jest.config.js --runInBand",
 		"test:unit": "jest --config=./test/unit/jest.config.js --coverage=true --coverage-reporters=json --verbose",
 		"prebuild": "rm -r dist-node/* || mkdir dist-node || true",
 		"build": "npm run build:node && npm run build:web",

--- a/framework-plugins/lisk-framework-faucet-plugin/test/functional/faucet.spec.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/test/functional/faucet.spec.ts
@@ -16,21 +16,21 @@ import { testing, PartialApplicationConfig } from 'lisk-framework';
 import { FaucetPlugin } from '../../src';
 
 describe('faucet plugin', () => {
-    let appEnv: testing.ApplicationEnv;
-    
+	let appEnv: testing.ApplicationEnv;
+
 	beforeAll(async () => {
 		const rootPath = '~/.lisk/faucet-plugin';
 		const config = {
 			rootPath,
-            label: 'faucet_functional',
-            plugins: {
-                faucet: {
-                    encryptedPassphrase: 'iterations=12&cipherText=1f06671e13c0329aee057fee995e08a516bdacd287c7ff2714a74be6099713c87bbc3e005c63d4d3d02f8ba89b42810a5854444ad2b76855007a0925fafa7d870875beb010&iv=3a583b21bbac609c7df3e7e0&salt=245c6859a96339a7735a6cac78ccf625&tag=63653f1d4e8d422a42d98b25d3844792&version=1',
-                    captchaSecretkey: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe',
-                    captchaSitekey: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
-                }
-            }
-           
+			label: 'faucet_functional',
+			plugins: {
+				faucet: {
+					encryptedPassphrase:
+						'iterations=12&cipherText=1f06671e13c0329aee057fee995e08a516bdacd287c7ff2714a74be6099713c87bbc3e005c63d4d3d02f8ba89b42810a5854444ad2b76855007a0925fafa7d870875beb010&iv=3a583b21bbac609c7df3e7e0&salt=245c6859a96339a7735a6cac78ccf625&tag=63653f1d4e8d422a42d98b25d3844792&version=1',
+					captchaSecretkey: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe',
+					captchaSitekey: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
+				},
+			},
 		} as PartialApplicationConfig;
 
 		appEnv = testing.createDefaultApplicationEnv({
@@ -44,15 +44,18 @@ describe('faucet plugin', () => {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
 		await appEnv.stopApplication();
-    });
-    
-    it('should enable faucet', async () => {
-        // Arrange
-        const authorizeResult = await appEnv.ipcClient.invoke<{ result: string }>('faucet:authorize', { enable: true, password: 'myTotal53cr3t%&'  });
-       
-        // Assert
-		expect(authorizeResult.result).toBe('Successfully enabled the faucet.');
-    });
+	});
 
-    // *Note*: From backend side, `fundTokens` endpoint cannot be tested without UI token
+	it('should enable faucet', async () => {
+		// Arrange
+		const authorizeResult = await appEnv.ipcClient.invoke<{ result: string }>('faucet:authorize', {
+			enable: true,
+			password: 'myTotal53cr3t%&',
+		});
+
+		// Assert
+		expect(authorizeResult.result).toBe('Successfully enabled the faucet.');
+	});
+
+	// *Note*: From backend side, `fundTokens` endpoint cannot be tested without UI token
 });

--- a/framework-plugins/lisk-framework-faucet-plugin/test/functional/faucet.spec.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/test/functional/faucet.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { testing, PartialApplicationConfig } from 'lisk-framework';
+import { FaucetPlugin } from '../../src';
+
+describe('faucet plugin', () => {
+    let appEnv: testing.ApplicationEnv;
+    
+	beforeAll(async () => {
+		const rootPath = '~/.lisk/faucet-plugin';
+		const config = {
+			rootPath,
+            label: 'faucet_functional',
+            plugins: {
+                faucet: {
+                    encryptedPassphrase: 'iterations=12&cipherText=1f06671e13c0329aee057fee995e08a516bdacd287c7ff2714a74be6099713c87bbc3e005c63d4d3d02f8ba89b42810a5854444ad2b76855007a0925fafa7d870875beb010&iv=3a583b21bbac609c7df3e7e0&salt=245c6859a96339a7735a6cac78ccf625&tag=63653f1d4e8d422a42d98b25d3844792&version=1',
+                    captchaSecretkey: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe',
+                    captchaSitekey: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
+                }
+            }
+           
+		} as PartialApplicationConfig;
+
+		appEnv = testing.createDefaultApplicationEnv({
+			config,
+			plugins: [FaucetPlugin],
+		});
+		await appEnv.startApplication();
+	});
+
+	afterAll(async () => {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		jest.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+		await appEnv.stopApplication();
+    });
+    
+    it('should enable faucet', async () => {
+        // Arrange
+        const authorizeResult = await appEnv.ipcClient.invoke<{ result: string }>('faucet:authorize', { enable: true, password: 'myTotal53cr3t%&'  });
+       
+        // Assert
+		expect(authorizeResult.result).toBe('Successfully enabled the faucet.');
+    });
+
+    // *Note*: From backend side, `fundTokens` endpoint cannot be tested without UI token
+});

--- a/framework-plugins/lisk-framework-faucet-plugin/test/functional/jest.config.js
+++ b/framework-plugins/lisk-framework-faucet-plugin/test/functional/jest.config.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+const base = require('../../jest.config');
+
+module.exports = {
+	...base,
+	rootDir: '../../',
+	setupFilesAfterEnv: ['<rootDir>/test/functional/setup.js'],
+	testMatch: ['<rootDir>/test/functional/**/*.(spec|test).ts'],
+};

--- a/framework-plugins/lisk-framework-faucet-plugin/test/functional/jest.config.js
+++ b/framework-plugins/lisk-framework-faucet-plugin/test/functional/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/framework-plugins/lisk-framework-faucet-plugin/test/functional/setup.js
+++ b/framework-plugins/lisk-framework-faucet-plugin/test/functional/setup.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+require('../_setup');
+
+jest.setTimeout(30000);

--- a/framework-plugins/lisk-framework-faucet-plugin/test/functional/setup.js
+++ b/framework-plugins/lisk-framework-faucet-plugin/test/functional/setup.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -11,6 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+
 require('../_setup');
 
 jest.setTimeout(30000);


### PR DESCRIPTION
### What was the problem?

This PR resolves #6247

### How was it solved?

- Added jest setup for functional testing
- Added functional test for faucet authorize endpoint

*Note*: `fundTokens` endpoint not covered since it requires `token` retrieved from UI

### How was it tested?

Added functional test for faucet plugin
