### PR TITLE
Rename cryptography function name regarding base32 address - Closes #6283

### DIFF
--- a/commander/src/commands/account/create.ts
+++ b/commander/src/commands/account/create.ts
@@ -16,7 +16,7 @@
 import {
 	getAddressFromPublicKey,
 	getKeys,
-	getBase32AddressFromPublicKey,
+	getLisk32AddressFromPublicKey,
 } from '@liskhq/lisk-cryptography';
 import { flags as flagParser } from '@oclif/command';
 
@@ -35,7 +35,7 @@ const createAccount = (): AccountInfo => {
 	const passphrase = createMnemonicPassphrase();
 	const { privateKey, publicKey } = getKeys(passphrase);
 	const binaryAddress = getAddressFromPublicKey(publicKey);
-	const address = getBase32AddressFromPublicKey(publicKey, 'lsk');
+	const address = getLisk32AddressFromPublicKey(publicKey, 'lsk');
 
 	return {
 		passphrase,

--- a/commander/src/commands/account/show.ts
+++ b/commander/src/commands/account/show.ts
@@ -16,7 +16,7 @@
 import {
 	getAddressFromPublicKey,
 	getKeys,
-	getBase32AddressFromPublicKey,
+	getLisk32AddressFromPublicKey,
 } from '@liskhq/lisk-cryptography';
 import { flags as flagParser } from '@oclif/command';
 
@@ -34,7 +34,7 @@ const processInput = (
 } => {
 	const { privateKey, publicKey } = getKeys(passphrase);
 	const binaryAddress = getAddressFromPublicKey(publicKey);
-	const address = getBase32AddressFromPublicKey(publicKey, 'lsk');
+	const address = getLisk32AddressFromPublicKey(publicKey, 'lsk');
 
 	return {
 		privateKey: privateKey.toString('hex'),

--- a/commander/test/commands/account/create.test.ts
+++ b/commander/test/commands/account/create.test.ts
@@ -71,7 +71,7 @@ describe('account:create', () => {
 					{
 						publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
 						privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
-						address: cryptography.getBase32AddressFromPublicKey(
+						address: cryptography.getLisk32AddressFromPublicKey(
 							cryptography.getKeys(defaultMnemonic).publicKey,
 							'lsk',
 						),
@@ -92,7 +92,7 @@ describe('account:create', () => {
 					{
 						publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
 						privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
-						address: cryptography.getBase32AddressFromPublicKey(
+						address: cryptography.getLisk32AddressFromPublicKey(
 							cryptography.getKeys(defaultMnemonic).publicKey,
 							'lsk',
 						),
@@ -102,7 +102,7 @@ describe('account:create', () => {
 					{
 						publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
 						privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
-						address: cryptography.getBase32AddressFromPublicKey(
+						address: cryptography.getLisk32AddressFromPublicKey(
 							cryptography.getKeys(secondDefaultMnemonic).publicKey,
 							'lsk',
 						),

--- a/commander/test/commands/account/show.test.ts
+++ b/commander/test/commands/account/show.test.ts
@@ -41,7 +41,7 @@ describe('account:show', () => {
 				return expect(printMethodStub).to.be.calledWith({
 					privateKey: cryptography.getKeys(passphraseInput).privateKey.toString('hex'),
 					publicKey: cryptography.getKeys(passphraseInput).publicKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
+					address: cryptography.getLisk32AddressFromPublicKey(
 						cryptography.getKeys(passphraseInput).publicKey,
 						'lsk',
 					),
@@ -58,7 +58,7 @@ describe('account:show', () => {
 				return expect(printMethodStub).to.be.calledWith({
 					privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
 					publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
+					address: cryptography.getLisk32AddressFromPublicKey(
 						cryptography.getKeys(secondDefaultMnemonic).publicKey,
 						'lsk',
 					),

--- a/elements/lisk-client/test/lisk-cryptography/keys.spec.ts
+++ b/elements/lisk-client/test/lisk-cryptography/keys.spec.ts
@@ -17,15 +17,15 @@ import { cryptography } from '../../src';
 
 const {
 	getAddressFromPublicKey,
-	getBase32AddressFromPublicKey,
+	getLisk32AddressFromPublicKey,
 	getPrivateAndPublicKeyFromPassphrase,
 	getKeys,
 	getAddressAndPublicKeyFromPassphrase,
 	getAddressFromPassphrase,
 	getAddressFromPrivateKey,
-	validateBase32Address,
-	getAddressFromBase32Address,
-	getBase32AddressFromAddress,
+	validateLisk32Address,
+	getAddressFromLisk32Address,
+	getLisk32AddressFromAddress,
 } = cryptography;
 
 describe('keys', () => {
@@ -104,21 +104,21 @@ describe('keys', () => {
 		});
 	});
 
-	describe('#getBase32AddressFromPublicKey', () => {
+	describe('#getLisk32AddressFromPublicKey', () => {
 		const publicKey = Buffer.from(
 			'0eb0a6d7b862dc35c856c02c47fde3b4f60f2f3571a888b9a8ca7540c6793243',
 			'hex',
 		);
-		const expectedBase32Address = 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
+		const expectedLisk32Address = 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 
 		it('should generate base32 address from publicKey', () => {
-			const address = getBase32AddressFromPublicKey(publicKey, 'lsk');
+			const address = getLisk32AddressFromPublicKey(publicKey, 'lsk');
 
-			expect(address).toBe(expectedBase32Address);
+			expect(address).toBe(expectedLisk32Address);
 		});
 	});
 
-	describe('#validateBase32Address', () => {
+	describe('#validateLisk32Address', () => {
 		describe('Given valid addresses', () => {
 			const addresses = [
 				'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu',
@@ -130,7 +130,7 @@ describe('keys', () => {
 
 			it('should return true', () => {
 				return addresses.forEach(address => {
-					return expect(validateBase32Address(address)).toBeTruthy();
+					return expect(validateLisk32Address(address)).toBeTruthy();
 				});
 			});
 		});
@@ -138,7 +138,7 @@ describe('keys', () => {
 		describe('Given an address that is too short', () => {
 			const address = 'lsk1';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Address length does not match requirements. Expected 41 characters.',
 				);
 			});
@@ -147,7 +147,7 @@ describe('keys', () => {
 		describe('Given an address that is too long', () => {
 			const address = 'lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmux2ga';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Address length does not match requirements. Expected 41 characters.',
 				);
 			});
@@ -156,7 +156,7 @@ describe('keys', () => {
 		describe('Given an address that is not prefixed with `lsk`', () => {
 			const address = 'LSK24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Invalid address prefix. Actual prefix: LSK, Expected prefix: lsk',
 				);
 			});
@@ -165,7 +165,7 @@ describe('keys', () => {
 		describe('Given an address containing non-base32 characters', () => {
 			const address = 'lsk1aknq582o6fw7sp82bm2hnj7pzp47mpmbmux2g';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					"Invalid character found in address. Only allow characters: 'abcdefghjkmnopqrstuvwxyz23456789'.",
 				);
 			});
@@ -174,14 +174,14 @@ describe('keys', () => {
 		describe('Given an address with invalid checksum', () => {
 			const address = 'lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmuxgg';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Invalid checksum for address.',
 				);
 			});
 		});
 	});
 
-	describe('getAddressFromBase32Address', () => {
+	describe('getAddressFromLisk32Address', () => {
 		const account = {
 			passphrase:
 				'boil typical oyster traffic ethics timber envelope undo lecture poverty space keep',
@@ -193,17 +193,17 @@ describe('keys', () => {
 		};
 
 		it('should throw error for invalid address', () => {
-			return expect(getAddressFromBase32Address.bind(null, 'invalid')).toThrow();
+			return expect(getAddressFromLisk32Address.bind(null, 'invalid')).toThrow();
 		});
 
 		it('should return an address given a base32 address', () => {
-			expect(getAddressFromBase32Address(account.address).toString('hex')).toBe(
+			expect(getAddressFromLisk32Address(account.address).toString('hex')).toBe(
 				account.binaryAddress,
 			);
 		});
 	});
 
-	describe('getBase32AddressFromAddress', () => {
+	describe('getLisk32AddressFromAddress', () => {
 		const account = {
 			passphrase:
 				'boil typical oyster traffic ethics timber envelope undo lecture poverty space keep',
@@ -215,7 +215,7 @@ describe('keys', () => {
 		};
 
 		it('should return base32 address given an address', () => {
-			expect(getBase32AddressFromAddress(Buffer.from(account.binaryAddress, 'hex'))).toBe(
+			expect(getLisk32AddressFromAddress(Buffer.from(account.binaryAddress, 'hex'))).toBe(
 				account.address,
 			);
 		});

--- a/elements/lisk-cryptography/src/constants.ts
+++ b/elements/lisk-cryptography/src/constants.ts
@@ -14,4 +14,5 @@
  */
 export const SIGNED_MESSAGE_PREFIX = 'Lisk Signed Message:\n';
 export const BINARY_ADDRESS_LENGTH = 20;
-export const DEFAULT_BASE32_ADDRESS_PREFIX = 'lsk';
+export const DEFAULT_LISK32_ADDRESS_PREFIX = 'lsk';
+export const DEFAULT_BASE32_ADDRESS_PREFIX = DEFAULT_LISK32_ADDRESS_PREFIX;

--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { BINARY_ADDRESS_LENGTH, DEFAULT_BASE32_ADDRESS_PREFIX } from './constants';
+import { BINARY_ADDRESS_LENGTH, DEFAULT_LISK32_ADDRESS_PREFIX } from './constants';
 // eslint-disable-next-line import/no-cycle
 import { convertUInt5ToBase32, convertUIntArray } from './convert';
 import { hash } from './hash';
@@ -98,7 +98,7 @@ export const createChecksum = (uint5Array: number[]): number[] => {
 export const verifyChecksum = (integerSequence: number[]): boolean =>
 	polymod(integerSequence) === 1;
 
-const addressToBase32 = (address: Buffer): string => {
+const addressToLisk32 = (address: Buffer): string => {
 	const byteSequence = [];
 	for (const b of address) {
 		byteSequence.push(b);
@@ -108,27 +108,37 @@ const addressToBase32 = (address: Buffer): string => {
 	return convertUInt5ToBase32(uint5Address.concat(uint5Checksum));
 };
 
-export const getBase32AddressFromPublicKey = (
+export const getLisk32AddressFromPublicKey = (
 	publicKey: Buffer,
-	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
-): string => `${prefix}${addressToBase32(getAddressFromPublicKey(publicKey))}`;
+	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
+): string => `${prefix}${addressToLisk32(getAddressFromPublicKey(publicKey))}`;
 
-export const getBase32AddressFromPassphrase = (
+/**
+ * @deprecated
+ */
+export const getBase32AddressFromPublicKey = getLisk32AddressFromPublicKey;
+
+export const getLisk32AddressFromPassphrase = (
 	passphrase: string,
-	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
 ): string => {
 	const { publicKey } = getAddressAndPublicKeyFromPassphrase(passphrase);
-	return getBase32AddressFromPublicKey(publicKey, prefix);
+	return getLisk32AddressFromPublicKey(publicKey, prefix);
 };
 
-const BASE32_ADDRESS_LENGTH = 41;
-const BASE32_CHARSET = 'zxvcpmbn3465o978uyrtkqew2adsjhfg';
+/**
+ * @deprecated
+ */
+export const getBase32AddressFromPassphrase = getLisk32AddressFromPassphrase;
 
-export const validateBase32Address = (
+const LISK32_ADDRESS_LENGTH = 41;
+const LISK32_CHARSET = 'zxvcpmbn3465o978uyrtkqew2adsjhfg';
+
+export const validateLisk32Address = (
 	address: string,
-	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
 ): boolean => {
-	if (address.length !== BASE32_ADDRESS_LENGTH) {
+	if (address.length !== LISK32_ADDRESS_LENGTH) {
 		throw new Error('Address length does not match requirements. Expected 41 characters.');
 	}
 
@@ -142,13 +152,13 @@ export const validateBase32Address = (
 
 	const addressSubstringArray = address.substring(3).split('');
 
-	if (!addressSubstringArray.every(char => BASE32_CHARSET.includes(char))) {
+	if (!addressSubstringArray.every(char => LISK32_CHARSET.includes(char))) {
 		throw new Error(
 			"Invalid character found in address. Only allow characters: 'abcdefghjkmnopqrstuvwxyz23456789'.",
 		);
 	}
 
-	const integerSequence = addressSubstringArray.map(char => BASE32_CHARSET.indexOf(char));
+	const integerSequence = addressSubstringArray.map(char => LISK32_CHARSET.indexOf(char));
 
 	if (!verifyChecksum(integerSequence)) {
 		throw new Error('Invalid checksum for address.');
@@ -157,11 +167,16 @@ export const validateBase32Address = (
 	return true;
 };
 
-export const getAddressFromBase32Address = (
+/**
+ * @deprecated
+ */
+export const validateBase32Address = validateLisk32Address;
+
+export const getAddressFromLisk32Address = (
 	base32Address: string,
-	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
+	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
 ): Buffer => {
-	validateBase32Address(base32Address, prefix);
+	validateLisk32Address(base32Address, prefix);
 	// Ignore lsk prefix and checksum
 	const base32AddressNoPrefixNoChecksum = base32Address.substring(
 		prefix.length,
@@ -169,13 +184,23 @@ export const getAddressFromBase32Address = (
 	);
 
 	const addressArray = base32AddressNoPrefixNoChecksum.split('');
-	const integerSequence = addressArray.map(char => BASE32_CHARSET.indexOf(char));
+	const integerSequence = addressArray.map(char => LISK32_CHARSET.indexOf(char));
 	const integerSequence8 = convertUIntArray(integerSequence, 5, 8);
 
 	return Buffer.from(integerSequence8);
 };
 
-export const getBase32AddressFromAddress = (
+/**
+ * @deprecated
+ */
+export const getAddressFromBase32Address = getAddressFromLisk32Address;
+
+export const getLisk32AddressFromAddress = (
 	address: Buffer,
-	prefix = DEFAULT_BASE32_ADDRESS_PREFIX,
-): string => `${prefix}${addressToBase32(address)}`;
+	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
+): string => `${prefix}${addressToLisk32(address)}`;
+
+/**
+ * @deprecated
+ */
+export const getBase32AddressFromAddress = getLisk32AddressFromAddress;

--- a/elements/lisk-cryptography/test/keys.spec.ts
+++ b/elements/lisk-cryptography/test/keys.spec.ts
@@ -14,16 +14,16 @@
  */
 import {
 	getAddressFromPublicKey,
-	getBase32AddressFromPublicKey,
+	getLisk32AddressFromPublicKey,
 	getPrivateAndPublicKeyFromPassphrase,
 	getKeys,
 	getAddressAndPublicKeyFromPassphrase,
 	getAddressFromPassphrase,
 	getAddressFromPrivateKey,
-	validateBase32Address,
-	getAddressFromBase32Address,
-	getBase32AddressFromAddress,
-	getBase32AddressFromPassphrase,
+	validateLisk32Address,
+	getAddressFromLisk32Address,
+	getLisk32AddressFromAddress,
+	getLisk32AddressFromPassphrase,
 } from '../src/keys';
 import { Keypair } from '../src/types';
 // Require is used for stubbing
@@ -115,35 +115,35 @@ describe('keys', () => {
 		});
 	});
 
-	describe('#getBase32AddressFromPublicKey', () => {
+	describe('#getLisk32AddressFromPublicKey', () => {
 		const publicKey = Buffer.from(
 			'0eb0a6d7b862dc35c856c02c47fde3b4f60f2f3571a888b9a8ca7540c6793243',
 			'hex',
 		);
 		const hash = 'c247a42e09e6aafd818821f75b2f5b0de47c8235';
-		const expectedBase32Address = 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
+		const expectedLisk32Address = 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 		beforeEach(() => {
 			return jest.spyOn(hashModule, 'hash').mockReturnValue(Buffer.from(hash, 'hex'));
 		});
 
-		it('should generate base32 address from publicKey', () => {
-			const address = getBase32AddressFromPublicKey(publicKey, 'lsk');
+		it('should generate lisk32 address from publicKey', () => {
+			const address = getLisk32AddressFromPublicKey(publicKey, 'lsk');
 
-			expect(address).toBe(expectedBase32Address);
+			expect(address).toBe(expectedLisk32Address);
 		});
 	});
 
-	describe('#getBase32AddressFromPassphrase', () => {
-		it('should generate valid base32 address from passphrase', () => {
+	describe('#getLisk32AddressFromPassphrase', () => {
+		it('should generate valid lisk32 address from passphrase', () => {
 			const passphrase =
 				'garden mass universe joke disorder fish reveal state course lottery near virus';
-			const address = getBase32AddressFromPassphrase(passphrase);
+			const address = getLisk32AddressFromPassphrase(passphrase);
 
-			expect(validateBase32Address(address)).toBeTrue();
+			expect(validateLisk32Address(address)).toBeTrue();
 		});
 	});
 
-	describe('#validateBase32Address', () => {
+	describe('#validateLisk32Address', () => {
 		describe('Given valid addresses', () => {
 			const addresses = [
 				'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu',
@@ -155,7 +155,7 @@ describe('keys', () => {
 
 			it('should return true', () => {
 				return addresses.forEach(address => {
-					return expect(validateBase32Address(address)).toBeTrue();
+					return expect(validateLisk32Address(address)).toBeTrue();
 				});
 			});
 		});
@@ -163,7 +163,7 @@ describe('keys', () => {
 		describe('Given an address that is too short', () => {
 			const address = 'lsk1';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Address length does not match requirements. Expected 41 characters.',
 				);
 			});
@@ -172,7 +172,7 @@ describe('keys', () => {
 		describe('Given an address that is too long', () => {
 			const address = 'lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmux2ga';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Address length does not match requirements. Expected 41 characters.',
 				);
 			});
@@ -181,16 +181,16 @@ describe('keys', () => {
 		describe('Given an address that is not prefixed with `lsk`', () => {
 			const address = 'LSK24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Invalid address prefix. Actual prefix: LSK, Expected prefix: lsk',
 				);
 			});
 		});
 
-		describe('Given an address containing non-base32 characters', () => {
+		describe('Given an address containing non-lisk32 characters', () => {
 			const address = 'lsk1aknq582o6fw7sp82bm2hnj7pzp47mpmbmux2g';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					"Invalid character found in address. Only allow characters: 'abcdefghjkmnopqrstuvwxyz23456789'.",
 				);
 			});
@@ -199,14 +199,14 @@ describe('keys', () => {
 		describe('Given an address with invalid checksum', () => {
 			const address = 'lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmuxgg';
 			it('should throw an error', () => {
-				return expect(validateBase32Address.bind(null, address)).toThrow(
+				return expect(validateLisk32Address.bind(null, address)).toThrow(
 					'Invalid checksum for address.',
 				);
 			});
 		});
 	});
 
-	describe('getAddressFromBase32Address', () => {
+	describe('getAddressFromLisk32Address', () => {
 		const account = {
 			passphrase:
 				'boil typical oyster traffic ethics timber envelope undo lecture poverty space keep',
@@ -218,31 +218,31 @@ describe('keys', () => {
 		};
 
 		it('should throw error for invalid address', () => {
-			return expect(getAddressFromBase32Address.bind(null, 'invalid')).toThrow();
+			return expect(getAddressFromLisk32Address.bind(null, 'invalid')).toThrow();
 		});
 
 		it('should throw error for invalid prefix', () => {
 			expect(() =>
-				getAddressFromBase32Address('abcvtr2zq9v36vyefjdvhxas92nf438z9ap8wnzav').toString('hex'),
+				getAddressFromLisk32Address('abcvtr2zq9v36vyefjdvhxas92nf438z9ap8wnzav').toString('hex'),
 			).toThrow('Invalid address prefix. Actual prefix: abc, Expected prefix: lsk');
 		});
 
-		it('should return an address given a base32 address with default prefix', () => {
-			expect(getAddressFromBase32Address(account.address).toString('hex')).toBe(
+		it('should return an address given a lisk32 address with default prefix', () => {
+			expect(getAddressFromLisk32Address(account.address).toString('hex')).toBe(
 				account.binaryAddress,
 			);
 		});
 
-		it('should return an address given a base32 address with custom prefix', () => {
+		it('should return an address given a lisk32 address with custom prefix', () => {
 			expect(
-				getAddressFromBase32Address('abcvtr2zq9v36vyefjdvhxas92nf438z9ap8wnzav', 'abc').toString(
+				getAddressFromLisk32Address('abcvtr2zq9v36vyefjdvhxas92nf438z9ap8wnzav', 'abc').toString(
 					'hex',
 				),
 			).toBe('14e58055a242851b7b9a17439db707f250f03724');
 		});
 	});
 
-	describe('getBase32AddressFromAddress', () => {
+	describe('getLisk32AddressFromAddress', () => {
 		const account = {
 			passphrase:
 				'boil typical oyster traffic ethics timber envelope undo lecture poverty space keep',
@@ -253,8 +253,8 @@ describe('keys', () => {
 			address: 'lsk3hyz7vtpcts3thsmduh98pwxrjnbw7ccoxchxu',
 		};
 
-		it('should return base32 address given an address', () => {
-			expect(getBase32AddressFromAddress(Buffer.from(account.binaryAddress, 'hex'))).toBe(
+		it('should return lisk32 address given an address', () => {
+			expect(getLisk32AddressFromAddress(Buffer.from(account.binaryAddress, 'hex'))).toBe(
 				account.address,
 			);
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6283

### How was it solved?

- Renamed original Base32 address functions to Lisk32 address
- Linked Base32 address functions originals 
- Marked these Base32 address functions as deprecated 
- Updated tests 

### How was it tested?

- Run all tests
