### PR TITLE
Add empty signature option - Closes #64670

### DIFF
--- a/elements/lisk-transactions/src/fee.ts
+++ b/elements/lisk-transactions/src/fee.ts
@@ -38,13 +38,11 @@ const computeTransactionMinFee = (
 	trx: Record<string, unknown>,
 	options?: Options,
 ): bigint => {
-	const mockSignatures = new Array(options?.numberOfSignatures ?? DEFAULT_NUMBER_OF_SIGNATURES).fill(
-		Buffer.alloc(DEFAULT_SIGNATURE_BYTE_SIZE),
-	);
+	const mockSignatures = new Array(
+		options?.numberOfSignatures ?? DEFAULT_NUMBER_OF_SIGNATURES,
+	).fill(Buffer.alloc(DEFAULT_SIGNATURE_BYTE_SIZE));
 	if (options?.numberOfEmptySignatures) {
-		mockSignatures.push(...new Array(options.numberOfEmptySignatures).fill(
-			Buffer.alloc(0),
-		));
+		mockSignatures.push(...new Array(options.numberOfEmptySignatures).fill(Buffer.alloc(0)));
 	}
 	const size = getBytes(assetSchema, {
 		...trx,

--- a/elements/lisk-transactions/src/fee.ts
+++ b/elements/lisk-transactions/src/fee.ts
@@ -22,9 +22,10 @@ interface BaseFee {
 }
 
 interface Options {
-	readonly minFeePerByte: number;
-	readonly baseFees: BaseFee[];
-	readonly numberOfSignatures: number;
+	readonly minFeePerByte?: number;
+	readonly baseFees?: BaseFee[];
+	readonly numberOfSignatures?: number;
+	readonly numberOfEmptySignatures?: number;
 }
 
 const DEFAULT_MIN_FEE_PER_BYTE = 1000;
@@ -37,14 +38,20 @@ const computeTransactionMinFee = (
 	trx: Record<string, unknown>,
 	options?: Options,
 ): bigint => {
+	const mockSignatures = new Array(options?.numberOfSignatures ?? DEFAULT_NUMBER_OF_SIGNATURES).fill(
+		Buffer.alloc(DEFAULT_SIGNATURE_BYTE_SIZE),
+	);
+	if (options?.numberOfEmptySignatures) {
+		mockSignatures.push(...new Array(options.numberOfEmptySignatures).fill(
+			Buffer.alloc(0),
+		));
+	}
 	const size = getBytes(assetSchema, {
 		...trx,
-		signatures: new Array(options?.numberOfSignatures ?? DEFAULT_NUMBER_OF_SIGNATURES).fill(
-			Buffer.alloc(DEFAULT_SIGNATURE_BYTE_SIZE),
-		),
+		signatures: mockSignatures,
 	}).length;
 	const baseFee =
-		options?.baseFees.find(bf => bf.moduleID === trx.moduleID && bf.assetID === trx.assetID)
+		options?.baseFees?.find(bf => bf.moduleID === trx.moduleID && bf.assetID === trx.assetID)
 			?.baseFee ?? DEFAULT_BASE_FEE;
 	return BigInt(size * (options?.minFeePerByte ?? DEFAULT_MIN_FEE_PER_BYTE)) + BigInt(baseFee);
 };

--- a/elements/lisk-transactions/test/fee.spec.ts
+++ b/elements/lisk-transactions/test/fee.spec.ts
@@ -104,8 +104,13 @@ describe('fee', () => {
 
 		it('should calculate minimum fee for transaction from multisignature account which has lower number of signatures than registered public keys', () => {
 			// Arrange
-			const options = { minFeePerByte: 1000, baseFees: [], numberOfSignatures: 2, numberOfEmptySignatures: 3 };
-			const transaction =  {
+			const options = {
+				minFeePerByte: 1000,
+				baseFees: [],
+				numberOfSignatures: 2,
+				numberOfEmptySignatures: 3,
+			};
+			const transaction = {
 				...validTransaction,
 				signatures: [
 					Buffer.alloc(64),
@@ -113,7 +118,7 @@ describe('fee', () => {
 					Buffer.alloc(0),
 					Buffer.alloc(0),
 					Buffer.alloc(64),
-				]
+				],
 			};
 			const minFee = computeMinFee(validAssetSchema, transaction, options);
 			const txBytes = getBytes(validAssetSchema, { ...transaction, fee: minFee });

--- a/elements/lisk-transactions/test/fee.spec.ts
+++ b/elements/lisk-transactions/test/fee.spec.ts
@@ -14,7 +14,7 @@
  */
 
 import { getAddressAndPublicKeyFromPassphrase } from '@liskhq/lisk-cryptography';
-import { computeMinFee } from '../src';
+import { computeMinFee, getBytes } from '../src';
 
 describe('fee', () => {
 	const validAssetSchema = {
@@ -100,6 +100,26 @@ describe('fee', () => {
 			// Assert
 			expect(minFee).not.toBeUndefined();
 			expect(minFee).toMatchSnapshot();
+		});
+
+		it('should calculate minimum fee for transaction from multisignature account which has lower number of signatures than registered public keys', () => {
+			// Arrange
+			const options = { minFeePerByte: 1000, baseFees: [], numberOfSignatures: 2, numberOfEmptySignatures: 3 };
+			const transaction =  {
+				...validTransaction,
+				signatures: [
+					Buffer.alloc(64),
+					Buffer.alloc(0),
+					Buffer.alloc(0),
+					Buffer.alloc(0),
+					Buffer.alloc(64),
+				]
+			};
+			const minFee = computeMinFee(validAssetSchema, transaction, options);
+			const txBytes = getBytes(validAssetSchema, { ...transaction, fee: minFee });
+
+			// Assert
+			expect(minFee.toString()).toEqual(BigInt(txBytes.length * 1000).toString());
 		});
 
 		it('should calculate minimum fee for delegate registration transaction', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6470 

### How was it solved?

- Add `numberOfEmptySignatures` option to specify number of empty signatures to include in calculation

### How was it tested?

- Add test case where signatures need to include empty signature
