### PR TITLE
Make application name configurable - Closes #6342

### DIFF
--- a/framework-plugins/lisk-framework-dashboard-plugin/src/plugin/dashboard_plugin.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/plugin/dashboard_plugin.ts
@@ -70,6 +70,7 @@ export class DashboardPlugin extends BasePlugin {
 		) as dashboardPluginOptions;
 		const config = {
 			applicationUrl: this._options.applicationUrl,
+			applicationName: this._options.applicationName,
 		};
 		const app = express();
 		app.use(express.static(join(__dirname, '../../build')));

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/plugin/defaults/config.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/plugin/defaults/config.ts
@@ -18,7 +18,7 @@ export const config = {
 	properties: {
 		applicationName: {
 			type: 'string',
-			description: 'Application name to be shown near Logo'
+			description: 'Application name to be shown near Logo',
 		},
 		applicationUrl: {
 			type: 'string',

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/plugin/defaults/config.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/plugin/defaults/config.ts
@@ -16,6 +16,10 @@ export const config = {
 	$id: '#/plugins/lisk-dashboard/config',
 	type: 'object',
 	properties: {
+		applicationName: {
+			type: 'string',
+			description: 'Application name to be shown near Logo'
+		},
 		applicationUrl: {
 			type: 'string',
 			format: 'uri',
@@ -36,5 +40,6 @@ export const config = {
 		applicationUrl: 'ws://localhost:8080/ws',
 		port: 4005,
 		host: '127.0.0.1',
+		applicationName: 'Lisk',
 	},
 };

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
@@ -208,7 +208,7 @@ const MainPage: React.FC = () => {
 	// Get config as whole
 	React.useEffect(() => {
 		const initConfig = async () => {
-			setDashboard({ ...dashboard, ...await getConfig() });
+			setDashboard({ ...dashboard, ...(await getConfig()) });
 		};
 
 		initConfig().catch(console.error);

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
@@ -39,7 +39,7 @@ import {
 	SendTransactionOptions,
 	CallActionOptions,
 } from '../types';
-import { getApplicationUrl, updateStatesOnNewBlock, updateStatesOnNewTransaction } from '../utils';
+import { getConfig, updateStatesOnNewBlock, updateStatesOnNewTransaction } from '../utils';
 import useRefState from '../utils/useRefState';
 import styles from './MainPage.module.scss';
 
@@ -73,6 +73,7 @@ const connectionErrorMessage = (
 interface DashboardState {
 	connected: boolean;
 	applicationUrl?: string;
+	applicationName?: string;
 }
 
 const MainPage: React.FC = () => {
@@ -187,6 +188,10 @@ const MainPage: React.FC = () => {
 		});
 	};
 
+	const loadApplicationName = async () => {
+		setDashboard({ ...dashboard, applicationName: await getConfig('applicationName')});
+	}
+
 	const generateNewAccount = () => {
 		const accountPassphrase = (passphrase.Mnemonic.generateMnemonic() as unknown) as string;
 		const { address, publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(
@@ -207,7 +212,7 @@ const MainPage: React.FC = () => {
 	// Get connection string
 	React.useEffect(() => {
 		const initConnectionStr = async () => {
-			setDashboard({ ...dashboard, applicationUrl: await getApplicationUrl() });
+			setDashboard({ ...dashboard, applicationUrl: await getConfig('applicationUrl') });
 		};
 
 		initConnectionStr().catch(console.error);
@@ -226,6 +231,7 @@ const MainPage: React.FC = () => {
 			subscribeEvents().catch(console.error);
 			loadNodeInfo().catch(console.error);
 			loadPeersInfo().catch(console.error);
+			loadApplicationName().catch(console.error);
 		}
 	}, [dashboard.connected]);
 
@@ -338,7 +344,7 @@ const MainPage: React.FC = () => {
 			<Grid container rowSpacing={6}>
 				<Grid row alignItems={'center'}>
 					<Grid xs={6} md={8}>
-						<Logo name={'Lisk'} />
+						<Logo name={dashboard.applicationName} />
 					</Grid>
 					<Grid xs={6} md={4} textAlign={'right'}>
 						<Button

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
@@ -188,10 +188,6 @@ const MainPage: React.FC = () => {
 		});
 	};
 
-	const loadApplicationName = async () => {
-		setDashboard({ ...dashboard, applicationName: await getConfig('applicationName')});
-	}
-
 	const generateNewAccount = () => {
 		const accountPassphrase = (passphrase.Mnemonic.generateMnemonic() as unknown) as string;
 		const { address, publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(
@@ -209,13 +205,13 @@ const MainPage: React.FC = () => {
 		setShowAccount(newAccount);
 	};
 
-	// Get connection string
+	// Get config as whole
 	React.useEffect(() => {
-		const initConnectionStr = async () => {
-			setDashboard({ ...dashboard, applicationUrl: await getConfig('applicationUrl') });
+		const initConfig = async () => {
+			setDashboard({ ...dashboard, ...await getConfig() });
 		};
 
-		initConnectionStr().catch(console.error);
+		initConfig().catch(console.error);
 	}, []);
 
 	// Init client
@@ -231,7 +227,6 @@ const MainPage: React.FC = () => {
 			subscribeEvents().catch(console.error);
 			loadNodeInfo().catch(console.error);
 			loadPeersInfo().catch(console.error);
-			loadApplicationName().catch(console.error);
 		}
 	}, [dashboard.connected]);
 

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
@@ -70,14 +70,14 @@ export const updateStatesOnNewTransaction = (
 	return [transaction, ...unconfirmedTransactions].slice(-1 * MAX_TRANSACTIONS) as Transaction[];
 };
 
-export const getConfig = async (prop: keyof Config) => {
+export const getConfig = async () => {
 	if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-		return configDevEnvValues[prop];
+		return configDevEnvValues;
 	}
 
 	const apiResponse = await fetch('/api/config');
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const result: Config = await apiResponse.json();
 	
-	return result[prop];
+	return result;
 };

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
@@ -14,6 +14,16 @@
 import { apiClient } from '@liskhq/lisk-client';
 import { Block, Transaction } from '../types';
 
+interface Config {
+	applicationUrl: string;
+	applicationName: string;
+}
+
+const configDevEnvValues: Config = {
+	applicationUrl: 'ws://localhost:5000/ws',
+	applicationName: 'Lisk',
+}
+
 const MAX_BLOCKS = 103 * 3;
 const MAX_TRANSACTIONS = 150;
 
@@ -60,12 +70,14 @@ export const updateStatesOnNewTransaction = (
 	return [transaction, ...unconfirmedTransactions].slice(-1 * MAX_TRANSACTIONS) as Transaction[];
 };
 
-export const getApplicationUrl = async () => {
+export const getConfig = async (prop: keyof Config) => {
 	if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-		return 'ws://localhost:5000/ws';
+		return configDevEnvValues[prop];
 	}
 
-	const result = ((await fetch('/api/config')).json() as unknown) as { applicationUrl: string };
-
-	return result.applicationUrl;
+	const apiResponse = await fetch('/api/config');
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+	const result: Config = await apiResponse.json();
+	
+	return result[prop];
 };

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
@@ -22,7 +22,7 @@ interface Config {
 const configDevEnvValues: Config = {
 	applicationUrl: 'ws://localhost:5000/ws',
 	applicationName: 'Lisk',
-}
+};
 
 const MAX_BLOCKS = 103 * 3;
 const MAX_TRANSACTIONS = 150;
@@ -78,6 +78,6 @@ export const getConfig = async () => {
 	const apiResponse = await fetch('/api/config');
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const result: Config = await apiResponse.json();
-	
+
 	return result;
 };

--- a/framework-plugins/lisk-framework-dashboard-plugin/test/unit/plugin/__snapshots__/dashboard_plugin.spec.ts.snap
+++ b/framework-plugins/lisk-framework-dashboard-plugin/test/unit/plugin/__snapshots__/dashboard_plugin.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`DashboardPlugin constructor should load default config 1`] = `
 Object {
+  "applicationName": "Lisk",
   "applicationUrl": "ws://localhost:8080/ws",
   "host": "127.0.0.1",
   "port": 4005,
@@ -12,11 +13,16 @@ exports[`DashboardPlugin defaults should return valid config schema with default
 Object {
   "$id": "#/plugins/lisk-dashboard/config",
   "default": Object {
+    "applicationName": "Lisk",
     "applicationUrl": "ws://localhost:8080/ws",
     "host": "127.0.0.1",
     "port": 4005,
   },
   "properties": Object {
+    "applicationName": Object {
+      "description": "Application name to be shown near Logo",
+      "type": "string",
+    },
     "applicationUrl": Object {
       "description": "URL to connect",
       "format": "uri",


### PR DESCRIPTION
### What was the problem?

This PR resolves #6342 

### How was it solved?

- Created a general Config retreiver along with an interface and a default value container
- In react app we fetch config for application after connection along with other loading functions
- Loaded application name is directly passed into Logo component since it has a protection of empty prop

### How was it tested?
- `yarn start:web` with lisk-core api-ws-port 5000 to see dev env values
- Running prod lisk-core to see prod default config values
- Running prod lisk-core with extra config to see config affects the react app
