### PR TITLE
Fix plugin import and asset regex - Closes #6446

### DIFF
--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init_plugin/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init_plugin/package.json
@@ -29,7 +29,7 @@
 		"prepublishOnly": "npm run lint && npm test && npm run build && npm run build:check"
 	},
 	"dependencies": {
-		"lisk-framework": "^0.8.0-alpha.0"
+		"lisk-sdk": "^5.1.0-alpha.1"
 	},
 	"devDependencies": {
 		"@types/jest": "26.0.21",

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init_plugin/src/plugin.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init_plugin/src/plugin.ts
@@ -1,5 +1,5 @@
-import { BasePlugin, PluginInfo } from 'lisk-sdk';
-import type { BaseChannel, EventsDefinition, ActionsDefinition } from 'lisk-framework';
+import { BasePlugin } from 'lisk-sdk';
+import type { BaseChannel, EventsDefinition, ActionsDefinition, PluginInfo } from 'lisk-sdk';
 
  /* eslint-disable class-methods-use-this */
  /* eslint-disable  @typescript-eslint/no-empty-function */

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/plugin/src/app/plugins/plugin.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/plugin/src/app/plugins/plugin.ts
@@ -1,5 +1,5 @@
 import { BasePlugin, PluginInfo } from 'lisk-sdk';
-import type { BaseChannel, EventsDefinition, ActionsDefinition, SchemaWithDefault } from 'lisk-framework';
+import type { BaseChannel, EventsDefinition, ActionsDefinition, SchemaWithDefault } from 'lisk-sdk';
 
  /* eslint-disable class-methods-use-this */
  /* eslint-disable  @typescript-eslint/no-empty-function */

--- a/commander/src/commands/generate/asset.ts
+++ b/commander/src/commands/generate/asset.ts
@@ -64,7 +64,7 @@ export default class AssetCommand extends BaseBootstrapCommand {
 		}
 
 		if (
-			regexCamelCase.test(assetName) ||
+			!regexCamelCase.test(assetName) ||
 			regexWhitespace.test(assetName) ||
 			regexAlphabets.test(assetName)
 		) {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6446 

### How was it solved?

- FIx to use `lisk-sdk` as dependency
- Fix invalid asset name check

### How was it tested?

- `/bin/run generate:plugin sample` and check dependency is only to sdk
- `/bin/run generate:asset moduleName Sample 1` will fail but `/bin/run generate:asset moduleName sample 1` should work
