### PR TITLE
Unstable lisk elements p2p tests - Closes #6289

### DIFF
--- a/elements/lisk-p2p/test/functional/message_rate.ts
+++ b/elements/lisk-p2p/test/functional/message_rate.ts
@@ -82,7 +82,7 @@ describe('Message rate limit', () => {
 		it('should track the message rate correctly when receiving messages', async () => {
 			const TOTAL_SENDS = 100;
 			const firstP2PNode = p2pNodeList[0];
-			const ratePerSecondLowerBound = 70;
+			const ratePerSecondLowerBound = 60;
 			const ratePerSecondUpperBound = 130;
 
 			const targetPeerPort = NETWORK_START_PORT + 3;
@@ -169,7 +169,7 @@ describe('Message rate limit', () => {
 		it('should track the request rate correctly when receiving requests', async () => {
 			const TOTAL_SENDS = 100;
 			const requesterP2PNode = p2pNodeList[1];
-			const ratePerSecondLowerBound = 70;
+			const ratePerSecondLowerBound = 60;
 			const ratePerSecondUpperBound = 130;
 
 			const targetPeerPort = NETWORK_START_PORT;


### PR DESCRIPTION
### What was the problem?

This PR resolves #6289

### How was it solved?

- Due to lower performance of CI server the message rate was decreased, so why decreased the lower bound expectation. 

### How was it tested?

- Run tests on Jenkins for multiple times 
