### PR TITLE
Fix random seed calculation - Closes #6381

### DIFF
--- a/framework/src/modules/dpos/random_seed.ts
+++ b/framework/src/modules/dpos/random_seed.ts
@@ -91,6 +91,11 @@ const selectSeedReveals = ({
 
 	for (let i = fromHeight; i >= toHeight; i -= 1) {
 		const header = headersMap[i];
+		// If header does not exist in map, consider the seed reveal is invalid
+		// This happens when height is before genesis block (regenesis) or negative height in early round
+		if (!header) {
+			continue;
+		}
 		const blockRound = rounds.calcRound(header.height);
 
 		const lastForgedBlock = findPreviousHeaderOfDelegate(
@@ -123,28 +128,11 @@ export const generateRandomSeeds = (
 ): FixedLengthArray<RandomSeed, 2> => {
 	// Middle range of a round to validate
 	const middleThreshold = Math.floor(rounds.blocksPerRound / 2);
-	const lastBlockHeight = headers[0].height;
 	const startOfRound = rounds.calcRoundStartHeight(round);
 	const middleOfRound = rounds.calcRoundMiddleHeight(round);
 	const startOfLastRound = rounds.calcRoundStartHeight(round - 1);
 	const endOfLastRound = rounds.calcRoundEndHeight(round - 1);
 	const startOfSecondLastRound = rounds.calcRoundStartHeight(round - 2);
-
-	if (lastBlockHeight < middleOfRound) {
-		throw new Error(
-			`Random seed can't be calculated earlier in a round. Wait till you pass middle of round. Current height: ${lastBlockHeight.toString()}`,
-		);
-	}
-
-	if (round === 1) {
-		debug('Returning static value because current round is 1');
-		const randomSeed1ForFirstRound = strippedHash(
-			intToBuffer(middleThreshold + 1, NUMBER_BYTE_SIZE),
-		);
-		const randomSeed2ForFirstRound = strippedHash(intToBuffer(0, NUMBER_BYTE_SIZE));
-
-		return [randomSeed1ForFirstRound, randomSeed2ForFirstRound];
-	}
 
 	/**
 	 * We need to build a map for current and last two rounds. To previously forged

--- a/framework/src/modules/dpos/rounds.ts
+++ b/framework/src/modules/dpos/rounds.ts
@@ -28,7 +28,7 @@ export class Rounds {
 	}
 
 	public calcRoundEndHeight(round: number): number {
-		return (round < 1 ? 1 : round) * this.blocksPerRound;
+		return (round < 1 ? 0 : round) * this.blocksPerRound;
 	}
 
 	public calcRoundMiddleHeight(round: number): number {

--- a/framework/test/unit/modules/dpos/random_seed.spec.ts
+++ b/framework/test/unit/modules/dpos/random_seed.spec.ts
@@ -18,8 +18,6 @@ import * as randomSeedsMultipleRounds from '../../../fixtures/dpos_random_seed_g
 import * as randomSeedsInvalidSeedReveal from '../../../fixtures/dpos_random_seed_generation/dpos_random_seed_generation_invalid_seed_reveal.json';
 import * as randomSeedsNotForgedEarlier from '../../../fixtures/dpos_random_seed_generation/dpos_random_seed_generation_not_forged_earlier.json';
 
-import * as randomSeedNotPassedMiddle from '../../../fixtures/dpos_random_seed_generation/dpos_random_seed_generation_not_passed_middle_of_round.json';
-
 import { generateRandomSeeds } from '../../../../src/modules/dpos/random_seed';
 import { Rounds } from '../../../../src/modules/dpos/rounds';
 
@@ -49,22 +47,6 @@ describe('random_seed', () => {
 	];
 
 	describe('generateRandomSeeds', () => {
-		it('should throw error if called before middle of the round', () => {
-			// Arrange
-			const { config, input } = randomSeedNotPassedMiddle.testCases[0] as any;
-			rounds = new Rounds({
-				blocksPerRound: config.blocksPerRound,
-			});
-			const round = rounds.calcRound(input.blocks[input.blocks.length - 1].height);
-			const headers = generateHeadersFromTest(input.blocks);
-
-			// Act & Assert
-			expect(() => generateRandomSeeds(round, rounds, headers)).toThrow(
-				// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-				`Random seed can't be calculated earlier in a round. Wait till you pass middle of round. Current height: ${input.blocks.length}`,
-			);
-		});
-
 		describe.each(testCases.map(testCase => [testCase.description, testCase]))(
 			'%s',
 			(_description, testCase) => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6381 

### How was it solved?

- Remove the special handling of `round === 1` because if the init round > 1, this will never be called. Also, it should be consistent with the case where all seed reveal was invalid
- if the block does not exist in memory, it skips the check instead of throwing. This happens on check before genesis block height

### How was it tested?

Sync with migrated testnet node