### PR TITLE
Update tree interface - Closes #6491 and #6510

### DIFF
--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -319,7 +319,7 @@ export class Chain {
 		});
 	}
 
-	public validateBlockHeader(block: Block): void {
+	public async validateBlockHeader(block: Block): Promise<void> {
 		const headerWithoutAsset = {
 			...block.header,
 			asset: Buffer.alloc(0),
@@ -352,7 +352,7 @@ export class Chain {
 		const encodedPayload = Buffer.concat(
 			block.payload.map(tx => this.dataAccess.encodeTransaction(tx)),
 		);
-		validateBlockProperties(block, encodedPayload, this.constants.maxPayloadLength);
+		await validateBlockProperties(block, encodedPayload, this.constants.maxPayloadLength);
 	}
 
 	public async verifyBlockHeader(block: Block, stateStore: StateStore): Promise<void> {

--- a/elements/lisk-chain/src/validate.ts
+++ b/elements/lisk-chain/src/validate.ts
@@ -59,17 +59,17 @@ export const validateReward = (block: Block, maxReward: bigint): void => {
 	}
 };
 
-const getTransactionRoot = (ids: Buffer[]): Buffer => {
-	const tree = new MerkleTree(ids);
-
+const getTransactionRoot = async (ids: Buffer[]): Promise<Buffer> => {
+	const tree = new MerkleTree();
+	await tree.init(ids);
 	return tree.root;
 };
 
-export const validateBlockProperties = (
+export const validateBlockProperties = async (
 	block: Block,
 	encodedPayload: Buffer,
 	maxPayloadLength: number,
-): void => {
+): Promise<void> => {
 	if (block.header.previousBlockID.length === 0) {
 		throw new Error('Previous block id must not be empty');
 	}
@@ -82,7 +82,7 @@ export const validateBlockProperties = (
 		transactionIds.push(transaction.id);
 	}
 
-	const transactionRoot = getTransactionRoot(transactionIds);
+	const transactionRoot = await getTransactionRoot(transactionIds);
 	if (!transactionRoot.equals(block.header.transactionRoot)) {
 		throw new Error('Invalid transaction root');
 	}

--- a/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
+++ b/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
@@ -57,19 +57,19 @@ describe('dataAccess.blocks', () => {
 			maxBlockHeaderCache: 5,
 		});
 		// Prepare sample data
-		const block300 = createValidDefaultBlock({
+		const block300 = await createValidDefaultBlock({
 			header: { height: 300 },
 			payload: [getTransaction()],
 		});
 
-		const block301 = createValidDefaultBlock({ header: { height: 301 } });
+		const block301 = await createValidDefaultBlock({ header: { height: 301 } });
 
-		const block302 = createValidDefaultBlock({
+		const block302 = await createValidDefaultBlock({
 			header: { height: 302 },
 			payload: [getTransaction({ nonce: BigInt(1) }), getTransaction({ nonce: BigInt(2) })],
 		});
 
-		const block303 = createValidDefaultBlock({ header: { height: 303 } });
+		const block303 = await createValidDefaultBlock({ header: { height: 303 } });
 
 		blocks = [block300, block301, block302, block303];
 		const batch = db.batch();
@@ -322,12 +322,15 @@ describe('dataAccess.blocks', () => {
 	});
 
 	describe('saveBlock', () => {
-		const block = createValidDefaultBlock({
-			header: { height: 304 },
-			payload: [getTransaction({ nonce: BigInt(10) }), getTransaction({ nonce: BigInt(20) })],
-		});
+		let block: Block;
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		const stateStore = { finalize: () => {} };
+		beforeAll(async () => {
+			block = await createValidDefaultBlock({
+				header: { height: 304 },
+				payload: [getTransaction({ nonce: BigInt(10) }), getTransaction({ nonce: BigInt(20) })],
+			});
+		});
 
 		it('should create block with all index required', async () => {
 			await dataAccess.saveBlock(block, stateStore as any, 0);

--- a/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
+++ b/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
@@ -37,7 +37,7 @@ describe('data_access', () => {
 	let db: any;
 	let block: Block;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		db = new KVStore('temp');
 		(db.createReadStream as jest.Mock).mockReturnValue(Readable.from([]));
 		(formatInt as jest.Mock).mockImplementation(num => num);
@@ -53,7 +53,7 @@ describe('data_access', () => {
 			minBlockHeaderCache: 3,
 			maxBlockHeaderCache: 5,
 		});
-		block = createValidDefaultBlock({ header: { height: 1 } });
+		block = await createValidDefaultBlock({ header: { height: 1 } });
 		dataAccess.decodeBlockHeader = jest.fn().mockResolvedValue(block.header);
 	});
 
@@ -246,11 +246,11 @@ describe('data_access', () => {
 			// Arrange
 			dataAccess.addBlockHeader(block.header);
 			const additionalBlocks = [
-				createValidDefaultBlock({ header: { height: 2 } }).header,
-				createValidDefaultBlock({ header: { height: 3 } }).header,
-				createValidDefaultBlock({ header: { height: 4 } }).header,
-				createValidDefaultBlock({ header: { height: 5 } }).header,
-				createValidDefaultBlock({ header: { height: 6 } }).header,
+				(await createValidDefaultBlock({ header: { height: 2 } })).header,
+				(await createValidDefaultBlock({ header: { height: 3 } })).header,
+				(await createValidDefaultBlock({ header: { height: 4 } })).header,
+				(await createValidDefaultBlock({ header: { height: 5 } })).header,
+				(await createValidDefaultBlock({ header: { height: 6 } })).header,
 			];
 			for (const header of additionalBlocks) {
 				dataAccess.addBlockHeader(header);

--- a/elements/lisk-chain/test/utils/block.ts
+++ b/elements/lisk-chain/test/utils/block.ts
@@ -132,13 +132,14 @@ export const encodedDefaultBlock = (block: Block): Buffer => {
  * Utility function to create a block object with valid computed properties while any property can be overridden
  * Calculates the signature, transactionRoot etc. internally. Facilitating the creation of block with valid signature and other properties
  */
-export const createValidDefaultBlock = (
+export const createValidDefaultBlock = async (
 	block?: { header?: Partial<BlockHeader>; payload?: Transaction[] },
 	networkIdentifier: Buffer = defaultNetworkIdentifier,
-): Block => {
+): Promise<Block> => {
 	const keypair = getKeyPair();
 	const payload = block?.payload ?? [];
-	const txTree = new MerkleTree(payload.map(tx => tx.id));
+	const txTree = new MerkleTree();
+	await txTree.init(payload.map(tx => tx.id));
 
 	const asset = {
 		maxHeightPreviouslyForged: 0,

--- a/elements/lisk-tree/benchmark/merkle_root.js
+++ b/elements/lisk-tree/benchmark/merkle_root.js
@@ -25,8 +25,9 @@ for (let i = 0; i < size; i += 1) {
 }
 
 suite
-	.add('constructor', () => {
-		new MerkleTree(testSamples);
+	.add('constructor', async () => {
+		const tree = new MerkleTree();
+		await tree.init(testSamples);
 	})
 	.on('cycle', function (event) {
 		console.log(String(event.target));

--- a/elements/lisk-tree/src/merkle_tree/constants.ts
+++ b/elements/lisk-tree/src/merkle_tree/constants.ts
@@ -19,3 +19,5 @@ export const BRANCH_PREFIX = Buffer.from('01', 'hex');
 export const LAYER_INDEX_SIZE = 1;
 export const NODE_INDEX_SIZE = 8;
 export const NODE_HASH_SIZE = 32;
+export const PREFIX_HASH_TO_VALUE = Buffer.from([0]);
+export const PREFIX_LOC_TO_HASH = Buffer.from([1]);

--- a/elements/lisk-tree/src/merkle_tree/error.ts
+++ b/elements/lisk-tree/src/merkle_tree/error.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+
+export class NotFoundError extends Error {
+}

--- a/elements/lisk-tree/src/merkle_tree/error.ts
+++ b/elements/lisk-tree/src/merkle_tree/error.ts
@@ -12,6 +12,4 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-
-export class NotFoundError extends Error {
-}
+export class NotFoundError extends Error {}

--- a/elements/lisk-tree/src/merkle_tree/inmemory_db.ts
+++ b/elements/lisk-tree/src/merkle_tree/inmemory_db.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { NotFoundError } from "./error";
+
+
+export class InMemoryDB {
+	private _data: Record<string, Buffer> = {};
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async get(key: Buffer): Promise<Buffer> {
+		const keyStr = key.toString('binary');
+		const val = this._data[keyStr];
+		if (!val) {
+			throw new NotFoundError(`Key ${key.toString('hex')} does not exist`);
+		}
+		return val;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async set(key: Buffer, value: Buffer): Promise<void> {
+		const keyStr = key.toString('binary');
+		this._data[keyStr] = value;
+	}
+}

--- a/elements/lisk-tree/src/merkle_tree/inmemory_db.ts
+++ b/elements/lisk-tree/src/merkle_tree/inmemory_db.ts
@@ -12,8 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { NotFoundError } from "./error";
-
+import { NotFoundError } from './error';
 
 export class InMemoryDB {
 	private _data: Record<string, Buffer> = {};

--- a/elements/lisk-tree/src/merkle_tree/merkle_tree.ts
+++ b/elements/lisk-tree/src/merkle_tree/merkle_tree.ts
@@ -24,41 +24,57 @@ import {
 	LEAF_PREFIX,
 	BRANCH_PREFIX,
 } from './constants';
-import { NodeData, NodeInfo, NodeType, NodeSide, Proof } from './types';
+import { InMemoryDB } from './inmemory_db';
+import { PrefixStore } from './prefix_store';
+import { NodeData, NodeInfo, NodeType, NodeSide, Proof, Database } from './types';
 import { generateHash, getBinaryString, isLeaf, getPairLocation } from './utils';
+
+const hashToValuePrefix = Buffer.from([0]);
+const locationToHashPrefix = Buffer.from([1]);
 
 export class MerkleTree {
 	private _root: Buffer;
-	private _width = 0;
+	private _size = 0;
 	private readonly _preHashedLeaf: boolean;
+	private readonly _db: Database;
 
-	// Object holds data in format { [hash]: value }
-	private _hashToValueMap: { [key: string]: Buffer | undefined } = {};
-	private _locationToHashMap: { [key: string]: Buffer | undefined } = {};
+	private readonly _hashToValueMap: PrefixStore;
+	private readonly _locationToHashMap: PrefixStore;
 
-	public constructor(initValues: Buffer[] = [], options?: { preHashedLeaf: boolean }) {
+	public constructor(options?: { preHashedLeaf?: boolean; db?: Database }) {
+		this._db = options?.db ?? new InMemoryDB();
+		this._hashToValueMap = new PrefixStore(this._db, hashToValuePrefix);
+		this._locationToHashMap = new PrefixStore(this._db, locationToHashPrefix);
+		this._preHashedLeaf = options?.preHashedLeaf ?? false;
+
+		this._root = EMPTY_HASH;
+	}
+
+	public async init(initValues: Buffer[]): Promise<void> {
 		if (initValues.length <= 1) {
 			const rootNode = initValues.length
-				? this._generateLeaf(initValues[0], 0)
+				? await this._generateLeaf(initValues[0], 0)
 				: { hash: EMPTY_HASH, value: Buffer.alloc(0) };
 			this._root = rootNode.hash;
-			this._hashToValueMap[this._root.toString('binary')] = rootNode.value;
-			this._locationToHashMap[`${getBinaryString(0, this._getHeight())}`] = this._root;
-			this._width = initValues.length ? 1 : 0;
-			this._preHashedLeaf = options?.preHashedLeaf ?? false;
+			await this._hashToValueMap.set(this._root, rootNode.value);
+			await this._locationToHashMap.set(getBinaryString(0, this._getHeight()), this._root);
+			this._size = initValues.length ? 1 : 0;
 			return;
 		}
 
-		this._preHashedLeaf = options?.preHashedLeaf ?? false;
-		this._root = this._build(initValues);
+		this._root = await this._build(initValues);
 	}
 
 	public get root(): Buffer {
 		return this._root;
 	}
 
-	public getNode(nodeHash: Buffer): NodeInfo {
-		const value = this._hashToValueMap[nodeHash.toString('binary')];
+	public get size(): number {
+		return this._size;
+	}
+
+	public async getNode(nodeHash: Buffer): Promise<NodeInfo> {
+		const value = await this._hashToValueMap.get(nodeHash);
 
 		if (!value) {
 			throw new Error(`Hash does not exist in merkle tree: ${nodeHash.toString('hex')}`);
@@ -87,27 +103,27 @@ export class MerkleTree {
 		};
 	}
 
-	public append(value: Buffer): Buffer {
-		if (this._width === 0) {
-			const leaf = this._generateLeaf(value, 0);
+	public async append(value: Buffer): Promise<Buffer> {
+		if (this._size === 0) {
+			const leaf = await this._generateLeaf(value, 0);
 			this._root = leaf.hash;
-			this._width += 1;
+			this._size += 1;
 			return this._root;
 		}
 
 		// Create the appendPath
 		const appendPath: NodeInfo[] = [];
-		let currentNode = this.getNode(this._root);
+		let currentNode = await this.getNode(this._root);
 
 		// If tree is fully balanced
-		if (this._width === 2 ** (this._getHeight() - 1)) {
+		if (this._size === 2 ** (this._getHeight() - 1)) {
 			appendPath.push(currentNode);
 		} else {
 			// We start from the root layer and traverse each layer down the tree on the right side
 			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
 			while (true) {
 				const currentLayer = currentNode.layerIndex;
-				let currentLayerSize = this._width >> currentLayer;
+				let currentLayerSize = this._size >> currentLayer;
 				// if layer has odd nodes and current node is odd (hence index is even)
 				if (currentLayerSize % 2 === 1 && currentNode.nodeIndex % 2 === 0) {
 					appendPath.push(currentNode);
@@ -117,19 +133,19 @@ export class MerkleTree {
 					break;
 				}
 				// if layer below is odd numbered, push left child
-				currentLayerSize = this._width >> (currentLayer - 1);
+				currentLayerSize = this._size >> (currentLayer - 1);
 				if (currentLayerSize % 2 === 1) {
-					const leftNode = this.getNode(currentNode.leftHash);
+					const leftNode = await this.getNode(currentNode.leftHash);
 					appendPath.push(leftNode);
 				}
 
 				// go to right child
-				currentNode = this.getNode(currentNode.rightHash);
+				currentNode = await this.getNode(currentNode.rightHash);
 			}
 		}
 
-		const appendData = this._generateLeaf(value, this._width);
-		const appendNode = this.getNode(appendData.hash);
+		const appendData = await this._generateLeaf(value, this._size);
+		const appendNode = await this.getNode(appendData.hash);
 		appendPath.push(appendNode);
 		// Loop through appendPath from the base layer
 		// Generate new branch nodes and push to appendPath
@@ -137,20 +153,21 @@ export class MerkleTree {
 		while (appendPath.length > 1) {
 			const rightNodeInfo = appendPath.pop();
 			const leftNodeInfo = appendPath.pop();
-			const newBranchNode = this._generateBranch(
+			const newBranchNode = await this._generateBranch(
 				(leftNodeInfo as NodeInfo).hash,
 				(rightNodeInfo as NodeInfo).hash,
 				(leftNodeInfo as NodeInfo).layerIndex + 1,
 				(leftNodeInfo as NodeInfo).nodeIndex + 1,
 			);
-			appendPath.push(this.getNode(newBranchNode.hash));
+			const nextNode = await this.getNode(newBranchNode.hash);
+			appendPath.push(nextNode);
 		}
 		this._root = appendPath[0].hash;
 		return this.root;
 	}
 
-	public generateProof(queryData: ReadonlyArray<Buffer>): Proof {
-		if (this._width === 0) {
+	public async generateProof(queryData: ReadonlyArray<Buffer>): Promise<Proof> {
+		if (this._size === 0) {
 			return {
 				path: [],
 				indexes: [],
@@ -165,7 +182,7 @@ export class MerkleTree {
 		for (let i = 0; i < queryData.length; i += 1) {
 			// Flag missing nodes
 			try {
-				queryNode = this.getNode(queryData[i]);
+				queryNode = await this.getNode(queryData[i]);
 			} catch (err) {
 				path.push({
 					hash: queryData[i],
@@ -180,7 +197,7 @@ export class MerkleTree {
 			}
 
 			// If tree has one non-empty leaf
-			if (this._width === 1 && this._root.equals(queryNode.hash)) {
+			if (this._size === 1 && this._root.equals(queryNode.hash)) {
 				if (!addedPath.has(queryNode.hash)) {
 					addedPath.add(queryNode.hash);
 					path.push({
@@ -210,12 +227,12 @@ export class MerkleTree {
 				} = getPairLocation({
 					layerIndex: currentNode.layerIndex,
 					nodeIndex: currentNode.nodeIndex,
-					dataLength: this._width,
+					dataLength: this._size,
 				});
 
-				const pairNodeHash = this._locationToHashMap[
-					`${getBinaryString(pairNodeIndex, this._getHeight() - pairLayerIndex)}`
-				] as Buffer;
+				const pairNodeHash = await this._locationToHashMap.get(
+					getBinaryString(pairNodeIndex, this._getHeight() - pairLayerIndex)
+				) as Buffer;
 				if (!addedPath.has(pairNodeHash)) {
 					addedPath.add(pairNodeHash);
 					path.push({
@@ -227,41 +244,29 @@ export class MerkleTree {
 				const leftHashBuffer = pairSide === NodeSide.LEFT ? pairNodeHash : currentNode.hash;
 				const rightHashBuffer = pairSide === NodeSide.RIGHT ? pairNodeHash : currentNode.hash;
 				const parentNodeHash = generateHash(BRANCH_PREFIX, leftHashBuffer, rightHashBuffer);
-				currentNode = this.getNode(parentNodeHash);
+				currentNode = await this.getNode(parentNodeHash);
 			}
 		}
 
 		return {
 			path,
 			indexes,
-			dataLength: this._width,
+			dataLength: this._size,
 		};
 	}
 
-	public clear(): void {
-		this._width = 0;
-		this._root = EMPTY_HASH;
-		this._hashToValueMap = { [this._root.toString('2')]: Buffer.alloc(0) };
-	}
-
-	public toString(): string {
-		if (this._width === 0) {
+	public async toString(): Promise<string> {
+		if (this._size === 0) {
 			return this.root.toString('hex');
 		}
 		return this._printNode(this.root);
 	}
 
-	public getData(): NodeInfo[] {
-		return this._width === 0
-			? []
-			: Object.keys(this._hashToValueMap).map(key => this.getNode(Buffer.from(key, 'binary')));
-	}
-
 	private _getHeight(): number {
-		return Math.ceil(Math.log2(this._width)) + 1;
+		return Math.ceil(Math.log2(this._size)) + 1;
 	}
 
-	private _generateLeaf(value: Buffer, nodeIndex: number): NodeData {
+	private async _generateLeaf(value: Buffer, nodeIndex: number): Promise<NodeData> {
 		const nodeIndexBuffer = Buffer.alloc(NODE_INDEX_SIZE);
 		nodeIndexBuffer.writeInt32BE(nodeIndex, 0);
 		// As per protocol nodeIndex is not included in hash
@@ -275,8 +280,8 @@ export class MerkleTree {
 			[LEAF_PREFIX, nodeIndexBuffer, value],
 			LEAF_PREFIX.length + nodeIndexBuffer.length + value.length,
 		);
-		this._hashToValueMap[leafHash.toString('binary')] = leafValueWithNodeIndex;
-		this._locationToHashMap[`${getBinaryString(nodeIndex, this._getHeight())}`] = leafHash;
+		await this._hashToValueMap.set(leafHash, leafValueWithNodeIndex);
+		await this._locationToHashMap.set(getBinaryString(nodeIndex, this._getHeight()), leafHash);
 
 		return {
 			value: leafValueWithNodeIndex,
@@ -284,12 +289,12 @@ export class MerkleTree {
 		};
 	}
 
-	private _generateBranch(
+	private async _generateBranch(
 		leftHashBuffer: Buffer,
 		rightHashBuffer: Buffer,
 		layerIndex: number,
 		nodeIndex: number,
-	): NodeData {
+	): Promise<NodeData> {
 		const layerIndexBuffer = Buffer.alloc(LAYER_INDEX_SIZE);
 		const nodeIndexBuffer = Buffer.alloc(NODE_INDEX_SIZE);
 		layerIndexBuffer.writeInt8(layerIndex, 0);
@@ -304,22 +309,20 @@ export class MerkleTree {
 				rightHashBuffer.length,
 		);
 		const branchHash = generateHash(BRANCH_PREFIX, leftHashBuffer, rightHashBuffer);
-		this._hashToValueMap[branchHash.toString('binary')] = branchValue;
-		this._locationToHashMap[
-			`${getBinaryString(nodeIndex, this._getHeight() - layerIndex)}`
-		] = branchHash;
+		await this._hashToValueMap.set(branchHash, branchValue);
+		await this._locationToHashMap.set(getBinaryString(nodeIndex, this._getHeight() - layerIndex), branchHash);
 		return {
 			hash: branchHash,
 			value: branchValue,
 		};
 	}
 
-	private _build(initValues: Buffer[]): Buffer {
+	private async _build(initValues: Buffer[]): Promise<Buffer> {
 		// Generate hash and buffer of leaves and store in memory
 		const leafHashes = [];
-		this._width = initValues.length;
+		this._size = initValues.length;
 		for (let i = 0; i < initValues.length; i += 1) {
-			const leaf = this._generateLeaf(initValues[i], i);
+			const leaf = await this._generateLeaf(initValues[i], i);
 			leafHashes.push(leaf.hash);
 		}
 
@@ -357,7 +360,7 @@ export class MerkleTree {
 			for (let i = 0; i < pairsOfHashes.length; i += 1) {
 				const leftHash = pairsOfHashes[i][0];
 				const rightHash = pairsOfHashes[i][1];
-				const node = this._generateBranch(leftHash, rightHash, currentLayerIndex + 1, i);
+				const node = await this._generateBranch(leftHash, rightHash, currentLayerIndex + 1, i);
 
 				parentLayerHashes.push(node.hash);
 			}
@@ -370,18 +373,19 @@ export class MerkleTree {
 		return currentLayerHashes[0];
 	}
 
-	private _printNode(hashValue: Buffer, level = 1): string {
-		const nodeValue = this._hashToValueMap[hashValue.toString('binary')];
+	private async _printNode(hashValue: Buffer, level = 1): Promise<string> {
+		const nodeValue = await this._hashToValueMap.get(hashValue);
 		if (nodeValue && isLeaf(nodeValue)) {
 			return hashValue.toString('hex');
 		}
 
-		const node = this.getNode(hashValue);
-
+		const node = await this.getNode(hashValue);
+		const left = await this._printNode(node.leftHash, level + 1);
+		const right = await this._printNode(node.rightHash, level + 1);
 		return [
 			hashValue.toString('hex'),
-			`├${' ─ '.repeat(level)} ${this._printNode(node.leftHash, level + 1)}`,
-			`├${' ─ '.repeat(level)} ${this._printNode(node.rightHash, level + 1)}`,
+			`├${' ─ '.repeat(level)} ${left}`,
+			`├${' ─ '.repeat(level)} ${right}`,
 		].join('\n');
 	}
 }

--- a/elements/lisk-tree/src/merkle_tree/merkle_tree.ts
+++ b/elements/lisk-tree/src/merkle_tree/merkle_tree.ts
@@ -23,14 +23,13 @@ import {
 	EMPTY_HASH,
 	LEAF_PREFIX,
 	BRANCH_PREFIX,
+	PREFIX_HASH_TO_VALUE,
+	PREFIX_LOC_TO_HASH,
 } from './constants';
 import { InMemoryDB } from './inmemory_db';
 import { PrefixStore } from './prefix_store';
 import { NodeData, NodeInfo, NodeType, NodeSide, Proof, Database } from './types';
 import { generateHash, getBinaryString, isLeaf, getPairLocation } from './utils';
-
-const hashToValuePrefix = Buffer.from([0]);
-const locationToHashPrefix = Buffer.from([1]);
 
 export class MerkleTree {
 	private _root: Buffer;
@@ -43,8 +42,8 @@ export class MerkleTree {
 
 	public constructor(options?: { preHashedLeaf?: boolean; db?: Database }) {
 		this._db = options?.db ?? new InMemoryDB();
-		this._hashToValueMap = new PrefixStore(this._db, hashToValuePrefix);
-		this._locationToHashMap = new PrefixStore(this._db, locationToHashPrefix);
+		this._hashToValueMap = new PrefixStore(this._db, PREFIX_HASH_TO_VALUE);
+		this._locationToHashMap = new PrefixStore(this._db, PREFIX_LOC_TO_HASH);
 		this._preHashedLeaf = options?.preHashedLeaf ?? false;
 
 		this._root = EMPTY_HASH;

--- a/elements/lisk-tree/src/merkle_tree/prefix_store.ts
+++ b/elements/lisk-tree/src/merkle_tree/prefix_store.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { NotFoundError } from './error';
+import { Database } from './types';
+
+export class PrefixStore {
+	private readonly _db: Database;
+	private readonly _prefix: Buffer;
+
+	public constructor(db: Database, prefix: Buffer) {
+		this._db = db;
+		this._prefix = prefix;
+	}
+
+	public async get(key: Buffer): Promise<Buffer | undefined> {
+		try {
+			const value = await this._db.get(Buffer.concat([this._prefix, key]));
+			return value;
+		} catch (error) {
+			if (error instanceof NotFoundError) {
+				return undefined;
+			}
+			throw error;
+		}
+	}
+
+	public async set(key: Buffer, value: Buffer): Promise<void> {
+		await this._db.set(Buffer.concat([this._prefix, key]), value);
+	}
+}

--- a/elements/lisk-tree/src/merkle_tree/types.ts
+++ b/elements/lisk-tree/src/merkle_tree/types.ts
@@ -57,3 +57,9 @@ export interface NodeLocation {
 }
 
 export type VerifyResult = ReadonlyArray<{ hash: Buffer; verified: boolean }>;
+
+
+export interface Database {
+	get(key: Buffer): Promise<Buffer>;
+	set(key: Buffer, value: Buffer): Promise<void>;
+}

--- a/elements/lisk-tree/src/merkle_tree/types.ts
+++ b/elements/lisk-tree/src/merkle_tree/types.ts
@@ -38,7 +38,7 @@ export interface TreeStructure {
 	[key: number]: NodeInfo[];
 }
 export interface Proof {
-	readonly path: ReadonlyArray<{
+	readonly siblingHashes: ReadonlyArray<{
 		hash: Buffer;
 		layerIndex: number | undefined;
 		nodeIndex: number | undefined;
@@ -47,7 +47,7 @@ export interface Proof {
 		layerIndex: number | undefined;
 		nodeIndex: number | undefined;
 	}>;
-	readonly dataLength: number;
+	readonly size: number;
 }
 
 export interface NodeLocation {
@@ -57,7 +57,6 @@ export interface NodeLocation {
 }
 
 export type VerifyResult = ReadonlyArray<{ hash: Buffer; verified: boolean }>;
-
 
 export interface Database {
 	get(key: Buffer): Promise<Buffer>;

--- a/elements/lisk-tree/src/merkle_tree/utils.ts
+++ b/elements/lisk-tree/src/merkle_tree/utils.ts
@@ -43,18 +43,20 @@ export const getLayerStructure = (dataLength: number): number[] => {
 	return structure;
 };
 
-export const getBinaryString = (num: number, length: number): string => {
+export const getBinaryString = (num: number, length: number): Buffer => {
 	if (length === 0) {
-		return '';
+		return Buffer.alloc(0);
 	}
 	let binaryString = num.toString(2);
-	while (binaryString.length < length) binaryString = `0${binaryString}`;
+	while (binaryString.length < length) {
+		binaryString = `0${binaryString}`;
+	}
 
-	return binaryString;
+	return Buffer.from(binaryString, 'utf8');
 };
 
 export const getBinary = (num: number, length: number): number[] => {
-	const binaryString = getBinaryString(num, length);
+	const binaryString = getBinaryString(num, length).toString('utf8');
 
 	return binaryString.split('').map(d => parseInt(d, 10));
 };

--- a/elements/lisk-tree/src/merkle_tree/utils.ts
+++ b/elements/lisk-tree/src/merkle_tree/utils.ts
@@ -26,18 +26,18 @@ export const generateHash = (prefix: Buffer, leftHash: Buffer, rightHash: Buffer
 		),
 	);
 
-export const getMaxIdxAtLayer = (layer: number, dataLength: number): number => {
-	let [max, r] = [dataLength, 0];
+export const getMaxIdxAtLayer = (layer: number, size: number): number => {
+	let [max, r] = [size, 0];
 	for (let i = 0; i < layer; i += 1) {
 		[max, r] = [[Math.floor, Math.ceil][r % 2](max / 2), r + (max % 2)];
 	}
 	return max;
 };
 
-export const getLayerStructure = (dataLength: number): number[] => {
+export const getLayerStructure = (size: number): number[] => {
 	const structure = [];
-	for (let i = 0; i <= Math.ceil(Math.log2(dataLength)); i += 1) {
-		structure.push(getMaxIdxAtLayer(i, dataLength));
+	for (let i = 0; i <= Math.ceil(Math.log2(size)); i += 1) {
+		structure.push(getMaxIdxAtLayer(i, size));
 	}
 
 	return structure;
@@ -64,11 +64,11 @@ export const getBinary = (num: number, length: number): number[] => {
 export const getPairLocation = (nodeInfo: {
 	layerIndex: number;
 	nodeIndex: number;
-	dataLength: number;
+	size: number;
 }): NodeLocation => {
-	const { layerIndex, nodeIndex, dataLength } = nodeInfo;
-	const treeHeight = Math.ceil(Math.log2(dataLength)) + 1;
-	const layerStructure = getLayerStructure(dataLength);
+	const { layerIndex, nodeIndex, size } = nodeInfo;
+	const treeHeight = Math.ceil(Math.log2(size)) + 1;
+	const layerStructure = getLayerStructure(size);
 	const numberOfNodesInLayer = layerStructure[layerIndex];
 	const binary = getBinary(nodeIndex, treeHeight - layerIndex);
 	const side = [NodeSide.LEFT, NodeSide.RIGHT][binary[binary.length - 1]];

--- a/elements/lisk-tree/test/merkle_tree/merkle_tree.spec.ts
+++ b/elements/lisk-tree/test/merkle_tree/merkle_tree.spec.ts
@@ -40,7 +40,7 @@ describe('MerkleTree', () => {
 
 							const chunk = 2 ** 2;
 							for (let i = 0; i < inputs.length; i += chunk) {
-								const tree = new MerkleTree()
+								const tree = new MerkleTree();
 								await tree.init(inputs.slice(i, i + chunk));
 								subTreeRoots.push(tree.root);
 							}
@@ -103,8 +103,14 @@ describe('MerkleTree', () => {
 					const inputs = test.input.transactionIds.map(hexString => Buffer.from(hexString, 'hex'));
 					const merkleTree = new MerkleTree();
 					await merkleTree.init(inputs);
-					const nodes = merkleTree.size !== 0 ? await Promise.all(Object.keys((merkleTree['_db'] as InMemoryDB)['_data']).filter(key => Buffer.from(key, 'binary')[0] === 0)
-						.map(async key => merkleTree.getNode(Buffer.from(key, 'binary').slice(1)))): [];
+					const nodes =
+						merkleTree.size !== 0
+							? await Promise.all(
+									Object.keys((merkleTree['_db'] as InMemoryDB)['_data'])
+										.filter(key => Buffer.from(key, 'binary')[0] === 0)
+										.map(async key => merkleTree.getNode(Buffer.from(key, 'binary').slice(1))),
+							  )
+							: [];
 					const queryData = nodes
 						.sort(() => 0.5 - Math.random())
 						.slice(0, Math.floor(Math.random() * nodes.length + 1))
@@ -122,9 +128,15 @@ describe('MerkleTree', () => {
 				it('should generate and verify invalid proof', async () => {
 					const inputs = test.input.transactionIds.map(hexString => Buffer.from(hexString, 'hex'));
 					const merkleTree = new MerkleTree();
-					await merkleTree.init(inputs)
-					const nodes = merkleTree.size !== 0 ? await Promise.all(Object.keys((merkleTree['_db'] as InMemoryDB)['_data']).filter(key => Buffer.from(key, 'binary')[0] === 0)
-						.map(async key => merkleTree.getNode(Buffer.from(key, 'binary').slice(1)))): [];
+					await merkleTree.init(inputs);
+					const nodes =
+						merkleTree.size !== 0
+							? await Promise.all(
+									Object.keys((merkleTree['_db'] as InMemoryDB)['_data'])
+										.filter(key => Buffer.from(key, 'binary')[0] === 0)
+										.map(async key => merkleTree.getNode(Buffer.from(key, 'binary').slice(1))),
+							  )
+							: [];
 					const randomizedQueryCount = Math.floor(Math.random() * nodes.length + 1);
 					const invalidNodeIndex =
 						inputs.length > 0 ? Math.floor(Math.random() * randomizedQueryCount + 1) : 0;

--- a/elements/lisk-tree/test/merkle_tree/merkle_tree.spec.ts
+++ b/elements/lisk-tree/test/merkle_tree/merkle_tree.spec.ts
@@ -15,22 +15,24 @@ import * as fixture from '../fixtures/transaction_merkle_root/transaction_merkle
 import { MerkleTree } from '../../src/merkle_tree/merkle_tree';
 import { EMPTY_HASH } from '../../src/merkle_tree/constants';
 import { verifyProof } from '../../src/merkle_tree/verify_proof';
+import { InMemoryDB } from '../../src/merkle_tree/inmemory_db';
 
 describe('MerkleTree', () => {
 	describe('constructor', () => {
 		for (const test of fixture.testCases) {
 			// eslint-disable-next-line jest/valid-title
 			describe(test.description, () => {
-				it('should result in correct merkle root', () => {
+				it('should result in correct merkle root', async () => {
 					const inputs = test.input.transactionIds.map(hexString => Buffer.from(hexString, 'hex'));
-					const merkleTree = new MerkleTree(inputs);
+					const merkleTree = new MerkleTree();
+					await merkleTree.init(inputs);
 
 					expect(merkleTree.root).toEqual(Buffer.from(test.output.transactionMerkleRoot, 'hex'));
 				});
 
 				describe('should allow pre-hashed leafs', () => {
 					if (test.input.transactionIds.length > 2 ** 2) {
-						it('should result in same merkle root if divided into sub tree of power of 2', () => {
+						it('should result in same merkle root if divided into sub tree of power of 2', async () => {
 							const inputs = test.input.transactionIds.map(hexString =>
 								Buffer.from(hexString, 'hex'),
 							);
@@ -38,15 +40,20 @@ describe('MerkleTree', () => {
 
 							const chunk = 2 ** 2;
 							for (let i = 0; i < inputs.length; i += chunk) {
-								subTreeRoots.push(new MerkleTree(inputs.slice(i, i + chunk)).root);
+								const tree = new MerkleTree()
+								await tree.init(inputs.slice(i, i + chunk));
+								subTreeRoots.push(tree.root);
 							}
 
-							expect(new MerkleTree(subTreeRoots, { preHashedLeaf: true }).root).toEqual(
+							const expectedTree = new MerkleTree({ preHashedLeaf: true });
+							await expectedTree.init(subTreeRoots);
+
+							expect(expectedTree.root).toEqual(
 								Buffer.from(test.output.transactionMerkleRoot, 'hex'),
 							);
 						});
 
-						it('should not result in same merkle root if divided into sub tree which is not power of 2', () => {
+						it('should not result in same merkle root if divided into sub tree which is not power of 2', async () => {
 							const inputs = test.input.transactionIds.map(hexString =>
 								Buffer.from(hexString, 'hex'),
 							);
@@ -54,10 +61,15 @@ describe('MerkleTree', () => {
 
 							const chunk = 3;
 							for (let i = 0; i < inputs.length; i += chunk) {
-								subTreeRoots.push(new MerkleTree(inputs.slice(i, i + chunk)).root);
+								const tree = new MerkleTree();
+								await tree.init(inputs.slice(i, i + chunk));
+								subTreeRoots.push(tree.root);
 							}
 
-							expect(new MerkleTree(subTreeRoots, { preHashedLeaf: true }).root).not.toEqual(
+							const expectedTree = new MerkleTree({ preHashedLeaf: true });
+							await expectedTree.init(subTreeRoots);
+
+							expect(expectedTree.root).not.toEqual(
 								Buffer.from(test.output.transactionMerkleRoot, 'hex'),
 							);
 						});
@@ -71,11 +83,12 @@ describe('MerkleTree', () => {
 		for (const test of fixture.testCases.slice(1)) {
 			// eslint-disable-next-line jest/valid-title
 			describe(test.description, () => {
-				it('should append and have correct root', () => {
+				it('should append and have correct root', async () => {
 					const inputs = test.input.transactionIds.map(hexString => Buffer.from(hexString, 'hex'));
 					const toAppend = inputs.pop();
-					const merkleTree = new MerkleTree(inputs);
-					merkleTree.append(toAppend as Buffer);
+					const merkleTree = new MerkleTree();
+					await merkleTree.init(inputs);
+					await merkleTree.append(toAppend as Buffer);
 					expect(merkleTree.root).toEqual(Buffer.from(test.output.transactionMerkleRoot, 'hex'));
 				});
 			});
@@ -86,16 +99,18 @@ describe('MerkleTree', () => {
 		for (const test of fixture.testCases) {
 			// eslint-disable-next-line jest/valid-title
 			describe(test.description, () => {
-				it('should generate and verify correct proof', () => {
+				it('should generate and verify correct proof', async () => {
 					const inputs = test.input.transactionIds.map(hexString => Buffer.from(hexString, 'hex'));
-					const merkleTree = new MerkleTree(inputs);
-					const nodes = merkleTree.getData();
+					const merkleTree = new MerkleTree();
+					await merkleTree.init(inputs);
+					const nodes = merkleTree.size !== 0 ? await Promise.all(Object.keys((merkleTree['_db'] as InMemoryDB)['_data']).filter(key => Buffer.from(key, 'binary')[0] === 0)
+						.map(async key => merkleTree.getNode(Buffer.from(key, 'binary').slice(1)))): [];
 					const queryData = nodes
 						.sort(() => 0.5 - Math.random())
 						.slice(0, Math.floor(Math.random() * nodes.length + 1))
 						.map((node: any) => node.hash);
-					const proof = merkleTree.generateProof(queryData);
-					const results = verifyProof({
+					const proof = await merkleTree.generateProof(queryData);
+					const results = await verifyProof({
 						queryData,
 						proof,
 						rootHash: merkleTree.root,
@@ -104,10 +119,12 @@ describe('MerkleTree', () => {
 					expect(results.every(result => result.verified)).toBeTrue();
 				});
 
-				it('should generate and verify invalid proof', () => {
+				it('should generate and verify invalid proof', async () => {
 					const inputs = test.input.transactionIds.map(hexString => Buffer.from(hexString, 'hex'));
-					const merkleTree = new MerkleTree(inputs);
-					const nodes = merkleTree.getData();
+					const merkleTree = new MerkleTree();
+					await merkleTree.init(inputs)
+					const nodes = merkleTree.size !== 0 ? await Promise.all(Object.keys((merkleTree['_db'] as InMemoryDB)['_data']).filter(key => Buffer.from(key, 'binary')[0] === 0)
+						.map(async key => merkleTree.getNode(Buffer.from(key, 'binary').slice(1)))): [];
 					const randomizedQueryCount = Math.floor(Math.random() * nodes.length + 1);
 					const invalidNodeIndex =
 						inputs.length > 0 ? Math.floor(Math.random() * randomizedQueryCount + 1) : 0;
@@ -119,8 +136,8 @@ describe('MerkleTree', () => {
 									.map((node: any) => node.hash)
 							: [];
 					queryData.splice(invalidNodeIndex, 1, EMPTY_HASH);
-					const proof = merkleTree.generateProof(queryData);
-					const results = verifyProof({
+					const proof = await merkleTree.generateProof(queryData);
+					const results = await verifyProof({
 						queryData,
 						proof,
 						rootHash: merkleTree.root,

--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -616,7 +616,9 @@ export class Forger {
 			transactionIds.push(transaction.id);
 		}
 
-		const transactionRoot = new MerkleTree(transactionIds).root;
+		const txTree = new MerkleTree();
+		await txTree.init(transactionIds);
+		const transactionRoot = txTree.root;
 
 		const header = {
 			version: BLOCK_VERSION,

--- a/framework/src/node/processor/processor.ts
+++ b/framework/src/node/processor/processor.ts
@@ -198,7 +198,7 @@ export class Processor {
 					block: encodedBlock.toString('hex'),
 				});
 
-				this._validate(block);
+				await this._validate(block);
 				const previousLastBlock = objects.cloneDeep(lastBlock);
 				await this._deleteBlock(lastBlock);
 				try {
@@ -223,14 +223,14 @@ export class Processor {
 				{ id: block.header.id, height: block.header.height },
 				'Processing valid block',
 			);
-			this._validate(block);
+			await this._validate(block);
 			await this._processValidated(block);
 		});
 	}
 
-	public validate(block: Block): void {
+	public async validate(block: Block): Promise<void> {
 		this._logger.debug({ id: block.header.id, height: block.header.height }, 'Validating block');
-		this._validate(block);
+		await this._validate(block);
 	}
 
 	// processValidated processes a block assuming that statically it's valid
@@ -416,14 +416,14 @@ export class Processor {
 		return block;
 	}
 
-	private _validate(block: Block): void {
+	private async _validate(block: Block): Promise<void> {
 		// If the schema or bytes does not match with version 2, it fails even before this
 		// This is for fail safe, and genesis block does not use this function
 		if (block.header.version !== BLOCK_VERSION) {
 			throw new ApplyPenaltyError(`Block version must be ${BLOCK_VERSION}`);
 		}
 		try {
-			this._chain.validateBlockHeader(block);
+			await this._chain.validateBlockHeader(block);
 			if (block.payload.length) {
 				for (const transaction of block.payload) {
 					this.validateTransaction(transaction);

--- a/framework/src/node/synchronizer/block_synchronization_mechanism.ts
+++ b/framework/src/node/synchronizer/block_synchronization_mechanism.ts
@@ -171,7 +171,7 @@ export class BlockSynchronizationMechanism extends BaseSynchronizer {
 					if (this._stop) {
 						return;
 					}
-					this.processorModule.validate(block);
+					await this.processorModule.validate(block);
 					await this.processorModule.processValidated(block);
 				}
 			} catch (err) {
@@ -433,7 +433,7 @@ export class BlockSynchronizationMechanism extends BaseSynchronizer {
 			'Received tip of the chain from peer',
 		);
 
-		const { valid: validBlock } = this._blockDetachedStatus(networkLastBlock);
+		const { valid: validBlock } = await this._blockDetachedStatus(networkLastBlock);
 
 		const forkStatus = this.bft.forkChoice(networkLastBlock.header, this._chain.lastBlock.header);
 
@@ -456,9 +456,11 @@ export class BlockSynchronizationMechanism extends BaseSynchronizer {
 	 * of the Pipeline but not in other cases
 	 * that's why we wrap it here.
 	 */
-	private _blockDetachedStatus(networkLastBlock: Block): { valid: boolean; err: Error | null } {
+	private async _blockDetachedStatus(
+		networkLastBlock: Block,
+	): Promise<{ valid: boolean; err: Error | null }> {
 		try {
-			this.processorModule.validate(networkLastBlock);
+			await this.processorModule.validate(networkLastBlock);
 			return { valid: true, err: null };
 		} catch (err) {
 			return { valid: false, err: err as Error };

--- a/framework/src/node/synchronizer/fast_chain_switching_mechanism.ts
+++ b/framework/src/node/synchronizer/fast_chain_switching_mechanism.ts
@@ -59,7 +59,7 @@ export class FastChainSwitchingMechanism extends BaseSynchronizer {
 		try {
 			const highestCommonBlock = await this._requestLastCommonBlock(peerId);
 			const blocks = await this._queryBlocks(receivedBlock, highestCommonBlock, peerId);
-			this._validateBlocks(blocks, peerId);
+			await this._validateBlocks(blocks, peerId);
 			await this._switchChain(highestCommonBlock as BlockHeader, blocks, peerId);
 		} catch (error) {
 			if (error instanceof ApplyPenaltyAndAbortError) {
@@ -197,7 +197,7 @@ export class FastChainSwitchingMechanism extends BaseSynchronizer {
 		return blocks;
 	}
 
-	private _validateBlocks(blocks: ReadonlyArray<Block>, peerId: string): void {
+	private async _validateBlocks(blocks: ReadonlyArray<Block>, peerId: string): Promise<void> {
 		this._logger.debug(
 			{
 				blocks: blocks.map(block => ({
@@ -216,7 +216,7 @@ export class FastChainSwitchingMechanism extends BaseSynchronizer {
 					},
 					'Validating block',
 				);
-				this.processor.validate(block);
+				await this.processor.validate(block);
 			}
 		} catch (err) {
 			throw new ApplyPenaltyAndAbortError(peerId, 'Block validation failed');

--- a/framework/src/node/synchronizer/synchronizer.ts
+++ b/framework/src/node/synchronizer/synchronizer.ts
@@ -111,7 +111,7 @@ export class Synchronizer {
 			);
 			// Moving to a Different Chain
 			// 1. Step: Validate new tip of chain
-			this.processorModule.validate(receivedBlock);
+			await this.processorModule.validate(receivedBlock);
 
 			// Choose the right mechanism to sync
 			const validMechanism = await this._determineSyncMechanism(receivedBlock, peerId);

--- a/framework/src/testing/create_block.ts
+++ b/framework/src/testing/create_block.ts
@@ -82,16 +82,17 @@ export const createFakeBlockHeader = <T = unknown>(
 	} as unknown) as BlockHeader<T>;
 };
 
-export const createBlock = <T = BlockHeaderAsset>({
+export const createBlock = async <T = BlockHeaderAsset>({
 	passphrase,
 	networkIdentifier,
 	timestamp,
 	previousBlockID,
 	payload,
 	header,
-}: CreateBlock<T>): Block<T> => {
+}: CreateBlock<T>): Promise<Block<T>> => {
 	const { publicKey, privateKey } = getPrivateAndPublicKeyFromPassphrase(passphrase);
-	const txTree = new MerkleTree(payload?.map(tx => tx.id));
+	const txTree = new MerkleTree();
+	await txTree.init(payload?.map(tx => tx.id) ?? []);
 
 	const asset = {
 		maxHeightPreviouslyForged: 0,

--- a/framework/test/fixtures/blocks.ts
+++ b/framework/test/fixtures/blocks.ts
@@ -86,13 +86,14 @@ export const createFakeBlockHeader = (header?: Partial<BlockHeader>): BlockHeade
  * Utility function to create a block object with valid computed properties while any property can be overridden
  * Calculates the signature, transactionRoot etc. internally. Facilitating the creation of block with valid signature and other properties
  */
-export const createValidDefaultBlock = (
+export const createValidDefaultBlock = async (
 	block?: { header?: Partial<BlockHeader>; payload?: Transaction[] },
 	networkIdentifier: Buffer = defaultNetworkIdentifier,
-): Block => {
+): Promise<Block> => {
 	const keypair = getKeyPair();
 	const payload = block?.payload ?? [];
-	const txTree = new MerkleTree(payload.map(tx => tx.id));
+	const txTree = new MerkleTree();
+	await txTree.init(payload.map(tx => tx.id));
 
 	const asset = {
 		maxHeightPreviouslyForged: 0,

--- a/framework/test/integration/node/processor/block_process/process_block.spec.ts
+++ b/framework/test/integration/node/processor/block_process/process_block.spec.ts
@@ -161,9 +161,9 @@ describe('Process block', () => {
 		describe('when processing the block', () => {
 			let newBlock: Block;
 
-			beforeAll(() => {
+			beforeAll(async () => {
 				const timestamp = getNextTimeslot(chain);
-				newBlock = testing.createBlock({
+				newBlock = await testing.createBlock({
 					passphrase: account.passphrase,
 					networkIdentifier,
 					timestamp,
@@ -210,9 +210,9 @@ describe('Process block', () => {
 		describe('when processing the block', () => {
 			let newBlock: Block;
 
-			beforeAll(() => {
+			beforeAll(async () => {
 				const timestamp = getNextTimeslot(chain);
-				newBlock = testing.createBlock({
+				newBlock = await testing.createBlock({
 					passphrase: genesis.passphrase,
 					networkIdentifier,
 					timestamp,
@@ -333,7 +333,7 @@ describe('Process block', () => {
 				const validator = await chain.getValidator(timestamp);
 				const passphrase = getPassphraseFromDefaultConfig(validator.address);
 
-				invalidBlock = testing.createBlock({
+				invalidBlock = await testing.createBlock({
 					passphrase,
 					networkIdentifier,
 					timestamp,
@@ -368,7 +368,7 @@ describe('Process block', () => {
 				const validator = await chain.getValidator(timestamp);
 				const passphrase = getPassphraseFromDefaultConfig(validator.address);
 
-				const tieBreakBlock = testing.createBlock({
+				const tieBreakBlock = await testing.createBlock({
 					passphrase,
 					networkIdentifier,
 					timestamp,

--- a/framework/test/integration/testing/block_processing_env.spec.ts
+++ b/framework/test/integration/testing/block_processing_env.spec.ts
@@ -64,7 +64,7 @@ describe('getBlockProcessingEnv', () => {
 		// Arrange
 		const lastBlockHeader = blockProcessEnv.getLastBlock().header;
 		const passphrase = await blockProcessEnv.getNextValidatorPassphrase(lastBlockHeader);
-		const block = createBlock({
+		const block = await createBlock({
 			passphrase,
 			networkIdentifier: blockProcessEnv.getNetworkId(),
 			timestamp: lastBlockHeader.timestamp + blockTime,

--- a/framework/test/unit/modules/dpos/dpos_module.spec.ts
+++ b/framework/test/unit/modules/dpos/dpos_module.spec.ts
@@ -188,23 +188,25 @@ describe('DPoSModule', () => {
 		const bootstrapRound = 5;
 		let context: AfterBlockApplyContext;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			(randomSeed.generateRandomSeeds as Mock).mockReturnValue([]);
 
 			const stateStore = new StateStoreMock({
 				lastBlockHeaders: [
-					testing.createBlock({
-						header: { height: 10 },
-						passphrase: getRandomBytes(20).toString('hex'),
-						networkIdentifier: getRandomBytes(20),
-						previousBlockID: getRandomBytes(20),
-						timestamp: 0,
-					}).header,
+					(
+						await testing.createBlock({
+							header: { height: 10 },
+							passphrase: getRandomBytes(20).toString('hex'),
+							networkIdentifier: getRandomBytes(20),
+							previousBlockID: getRandomBytes(20),
+							timestamp: 0,
+						})
+					).header,
 				],
 			});
 
 			context = testing.createAfterBlockApplyContext({
-				block: testing.createBlock({
+				block: await testing.createBlock({
 					passphrase: getRandomBytes(20).toString('hex'),
 					networkIdentifier: getRandomBytes(20),
 					previousBlockID: getRandomBytes(20),
@@ -256,7 +258,7 @@ describe('DPoSModule', () => {
 			beforeEach(async () => {
 				blockRound = bootstrapRound + 1;
 
-				context.block = testing.createBlock({
+				context.block = await testing.createBlock({
 					header: { height: blockRound * 103 },
 					passphrase: getRandomBytes(20).toString('hex'),
 					networkIdentifier: getRandomBytes(20),
@@ -287,7 +289,7 @@ describe('DPoSModule', () => {
 
 		describe('when its not the last block of round', () => {
 			beforeEach(async () => {
-				context.block = testing.createBlock({
+				context.block = await testing.createBlock({
 					header: { height: (bootstrapRound + 1) * 103 + 3 },
 					passphrase: getRandomBytes(20).toString('hex'),
 					networkIdentifier: getRandomBytes(20),

--- a/framework/test/unit/node/processor/processor.spec.ts
+++ b/framework/test/unit/node/processor/processor.spec.ts
@@ -523,7 +523,7 @@ describe('processor', () => {
 			processor.register(customModule1);
 		});
 
-		it('should throw error if version is not 2', () => {
+		it('should throw error if version is not 2', async () => {
 			const blockV3 = {
 				...blockV2,
 				header: {
@@ -531,22 +531,22 @@ describe('processor', () => {
 					version: 3,
 				},
 			};
-			expect(() => processor.validate(blockV3)).toThrow('Block version must be 2');
+			await expect(processor.validate(blockV3)).rejects.toThrow('Block version must be 2');
 		});
 
-		it('should validate basic properties of block header', () => {
-			processor.validate(blockV2);
+		it('should validate basic properties of block header', async () => {
+			await processor.validate(blockV2);
 			expect(chainModuleStub.validateBlockHeader).toHaveBeenCalledTimes(1);
 		});
 
-		it('should validate payload', () => {
-			processor.validate(blockV2);
+		it('should validate payload', async () => {
+			await processor.validate(blockV2);
 			expect(chainModuleStub.validateTransaction).toHaveBeenCalledTimes(1);
 		});
 
-		it('should validate payload asset', () => {
+		it('should validate payload asset', async () => {
 			jest.spyOn(validator, 'validate');
-			processor.validate(blockV2);
+			await processor.validate(blockV2);
 			expect(validator.validate).toHaveBeenCalledTimes(1);
 			expect(validator.validate).toHaveBeenCalledWith(
 				customModule0.transactionAssets[0].schema,
@@ -554,7 +554,7 @@ describe('processor', () => {
 			);
 		});
 
-		it('should fail when module id does not exist', () => {
+		it('should fail when module id does not exist', async () => {
 			const block = ({
 				header: {
 					id: Buffer.from('fakelock2'),
@@ -573,10 +573,10 @@ describe('processor', () => {
 					}),
 				],
 			} as unknown) as Block;
-			expect(() => processor.validate(block)).toThrow('Module id 20 does not exist');
+			await expect(processor.validate(block)).rejects.toThrow('Module id 20 does not exist');
 		});
 
-		it('should fail when asset id does not exist', () => {
+		it('should fail when asset id does not exist', async () => {
 			const block = ({
 				header: {
 					id: Buffer.from('fakelock2'),
@@ -595,7 +595,9 @@ describe('processor', () => {
 					}),
 				],
 			} as unknown) as Block;
-			expect(() => processor.validate(block)).toThrow('Asset id 5 does not exist in module id 3.');
+			await expect(processor.validate(block)).rejects.toThrow(
+				'Asset id 5 does not exist in module id 3.',
+			);
 		});
 	});
 

--- a/framework/test/unit/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
+++ b/framework/test/unit/node/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
@@ -258,16 +258,16 @@ describe('fast_chain_switching_mechanism', () => {
 		};
 
 		beforeEach(async () => {
-			finalizedBlock = createValidDefaultBlock({
+			finalizedBlock = await createValidDefaultBlock({
 				header: { height: finalizedHeight },
 			});
 
-			aBlock = createValidDefaultBlock();
+			aBlock = await createValidDefaultBlock();
 			// chainModule.init will check whether the genesisBlock in storage matches the genesisBlock in
 			// memory. The following mock fakes this to be true
 			// chainModule.init will load the last block from storage and store it in ._lastBlock variable. The following mock
 			// simulates the last block in storage. So the storage has 2 blocks, the genesis block + a new one.
-			lastBlock = createValidDefaultBlock({
+			lastBlock = await createValidDefaultBlock({
 				header: { height: finalizedHeight + 1 },
 			});
 
@@ -437,7 +437,7 @@ describe('fast_chain_switching_mechanism', () => {
 
 				// Act
 				// the difference in height between the common block and the received block is > delegatesPerRound*2
-				const receivedBlock = createValidDefaultBlock({
+				const receivedBlock = await createValidDefaultBlock({
 					header: {
 						height: highestCommonBlock.height + chainModule.numberOfValidators * 2 + 1,
 					},
@@ -465,7 +465,7 @@ describe('fast_chain_switching_mechanism', () => {
 					height: lastBlock.header.height + 1,
 				});
 				// Difference in height between the common block and the last block is > delegatesPerRound*2
-				lastBlock = createValidDefaultBlock({
+				lastBlock = await createValidDefaultBlock({
 					header: {
 						height: highestCommonBlock.height + chainModule.numberOfValidators * 2 + 1,
 					},
@@ -524,7 +524,7 @@ describe('fast_chain_switching_mechanism', () => {
 					} as never);
 
 				// Act
-				const receivedBlock = createValidDefaultBlock({
+				const receivedBlock = await createValidDefaultBlock({
 					header: {
 						height: highestCommonBlock.height + chainModule.numberOfValidators * 2 + 1,
 					},
@@ -623,13 +623,13 @@ describe('fast_chain_switching_mechanism', () => {
 				});
 
 				const requestedBlocks = [
-					createValidDefaultBlock({
+					await createValidDefaultBlock({
 						header: {
 							height: highestCommonBlock.height + 1,
 							previousBlockID: highestCommonBlock.id,
 						},
 					}),
-					...new Array(34).fill(0).map(() => createValidDefaultBlock()),
+					...(await Promise.all(new Array(34).fill(0).map(async () => createValidDefaultBlock()))),
 					aBlock,
 				];
 
@@ -702,13 +702,13 @@ describe('fast_chain_switching_mechanism', () => {
 				});
 
 				const requestedBlocks = [
-					createValidDefaultBlock({
+					await createValidDefaultBlock({
 						header: {
 							height: highestCommonBlock.height + 1,
 							previousBlockID: highestCommonBlock.id,
 						},
 					}),
-					...new Array(34).fill(0).map(() => createValidDefaultBlock()),
+					...(await Promise.all(new Array(34).fill(0).map(async () => createValidDefaultBlock()))),
 					aBlock,
 				];
 
@@ -767,13 +767,13 @@ describe('fast_chain_switching_mechanism', () => {
 					height: finalizedBlock.header.height,
 				});
 				const requestedBlocks = [
-					createValidDefaultBlock({
+					await createValidDefaultBlock({
 						header: {
 							height: highestCommonBlock.height + 1,
 							previousBlockID: highestCommonBlock.id,
 						},
 					}),
-					...new Array(34).fill(0).map(() => createValidDefaultBlock()),
+					...(await Promise.all(new Array(34).fill(0).map(async () => createValidDefaultBlock()))),
 					aBlock,
 				];
 
@@ -878,13 +878,13 @@ describe('fast_chain_switching_mechanism', () => {
 					height: finalizedBlock.header.height,
 				});
 				const requestedBlocks = [
-					createValidDefaultBlock({
+					await createValidDefaultBlock({
 						header: {
 							height: highestCommonBlock.height + 1,
 							previousBlockID: highestCommonBlock.id,
 						},
 					}),
-					...new Array(34).fill(0).map(() => createValidDefaultBlock()),
+					...(await Promise.all(new Array(34).fill(0).map(async () => createValidDefaultBlock()))),
 					aBlock,
 				];
 
@@ -912,8 +912,8 @@ describe('fast_chain_switching_mechanism', () => {
 					.calledWith(highestCommonBlock.id)
 					.mockResolvedValue(highestCommonBlock as never);
 
-				processorModule.deleteLastBlock.mockImplementation(() => {
-					chainModule._lastBlock = createValidDefaultBlock({
+				processorModule.deleteLastBlock.mockImplementation(async () => {
+					chainModule._lastBlock = await createValidDefaultBlock({
 						header: { height: chainModule._lastBlock.header.height - 1 },
 					});
 				});

--- a/framework/test/unit/node/synchronizer/synchronizer.spec.ts
+++ b/framework/test/unit/node/synchronizer/synchronizer.spec.ts
@@ -156,9 +156,9 @@ describe('Synchronizer', () => {
 	});
 
 	describe('init()', () => {
-		beforeEach(() => {
+		beforeEach(async () => {
 			// Arrange
-			const lastBlock = createValidDefaultBlock({
+			const lastBlock = await createValidDefaultBlock({
 				header: { height: genesisBlock.header.height + 1 },
 			});
 			when(chainModule.dataAccess.getBlockHeaderByID)
@@ -183,18 +183,19 @@ describe('Synchronizer', () => {
 
 			it('should restore blocks from blocks temporary table into blocks table if tip of temp table chain has preference over current tip (FORK_STATUS_DIFFERENT_CHAIN)', async () => {
 				// Arrange
-				const blocksTempTableEntries = new Array(10)
-					.fill(0)
-					.map((_, index) => ({
-						...createValidDefaultBlock({
-							header: {
-								height: index,
-								version: 2,
-							},
-						}),
-					}))
-					.slice(genesisBlock.header.height + 2);
-				const initialLastBlock = createValidDefaultBlock({
+				const blocksTempTableEntries = (
+					await Promise.all(
+						new Array(10).fill(0).map(async (_, index) =>
+							createValidDefaultBlock({
+								header: {
+									height: index,
+									version: 2,
+								},
+							}),
+						),
+					)
+				).slice(genesisBlock.header.height + 2);
+				const initialLastBlock = await createValidDefaultBlock({
 					header: {
 						height: genesisBlock.header.height + 3,
 						previousBlockID: genesisBlock.header.id,
@@ -255,7 +256,7 @@ describe('Synchronizer', () => {
 
 			it('should restore blocks from blocks temporary table into blocks table if tip of temp table chain has preference over current tip (FORK_STATUS_VALID_BLOCK)', async () => {
 				// Arrange
-				const initialLastBlock = createValidDefaultBlock({
+				const initialLastBlock = await createValidDefaultBlock({
 					header: {
 						height: genesisBlock.header.height + 1,
 						previousBlockID: genesisBlock.header.id,
@@ -302,7 +303,7 @@ describe('Synchronizer', () => {
 
 			it('should clear the blocks temp table if the tip of the temp table does not have priority over current tip (Any other Fork Choice code', async () => {
 				// Arrange
-				const initialLastBlock = createValidDefaultBlock({
+				const initialLastBlock = await createValidDefaultBlock({
 					header: {
 						height: genesisBlock.header.height + 1,
 						previousBlockID: genesisBlock.header.id,
@@ -340,18 +341,19 @@ describe('Synchronizer', () => {
 
 		it('should catch any errors and error log it', async () => {
 			// Arrange
-			const blocksTempTableEntries = new Array(10)
-				.fill(0)
-				.map((_, index) => ({
-					...createValidDefaultBlock({
-						header: {
-							height: index,
-							version: 2,
-						},
-					}),
-				}))
-				.slice(genesisBlock.header.height + 2);
-			const initialLastBlock = createValidDefaultBlock({
+			const blocksTempTableEntries = (
+				await Promise.all(
+					new Array(10).fill(0).map(async (_, index) =>
+						createValidDefaultBlock({
+							header: {
+								height: index,
+								version: 2,
+							},
+						}),
+					),
+				)
+			).slice(genesisBlock.header.height + 2);
+			const initialLastBlock = await createValidDefaultBlock({
 				header: {
 					height: genesisBlock.header.height + 1,
 					previousBlockID: genesisBlock.header.id,
@@ -464,8 +466,8 @@ describe('Synchronizer', () => {
 		const aPeerId = '127.0.0.1:5000';
 		let aReceivedBlock: Block;
 
-		beforeEach(() => {
-			aReceivedBlock = createValidDefaultBlock(); // newBlock() creates a block instance, and we want to simulate a block in JSON format that comes from the network
+		beforeEach(async () => {
+			aReceivedBlock = await createValidDefaultBlock(); // newBlock() creates a block instance, and we want to simulate a block in JSON format that comes from the network
 		});
 
 		it('should reject with error if there is already an active mechanism', () => {

--- a/framework/test/unit/node/synchronizer/utils.spec.ts
+++ b/framework/test/unit/node/synchronizer/utils.spec.ts
@@ -23,9 +23,9 @@ describe('#synchronizer/utils', () => {
 	let processorMock: any;
 	let loggerMock: any;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		chainMock = {
-			lastBlock: createValidDefaultBlock({ header: { height: 1 } }),
+			lastBlock: await createValidDefaultBlock({ header: { height: 1 } }),
 			dataAccess: {
 				getTempBlocks: jest.fn(),
 				clearTempBlocks: jest.fn(),
@@ -51,7 +51,7 @@ describe('#synchronizer/utils', () => {
 	describe('restoreBlocks()', () => {
 		it('should return true on success', async () => {
 			// Arrange
-			const blocks = [createValidDefaultBlock(), createValidDefaultBlock()];
+			const blocks = [await createValidDefaultBlock(), await createValidDefaultBlock()];
 			chainMock.dataAccess.getTempBlocks = jest.fn().mockReturnValue(blocks);
 
 			// Act
@@ -63,7 +63,7 @@ describe('#synchronizer/utils', () => {
 
 		it('should pass block to processValidated with right flags', async () => {
 			// Arrange
-			const blocks = [createValidDefaultBlock(), createValidDefaultBlock()];
+			const blocks = [await createValidDefaultBlock(), await createValidDefaultBlock()];
 			chainMock.dataAccess.getTempBlocks = jest.fn().mockReturnValue(blocks);
 
 			// Act
@@ -96,9 +96,9 @@ describe('#synchronizer/utils', () => {
 
 	describe('restoreBlocksUponStartup()', () => {
 		let tempBlocks: Block[];
-		beforeEach(() => {
+		beforeEach(async () => {
 			tempBlocks = [
-				createValidDefaultBlock({
+				await createValidDefaultBlock({
 					header: {
 						height: 11,
 						asset: {
@@ -108,7 +108,7 @@ describe('#synchronizer/utils', () => {
 						},
 					},
 				}),
-				createValidDefaultBlock({
+				await createValidDefaultBlock({
 					header: {
 						height: 10,
 						asset: {

--- a/framework/test/unit/node/transport/transport_private.spec.ts
+++ b/framework/test/unit/node/transport/transport_private.spec.ts
@@ -395,10 +395,10 @@ describe('transport', () => {
 		});
 
 		describe('Transport', () => {
-			beforeEach(() => {
+			beforeEach(async () => {
 				blocksList = [];
 				for (let j = 0; j < 10; j += 1) {
-					const auxBlock = createValidDefaultBlock();
+					const auxBlock = await createValidDefaultBlock();
 					blocksList.push(auxBlock);
 				}
 			});

--- a/framework/test/unit/testing/create_block.spec.ts
+++ b/framework/test/unit/testing/create_block.spec.ts
@@ -38,8 +38,8 @@ describe('Create Block', () => {
 			.genesisBlock;
 	});
 
-	it('should return a valid default block', () => {
-		const block = createBlock({
+	it('should return a valid default block', async () => {
+		const block = await createBlock({
 			passphrase: genesis.passphrase,
 			networkIdentifier: Buffer.from(networkIdentifier, 'hex'),
 			timestamp: genesisBlock.header.timestamp,
@@ -71,7 +71,7 @@ describe('Create Block', () => {
 		expect(block).toEqual(expect.objectContaining(expectedBlock));
 	});
 
-	it('should return a valid block for given block header', () => {
+	it('should return a valid block for given block header', async () => {
 		const expectedAsset = {
 			maxHeightPreviouslyForged: 10,
 			maxHeightPrevoted: 10,
@@ -94,7 +94,7 @@ describe('Create Block', () => {
 			payload: [],
 		};
 
-		const block = createBlock({
+		const block = await createBlock({
 			passphrase: genesis.passphrase,
 			networkIdentifier: Buffer.from(networkIdentifier, 'hex'),
 			timestamp: genesisBlock.header.timestamp,
@@ -112,8 +112,8 @@ describe('Create Block', () => {
 		expect(block).toEqual(expect.objectContaining(expectedBlock));
 	});
 
-	it('should return a valid previous block id and timestamp from genesis block', () => {
-		const block = createBlock({
+	it('should return a valid previous block id and timestamp from genesis block', async () => {
+		const block = await createBlock({
 			passphrase: genesis.passphrase,
 			networkIdentifier: Buffer.from(networkIdentifier, 'hex'),
 			timestamp: genesisBlock.header.timestamp + 10,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6491 and #6510

### How was it solved?

- Create database interface and expect to be optional input in constructor
- Update merkle tree initialization to be separate function because it's asynchronous task now
- Rename the variable to be consistent with SMT
- Remove unnecessary interface which cannot be supported with DB

### How was it tested?

- All test should be passing
