### PR TITLE
With the sentry node setup, forging node do not get block on time - Closes #6300

### DIFF
--- a/elements/lisk-p2p/src/utils/select.ts
+++ b/elements/lisk-p2p/src/utils/select.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { ConnectionKind } from '../constants';
+import { ConnectionKind, PeerKind } from '../constants';
 // eslint-disable-next-line import/no-cycle
 import {
 	P2PPeerInfo,
@@ -85,6 +85,10 @@ export const selectPeersForSend = (
 			: false,
 	);
 
+	const fixedPeers = shuffledPeers.filter((peerInfo: P2PPeerInfo) =>
+		peerInfo.internalState ? peerInfo.internalState.peerKind === PeerKind.FIXED_PEER : false,
+	);
+
 	let shortestPeersList;
 	let longestPeersList;
 
@@ -99,8 +103,13 @@ export const selectPeersForSend = (
 	const selectedFirstKindPeers = shortestPeersList.slice(0, halfPeerLimit);
 	const remainingPeerLimit = peerLimit - selectedFirstKindPeers.length;
 	const selectedSecondKindPeers = longestPeersList.slice(0, remainingPeerLimit);
+	const selectedPeers = selectedFirstKindPeers.concat(selectedSecondKindPeers).concat(fixedPeers);
+	const uniquePeerIds = [...new Set(selectedPeers.map(p => p.peerId))];
+	const uniquePeers = uniquePeerIds.map(peerId =>
+		selectedPeers.find(p => p.peerId === peerId),
+	) as ReadonlyArray<P2PPeerInfo>;
 
-	return selectedFirstKindPeers.concat(selectedSecondKindPeers);
+	return uniquePeers;
 };
 
 export const selectPeersForConnection = (


### PR DESCRIPTION
### What was the problem?

This PR resolves #6300

### How was it solved?

- Must Include all fixed peers while sending the message
- Add forging node as fixed peer to the sentry nodes
- Add sentry nodes as fixed peers to forging node 

### How was it tested?

1. Created two VPS one for forging node and one for sentry node. 
2. Add sentry node IP info as fixed peers to forging node 
3. Set incoming connections limit to zero for the forging node
4. Set outgoing connections limit to one for the forging node
5. Add forging node as fixed peers for the sentry node 
6. Observed the block propagation for 20-25 blocks each time sentry node received the block its immediately been sent to forging node and forging node always stayed in sync. 
7. Added unit tests for peer selection logic 
