### PR TITLE
Fix unstable application url fetch - Closes #6362

### DIFF
--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
@@ -65,7 +65,7 @@ export const getApplicationUrl = async () => {
 		return 'ws://localhost:5000/ws';
 	}
 
-	const result = ((await fetch('/api/config')).json() as unknown) as { applicationUrl: string };
+	const result = (await (await fetch('/api/config')).json() as unknown) as { applicationUrl: string };
 
 	return result.applicationUrl;
 };

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
@@ -65,7 +65,9 @@ export const getApplicationUrl = async () => {
 		return 'ws://localhost:5000/ws';
 	}
 
-	const result = (await (await fetch('/api/config')).json() as unknown) as { applicationUrl: string };
-
+	const apiResponse = await fetch('/api/config');
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const result: { applicationUrl: string } = await apiResponse.json();
+	
 	return result.applicationUrl;
 };


### PR DESCRIPTION
### What was the problem?

This PR resolves #6362 

### How was it solved?

- Add `await` to `.json()` call's returning promise

### How was it tested?

- Check if dashboard plugin react app works in prod env with default ws port 8080, manually
- Check if dashboard plugin react app works in dev env with ws port 5000, manually
