### PR TITLE
Start command network flag shows invalid error message - Closes #6408, #6409

### DIFF
--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -62,17 +62,21 @@ export abstract class StartCommand extends Command {
 		}),
 		'api-ipc': flagParser.boolean({
 			description:
-				'Enable IPC communication. This will load plugins as a child process and communicate over IPC.',
+				'Enable IPC communication. This will load plugins as a child process and communicate over IPC. Environment variable "LISK_API_IPC" can also be used.',
+			env: 'LISK_API_IPC',
 			default: false,
 			exclusive: ['api-ws'],
 		}),
 		'api-ws': flagParser.boolean({
-			description: 'Enable websocket communication for api-client.',
+			description:
+				'Enable websocket communication for api-client. Environment variable "LISK_API_WS" can also be used.',
+			env: 'LISK_API_WS',
 			default: false,
 			exclusive: ['api-ipc'],
 		}),
 		'api-ws-port': flagParser.integer({
-			description: 'Port to be used for api-client websocket. Environment variable "LISK_API_WS_PORT" can also be used.',
+			description:
+				'Port to be used for api-client websocket. Environment variable "LISK_API_WS_PORT" can also be used.',
 			env: 'LISK_API_WS_PORT',
 			dependsOn: ['api-ws'],
 		}),
@@ -106,7 +110,9 @@ export abstract class StartCommand extends Command {
 		const defaultNetworkConfigDir = getConfigDirs(this.getApplicationConfigDir(), true);
 		if (!defaultNetworkConfigDir.includes(flags.network)) {
 			this.error(
-				`Network ${flags.network} is not supported, supported networks: ${defaultNetworkConfigDir.join(',')}.`,
+				`Network ${
+					flags.network
+				} is not supported, supported networks: ${defaultNetworkConfigDir.join(',')}.`,
 			);
 		}
 

--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -33,7 +33,7 @@ import {
 
 const LOG_OPTIONS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 export abstract class StartCommand extends Command {
-	static description = 'Start Blockchain Client.';
+	static description = 'Start Blockchain Node.';
 
 	static examples = [
 		'start',

--- a/commander/src/bootstrapping/commands/start.ts
+++ b/commander/src/bootstrapping/commands/start.ts
@@ -33,7 +33,7 @@ import {
 
 const LOG_OPTIONS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 export abstract class StartCommand extends Command {
-	static description = 'Start Lisk Core Node.';
+	static description = 'Start Blockchain Client.';
 
 	static examples = [
 		'start',
@@ -72,7 +72,8 @@ export abstract class StartCommand extends Command {
 			exclusive: ['api-ipc'],
 		}),
 		'api-ws-port': flagParser.integer({
-			description: 'Port to be used for api-client websocket.',
+			description: 'Port to be used for api-client websocket. Environment variable "LISK_API_WS_PORT" can also be used.',
+			env: 'LISK_API_WS_PORT',
 			dependsOn: ['api-ws'],
 		}),
 		'console-log': flagParser.string({
@@ -105,9 +106,7 @@ export abstract class StartCommand extends Command {
 		const defaultNetworkConfigDir = getConfigDirs(this.getApplicationConfigDir(), true);
 		if (!defaultNetworkConfigDir.includes(flags.network)) {
 			this.error(
-				`Network must be one of ${defaultNetworkConfigDir.join(',')} but received ${
-					flags.network
-				}.`,
+				`Network ${flags.network} is not supported, supported networks: ${defaultNetworkConfigDir.join(',')}.`,
 			);
 		}
 

--- a/commander/test/bootstrapping/commands/start.spec.ts
+++ b/commander/test/bootstrapping/commands/start.spec.ts
@@ -114,7 +114,7 @@ describe('start', () => {
 	describe('when unknown network is specified', () => {
 		it('should throw an error', async () => {
 			await expect(StartCommandExtended.run(['-n', 'unknown'], config)).rejects.toThrow(
-				'Network must be one of default but received unknown.',
+				'Network unknown is not supported, supported networks: default.',
 			);
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6408, #6409

### How was it solved?

- Updated description, env and error message

### How was it tested?

- `./bin/run init ./sample_lisk_app --registry https://npm.lisk.io`
- `./bin/run start --network=testme`
