### PR TITLE
Example of `lisk generate:plugin` command does not work - Closes #6475

### DIFF
--- a/commander/src/base_bootstrap_command.ts
+++ b/commander/src/base_bootstrap_command.ts
@@ -14,6 +14,8 @@
  *
  */
 import { Command, flags as flagParser } from '@oclif/command';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { env } from './bootstrapping/env';
 
 interface BootstrapFlags {
@@ -50,6 +52,10 @@ export default abstract class BaseBootstrapCommand extends Command {
 				throw err;
 			}
 		});
+	}
+
+	protected _isLiskAppDir(path: string): boolean {
+		return existsSync(join(path, '.liskrc.json'));
 	}
 
 	protected async _runBootstrapCommand(

--- a/commander/src/commands/generate/asset.ts
+++ b/commander/src/commands/generate/asset.ts
@@ -75,6 +75,12 @@ export default class AssetCommand extends BaseBootstrapCommand {
 			this.error('Invalid asset ID, only positive integers are allowed');
 		}
 
+		if (!this._isLiskAppDir(process.cwd())) {
+			this.error(
+				'You can run this command only in lisk app directory. Run "lisk init --help" command for more details.',
+			);
+		}
+
 		this.log(
 			`Creating asset skeleton with asset name "${assetName}" and asset ID "${assetID}" for module "${moduleName}"`,
 		);

--- a/commander/src/commands/generate/module.ts
+++ b/commander/src/commands/generate/module.ts
@@ -59,6 +59,12 @@ export default class ModuleCommand extends BaseBootstrapCommand {
 			);
 		}
 
+		if (!this._isLiskAppDir(process.cwd())) {
+			this.error(
+				'You can run this command only in lisk app directory. Run "lisk init --help" command for more details.',
+			);
+		}
+
 		this.log(
 			`Creating module skeleton with module name "${moduleName as string}" and module ID "${
 				moduleID as string

--- a/commander/src/commands/generate/plugin.ts
+++ b/commander/src/commands/generate/plugin.ts
@@ -19,8 +19,8 @@ import BaseBootstrapCommand from '../../base_bootstrap_command';
 export default class PluginCommand extends BaseBootstrapCommand {
 	static description = 'Creates custom plugin.';
 	static examples = [
-		'generate:plugin my-plugin',
-		'generate:plugin my-plugin --standalone --output ./myplugin',
+		'generate:plugin myPlugin',
+		'generate:plugin myPlugin --standalone --output ./my_plugin',
 	];
 
 	static args = [

--- a/commander/src/commands/generate/plugin.ts
+++ b/commander/src/commands/generate/plugin.ts
@@ -70,6 +70,12 @@ export default class PluginCommand extends BaseBootstrapCommand {
 			});
 		}
 
+		if (!this._isLiskAppDir(process.cwd())) {
+			this.error(
+				'You can run this command only in lisk app directory. Run "lisk init --help" command for more details.',
+			);
+		}
+
 		return this._runBootstrapCommand('lisk:generate:plugin', {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 			alias,

--- a/commander/test/base_bootstrap_command.spec.ts
+++ b/commander/test/base_bootstrap_command.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import * as Config from '@oclif/config';
+import * as fs from 'fs';
+import BaseBootstrapCommand from '../src/base_bootstrap_command';
+import { getConfig } from './helpers/config';
+
+class MyCommand extends BaseBootstrapCommand {
+	run(): PromiseLike<any> {
+		throw new Error('Method not implemented.');
+	}
+}
+
+describe('base_bootstrap_command command', () => {
+	let stdout: string[];
+	let stderr: string[];
+	let config: Config.IConfig;
+
+	beforeEach(async () => {
+		stdout = [];
+		stderr = [];
+		config = await getConfig();
+		jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
+		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
+	});
+
+	describe('_isLiskAppDir', () => {
+		it('should to check .liskrc.json file', async () => {
+			jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+			new MyCommand([], config)['_isLiskAppDir']('/my/dir');
+
+			expect(fs.existsSync).toHaveBeenCalledWith('/my/dir/.liskrc.json');
+		});
+	});
+});

--- a/commander/test/commands/generate/asset.spec.ts
+++ b/commander/test/commands/generate/asset.spec.ts
@@ -16,10 +16,10 @@
 
 import * as Config from '@oclif/config';
 import BaseBootstrapCommand from '../../../src/base_bootstrap_command';
-import ModuleCommand from '../../../src/commands/generate/module';
+import AssetCommand from '../../../src/commands/generate/asset';
 import { getConfig } from '../../helpers/config';
 
-describe('generate:module command', () => {
+describe('generate:asset command', () => {
 	let stdout: string[];
 	let stderr: string[];
 	let config: Config.IConfig;
@@ -32,34 +32,36 @@ describe('generate:module command', () => {
 		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
 	});
 
-	describe('generate:module', () => {
+	describe('generate:asset', () => {
 		it('should throw an error when all arg is not provided', async () => {
-			await expect(ModuleCommand.run([], config)).rejects.toThrow('Missing 2 required arg');
+			await expect(AssetCommand.run([], config)).rejects.toThrow('Missing 3 required arg');
 		});
 
 		it('should throw an error when a arg is not provided', async () => {
-			await expect(ModuleCommand.run(['nft'], config)).rejects.toThrow('Missing 1 required arg');
+			await expect(AssetCommand.run(['nft'], config)).rejects.toThrow('Missing 2 required arg');
 		});
 	});
 
-	describe('generate:module invalidModuleName invalidModuleID', () => {
-		it('should throw an error when module name is invalid', async () => {
-			await expect(ModuleCommand.run(['nft$5', '1001'], config)).rejects.toThrow(
-				'Invalid module name',
+	describe('generate:asset invalidAssetName invalidAssetID', () => {
+		it('should throw an error when asset name is invalid', async () => {
+			await expect(AssetCommand.run(['nft', 'register$5', '1001'], config)).rejects.toThrow(
+				'Invalid asset name',
 			);
 		});
 
-		it('should throw an error when module ID is invalid', async () => {
-			await expect(ModuleCommand.run(['nft', '5r'], config)).rejects.toThrow('Invalid module ID');
+		it('should throw an error when asset ID is invalid', async () => {
+			await expect(AssetCommand.run(['nft', 'register', '5r'], config)).rejects.toThrow(
+				'Invalid asset ID, only positive integers are allowed',
+			);
 		});
 	});
 
-	describe('generate:module should check app directory', () => {
+	describe('generate:asset should check app directory', () => {
 		it('should throw error if cwd is not a lisk app directory', async () => {
 			jest.spyOn<any, any>(BaseBootstrapCommand.prototype, '_isLiskAppDir').mockReturnValue(false);
 			jest.spyOn(process, 'cwd').mockReturnValue('/my/dir');
 
-			await expect(ModuleCommand.run(['nft', '1001'], config)).rejects.toThrow(
+			await expect(AssetCommand.run(['nft', 'register', '1001'], config)).rejects.toThrow(
 				'You can run this command only in lisk app directory. Run "lisk init --help" command for more details.',
 			);
 			expect(BaseBootstrapCommand.prototype['_isLiskAppDir']).toHaveBeenCalledWith('/my/dir');
@@ -67,16 +69,21 @@ describe('generate:module command', () => {
 
 		it('should not throw error if cwd is a lisk app directory', async () => {
 			jest.spyOn<any, any>(BaseBootstrapCommand.prototype, '_isLiskAppDir').mockReturnValue(true);
+			jest.spyOn(process, 'cwd').mockReturnValue('/my/dir');
 			jest
 				.spyOn<any, any>(BaseBootstrapCommand.prototype, '_runBootstrapCommand')
 				.mockResolvedValue(null as never);
-			jest.spyOn(process, 'cwd').mockReturnValue('/my/dir');
 
-			await expect(ModuleCommand.run(['nft', '1001'], config)).resolves.toBeNull();
+			await expect(AssetCommand.run(['nft', 'register', '1001'], config)).resolves.toBeNull();
 			expect(BaseBootstrapCommand.prototype['_isLiskAppDir']).toHaveBeenCalledWith('/my/dir');
-			expect(
-				BaseBootstrapCommand.prototype['_runBootstrapCommand'],
-			).toHaveBeenCalledWith('lisk:generate:module', { moduleID: '1001', moduleName: 'nft' });
+			expect(BaseBootstrapCommand.prototype['_runBootstrapCommand']).toHaveBeenCalledWith(
+				'lisk:generate:asset',
+				{
+					moduleName: 'nft',
+					assetID: '1001',
+					assetName: 'register',
+				},
+			);
 		});
 	});
 });

--- a/commander/test/commands/generate/plugin.spec.ts
+++ b/commander/test/commands/generate/plugin.spec.ts
@@ -16,10 +16,10 @@
 
 import * as Config from '@oclif/config';
 import BaseBootstrapCommand from '../../../src/base_bootstrap_command';
-import ModuleCommand from '../../../src/commands/generate/module';
+import PluginCommand from '../../../src/commands/generate/plugin';
 import { getConfig } from '../../helpers/config';
 
-describe('generate:module command', () => {
+describe('generate:plugin command', () => {
 	let stdout: string[];
 	let stderr: string[];
 	let config: Config.IConfig;
@@ -32,34 +32,24 @@ describe('generate:module command', () => {
 		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
 	});
 
-	describe('generate:module', () => {
+	describe('generate:plugin', () => {
 		it('should throw an error when all arg is not provided', async () => {
-			await expect(ModuleCommand.run([], config)).rejects.toThrow('Missing 2 required arg');
-		});
-
-		it('should throw an error when a arg is not provided', async () => {
-			await expect(ModuleCommand.run(['nft'], config)).rejects.toThrow('Missing 1 required arg');
+			await expect(PluginCommand.run([], config)).rejects.toThrow('Missing 1 required arg');
 		});
 	});
 
-	describe('generate:module invalidModuleName invalidModuleID', () => {
+	describe('generate:plugin invalidAlias', () => {
 		it('should throw an error when module name is invalid', async () => {
-			await expect(ModuleCommand.run(['nft$5', '1001'], config)).rejects.toThrow(
-				'Invalid module name',
-			);
-		});
-
-		it('should throw an error when module ID is invalid', async () => {
-			await expect(ModuleCommand.run(['nft', '5r'], config)).rejects.toThrow('Invalid module ID');
+			await expect(PluginCommand.run(['http$5'], config)).rejects.toThrow('Invalid plugin alias');
 		});
 	});
 
-	describe('generate:module should check app directory', () => {
+	describe('generate:plugin should check app directory', () => {
 		it('should throw error if cwd is not a lisk app directory', async () => {
 			jest.spyOn<any, any>(BaseBootstrapCommand.prototype, '_isLiskAppDir').mockReturnValue(false);
 			jest.spyOn(process, 'cwd').mockReturnValue('/my/dir');
 
-			await expect(ModuleCommand.run(['nft', '1001'], config)).rejects.toThrow(
+			await expect(PluginCommand.run(['httpPlugin'], config)).rejects.toThrow(
 				'You can run this command only in lisk app directory. Run "lisk init --help" command for more details.',
 			);
 			expect(BaseBootstrapCommand.prototype['_isLiskAppDir']).toHaveBeenCalledWith('/my/dir');
@@ -72,11 +62,30 @@ describe('generate:module command', () => {
 				.mockResolvedValue(null as never);
 			jest.spyOn(process, 'cwd').mockReturnValue('/my/dir');
 
-			await expect(ModuleCommand.run(['nft', '1001'], config)).resolves.toBeNull();
+			await expect(PluginCommand.run(['httpPlugin'], config)).resolves.toBeNull();
 			expect(BaseBootstrapCommand.prototype['_isLiskAppDir']).toHaveBeenCalledWith('/my/dir');
 			expect(
 				BaseBootstrapCommand.prototype['_runBootstrapCommand'],
-			).toHaveBeenCalledWith('lisk:generate:module', { moduleID: '1001', moduleName: 'nft' });
+			).toHaveBeenCalledWith('lisk:generate:plugin', { alias: 'httpPlugin' });
+		});
+
+		it('should not throw error if cwd is not lisk app directory and --standalone was provided', async () => {
+			jest.spyOn<any, any>(BaseBootstrapCommand.prototype, '_isLiskAppDir');
+			jest
+				.spyOn<any, any>(BaseBootstrapCommand.prototype, '_runBootstrapCommand')
+				.mockResolvedValue(null as never);
+
+			await expect(
+				PluginCommand.run(['httpPlugin', '--standalone', '--output', '/my/dir'], config),
+			).resolves.toBeNull();
+			expect(BaseBootstrapCommand.prototype['_isLiskAppDir']).not.toHaveBeenCalled();
+			expect(BaseBootstrapCommand.prototype['_runBootstrapCommand']).toHaveBeenCalledWith(
+				'lisk:init:plugin',
+				{
+					alias: 'httpPlugin',
+					projectPath: '/my/dir',
+				},
+			);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #6475

### How was it solved?

- Added the error message if current working directory is not lisk app directory 

### How was it tested?

- Added unit tests
