### PR TITLE
Add lisk console to application command - Closes #6306

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -93,6 +93,7 @@
 	"dependencies": {
 		"@liskhq/lisk-api-client": "^5.0.3",
 		"@liskhq/lisk-chain": "^0.2.1",
+		"@liskhq/lisk-client": "^5.0.4",
 		"@liskhq/lisk-codec": "^0.1.1",
 		"@liskhq/lisk-cryptography": "^3.0.1",
 		"@liskhq/lisk-db": "^0.1.0",

--- a/commander/package.json
+++ b/commander/package.json
@@ -57,6 +57,12 @@
 			"account": {
 				"description": "Commands relating to Lisk accounts."
 			},
+			"console": {
+				"description": "Lisk interactive REPL session to run commands."
+			},
+			"generate": {
+				"description": "Commands relating to Lisk generator."
+			},
 			"hash-onion": {
 				"description": "Create hash onions to be used by the forger."
 			},
@@ -74,9 +80,6 @@
 			},
 			"passphrase": {
 				"description": "Commands relating to Lisk passphrases."
-			},
-			"generate": {
-				"description": "Commands relating to Lisk generator."
 			}
 		}
 	},

--- a/commander/src/bootstrapping/commands/console.ts
+++ b/commander/src/bootstrapping/commands/console.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as repl from 'repl';
+import Command, { flags as flagParser } from '@oclif/command';
+import * as liskClient from '@liskhq/lisk-client';
+
+export class ConsoleCommand extends Command {
+	static description = 'Lisk interactive REPL session to run commands';
+
+	static examples = [
+		'console',
+		'console --api-ws=ws://localhost:8080',
+		'console --api-ipc=/path/to/server',
+	];
+
+	static flags = {
+		'api-ipc': flagParser.string({
+			description: 'Enable api-client with IPC communication.',
+			exclusive: ['api-ws'],
+		}),
+		'api-ws': flagParser.string({
+			description: 'Enable api-client with Websocket communication.',
+			exclusive: ['api-ipc'],
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = this.parse(ConsoleCommand);
+
+		this.log('Entering Lisk REPL: type `Ctrl+C` or `.exit` to exit');
+
+		const replServer = repl.start('lisk > ');
+		for (const element in liskClient) {
+			// @ts-ignore
+			replServer.context[element] = liskClient[element];
+		}
+
+		if (flags['api-ipc']) {
+			const ipcClient = await liskClient.apiClient.createIPCClient(flags['api-ipc']);
+			replServer.context.client = ipcClient;
+		}
+
+		if (flags['api-ws']) {
+			const wsClient = await liskClient.apiClient.createWSClient(flags['api-ws']);
+			replServer.context.client = wsClient;
+		}
+
+		replServer.on('exit', () => {
+			this.log('Received "exit" event from lisk!');
+			process.exit();
+		});
+	}
+}

--- a/commander/src/bootstrapping/commands/console.ts
+++ b/commander/src/bootstrapping/commands/console.ts
@@ -18,7 +18,7 @@ import Command, { flags as flagParser } from '@oclif/command';
 import * as liskClient from '@liskhq/lisk-client';
 
 export class ConsoleCommand extends Command {
-	static description = 'Lisk interactive REPL session to run commands';
+	static description = 'Lisk interactive REPL session to run commands.';
 
 	static examples = [
 		'console',

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
@@ -55,17 +55,23 @@
 			"blockchain": {
 				"description": "Commands relating to <%= appName %> blockchain data."
 			},
+			"console": {
+				"description": "<%= appName %> interactive REPL session to run commands."
+			},
+			"config": {
+				"description": "Commands relating to <%= appName %> node configuration."
+			},
 			"forger-info": {
 				"description": "Commands relating to <%= appName %> forger-info data."
 			},
 			"forging": {
 				"description": "Commands relating to <%= appName %> forging."
 			},
+			"hash-onion": {
+				"description": "Create hash onions to be used by the forger."
+			},
 			"node": {
 				"description": "Commands relating to <%= appName %> node."
-			},
-			"config": {
-				"description": "Commands relating to <%= appName %> node configuration."
 			},
 			"passphrase": {
 				"description": "Commands relating to <%= appName %> passphrases."

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
@@ -120,7 +120,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0-alpha.0",
+		"eslint-config-lisk-base": "2.0.0",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"globby": "10.0.2",

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package.json
@@ -98,7 +98,7 @@
 		"fs-extra": "9.0.1",
 		"inquirer": "7.3.2",
 		"lisk-sdk": "5.0.4",
-		"lisk-commander": "5.0.0",
+		"lisk-commander": "5.0.1",
 		"tar": "6.0.2",
 		"tslib": "1.13.0",
 		"axios": "0.21.1"

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/commands/console.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/commands/console.ts
@@ -1,0 +1,1 @@
+export { ConsoleCommand } from 'lisk-commander';

--- a/commander/src/commands/console.ts
+++ b/commander/src/commands/console.ts
@@ -1,0 +1,16 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+export { ConsoleCommand } from '../bootstrapping/commands/console';

--- a/commander/src/index.ts
+++ b/commander/src/index.ts
@@ -51,3 +51,4 @@ export {
 export { HashOnionCommand } from './bootstrapping/commands/hash-onion';
 export { StartCommand as BaseStartCommand } from './bootstrapping/commands/start';
 export { BaseGenesisBlockCommand } from './bootstrapping/commands/genesis-block/create';
+export { ConsoleCommand } from './bootstrapping/commands/console';

--- a/commander/test/bootstrapping/commands/console.spec.ts
+++ b/commander/test/bootstrapping/commands/console.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as repl from 'repl';
+import * as Config from '@oclif/config';
+import * as liskClient from '@liskhq/lisk-client';
+import { ConsoleCommand } from '../../../src/bootstrapping/commands/console';
+import { getConfig } from '../../helpers/config';
+
+jest.mock('@liskhq/lisk-client');
+jest.mock('repl');
+
+describe('hash-onion command', () => {
+  let config: Config.IConfig;
+  let stdout: string[];
+
+  beforeEach(async () => {
+    stdout = [];
+    config = await getConfig();
+    jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
+    jest.spyOn(repl, 'start').mockReturnValue({ context: {}, on: jest.fn() } as unknown as repl.REPLServer);
+  });
+
+  describe('console', () => {
+    it('should create repl server', async () => {
+      await ConsoleCommand.run([], config);
+      expect(repl.start).toHaveBeenCalledWith('lisk > ');
+      expect(liskClient.apiClient.createWSClient).toHaveBeenCalledTimes(0);
+      expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('console --api-ws=ws://localhost:8080/ws', () => {
+    it('should create repl server with ws client', async () => {
+      await ConsoleCommand.run(['--api-ws=ws://localhost:8080/ws'], config);
+      expect(liskClient.apiClient.createWSClient).toHaveBeenCalledWith('ws://localhost:8080/ws');
+      expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('console --api-ipc=~/.lisk/lisk-core', () => {
+    it('should create repl server with ipc client', async () => {
+      await ConsoleCommand.run(['--api-ipc=~/.lisk/lisk-core'], config);
+      expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledWith('~/.lisk/lisk-core');
+      expect(liskClient.apiClient.createWSClient).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/commander/test/bootstrapping/commands/console.spec.ts
+++ b/commander/test/bootstrapping/commands/console.spec.ts
@@ -23,38 +23,40 @@ jest.mock('@liskhq/lisk-client');
 jest.mock('repl');
 
 describe('hash-onion command', () => {
-  let config: Config.IConfig;
-  let stdout: string[];
+	let config: Config.IConfig;
+	let stdout: string[];
 
-  beforeEach(async () => {
-    stdout = [];
-    config = await getConfig();
-    jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
-    jest.spyOn(repl, 'start').mockReturnValue({ context: {}, on: jest.fn() } as unknown as repl.REPLServer);
-  });
+	beforeEach(async () => {
+		stdout = [];
+		config = await getConfig();
+		jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
+		jest
+			.spyOn(repl, 'start')
+			.mockReturnValue(({ context: {}, on: jest.fn() } as unknown) as repl.REPLServer);
+	});
 
-  describe('console', () => {
-    it('should create repl server', async () => {
-      await ConsoleCommand.run([], config);
-      expect(repl.start).toHaveBeenCalledWith('lisk > ');
-      expect(liskClient.apiClient.createWSClient).toHaveBeenCalledTimes(0);
-      expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledTimes(0);
-    });
-  });
+	describe('console', () => {
+		it('should create repl server', async () => {
+			await ConsoleCommand.run([], config);
+			expect(repl.start).toHaveBeenCalledWith({ prompt: `${config.pjson.name} > ` });
+			expect(liskClient.apiClient.createWSClient).toHaveBeenCalledTimes(0);
+			expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledTimes(0);
+		});
+	});
 
-  describe('console --api-ws=ws://localhost:8080/ws', () => {
-    it('should create repl server with ws client', async () => {
-      await ConsoleCommand.run(['--api-ws=ws://localhost:8080/ws'], config);
-      expect(liskClient.apiClient.createWSClient).toHaveBeenCalledWith('ws://localhost:8080/ws');
-      expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledTimes(0);
-    });
-  });
+	describe('console --api-ws=ws://localhost:8080/ws', () => {
+		it('should create repl server with ws client', async () => {
+			await ConsoleCommand.run(['--api-ws=ws://localhost:8080/ws'], config);
+			expect(liskClient.apiClient.createWSClient).toHaveBeenCalledWith('ws://localhost:8080/ws');
+			expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledTimes(0);
+		});
+	});
 
-  describe('console --api-ipc=~/.lisk/lisk-core', () => {
-    it('should create repl server with ipc client', async () => {
-      await ConsoleCommand.run(['--api-ipc=~/.lisk/lisk-core'], config);
-      expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledWith('~/.lisk/lisk-core');
-      expect(liskClient.apiClient.createWSClient).toHaveBeenCalledTimes(0);
-    });
-  });
+	describe('console --api-ipc=~/.lisk/lisk-core', () => {
+		it('should create repl server with ipc client', async () => {
+			await ConsoleCommand.run(['--api-ipc=~/.lisk/lisk-core'], config);
+			expect(liskClient.apiClient.createIPCClient).toHaveBeenCalledWith('~/.lisk/lisk-core');
+			expect(liskClient.apiClient.createWSClient).toHaveBeenCalledTimes(0);
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #6306 

### How was it solved?

- Introduced new console command

### How was it tested?

- Added unit tests

For manual testing
- Initialise console with lisk client only `./commander/bin/run console`
- Initialise console with lisk client and ws client `./commander/bin/run console --api-ws=ws://localhost:8080/ws`
- Initialise console with lisk client and ipc client `./commander/bin/run console --api-ipc=/path/to/client`

To use await in console
- `NODE_OPTIONS=--experimental-repl-await ./commander/bin/run console --api-ws=ws://localhost:8080/ws`
