### PR TITLE
Update faucet config to use API - Closes #6384

### DIFF
--- a/framework-plugins/lisk-framework-dashboard-plugin/package.json
+++ b/framework-plugins/lisk-framework-dashboard-plugin/package.json
@@ -35,7 +35,7 @@
 		"build": "npm run build:node && npm run build:web",
 		"build:node": "tsc",
 		"build:web": "node scripts/build.js --jsx react",
-		"start:web": "node scripts/start.js",
+		"start:web": "NODE_ENV=development node scripts/start.js",
 		"build:check": "node -e \"require('./dist-node')\"",
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/utils/index.ts
@@ -20,7 +20,7 @@ interface Config {
 }
 
 const configDevEnvValues: Config = {
-	applicationUrl: 'ws://localhost:5000/ws',
+	applicationUrl: 'ws://localhost:8080/ws',
 	applicationName: 'Lisk',
 };
 
@@ -74,7 +74,7 @@ export const updateStatesOnNewTransaction = (
 };
 
 export const getConfig = async () => {
-	if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+	if (process.env.NODE_ENV === 'development') {
 		return configDevEnvValues;
 	}
 

--- a/framework-plugins/lisk-framework-faucet-plugin/package.json
+++ b/framework-plugins/lisk-framework-faucet-plugin/package.json
@@ -36,7 +36,7 @@
 		"build": "npm run build:node && npm run build:web",
 		"build:node": "tsc",
 		"build:web": "node scripts/build.js --jsx react",
-		"start:web": "node scripts/start.js",
+		"start:web": "NODE_ENV=development node scripts/start.js",
 		"build:check": "node -e \"require('./dist-node')\"",
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},

--- a/framework-plugins/lisk-framework-faucet-plugin/public/index.html
+++ b/framework-plugins/lisk-framework-faucet-plugin/public/index.html
@@ -27,7 +27,6 @@
 </head>
 
 <body>
-  <script src="%PUBLIC_URL%/config.js"></script>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
   <!--

--- a/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
@@ -33,7 +33,6 @@ import {
 import * as express from 'express';
 import { join } from 'path';
 import { Server } from 'http';
-import { writeFileSync } from 'fs';
 import * as defaults from './defaults';
 import { FaucetPluginOptions, State } from './types';
 
@@ -194,12 +193,8 @@ export class FaucetPlugin extends BasePlugin {
 			captchaSitekey: this._options.captchaSitekey,
 			logoURL: this._options.logoURL,
 		};
-		// Write config file for faucet
-		writeFileSync(
-			join(__dirname, '../../build', 'config.js'),
-			`window.FAUCET_CONFIG = ${JSON.stringify(config)}`,
-		);
 		const app = express();
+		app.get('/api/config', (_req, res) => res.json(config));
 		app.use(express.static(join(__dirname, '../../build')));
 		this._server = app.listen(this._options.port, this._options.host);
 	}

--- a/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
@@ -125,8 +125,8 @@ export const App: React.FC = () => {
 				<div className={styles.main}>
 					<h1>All tokens are for testing purposes only</h1>
 					<h2>
-						Please enter your address to receive {config.amount} {config.tokenPrefix.toLocaleUpperCase()} tokens for
-						free
+						Please enter your address to receive {config.amount}{' '}
+						{config.tokenPrefix.toLocaleUpperCase()} tokens for free
 					</h2>
 					<div className={styles.inputArea}>
 						<div className={styles.input}>


### PR DESCRIPTION
### What was the problem?

This PR resolves #6384 

### How was it solved?
- Update to fetch config from API in faucet
- Update default application port to 8080 (which is default in framework)


### How was it tested?

- Run `npm run start:web`
- Connect to core and run the plugin

Both should connect to the core properly
