### PR TITLE
Add alphabet validation for plugin alias - Closes #6394

### DIFF
--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/asset_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/asset_generator.ts
@@ -17,6 +17,7 @@
 import { join } from 'path';
 import { Project } from 'ts-morph';
 import * as Generator from 'yeoman-generator';
+import { camelToUpperCamel, camelToSnake } from '../../../../utils/convert';
 
 interface AssetGeneratorOptions extends Generator.GeneratorOptions {
 	moduleName: string;
@@ -27,8 +28,10 @@ interface AssetGeneratorOptions extends Generator.GeneratorOptions {
 export default class AssetGenerator extends Generator {
 	protected _moduleClass: string;
 	protected _moduleName: string;
+	protected _moduleFileName: string;
 	protected _assetName: string;
 	protected _assetID: number;
+	protected _assetFileName: string;
 	protected _templatePath: string;
 	protected _assetClass: string;
 
@@ -38,11 +41,11 @@ export default class AssetGenerator extends Generator {
 		this._moduleName = opts.moduleName;
 		this._assetName = opts.assetName;
 		this._assetID = opts.assetID;
+		this._moduleFileName = camelToSnake(this._moduleName);
 		this._templatePath = join(__dirname, '..', 'templates', 'asset');
-		this._assetClass = `${this._assetName.charAt(0).toUpperCase() + this._assetName.slice(1)}Asset`;
-		this._moduleClass = `${
-			this._moduleName.charAt(0).toUpperCase() + this._moduleName.slice(1)
-		}Module`;
+		this._assetClass = `${camelToUpperCamel(this._assetName)}Asset`;
+		this._assetFileName = camelToSnake(this._assetName);
+		this._moduleClass = `${camelToUpperCamel(this._moduleName)}Module`;
 	}
 
 	public writing(): void {
@@ -50,7 +53,7 @@ export default class AssetGenerator extends Generator {
 		this.fs.copyTpl(
 			`${this._templatePath}/src/app/modules/assets/asset.ts`,
 			this.destinationPath(
-				`src/app/modules/${this._moduleName}/assets/${this._assetName}_asset.ts`,
+				`src/app/modules/${this._moduleFileName}/assets/${this._assetFileName}_asset.ts`,
 			),
 			{
 				moduleName: this._moduleName,
@@ -66,7 +69,7 @@ export default class AssetGenerator extends Generator {
 		this.fs.copyTpl(
 			`${this._templatePath}/test/unit/modules/assets/asset.spec.ts`,
 			this.destinationPath(
-				`test/unit/modules/${this._moduleName}/assets/${this._assetName}_asset.spec.ts`,
+				`test/unit/modules/${this._moduleFileName}/assets/${this._assetFileName}_asset.spec.ts`,
 			),
 			{
 				moduleName: this._moduleName,
@@ -86,12 +89,12 @@ export default class AssetGenerator extends Generator {
 		project.addSourceFilesAtPaths('src/app/**/*.ts');
 
 		const moduleFile = project.getSourceFileOrThrow(
-			`src/app/modules/${this._moduleName}/${this._moduleName}_module.ts`,
+			`src/app/modules/${this._moduleFileName}/${this._moduleFileName}_module.ts`,
 		);
 
 		moduleFile.addImportDeclaration({
 			namedImports: [this._assetClass],
-			moduleSpecifier: `./assets/${this._assetName}`,
+			moduleSpecifier: `./assets/${this._assetFileName}`,
 		});
 
 		const moduleClass = moduleFile.getClassOrThrow(this._moduleClass);

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/asset_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/asset_generator.ts
@@ -17,7 +17,7 @@
 import { join } from 'path';
 import { Project } from 'ts-morph';
 import * as Generator from 'yeoman-generator';
-import { camelToUpperCamel, camelToSnake } from '../../../../utils/convert';
+import { camelToPascal, camelToSnake } from '../../../../utils/convert';
 
 interface AssetGeneratorOptions extends Generator.GeneratorOptions {
 	moduleName: string;
@@ -43,9 +43,9 @@ export default class AssetGenerator extends Generator {
 		this._assetID = opts.assetID;
 		this._moduleFileName = camelToSnake(this._moduleName);
 		this._templatePath = join(__dirname, '..', 'templates', 'asset');
-		this._assetClass = `${camelToUpperCamel(this._assetName)}Asset`;
+		this._assetClass = `${camelToPascal(this._assetName)}Asset`;
 		this._assetFileName = camelToSnake(this._assetName);
-		this._moduleClass = `${camelToUpperCamel(this._moduleName)}Module`;
+		this._moduleClass = `${camelToPascal(this._moduleName)}Module`;
 	}
 
 	public writing(): void {

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
@@ -45,7 +45,9 @@ export default class ModuleGenerator extends Generator {
 		// Writing module file
 		this.fs.copyTpl(
 			`${this._templatePath}/src/app/modules/module.ts`,
-			this.destinationPath(`src/app/modules/${this._moduleFileName}/${this._moduleFileName}_module.ts`),
+			this.destinationPath(
+				`src/app/modules/${this._moduleFileName}/${this._moduleFileName}_module.ts`,
+			),
 			{
 				moduleName: this._moduleName,
 				moduleID: this._moduleID,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
@@ -17,7 +17,7 @@
 import { join } from 'path';
 import { Project, SyntaxKind } from 'ts-morph';
 import * as Generator from 'yeoman-generator';
-import { camelToSnake, camelToUpperCamel } from '../../../../utils/convert';
+import { camelToSnake, camelToPascal } from '../../../../utils/convert';
 
 interface ModuleGeneratorOptions extends Generator.GeneratorOptions {
 	moduleName: string;
@@ -38,7 +38,7 @@ export default class ModuleGenerator extends Generator {
 		this._moduleName = (this.options as ModuleGeneratorOptions).moduleName;
 		this._moduleFileName = camelToSnake(this._moduleName);
 		this._moduleID = (this.options as ModuleGeneratorOptions).moduleID;
-		this._moduleClass = `${camelToUpperCamel(this._moduleName)}Module`;
+		this._moduleClass = `${camelToPascal(this._moduleName)}Module`;
 	}
 
 	public writing(): void {

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
@@ -17,6 +17,7 @@
 import { join } from 'path';
 import { Project, SyntaxKind } from 'ts-morph';
 import * as Generator from 'yeoman-generator';
+import { camelToSnake, camelToUpperCamel } from '../../../../utils/convert';
 
 interface ModuleGeneratorOptions extends Generator.GeneratorOptions {
 	moduleName: string;
@@ -26,6 +27,7 @@ interface ModuleGeneratorOptions extends Generator.GeneratorOptions {
 export default class ModuleGenerator extends Generator {
 	protected _moduleName: string;
 	protected _moduleClass: string;
+	protected _moduleFileName: string;
 	protected _moduleID: string;
 	protected _templatePath: string;
 
@@ -34,17 +36,16 @@ export default class ModuleGenerator extends Generator {
 
 		this._templatePath = join(__dirname, '..', 'templates', 'module');
 		this._moduleName = (this.options as ModuleGeneratorOptions).moduleName;
+		this._moduleFileName = camelToSnake(this._moduleName);
 		this._moduleID = (this.options as ModuleGeneratorOptions).moduleID;
-		this._moduleClass = `${
-			this._moduleName.charAt(0).toUpperCase() + this._moduleName.slice(1)
-		}Module`;
+		this._moduleClass = `${camelToUpperCamel(this._moduleName)}Module`;
 	}
 
 	public writing(): void {
 		// Writing module file
 		this.fs.copyTpl(
 			`${this._templatePath}/src/app/modules/module.ts`,
-			this.destinationPath(`src/app/modules/${this._moduleName}/${this._moduleName}_module.ts`),
+			this.destinationPath(`src/app/modules/${this._moduleFileName}/${this._moduleFileName}_module.ts`),
 			{
 				moduleName: this._moduleName,
 				moduleID: this._moduleID,
@@ -58,7 +59,7 @@ export default class ModuleGenerator extends Generator {
 		this.fs.copyTpl(
 			`${this._templatePath}/test/unit/modules/module.spec.ts`,
 			this.destinationPath(
-				`test/unit/modules/${this._moduleName}/${this._moduleName}_module.spec.ts`,
+				`test/unit/modules/${this._moduleFileName}/${this._moduleFileName}_module.spec.ts`,
 			),
 			{
 				moduleClass: this._moduleClass,
@@ -79,7 +80,7 @@ export default class ModuleGenerator extends Generator {
 
 		modulesFile.addImportDeclaration({
 			namedImports: [this._moduleClass],
-			moduleSpecifier: `./modules/${this._moduleName}/${this._moduleName}_module`,
+			moduleSpecifier: `./modules/${this._moduleFileName}/${this._moduleFileName}_module`,
 		});
 
 		const registerFunction = modulesFile
@@ -87,7 +88,7 @@ export default class ModuleGenerator extends Generator {
 			.getInitializerIfKindOrThrow(SyntaxKind.ArrowFunction);
 
 		registerFunction.setBodyText(
-			`${registerFunction.getBodyText()} _app.registerModule(${this._moduleClass});`,
+			`${registerFunction.getBodyText()}\napp.registerModule(${this._moduleClass});`,
 		);
 
 		modulesFile.organizeImports();

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/plugin_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/plugin_generator.ts
@@ -80,7 +80,9 @@ export default class PluginGenerator extends Generator {
 		// Create plugin
 		this.fs.copyTpl(
 			`${this._templatePath}/src/app/plugins/plugin.ts`,
-			this.destinationPath(`src/app/plugins/${this._pluginFileName}/${this._pluginFileName}_plugin.ts`),
+			this.destinationPath(
+				`src/app/plugins/${this._pluginFileName}/${this._pluginFileName}_plugin.ts`,
+			),
 			{
 				alias: this._alias,
 				className: this._className,
@@ -95,7 +97,9 @@ export default class PluginGenerator extends Generator {
 		// Create unit tests
 		this.fs.copyTpl(
 			`${this._templatePath}/test/unit/plugins/plugin.spec.ts`,
-			this.destinationPath(`test/unit/plugins/${this._pluginFileName}/${this._pluginFileName}_plugin.spec.ts`),
+			this.destinationPath(
+				`test/unit/plugins/${this._pluginFileName}/${this._pluginFileName}_plugin.spec.ts`,
+			),
 			{
 				alias: this._alias,
 				className: this._className,

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/plugin_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/plugin_generator.ts
@@ -17,6 +17,7 @@
 import { join } from 'path';
 import { Project, SyntaxKind } from 'ts-morph';
 import * as Generator from 'yeoman-generator';
+import { camelToSnake } from '../../../../utils/convert';
 
 interface PluginPrompts {
 	author: string;
@@ -33,12 +34,14 @@ export default class PluginGenerator extends Generator {
 	protected _templatePath: string;
 	protected _packageJSON: Record<string, unknown> | undefined;
 	protected _className: string;
+	protected _pluginFileName: string;
 	protected _alias: string;
 
 	public constructor(args: string | string[], opts: PluginGeneratorOptions) {
 		super(args, opts);
 		this._templatePath = join(__dirname, '..', 'templates', 'plugin');
 		this._alias = (this.options as PluginGeneratorOptions).alias;
+		this._pluginFileName = camelToSnake(this._alias);
 		this._className = `${this._alias.charAt(0).toUpperCase() + this._alias.slice(1)}Plugin`;
 	}
 
@@ -77,7 +80,7 @@ export default class PluginGenerator extends Generator {
 		// Create plugin
 		this.fs.copyTpl(
 			`${this._templatePath}/src/app/plugins/plugin.ts`,
-			this.destinationPath(`src/app/plugins/${this._alias}/${this._alias}.ts`),
+			this.destinationPath(`src/app/plugins/${this._pluginFileName}/${this._pluginFileName}_plugin.ts`),
 			{
 				alias: this._alias,
 				className: this._className,
@@ -92,7 +95,7 @@ export default class PluginGenerator extends Generator {
 		// Create unit tests
 		this.fs.copyTpl(
 			`${this._templatePath}/test/unit/plugins/plugin.spec.ts`,
-			this.destinationPath(`test/unit/plugins/${this._alias}/${this._alias}.spec.ts`),
+			this.destinationPath(`test/unit/plugins/${this._pluginFileName}/${this._pluginFileName}_plugin.spec.ts`),
 			{
 				alias: this._alias,
 				className: this._className,
@@ -112,7 +115,7 @@ export default class PluginGenerator extends Generator {
 
 		pluginsFile.addImportDeclaration({
 			namedImports: [`${this._className}`],
-			moduleSpecifier: `./plugins/${this._alias}/${this._alias}`,
+			moduleSpecifier: `./plugins/${this._pluginFileName}/${this._pluginFileName}_plugin`,
 		});
 
 		const registerFunction = pluginsFile

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/modules.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/modules.ts
@@ -1,4 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { Application } from 'lisk-sdk';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-export const registerModules = (_app: Application): void => {};
+// @ts-expect-error Unsused variable error happens here until at least one module is registered
+export const registerModules = (app: Application): void => {};

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/plugins.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/plugins.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { Application } from 'lisk-sdk';
 
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-export const registerPlugins = (_app: Application): void => {
+// @ts-expect-error Unsused variable error happens here until at least one module is registered
+export const registerPlugins = (app: Application): void => {
 };

--- a/commander/src/commands/generate/asset.ts
+++ b/commander/src/commands/generate/asset.ts
@@ -56,7 +56,7 @@ export default class AssetCommand extends BaseBootstrapCommand {
 		const regexAlphabets = /[^A-Za-z]/;
 
 		if (
-			regexCamelCase.test(moduleName) ||
+			!regexCamelCase.test(moduleName) ||
 			regexWhitespace.test(moduleName) ||
 			regexAlphabets.test(moduleName)
 		) {

--- a/commander/src/commands/generate/asset.ts
+++ b/commander/src/commands/generate/asset.ts
@@ -52,7 +52,7 @@ export default class AssetCommand extends BaseBootstrapCommand {
 
 		// validate folder name to not include camelcase or whitespace
 		const regexWhitespace = /\s/g;
-		const regexCamelCase = /^([a-z]+)(([A-Z]([a-z]+))+)$/;
+		const regexCamelCase = /[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?/;
 		const regexAlphabets = /[^A-Za-z]/;
 
 		if (

--- a/commander/src/commands/generate/module.ts
+++ b/commander/src/commands/generate/module.ts
@@ -46,7 +46,7 @@ export default class ModuleCommand extends BaseBootstrapCommand {
 		const regexAlphabets = /[^A-Za-z]/;
 
 		if (
-			regexCamelCase.test(moduleName) ||
+			!regexCamelCase.test(moduleName) ||
 			regexWhitespace.test(moduleName) ||
 			regexAlphabets.test(moduleName)
 		) {

--- a/commander/src/commands/generate/module.ts
+++ b/commander/src/commands/generate/module.ts
@@ -42,7 +42,7 @@ export default class ModuleCommand extends BaseBootstrapCommand {
 
 		// validate folder name to not include camelcase or whitespace
 		const regexWhitespace = /\s/g;
-		const regexCamelCase = /^([a-z]+)(([A-Z]([a-z]+))+)$/;
+		const regexCamelCase = /[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?/;
 		const regexAlphabets = /[^A-Za-z]/;
 
 		if (

--- a/commander/src/commands/generate/plugin.ts
+++ b/commander/src/commands/generate/plugin.ts
@@ -58,7 +58,8 @@ export default class PluginCommand extends BaseBootstrapCommand {
 		// validate folder name to not include camelcase or whitespace
 		const regexWhitespace = /\s/g;
 		const regexCamelCase = /^([a-z]+)(([A-Z]([a-z]+))+)$/;
-		if (regexCamelCase.test(alias) || regexWhitespace.test(alias)) {
+		const regexAlphabets = /[^A-Za-z]/;
+		if (regexCamelCase.test(alias) || regexWhitespace.test(alias) || regexAlphabets.test(alias)) {
 			this.error('Invalid plugin alias');
 		}
 		if (standalone) {

--- a/commander/src/commands/generate/plugin.ts
+++ b/commander/src/commands/generate/plugin.ts
@@ -39,7 +39,6 @@ export default class PluginCommand extends BaseBootstrapCommand {
 		output: flagParser.string({
 			description: 'Path to create the plugin.',
 			char: 'o',
-			default: process.env.INIT_CWD ?? process.cwd(),
 			dependsOn: ['standalone'],
 		}),
 		registry: flagParser.string({
@@ -59,14 +58,14 @@ export default class PluginCommand extends BaseBootstrapCommand {
 		const regexWhitespace = /\s/g;
 		const regexCamelCase = /^([a-z]+)(([A-Z]([a-z]+))+)$/;
 		const regexAlphabets = /[^A-Za-z]/;
-		if (regexCamelCase.test(alias) || regexWhitespace.test(alias) || regexAlphabets.test(alias)) {
+		if (!regexCamelCase.test(alias) || regexWhitespace.test(alias) || regexAlphabets.test(alias)) {
 			this.error('Invalid plugin alias');
 		}
 		if (standalone) {
 			return this._runBootstrapCommand('lisk:init:plugin', {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				alias,
-				projectPath: output,
+				projectPath: output??process.env.INIT_CWD ?? process.cwd(),
 				registry,
 			});
 		}

--- a/commander/src/commands/generate/plugin.ts
+++ b/commander/src/commands/generate/plugin.ts
@@ -56,7 +56,7 @@ export default class PluginCommand extends BaseBootstrapCommand {
 
 		// validate folder name to not include camelcase or whitespace
 		const regexWhitespace = /\s/g;
-		const regexCamelCase = /^([a-z]+)(([A-Z]([a-z]+))+)$/;
+		const regexCamelCase = /[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?/;
 		const regexAlphabets = /[^A-Za-z]/;
 		if (!regexCamelCase.test(alias) || regexWhitespace.test(alias) || regexAlphabets.test(alias)) {
 			this.error('Invalid plugin alias');

--- a/commander/src/commands/generate/plugin.ts
+++ b/commander/src/commands/generate/plugin.ts
@@ -65,7 +65,7 @@ export default class PluginCommand extends BaseBootstrapCommand {
 			return this._runBootstrapCommand('lisk:init:plugin', {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				alias,
-				projectPath: output??process.env.INIT_CWD ?? process.cwd(),
+				projectPath: output ?? process.env.INIT_CWD ?? process.cwd(),
 				registry,
 			});
 		}

--- a/commander/src/utils/convert.ts
+++ b/commander/src/utils/convert.ts
@@ -1,0 +1,21 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+export const camelToSnake = (name: string): string =>
+	name.replace(/([A-Z])/g, "_$1").toLowerCase();
+
+export const camelToUpperCamel = (name: string): string =>
+	`${name.charAt(0).toUpperCase() + name.slice(1)}`;

--- a/commander/src/utils/convert.ts
+++ b/commander/src/utils/convert.ts
@@ -14,8 +14,7 @@
  *
  */
 
-export const camelToSnake = (name: string): string =>
-	name.replace(/([A-Z])/g, "_$1").toLowerCase();
+export const camelToSnake = (name: string): string => name.replace(/([A-Z])/g, '_$1').toLowerCase();
 
 export const camelToUpperCamel = (name: string): string =>
 	`${name.charAt(0).toUpperCase() + name.slice(1)}`;

--- a/commander/src/utils/convert.ts
+++ b/commander/src/utils/convert.ts
@@ -16,5 +16,5 @@
 
 export const camelToSnake = (name: string): string => name.replace(/([A-Z])/g, '_$1').toLowerCase();
 
-export const camelToUpperCamel = (name: string): string =>
+export const camelToPascal = (name: string): string =>
 	`${name.charAt(0).toUpperCase() + name.slice(1)}`;


### PR DESCRIPTION
### What was the problem?

This PR resolves #6394 

### How was it solved?

- Add same validation rule as module (only alphabet restriction was missing in the plugin)

### How was it tested?

- Try generating a plugin with `generate:plugin sample-plugin` and it should fail