### PR TITLE
Forging fails when genesis block timestamp is in the future - Closes #6356

### DIFF
--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -385,7 +385,7 @@ export class Forger {
 
 		const validator = await this._chainModule.getValidator(currentTime);
 		if (!validator) {
-			this._logger.trace(
+			this._logger.debug(
 				{ currentSlot: this._chainModule.slots.getSlotNumber() },
 				'No validator is set for current time slot',
 			);
@@ -394,7 +394,7 @@ export class Forger {
 		const validatorKeypair = this._keypairs.get(validator.address);
 
 		if (validatorKeypair === undefined) {
-			this._logger.trace(
+			this._logger.debug(
 				{ currentSlot: this._chainModule.slots.getSlotNumber() },
 				'Waiting for delegate slot',
 			);

--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -387,7 +387,7 @@ export class Forger {
 		if (!validator) {
 			this._logger.trace(
 				{ currentSlot: this._chainModule.slots.getSlotNumber() },
-				'Waiting for delegate slot',
+				'No validator is set for current time slot',
 			);
 			return;
 		}

--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -384,6 +384,13 @@ export class Forger {
 		}
 
 		const validator = await this._chainModule.getValidator(currentTime);
+		if (!validator) {
+			this._logger.trace(
+				{ currentSlot: this._chainModule.slots.getSlotNumber() },
+				'Waiting for delegate slot',
+			);
+			return;
+		}
 		const validatorKeypair = this._keypairs.get(validator.address);
 
 		if (validatorKeypair === undefined) {

--- a/framework/test/unit/node/forger/forger.spec.ts
+++ b/framework/test/unit/node/forger/forger.spec.ts
@@ -949,14 +949,8 @@ describe('forger', () => {
 
 				chainModuleStub.slots.getSlotTime.mockReturnValue(futureSlotTime);
 
-				const data = await forgeModule.forge();
-
-				expect(data).toBeUndefined();
-				expect(loggerStub.trace).toHaveBeenCalledTimes(1);
-				expect(loggerStub.trace).toHaveBeenCalledWith(
-					{ currentSlot: 5 },
-					'Waiting for delegate slot',
-				);
+				await expect(forgeModule.forge()).toResolve();
+				expect(dbStub.put).not.toHaveBeenCalled();
 				dateNowMockFn.mockRestore();
 			});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6356

### How was it solved?

- Check for validator existence
 
### How was it tested?

- Added unit test
- Tested manually by updating devnet genesis block timestamp to future(100sec)