### PR TITLE
Fix module generation convention to follow plugin - Closes #6378

### DIFF
--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/asset_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/asset_generator.ts
@@ -40,14 +40,18 @@ export default class AssetGenerator extends Generator {
 		this._assetID = opts.assetID;
 		this._templatePath = join(__dirname, '..', 'templates', 'asset');
 		this._assetClass = `${this._assetName.charAt(0).toUpperCase() + this._assetName.slice(1)}Asset`;
-		this._moduleClass = this._moduleName.charAt(0).toUpperCase() + this._moduleName.slice(1);
+		this._moduleClass = `${
+			this._moduleName.charAt(0).toUpperCase() + this._moduleName.slice(1)
+		}Module`;
 	}
 
 	public writing(): void {
 		// Writing asset file
 		this.fs.copyTpl(
 			`${this._templatePath}/src/app/modules/assets/asset.ts`,
-			this.destinationPath(`src/app/modules/${this._moduleName}/assets/${this._assetName}.ts`),
+			this.destinationPath(
+				`src/app/modules/${this._moduleName}/assets/${this._assetName}_asset.ts`,
+			),
 			{
 				moduleName: this._moduleName,
 				assetName: this._assetName,
@@ -62,7 +66,7 @@ export default class AssetGenerator extends Generator {
 		this.fs.copyTpl(
 			`${this._templatePath}/test/unit/modules/assets/asset.spec.ts`,
 			this.destinationPath(
-				`test/unit/modules/${this._moduleName}/assets/${this._assetName}.spec.ts`,
+				`test/unit/modules/${this._moduleName}/assets/${this._assetName}_asset.spec.ts`,
 			),
 			{
 				moduleName: this._moduleName,
@@ -82,7 +86,7 @@ export default class AssetGenerator extends Generator {
 		project.addSourceFilesAtPaths('src/app/**/*.ts');
 
 		const moduleFile = project.getSourceFileOrThrow(
-			`src/app/modules/${this._moduleName}/${this._moduleName}.ts`,
+			`src/app/modules/${this._moduleName}/${this._moduleName}_module.ts`,
 		);
 
 		moduleFile.addImportDeclaration({

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
@@ -35,14 +35,16 @@ export default class ModuleGenerator extends Generator {
 		this._templatePath = join(__dirname, '..', 'templates', 'module');
 		this._moduleName = (this.options as ModuleGeneratorOptions).moduleName;
 		this._moduleID = (this.options as ModuleGeneratorOptions).moduleID;
-		this._moduleClass = this._moduleName.charAt(0).toUpperCase() + this._moduleName.slice(1);
+		this._moduleClass = `${
+			this._moduleName.charAt(0).toUpperCase() + this._moduleName.slice(1)
+		}Module`;
 	}
 
 	public writing(): void {
 		// Writing module file
 		this.fs.copyTpl(
 			`${this._templatePath}/src/app/modules/module.ts`,
-			this.destinationPath(`src/app/modules/${this._moduleName}/${this._moduleName}.ts`),
+			this.destinationPath(`src/app/modules/${this._moduleName}/${this._moduleName}_module.ts`),
 			{
 				moduleName: this._moduleName,
 				moduleID: this._moduleID,
@@ -55,7 +57,9 @@ export default class ModuleGenerator extends Generator {
 		// Writing test file for the generated module
 		this.fs.copyTpl(
 			`${this._templatePath}/test/unit/modules/module.spec.ts`,
-			this.destinationPath(`test/unit/modules/${this._moduleName}/${this._moduleName}.spec.ts`),
+			this.destinationPath(
+				`test/unit/modules/${this._moduleName}/${this._moduleName}_module.spec.ts`,
+			),
 			{
 				moduleClass: this._moduleClass,
 				moduleName: this._moduleName,
@@ -75,7 +79,7 @@ export default class ModuleGenerator extends Generator {
 
 		modulesFile.addImportDeclaration({
 			namedImports: [this._moduleClass],
-			moduleSpecifier: `./modules/${this._moduleName}/${this._moduleName}`,
+			moduleSpecifier: `./modules/${this._moduleName}/${this._moduleName}_module`,
 		});
 
 		const registerFunction = modulesFile


### PR DESCRIPTION
### What was the problem?

This PR resolves #6378

### How was it solved?

- Update create file name by `generate:module`
- Update created class name by `generate:module`

### How was it tested?

- use `generate:module` and check the generated module
