### PR TITLE
Update recent event widget body to render limited data - Closes #6355

### DIFF
--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/RecentEventWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/RecentEventWidget.tsx
@@ -61,9 +61,7 @@ const RecentEventWidget: React.FC<Props> = props => {
 						<Text type={'h3'}>{name}</Text>
 						<br />
 						<Text type={'p'} color="yellow">
-							<pre className={styles['recent-events-data']}>
-								{JSON.stringify(data, null, '\t')}
-							</pre>
+							<pre className={styles['recent-events-data']}>{JSON.stringify(data, null, '\t')}</pre>
 						</Text>
 					</Box>
 				))}

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/RecentEventWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/RecentEventWidget.tsx
@@ -61,7 +61,9 @@ const RecentEventWidget: React.FC<Props> = props => {
 						<Text type={'h3'}>{name}</Text>
 						<br />
 						<Text type={'p'} color="yellow">
-							{JSON.stringify(data, null, '\t')}
+							<pre className={styles['recent-events-data']}>
+								{JSON.stringify(data, null, '\t')}
+							</pre>
 						</Text>
 					</Box>
 				))}

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/Widgets.module.scss
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/Widgets.module.scss
@@ -32,3 +32,9 @@
 		display: none;
 	}
 }
+
+.recent-events-data {
+	padding: 10px 20px;
+	word-wrap: break-word;
+	white-space: pre-wrap;
+}

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
@@ -63,6 +63,7 @@ const nodeInfoDefaultValue: NodeInfo = {
 		baseFees: [],
 	},
 };
+const MAX_RECENT_EVENT = 100;
 
 const connectionErrorMessage = (
 	<Text type={'h3'}>
@@ -145,7 +146,8 @@ const MainPage: React.FC = () => {
 		(name: string, event?: Record<string, unknown>) => {
 			if (eventSubscriptionListRef.current.includes(name)) {
 				eventsDataRef.current.unshift({ name, data: event ?? {} });
-				setEventsData(eventsDataRef.current);
+				const recentEventsData = eventsDataRef.current.slice(-1 * MAX_RECENT_EVENT) ;
+				setEventsData(recentEventsData);
 			}
 		},
 		[dashboard.connected],

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
@@ -146,7 +146,7 @@ const MainPage: React.FC = () => {
 		(name: string, event?: Record<string, unknown>) => {
 			if (eventSubscriptionListRef.current.includes(name)) {
 				eventsDataRef.current.unshift({ name, data: event ?? {} });
-				const recentEventsData = eventsDataRef.current.slice(-1 * MAX_RECENT_EVENT) ;
+				const recentEventsData = eventsDataRef.current.slice(-1 * MAX_RECENT_EVENT);
 				setEventsData(recentEventsData);
 			}
 		},


### PR DESCRIPTION
### What was the problem?

This PR resolves #6355 

### How was it solved?

- Update recent events widget to show last 100 events
- Update recent events widget to show json in pretty format

### How was it tested?

- start web, select events and observe UI