### PR TITLE
Remove double module registration - Closes #6457

### DIFF
--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/commands/genesis-block/create.ts
@@ -1,7 +1,6 @@
 import { BaseGenesisBlockCommand } from 'lisk-commander';
 import { Application, PartialApplicationConfig } from 'lisk-sdk';
 import { getApplication } from '../../app/app';
-import { registerModules } from '../../app/modules';
 
 export class GenesisBlockCommand extends BaseGenesisBlockCommand {
 	public getApplication(
@@ -9,7 +8,6 @@ export class GenesisBlockCommand extends BaseGenesisBlockCommand {
 		config: PartialApplicationConfig,
 	): Application {
 		const app = getApplication(genesisBlock, config);
-		registerModules(app);
 		return app;
 	}
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves #6457 

### How was it solved?

- Remove duplicate module registration

### How was it tested?

1. Create new application from this branch
2. Create new module
3. Create new genesis block
