### PR TITLE
Expose BaseIPCClientCommand from the lisk-commander - Closes #6383

### DIFF
--- a/commander/src/index.ts
+++ b/commander/src/index.ts
@@ -13,6 +13,7 @@
  *
  */
 export { run } from '@oclif/command';
+export { BaseIPCClientCommand } from './bootstrapping/commands/base_ipc_client';
 export {
 	AccountCreateCommand,
 	AccountGetCommand,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6383

### How was it solved?

- Exposed the `BaseIPCCommand` from `lisk-commander` package. 

### How was it tested?

- Run all unit tests
