### PR TITLE
Dashboard and Faucet build should include index.html - Closes #6438

### DIFF
--- a/framework-plugins/lisk-framework-dashboard-plugin/.npmignore
+++ b/framework-plugins/lisk-framework-dashboard-plugin/.npmignore
@@ -8,7 +8,6 @@
 .prettierrc.json
 .prettierignore
 cypress.json
-index.html
 Jenkinsfile*
 *.log
 

--- a/framework-plugins/lisk-framework-faucet-plugin/.npmignore
+++ b/framework-plugins/lisk-framework-faucet-plugin/.npmignore
@@ -8,7 +8,6 @@
 .prettierrc.json
 .prettierignore
 cypress.json
-index.html
 Jenkinsfile*
 *.log
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6438

### How was it solved?

Removed index.html from npmignore

### How was it tested?

```
npm install --global lisk-commander --registry https://npm.lisk.io
lisk init /tmp/testme --registry https://npm.lisk.io
cd /tmp/testme
cp lisk-sdk/framework-plugins/lisk-framework-dashboard-plugin/build/index.html node_modules/@liskhq/lisk-framework-dashboard-plugin/build/
./bin/run start --enable-dashboard-plugin --api-ws --api-ws-port 8080
```