### PR TITLE
Fix faucet config handling and the submit feedback - Closes #6454

### DIFF
--- a/commander/src/bootstrapping/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/commands/genesis-block/create.ts
@@ -79,7 +79,7 @@ export abstract class BaseGenesisBlockCommand extends Command {
 		'token-distribution': flagParser.integer({
 			char: 't',
 			description: 'Amount of tokens distributed to each account',
-			default: 10000000,
+			default: 100000000000,
 		}),
 		'validators-passphrase-encryption-iterations': flagParser.integer({
 			description: 'Number of iterations to use for passphrase encryption',

--- a/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/plugin/faucet_plugin.ts
@@ -19,6 +19,7 @@ import {
 	decryptPassphraseWithPassword,
 	parseEncryptedPassphrase,
 	getAddressAndPublicKeyFromPassphrase,
+	getLisk32AddressFromPublicKey,
 } from '@liskhq/lisk-cryptography';
 import { objects } from '@liskhq/lisk-utils';
 import axios from 'axios';
@@ -186,15 +187,20 @@ export class FaucetPlugin extends BasePlugin {
 			this.options,
 		) as FaucetPluginOptions;
 
-		const config = {
-			applicationUrl: this._options.applicationUrl,
-			amount: this._options.amount,
-			tokenPrefix: this._options.tokenPrefix,
-			captchaSitekey: this._options.captchaSitekey,
-			logoURL: this._options.logoURL,
-		};
 		const app = express();
-		app.get('/api/config', (_req, res) => res.json(config));
+		app.get('/api/config', (_req, res) => {
+			const config = {
+				applicationUrl: this._options.applicationUrl,
+				amount: this._options.amount,
+				tokenPrefix: this._options.tokenPrefix,
+				captchaSitekey: this._options.captchaSitekey,
+				logoURL: this._options.logoURL,
+				faucetAddress: this._state.publicKey
+					? getLisk32AddressFromPublicKey(this._state.publicKey)
+					: undefined,
+			};
+			res.json(config);
+		});
 		app.use(express.static(join(__dirname, '../../build')));
 		this._server = app.listen(this._options.port, this._options.host);
 	}

--- a/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.module.scss
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.module.scss
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
+
 $color-white: #ffffff;
 $color-blue-gray: #8a8ca2;
 $color-fury-red: #ff4557;
@@ -224,4 +226,140 @@ $breakpoint-down: (
 	position: absolute;
 	top: 10px;
 	right: 10px;
+}
+
+.dialogRoot {
+	display: none;
+	position: fixed;
+	height: 100%;
+	width: 100%;
+	top: 0;
+	left: 0;
+	transform: scale(1);
+	overflow: auto;
+	z-index: 10;
+}
+
+.dialogBackground {
+	background: rgba(15, 25, 51, 0.85);
+	text-align: center;
+	width: 100%;
+	min-height: 100%;
+}
+
+.dialogModal {
+	display: inline-block;
+	position: relative;
+	background: #0c152e;
+	backdrop-filter: blur(75px);
+	border-radius: 8px;
+	padding: 0px;
+	box-sizing: border-box;
+
+	margin: 130px auto;
+
+	width: 40%;
+
+	@include mq-down('md') {
+		max-width: 80%;
+		margin: 50px auto;
+	}
+
+	@include mq-down('sm') {
+		width: 100%;
+		max-width: 100%;
+		margin: 0;
+		height: 100%;
+	}
+}
+
+.dialogOpen {
+	transform: scale(1);
+	display: block;
+	transition: transform 0.3s;
+
+	.dialogModal {
+		animation: blowUpModal 0.3s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
+	}
+}
+
+.dialogClose {
+	transform: scale(0);
+	transition: transform 0.3s;
+
+	.dialogModal {
+		animation: blowUpModalTwo 0.5s cubic-bezier(0.165, 0.84, 0.44, 1) forwards;
+	}
+}
+
+.dialogHeader {
+	padding: 20px;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+.dialogHeaderContent {
+	flex-grow: 1;
+	margin-right: 20px;
+	font-family: 'Poppins';
+	font-size: 28px;
+	font-weight: 700;
+	line-height: 1.2;
+	letter-spacing: 0;
+	color: $color-white;
+	text-align: left;
+}
+
+.dialogBody {
+	padding: 16px;
+	margin: 0px 22px 22px;
+	font-family: Roboto;
+	font-style: normal;
+	font-weight: normal;
+	font-size: 16px;
+	line-height: 22px;
+	letter-spacing: 0.2px;
+	text-align: left;
+	color: $color-white;
+
+	@include mq-down('sm') {
+		height: 90%;
+		overflow: auto;
+	}
+}
+
+.dialogAdddress {
+	color: #4070f4;
+}
+
+.iconButton {
+	display: inline-block;
+	cursor: pointer;
+}
+
+.icon {
+	font-family: 'Material Icons';
+	font-weight: normal;
+	font-style: normal;
+	font-size: $font-size-m;
+	display: inline-block;
+	line-height: 1;
+	text-transform: none;
+	letter-spacing: normal;
+	word-wrap: normal;
+	white-space: nowrap;
+	direction: ltr;
+	color: $color-white;
+
+	/* Support for all WebKit browsers. */
+	-webkit-font-smoothing: antialiased;
+	/* Support for Safari and Chrome. */
+	text-rendering: optimizeLegibility;
+
+	/* Support for Firefox. */
+	-moz-osx-font-smoothing: grayscale;
+
+	/* Support for IE. */
+	font-feature-settings: 'liga';
 }

--- a/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
@@ -161,7 +161,7 @@ export const App: React.FC = () => {
 					}}
 				>
 					<p>
-						Successfully sent a funding transaction to:
+						Successfully submitted to transfer funds to:
 						<br />
 						{input}.
 					</p>

--- a/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable arrow-body-style */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import * as React from 'react';
@@ -20,14 +21,14 @@ interface FaucetConfig {
 	applicationUrl: string;
 	tokenPrefix: string;
 	logoURL?: string;
-	captchaSitekey: string;
+	captchaSitekey?: string;
+	faucetAddress?: string;
 }
 
 const defaultFaucetConfig: FaucetConfig = {
 	amount: '10000000000',
 	applicationUrl: 'ws://localhost:8080/ws',
 	tokenPrefix: 'lsk',
-	captchaSitekey: 'temp',
 };
 
 export const getConfig = async () => {
@@ -44,26 +45,55 @@ export const getConfig = async () => {
 
 declare global {
 	interface Window {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		grecaptcha: any;
 	}
 }
 
 const WarningIcon = () => <span className={`${styles.icon} ${styles.warning}`}>&#xE8B2;</span>;
 
+interface DialogProps {
+	open?: boolean;
+	onClose?: () => void;
+}
+
+const SuccessDialog: React.FC<DialogProps> = props => {
+	return (
+		<div className={`${styles.dialogRoot} ${props.open ? styles.dialogOpen : styles.dialogClose}`}>
+			<div className={styles.dialogBackground}>
+				<div className={styles.dialogModal}>
+					<div className={styles.dialogHeader}>
+						<div className={styles.dialogHeaderContent}>Success</div>
+						<div className={styles.iconButton} onClick={props.onClose}>
+							<span className={styles.icon}>close</span>;
+						</div>
+					</div>
+					<div className={styles.dialogBody}>{props.children}</div>
+				</div>
+			</div>
+		</div>
+	);
+};
+
 export const App: React.FC = () => {
-	const faucetAddress = 'lskdwsyfmcko6mcd357446yatromr9vzgu7eb8y99';
 	const [input, updateInput] = React.useState('');
 	const [errorMsg, updateErrorMsg] = React.useState('');
+	const [showSuccessDialog, updateShowSuccessDialog] = React.useState(false);
 	const [token, updateToken] = React.useState<string | undefined>();
 	const [recaptchaReady, updateRecaptchaReady] = React.useState(false);
 	const [config, setConfig] = React.useState<FaucetConfig>(defaultFaucetConfig);
 	React.useEffect(() => {
 		const initConfig = async () => {
 			const fetchedConfig = await getConfig();
-			setConfig(fetchedConfig);
+			setConfig({ ...fetchedConfig });
 		};
 		initConfig().catch(console.error);
-
+	}, []);
+	React.useEffect(() => {
+		if (config.captchaSitekey === undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			return () => {};
+		}
 		const script = document.createElement('script');
 		script.src = 'https://www.google.com/recaptcha/api.js';
 		script.async = true;
@@ -90,7 +120,7 @@ export const App: React.FC = () => {
 		return () => {
 			document.body.removeChild(script);
 		};
-	}, []);
+	}, [config]);
 
 	const onChange = (val: string) => {
 		updateInput(val);
@@ -111,6 +141,7 @@ export const App: React.FC = () => {
 				token,
 			});
 			updateErrorMsg('');
+			updateShowSuccessDialog(true);
 		} catch (error) {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			updateErrorMsg(error?.message ?? 'Fail to connect to server');
@@ -122,6 +153,19 @@ export const App: React.FC = () => {
 				<img src={config.logoURL ?? logo} className={styles.logo} alt="logo" />
 			</header>
 			<section className={styles.content}>
+				<SuccessDialog
+					open={showSuccessDialog}
+					onClose={() => {
+						updateInput('');
+						updateShowSuccessDialog(false);
+					}}
+				>
+					<p>
+						Successfully sent a funding transaction to:
+						<br />
+						{input}.
+					</p>
+				</SuccessDialog>
 				<div className={styles.main}>
 					<h1>All tokens are for testing purposes only</h1>
 					<h2>
@@ -132,7 +176,7 @@ export const App: React.FC = () => {
 						<div className={styles.input}>
 							<input
 								className={`${errorMsg !== '' ? styles.error : ''}`}
-								placeholder={faucetAddress}
+								placeholder={config.faucetAddress}
 								value={input}
 								onChange={e => onChange(e.target.value)}
 							/>
@@ -150,7 +194,7 @@ export const App: React.FC = () => {
 					<div className={styles.address}>
 						<p>
 							<span className={styles.addressLabel}>Faucet address:</span>
-							<span className={styles.addressValue}>{faucetAddress}</span>
+							<span className={styles.addressValue}>{config.faucetAddress}</span>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
### What was the problem?

This PR resolves #6454 

### How was it solved?

- Config on the UI was not updated with the config from server on time
- Faucet address was not updated with authroized account
- No feedback after submitting the action

### How was it tested?

1. Create new application with `lisk init`
2. link the faucet plugin with this branch
3. Run the application with faucet
```
"faucet": {
			"encryptedPassphrase": "iterations=1000000&cipherText=37dcceae0828ffc96501025bc3494e9e94926c68b0af19367dc1e0d5693652ac7649849a8640b8376bdad5f35df0f3a5eec2f887894a96a48ccff551381b5dd0a9dc00e1ccaa77f7802845f24fb0c85b6347&iv=d80fd35a0c1cfc855a32f896&salt=f4ba7449c7f22d761ea7fa3c8a77f954&tag=2b3c2fad962399d0d28b7db219cb75e6&version=1",
			"captchaSecretkey": "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe",
			"captchaSitekey": "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
		}
```
for testing, this setting can be used
4. Enable faucet
```
lisk console --api-ws=ws://localhost:8080/ws  
 client.invoke('faucet:authorize', { password: '123', enable: true }).then(console.log)
```
5. Use faucet to get the token