### PR TITLE
Update init to use low hash onion and passphrase encryption - Closes #6380

### DIFF
--- a/commander/src/bootstrapping/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/commands/genesis-block/create.ts
@@ -97,7 +97,15 @@ export abstract class BaseGenesisBlockCommand extends Command {
 
 	async run(): Promise<void> {
 		const {
-			flags: { output, accounts, validators, 'token-distribution': tokenDistribution, 'validators-hash-onion-count': validatorsHashOnionCount, 'validators-hash-onion-distance': validatorsHashOnionDistance, 'validators-passphrase-encryption-iterations': validatorsPassphraseEncryptionIterations },
+			flags: {
+				output,
+				accounts,
+				validators,
+				'token-distribution': tokenDistribution,
+				'validators-hash-onion-count': validatorsHashOnionCount,
+				'validators-hash-onion-distance': validatorsHashOnionDistance,
+				'validators-passphrase-encryption-iterations': validatorsPassphraseEncryptionIterations,
+			},
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		} = this.parse(BaseGenesisBlockCommand);
 
@@ -141,7 +149,11 @@ export abstract class BaseGenesisBlockCommand extends Command {
 			const info = {
 				// TODO: use a better password, user sourced using flag
 				encryptedPassphrase: cryptography.stringifyEncryptedPassphrase(
-					cryptography.encryptPassphraseWithPassword(delegate.passphrase, password, validatorsPassphraseEncryptionIterations),
+					cryptography.encryptPassphraseWithPassword(
+						delegate.passphrase,
+						password,
+						validatorsPassphraseEncryptionIterations,
+					),
 				),
 				hashOnion: {
 					count: validatorsHashOnionCount,

--- a/commander/src/bootstrapping/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/commands/genesis-block/create.ts
@@ -87,7 +87,7 @@ export abstract class BaseGenesisBlockCommand extends Command {
 		}),
 		'validators-hash-onion-count': flagParser.integer({
 			description: 'Number of hashes to produce for each hash-onion',
-			default: 10000,
+			default: 100000,
 		}),
 		'validators-hash-onion-distance': flagParser.integer({
 			description: 'Distance between each hashes for hash-onion',

--- a/commander/src/bootstrapping/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/commands/genesis-block/create.ts
@@ -81,11 +81,23 @@ export abstract class BaseGenesisBlockCommand extends Command {
 			description: 'Amount of tokens distributed to each account',
 			default: 10000000,
 		}),
+		'validators-passphrase-encryption-iterations': flagParser.integer({
+			description: 'Number of iterations to use for passphrase encryption',
+			default: 1000000,
+		}),
+		'validators-hash-onion-count': flagParser.integer({
+			description: 'Number of hashes to produce for each hash-onion',
+			default: 10000,
+		}),
+		'validators-hash-onion-distance': flagParser.integer({
+			description: 'Distance between each hashes for hash-onion',
+			default: 1000,
+		}),
 	};
 
 	async run(): Promise<void> {
 		const {
-			flags: { output, accounts, validators, 'token-distribution': tokenDistribution },
+			flags: { output, accounts, validators, 'token-distribution': tokenDistribution, 'validators-hash-onion-count': validatorsHashOnionCount, 'validators-hash-onion-distance': validatorsHashOnionDistance, 'validators-passphrase-encryption-iterations': validatorsPassphraseEncryptionIterations },
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		} = this.parse(BaseGenesisBlockCommand);
 
@@ -122,8 +134,6 @@ export abstract class BaseGenesisBlockCommand extends Command {
 			total: validators - 1,
 		});
 		const onionSeed = cryptography.generateHashOnionSeed();
-		const onionCount = 10000;
-		const onionDistance = 1000;
 		const password = createMnemonicPassphrase();
 		const passwordList = { defaultPassword: password };
 
@@ -131,13 +141,13 @@ export abstract class BaseGenesisBlockCommand extends Command {
 			const info = {
 				// TODO: use a better password, user sourced using flag
 				encryptedPassphrase: cryptography.stringifyEncryptedPassphrase(
-					cryptography.encryptPassphraseWithPassword(delegate.passphrase, password),
+					cryptography.encryptPassphraseWithPassword(delegate.passphrase, password, validatorsPassphraseEncryptionIterations),
 				),
 				hashOnion: {
-					count: onionCount,
-					distance: onionDistance,
+					count: validatorsHashOnionCount,
+					distance: validatorsHashOnionDistance,
 					hashes: cryptography
-						.hashOnion(onionSeed, onionCount, onionDistance)
+						.hashOnion(onionSeed, validatorsHashOnionCount, validatorsHashOnionDistance)
 						.map(buf => buf.toString('hex')),
 				},
 				address: delegate.address,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -82,6 +82,12 @@ export default class InitGenerator extends Generator {
 			'genesis-block:create',
 			'--output',
 			'config/default',
+			'--validators-passphrase-encryption-iterations',
+			'1',
+			'--validators-hash-onion-count',
+			'10000',
+			'--validators-hash-onion-distance',
+			'1000',
 		]);
 		this.spawnCommandSync(`${this.destinationPath('bin/run')}`, [
 			'config:create',


### PR DESCRIPTION
### What was the problem?

This PR resolves #6380 

### How was it solved?

- Update to use iteration 1 for bootstrap application default forger passphrase encryption
- Update to use 10000 hash onions with 1000 distance for default forger hash onion

### How was it tested?

```
this.spawnCommandSync(`yarn`, [
			'link',
			'lisk-commander',
		]);
```
add above before the genesis block creation and generate new application
