### PR TITLE
Fix npm install for generated app - Closes #6440

### DIFF
--- a/commander/src/bootstrapping/generators/init_generator.ts
+++ b/commander/src/bootstrapping/generators/init_generator.ts
@@ -20,6 +20,8 @@ export default class InitGenerator extends BaseGenerator {
 	public async initializing(): Promise<void> {
 		await this._loadAndValidateTemplate();
 
+		// Enable slipInstall for env so that the only generator install will run
+		this.env.options.skipInstall = true;
 		this.log('Initializing git repository');
 		this.spawnCommandSync('git', ['init', '--quiet']);
 	}

--- a/commander/src/bootstrapping/generators/init_generator.ts
+++ b/commander/src/bootstrapping/generators/init_generator.ts
@@ -20,7 +20,7 @@ export default class InitGenerator extends BaseGenerator {
 	public async initializing(): Promise<void> {
 		await this._loadAndValidateTemplate();
 
-		// Enable slipInstall for env so that the only generator install will run
+		// Enable skipInstall for env so that the only generator install will run
 		this.env.options.skipInstall = true;
 		this.log('Initializing git repository');
 		this.spawnCommandSync('git', ['init', '--quiet']);

--- a/commander/src/bootstrapping/generators/init_plugin_generator.ts
+++ b/commander/src/bootstrapping/generators/init_plugin_generator.ts
@@ -28,7 +28,7 @@ export default class InitPluginGenerator extends BaseGenerator {
 		this._liskInitPluginArgs = {
 			alias: opts.alias,
 		};
-		// Enable slipInstall for env so that the only generator install will run
+		// Enable skipInstall for env so that the only generator install will run
 		this.env.options.skipInstall = true;
 		this._registry = opts.registry;
 	}

--- a/commander/src/bootstrapping/generators/init_plugin_generator.ts
+++ b/commander/src/bootstrapping/generators/init_plugin_generator.ts
@@ -28,6 +28,8 @@ export default class InitPluginGenerator extends BaseGenerator {
 		this._liskInitPluginArgs = {
 			alias: opts.alias,
 		};
+		// Enable slipInstall for env so that the only generator install will run
+		this.env.options.skipInstall = true;
 		this._registry = opts.registry;
 	}
 

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -74,6 +74,8 @@ export default class InitGenerator extends Generator {
 			{},
 			{ globOptions: { dot: true, ignore: ['.DS_Store'] } },
 		);
+		// package-template is used because "files" will be in effect while publishing the commander, which ignores the template files in the publish process
+		this.fs.move(this.destinationPath('package-template.json'), this.destinationPath('package.json'))
 	}
 
 	public end(): void {

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -75,7 +75,10 @@ export default class InitGenerator extends Generator {
 			{ globOptions: { dot: true, ignore: ['.DS_Store'] } },
 		);
 		// package-template is used because "files" will be in effect while publishing the commander, which ignores the template files in the publish process
-		this.fs.move(this.destinationPath('package-template.json'), this.destinationPath('package.json'))
+		this.fs.move(
+			this.destinationPath('package-template.json'),
+			this.destinationPath('package.json'),
+		);
 	}
 
 	public end(): void {

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package-template.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package-template.json
@@ -84,6 +84,14 @@
 			}
 		}
 	},
+	"files": [
+		"/bin",
+		"/npm-shrinkwrap.json",
+		"/oclif.manifest.json",
+		"/dist",
+		"/config",
+		"/docs"
+	],
 	"husky": {
 		"hooks": {
 			"pre-commit": "lint-staged"

--- a/commander/src/commands/init.ts
+++ b/commander/src/commands/init.ts
@@ -13,7 +13,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-
 import { flags as flagParser } from '@oclif/command';
 import BaseBootstrapCommand from '../base_bootstrap_command';
 
@@ -50,7 +49,7 @@ export default class InitCommand extends BaseBootstrapCommand {
 		} = this.parse(InitCommand) as { args: { projectPath: string }; flags: { registry?: string } };
 
 		return this._runBootstrapCommand('lisk:init', {
-			projectPath: projectPath ?? process.env.INIT_CWD ?? process.cwd(),
+			projectPath,
 			registry,
 		});
 	}


### PR DESCRIPTION
### What was the problem?

This PR resolves #6440

### How was it solved?

- Change package.json to package-template.json and rename during the generation so that it will not be used during the npm pack
- Add skipInstall to ignore the npm install by yeoman-environment

### How was it tested?

```
mkdir sample
cd sample
${abs path to commander}/bin/run init --registry https://npm.lisk.io
```
