### PR TITLE
Implement utility functions for sparse Merkle tree - Closes #6496 

### DIFF
--- a/elements/lisk-tree/src/sparse_merkle_tree/constants.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/constants.ts
@@ -14,5 +14,4 @@
 
 import { hash } from '@liskhq/lisk-cryptography';
 
-export const KEY_LENGTH_BYTES = 4;
 export const EMPTY_HASH = hash(Buffer.alloc(0));

--- a/elements/lisk-tree/src/sparse_merkle_tree/constants.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/constants.ts
@@ -12,18 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export interface InclusionProof {
-	readonly siblingHashes: Buffer[];
-	readonly queries: InclusionProofQuery[];
-}
+import { hash } from '@liskhq/lisk-cryptography';
 
-export interface InclusionProofQuery {
-	readonly key: Buffer;
-	readonly value: Buffer;
-	readonly bitmap: Buffer;
-}
-
-export interface InclusionProofQueryWithHash extends InclusionProofQuery {
-	hash: Buffer;
-	binaryBitmap: string;
-}
+export const KEY_LENGTH_BYTES = 4;
+export const EMPTY_HASH = hash(Buffer.alloc(0));

--- a/elements/lisk-tree/src/sparse_merkle_tree/types.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/types.ts
@@ -12,20 +12,21 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export interface InclusionProof {
+export interface Proof {
 	readonly siblingHashes: Buffer[];
-	readonly queries: InclusionProofQuery[];
+	readonly queries: ProofQuery[];
 }
 
-export interface InclusionProofQuery {
+export interface ProofQuery {
 	readonly key: Buffer;
 	readonly value: Buffer;
-	readonly bitmap: Buffer;
+	// During calculations bitmap values can change so these are not readonly
+	bitmap: Buffer;
+	binaryBitmap: string;
 }
 
-export interface InclusionProofQueryWithHash extends InclusionProofQuery {
+export interface ProofQueryWithHash extends ProofQuery {
 	hash: Buffer;
-	binaryBitmap: string;
 }
 
 export interface Database {

--- a/elements/lisk-tree/src/sparse_merkle_tree/types.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export interface InclusionProof {
+	readonly siblingHashes: Buffer[];
+	readonly queries: InclusionProofQueryResult[];
+}
+
+export interface InclusionProofQueryResult {
+	key: Buffer;
+	value: Buffer;
+	bitmap: Buffer;
+}

--- a/elements/lisk-tree/src/sparse_merkle_tree/types.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/types.ts
@@ -14,19 +14,13 @@
 
 export interface Proof {
 	readonly siblingHashes: Buffer[];
-	readonly queries: ProofQuery[];
+	readonly queries: Query[];
 }
 
-export interface ProofQuery {
+export interface Query {
 	readonly key: Buffer;
 	readonly value: Buffer;
-	// During calculations bitmap values can change so these are not readonly
-	bitmap: Buffer;
-	binaryBitmap: string;
-}
-
-export interface ProofQueryWithHash extends ProofQuery {
-	hash: Buffer;
+	readonly bitmap: Buffer;
 }
 
 export interface Database {

--- a/elements/lisk-tree/src/sparse_merkle_tree/utils.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/utils.ts
@@ -170,7 +170,10 @@ export const binaryStringToBuffer = (str: string) => {
 };
 
 // TODO: Replace with actual method
-const leafNode = (_key: Buffer, _value: Buffer): { hash: Buffer } => ({ hash: EMPTY_HASH });
+const leafNode = (key: Buffer, value: Buffer): { hash: Buffer } => ({
+	hash: Buffer.concat([key, value]),
+});
 
 // TODO: Replace with actual method
-const branchHash = (_hash: Buffer, _siblingHash: Buffer): Buffer => EMPTY_HASH;
+const branchHash = (hash: Buffer, siblingHash: Buffer): Buffer =>
+	Buffer.concat([hash, siblingHash]);

--- a/elements/lisk-tree/src/sparse_merkle_tree/utils.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/utils.ts
@@ -54,17 +54,23 @@ export const filterQueries = <T extends InclusionProofQuery>(queries: T[]): T[] 
 // children of the same branch node, with q1 and q2 the left and right
 // child respectively
 // https://github.com/LiskHQ/lips-staging/blob/master/proposals/lip-0039.md#proof-verification
-export const areSiblingQueries = (q1: InclusionProofQuery, q2: InclusionProofQuery): boolean => {
+export const areSiblingQueries = (
+	q1: InclusionProofQuery,
+	q2: InclusionProofQuery,
+	keyLength?: number,
+): boolean => {
 	const q1BinaryBitmap = bufferToBinaryString(q1.bitmap);
-	const q2BinaryBitmap = bufferToBinaryString(q1.bitmap);
+	const q2BinaryBitmap = bufferToBinaryString(q2.bitmap);
 
 	if (q1BinaryBitmap.length !== q2BinaryBitmap.length) {
 		return false;
 	}
 
 	const h = q1BinaryBitmap.length;
-	const binaryKey1 = binaryExpansion(q1.key);
-	const binaryKey2 = binaryExpansion(q2.key);
+	const binaryKey1 = binaryExpansion(q1.key, keyLength);
+	const binaryKey2 = binaryExpansion(q2.key, keyLength);
+
+	// end of string is exclusive
 	const keyPrefix1 = binaryKey1.substring(0, h - 1);
 	const keyPrefix2 = binaryKey2.substring(0, h - 1);
 
@@ -75,7 +81,7 @@ export const areSiblingQueries = (q1: InclusionProofQuery, q2: InclusionProofQue
 	const d1 = binaryKey1[h];
 	const d2 = binaryKey2[h];
 
-	return d1 === '0' && d2 === '1';
+	return (d1 === '0' && d2 === '1') || (d1 === '1' && d2 === '0');
 };
 
 // https://github.com/LiskHQ/lips-staging/blob/master/proposals/lip-0039.md#proof-verification
@@ -142,8 +148,8 @@ export const calculateRoot = (sibHashes: Buffer[], queries: InclusionProofQuery[
 	throw new Error('Can not calculate root hash');
 };
 
-export const binaryExpansion = (k: Buffer, length = 8 * KEY_LENGTH_BYTES) =>
-	bufferToBinaryString(k).padStart(length, '0');
+export const binaryExpansion = (k: Buffer, _keyLength = KEY_LENGTH_BYTES) =>
+	bufferToBinaryString(k).padStart(3, '0');
 
 export const bufferToBinaryString = (buf: Buffer) => {
 	let result = '';

--- a/elements/lisk-tree/src/sparse_merkle_tree/utils.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/utils.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { InclusionProofQueryResult } from './types';
+
+export const sortByBitmapAndKey = (
+	queries: InclusionProofQueryResult[],
+): InclusionProofQueryResult[] =>
+	queries.sort((q1, q2) => {
+		if (q1.bitmap.byteLength === q2.bitmap.byteLength) {
+			return q1.key.byteLength - q2.key.byteLength;
+		}
+
+		return q2.bitmap.byteLength - q1.bitmap.byteLength;
+	});

--- a/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
+++ b/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
@@ -18,6 +18,8 @@ import {
 	binaryStringToBuffer,
 	bufferToBinaryString,
 	areSiblingQueries,
+	filterQueries,
+	calculateRoot,
 } from '../../src/sparse_merkle_tree/utils';
 import { InclusionProofQuery } from '../../src/sparse_merkle_tree/types';
 
@@ -95,9 +97,9 @@ describe('utils', () => {
 		});
 	});
 
-	describe.only('areSiblingQueries', () => {
+	describe('areSiblingQueries', () => {
 		it('should return true for valid sibling queries', () => {
-			// These values are generate from specs for keys "11101101" and "11100001"
+			// These values are generate from inclusion proof tree diagram for keys "11101101" and "11100001"
 			expect(
 				areSiblingQueries(
 					createQueryObject({ key: 'ed', value: 'f3df1f9c', bitmap: '17' }),
@@ -108,7 +110,7 @@ describe('utils', () => {
 		});
 
 		it('should return true for valid sibling queries even if swapped', () => {
-			// These values are generate from specs for keys "11101101" and "11100001"
+			// These values are generate from inclusion proof tree diagram for keys "11101101" and "11100001"
 			expect(
 				areSiblingQueries(
 					createQueryObject({ key: 'e1', value: 'f031efa5', bitmap: '17' }),
@@ -119,7 +121,7 @@ describe('utils', () => {
 		});
 
 		it('should return false for invalid sibling queries', () => {
-			// These values are generate from specs for keys "00110011" and "01101100"
+			// These values are generate from inclusion proof tree diagram for keys "00110011" and "01101100"
 			expect(
 				areSiblingQueries(
 					createQueryObject({ key: '33', value: '4e074085', bitmap: '17' }),
@@ -130,7 +132,7 @@ describe('utils', () => {
 		});
 
 		it('should return false for invalid sibling queries even if swapped', () => {
-			// These values are generate from specs for keys "00110011" and "01101100"
+			// These values are generate from inclusion proof tree diagram for keys "00110011" and "01101100"
 			expect(
 				areSiblingQueries(
 					createQueryObject({ key: '6c', value: 'acac86c0', bitmap: '1f' }),
@@ -138,6 +140,40 @@ describe('utils', () => {
 					1,
 				),
 			).toBeFalse();
+		});
+	});
+
+	describe('filterQueries', () => {
+		it('should remove queries which are merged together', () => {
+			// These values are generate from inclusion proof tree diagram
+			// for keys "01111110", "01110110", "01110111", "01011010"
+			const q1 = createQueryObject({ key: '7e', value: '7ace431c', bitmap: '1f' });
+			const q2 = createQueryObject({ key: '76', value: '4c94485e', bitmap: '1f' });
+			const q3 = createQueryObject({ key: '76', value: '4c94485e', bitmap: '1f' });
+			const q4 = createQueryObject({ key: '5a', value: 'bbeebd87', bitmap: '07' });
+
+			expect(filterQueries([q1, q2, q3, q4], 1)).toEqual([q1, q2, q4]);
+		});
+	});
+
+	describe('calculateRoot', () => {
+		// Enable this test once we have right implementation of "leafNode" and "branchHash"
+		// eslint-disable-next-line jest/no-disabled-tests
+		it.skip('should calculate correct root hash', () => {
+			const siblingHashes = [
+				'508e7ce32a2dfb6c39123ad6daaea8dde3bbcb096dd255bea05bea9b717898c3',
+				'99b0161609748a131c16d46c72ff79ffbfa85e9e2694c52ee665635c4d48ecae',
+				'7ef9d01187c522f5d7198874a28cdb495abefe4fc5b3fa4fb235ba21633928a6',
+			].map(h => Buffer.from(h, 'hex'));
+			const queries = [
+				createQueryObject({ key: '7e', value: '7ace431c', bitmap: '1f' }),
+				createQueryObject({ key: '76', value: '4c94485e', bitmap: '1f' }),
+				createQueryObject({ key: '76', value: '4c94485e', bitmap: '1f' }),
+				createQueryObject({ key: '5a', value: 'bbeebd87', bitmap: '07' }),
+			];
+			const rootHash = '21ecda9db382eff32c9ec899fc7090cf58858e8c22a2af82510cd4d9c9a42c2f';
+
+			expect(calculateRoot(siblingHashes, queries, 1).toString('hex')).toEqual(rootHash);
 		});
 	});
 

--- a/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
+++ b/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
@@ -17,6 +17,7 @@ import {
 	sortByBitmapAndKey,
 	binaryStringToBuffer,
 	bufferToBinaryString,
+	areSiblingQueries,
 } from '../../src/sparse_merkle_tree/utils';
 import { InclusionProofQuery } from '../../src/sparse_merkle_tree/types';
 
@@ -28,6 +29,20 @@ const binarySampleData = [
 	{ str: '10101001101100', buf: '2A6C' },
 	{ str: '1111110010101001101100', buf: '3F2A6C' },
 ];
+
+const createQueryObject = ({
+	key,
+	value,
+	bitmap,
+}: {
+	key: string;
+	value: string;
+	bitmap: string;
+}): InclusionProofQuery => ({
+	key: Buffer.from(key, 'hex'),
+	value: Buffer.from(value, 'hex'),
+	bitmap: Buffer.from(bitmap, 'hex'),
+});
 
 describe('utils', () => {
 	describe('sortByBitmapAndKey', () => {
@@ -77,6 +92,52 @@ describe('utils', () => {
 			};
 
 			expect(sortByBitmapAndKey([res1, res2])).toEqual([res1, res2]);
+		});
+	});
+
+	describe.only('areSiblingQueries', () => {
+		it('should return true for valid sibling queries', () => {
+			// These values are generate from specs for keys "11101101" and "11100001"
+			expect(
+				areSiblingQueries(
+					createQueryObject({ key: 'ed', value: 'f3df1f9c', bitmap: '17' }),
+					createQueryObject({ key: 'e1', value: 'f031efa5', bitmap: '17' }),
+					1,
+				),
+			).toBeTrue();
+		});
+
+		it('should return true for valid sibling queries even if swapped', () => {
+			// These values are generate from specs for keys "11101101" and "11100001"
+			expect(
+				areSiblingQueries(
+					createQueryObject({ key: 'e1', value: 'f031efa5', bitmap: '17' }),
+					createQueryObject({ key: 'ed', value: 'f3df1f9c', bitmap: '17' }),
+					1,
+				),
+			).toBeTrue();
+		});
+
+		it('should return false for invalid sibling queries', () => {
+			// These values are generate from specs for keys "00110011" and "01101100"
+			expect(
+				areSiblingQueries(
+					createQueryObject({ key: '33', value: '4e074085', bitmap: '17' }),
+					createQueryObject({ key: '6c', value: 'acac86c0', bitmap: '1f' }),
+					1,
+				),
+			).toBeFalse();
+		});
+
+		it('should return false for invalid sibling queries even if swapped', () => {
+			// These values are generate from specs for keys "00110011" and "01101100"
+			expect(
+				areSiblingQueries(
+					createQueryObject({ key: '6c', value: 'acac86c0', bitmap: '1f' }),
+					createQueryObject({ key: '33', value: '4e074085', bitmap: '17' }),
+					1,
+				),
+			).toBeFalse();
 		});
 	});
 

--- a/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
+++ b/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
@@ -13,19 +13,32 @@
  */
 
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
-import { sortByBitmapAndKey } from '../../src/sparse_merkle_tree/utils';
-import { InclusionProofQueryResult } from '../../src/sparse_merkle_tree/types';
+import {
+	sortByBitmapAndKey,
+	binaryStringToBuffer,
+	bufferToBinaryString,
+} from '../../src/sparse_merkle_tree/utils';
+import { InclusionProofQuery } from '../../src/sparse_merkle_tree/types';
+
+const binarySampleData = [
+	{ str: '101', buf: '05' },
+	{ str: '11111111', buf: 'FF' },
+	{ str: '11111111', buf: 'FF' },
+	{ str: '100000000', buf: '0100' },
+	{ str: '10101001101100', buf: '2A6C' },
+	{ str: '1111110010101001101100', buf: '3F2A6C' },
+];
 
 describe('utils', () => {
 	describe('sortByBitmapAndKey', () => {
 		it('should sort by longest bitmap', () => {
-			const res1: InclusionProofQueryResult = {
+			const res1: InclusionProofQuery = {
 				key: getRandomBytes(2),
 				value: getRandomBytes(20),
 				bitmap: getRandomBytes(1),
 			};
 
-			const res2: InclusionProofQueryResult = {
+			const res2: InclusionProofQuery = {
 				key: getRandomBytes(2),
 				value: getRandomBytes(20),
 				bitmap: getRandomBytes(2),
@@ -35,13 +48,13 @@ describe('utils', () => {
 		});
 
 		it('should sort by longest bitmap breaking tie with smaller key', () => {
-			const res1: InclusionProofQueryResult = {
+			const res1: InclusionProofQuery = {
 				key: getRandomBytes(2),
 				value: getRandomBytes(20),
 				bitmap: getRandomBytes(2),
 			};
 
-			const res2: InclusionProofQueryResult = {
+			const res2: InclusionProofQuery = {
 				key: getRandomBytes(1),
 				value: getRandomBytes(20),
 				bitmap: getRandomBytes(2),
@@ -51,19 +64,31 @@ describe('utils', () => {
 		});
 
 		it('should not effect sorting if same byte length of key and bitmap are same', () => {
-			const res1: InclusionProofQueryResult = {
+			const res1: InclusionProofQuery = {
 				key: getRandomBytes(2),
 				value: getRandomBytes(20),
 				bitmap: getRandomBytes(2),
 			};
 
-			const res2: InclusionProofQueryResult = {
+			const res2: InclusionProofQuery = {
 				key: getRandomBytes(2),
 				value: getRandomBytes(20),
 				bitmap: getRandomBytes(2),
 			};
 
 			expect(sortByBitmapAndKey([res1, res2])).toEqual([res1, res2]);
+		});
+	});
+
+	describe('binaryStringToBuffer', () => {
+		it.each(binarySampleData)('should convert binary string "%o" to correct buffer value', data => {
+			expect(binaryStringToBuffer(data.str)).toEqual(Buffer.from(data.buf, 'hex'));
+		});
+	});
+
+	describe('bufferToBinaryString', () => {
+		it.each(binarySampleData)('should convert buffer "%o" to correct binary string', data => {
+			expect(bufferToBinaryString(Buffer.from(data.buf, 'hex'))).toEqual(data.str);
 		});
 	});
 });

--- a/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
+++ b/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
@@ -79,22 +79,6 @@ describe('utils', () => {
 
 			expect(sortByBitmapAndKey([res1, res2])).toEqual([res2, res1]);
 		});
-
-		it('should not effect sorting if same byte length of key and bitmap are same', () => {
-			const res1: InclusionProofQuery = {
-				key: getRandomBytes(2),
-				value: getRandomBytes(20),
-				bitmap: getRandomBytes(2),
-			};
-
-			const res2: InclusionProofQuery = {
-				key: getRandomBytes(2),
-				value: getRandomBytes(20),
-				bitmap: getRandomBytes(2),
-			};
-
-			expect(sortByBitmapAndKey([res1, res2])).toEqual([res1, res2]);
-		});
 	});
 
 	describe('areSiblingQueries', () => {

--- a/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
+++ b/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { sortByBitmapAndKey } from '../../src/sparse_merkle_tree/utils';
+import { InclusionProofQueryResult } from '../../src/sparse_merkle_tree/types';
+
+describe('utils', () => {
+	describe('sortByBitmapAndKey', () => {
+		it('should sort by longest bitmap', () => {
+			const res1: InclusionProofQueryResult = {
+				key: getRandomBytes(2),
+				value: getRandomBytes(20),
+				bitmap: getRandomBytes(1),
+			};
+
+			const res2: InclusionProofQueryResult = {
+				key: getRandomBytes(2),
+				value: getRandomBytes(20),
+				bitmap: getRandomBytes(2),
+			};
+
+			expect(sortByBitmapAndKey([res1, res2])).toEqual([res2, res1]);
+		});
+
+		it('should sort by longest bitmap breaking tie with smaller key', () => {
+			const res1: InclusionProofQueryResult = {
+				key: getRandomBytes(2),
+				value: getRandomBytes(20),
+				bitmap: getRandomBytes(2),
+			};
+
+			const res2: InclusionProofQueryResult = {
+				key: getRandomBytes(1),
+				value: getRandomBytes(20),
+				bitmap: getRandomBytes(2),
+			};
+
+			expect(sortByBitmapAndKey([res1, res2])).toEqual([res2, res1]);
+		});
+
+		it('should not effect sorting if same byte length of key and bitmap are same', () => {
+			const res1: InclusionProofQueryResult = {
+				key: getRandomBytes(2),
+				value: getRandomBytes(20),
+				bitmap: getRandomBytes(2),
+			};
+
+			const res2: InclusionProofQueryResult = {
+				key: getRandomBytes(2),
+				value: getRandomBytes(20),
+				bitmap: getRandomBytes(2),
+			};
+
+			expect(sortByBitmapAndKey([res1, res2])).toEqual([res1, res2]);
+		});
+	});
+});

--- a/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
+++ b/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
@@ -21,7 +21,7 @@ import {
 	filterQueries,
 	calculateRoot,
 } from '../../src/sparse_merkle_tree/utils';
-import { InclusionProofQuery } from '../../src/sparse_merkle_tree/types';
+import { ProofQuery } from '../../src/sparse_merkle_tree/types';
 
 const binarySampleData = [
 	{ str: '101', buf: '05' },
@@ -40,41 +40,38 @@ const createQueryObject = ({
 	key: string;
 	value: string;
 	bitmap: string;
-}): InclusionProofQuery => ({
+}): ProofQuery => ({
 	key: Buffer.from(key, 'hex'),
 	value: Buffer.from(value, 'hex'),
 	bitmap: Buffer.from(bitmap, 'hex'),
+	binaryBitmap: bufferToBinaryString(Buffer.from(bitmap, 'hex')),
 });
 
 describe('utils', () => {
 	describe('sortByBitmapAndKey', () => {
 		it('should sort by longest bitmap', () => {
-			const res1: InclusionProofQuery = {
+			const res1 = {
 				key: getRandomBytes(2),
-				value: getRandomBytes(20),
-				bitmap: getRandomBytes(1),
+				binaryBitmap: '011',
 			};
 
-			const res2: InclusionProofQuery = {
+			const res2 = {
 				key: getRandomBytes(2),
-				value: getRandomBytes(20),
-				bitmap: getRandomBytes(2),
+				binaryBitmap: '0011',
 			};
 
 			expect(sortByBitmapAndKey([res1, res2])).toEqual([res2, res1]);
 		});
 
 		it('should sort by longest bitmap breaking tie with smaller key', () => {
-			const res1: InclusionProofQuery = {
+			const res1 = {
 				key: getRandomBytes(2),
-				value: getRandomBytes(20),
-				bitmap: getRandomBytes(2),
+				binaryBitmap: '111',
 			};
 
-			const res2: InclusionProofQuery = {
+			const res2 = {
 				key: getRandomBytes(1),
-				value: getRandomBytes(20),
-				bitmap: getRandomBytes(2),
+				binaryBitmap: '111',
 			};
 
 			expect(sortByBitmapAndKey([res1, res2])).toEqual([res2, res1]);
@@ -141,19 +138,136 @@ describe('utils', () => {
 	});
 
 	describe('calculateRoot', () => {
-		it('should calculate correct root hash', () => {
+		it('should calculate correct root hash for single proof', () => {
 			const siblingHashes = [
+				'e6fa536eaac055d524e29fb4682893e3111bf3a027f7cd5ba312aec56460eb1b',
+				'63a154f88e6f5898bada58cbcb0dfcfa84e18cd5d50783e6703d904bef8be36b',
+				'da7f3bd33f419f025fc34ada50e26bc0094a7f0018f91fa7e51b66c88c6a7e78',
+				'ed9b2d408363d6edec46b055de68e67b37091f5b7dece4415200082ba01bc73e',
+			].map(h => Buffer.from(h, 'hex'));
+			const queries = [
+				createQueryObject({
+					key: 'e1',
+					value: 'f031efa58744e97a34555ca98621d4e8a52ceb5f20b891d5c44ccae0daaaa644',
+					bitmap: '17',
+				}),
+			];
+			const rootHash = '21ecda9db382eff32c9ec899fc7090cf58858e8c22a2af82510cd4d9c9a42c2f';
+
+			expect(calculateRoot(siblingHashes, queries, 1).toString('hex')).toEqual(rootHash);
+		});
+
+		it('should calculate correct root hash for multi proof', () => {
+			const siblingHashes = [
+				'b2157891142f7416efc259560b181fcbb52d95abe326409f55754b7f453455b4',
+				'c5368d8ea5128f897a723662ea8ca092ee30029175f193e9fe37d3e7f6641264',
+				'e6fa536eaac055d524e29fb4682893e3111bf3a027f7cd5ba312aec56460eb1b',
+				'ecb4e7940250348fcbd38c3eb7982ce7d0a748fd832f48a0154b4ff7ded6fe04',
+				'63a154f88e6f5898bada58cbcb0dfcfa84e18cd5d50783e6703d904bef8be36b',
+				'99b0161609748a131c16d46c72ff79ffbfa85e9e2694c52ee665635c4d48ecae',
+				'da7f3bd33f419f025fc34ada50e26bc0094a7f0018f91fa7e51b66c88c6a7e78',
+			].map(h => Buffer.from(h, 'hex'));
+
+			const queries = [
+				createQueryObject({
+					key: 'e1',
+					value: 'f031efa58744e97a34555ca98621d4e8a52ceb5f20b891d5c44ccae0daaaa644',
+					bitmap: '17',
+				}),
+				createQueryObject({
+					key: '60',
+					value: '8d33f520a3c4cef80d2453aef81b612bfe1cb44c8b2025630ad38662763f13d3',
+					bitmap: '1f',
+				}),
+				createQueryObject({
+					key: '7e',
+					value: '7ace431cb61584cb9b8dc7ec08cf38ac0a2d649660be86d349fb43108b542fa4',
+					bitmap: '1f',
+				}),
+			];
+			const rootHash = '21ecda9db382eff32c9ec899fc7090cf58858e8c22a2af82510cd4d9c9a42c2f';
+
+			expect(calculateRoot(siblingHashes, queries, 1).toString('hex')).toEqual(rootHash);
+		});
+
+		it('should calculate correct root hash for single proof of exclusion', () => {
+			const siblingHashes = [
+				'c4d5a0ec88593441501521e1217be34f8875d1a2f8d2d882f6a411debaa7467e',
 				'508e7ce32a2dfb6c39123ad6daaea8dde3bbcb096dd255bea05bea9b717898c3',
+				'ecb4e7940250348fcbd38c3eb7982ce7d0a748fd832f48a0154b4ff7ded6fe04',
 				'99b0161609748a131c16d46c72ff79ffbfa85e9e2694c52ee665635c4d48ecae',
 				'7ef9d01187c522f5d7198874a28cdb495abefe4fc5b3fa4fb235ba21633928a6',
 			].map(h => Buffer.from(h, 'hex'));
+
 			const queries = [
-				createQueryObject({ key: '7e', value: '7ace431c', bitmap: '1f' }),
-				createQueryObject({ key: '76', value: '4c94485e', bitmap: '1f' }),
-				createQueryObject({ key: '76', value: '4c94485e', bitmap: '1f' }),
-				createQueryObject({ key: '5a', value: 'bbeebd87', bitmap: '07' }),
+				createQueryObject({
+					key: '76',
+					value: '4c94485e0c21ae6c41ce1dfe7b6bfaceea5ab68e40a2476f50208e526f506080',
+					bitmap: '1f',
+				}),
 			];
-			const rootHash = 'fe737e0f3efe19d62e6e0ba4997140db64bf615a5a8935270543bf18c0ce1815';
+			const rootHash = '21ecda9db382eff32c9ec899fc7090cf58858e8c22a2af82510cd4d9c9a42c2f';
+
+			expect(calculateRoot(siblingHashes, queries, 1).toString('hex')).toEqual(rootHash);
+		});
+
+		it('should calculate correct root hash for multi proof of exclusion', () => {
+			const siblingHashes = [
+				'60a8e2b790e91ca7e05c6eb758a694e42635772b2fa23c0706df4c3423d92a11',
+				'c4d5a0ec88593441501521e1217be34f8875d1a2f8d2d882f6a411debaa7467e',
+				'ecb4e7940250348fcbd38c3eb7982ce7d0a748fd832f48a0154b4ff7ded6fe04',
+				'99b0161609748a131c16d46c72ff79ffbfa85e9e2694c52ee665635c4d48ecae',
+				'7ef9d01187c522f5d7198874a28cdb495abefe4fc5b3fa4fb235ba21633928a6',
+			].map(h => Buffer.from(h, 'hex'));
+
+			const queries = [
+				createQueryObject({
+					key: '76',
+					value: '4c94485e0c21ae6c41ce1dfe7b6bfaceea5ab68e40a2476f50208e526f506080',
+					bitmap: '1f',
+				}),
+				createQueryObject({
+					key: '6c',
+					value: 'acac86c0e609ca906f632b0e2dacccb2b77d22b0621f20ebece1a4835b93f6f0',
+					bitmap: '1f',
+				}),
+			];
+			const rootHash = '21ecda9db382eff32c9ec899fc7090cf58858e8c22a2af82510cd4d9c9a42c2f';
+
+			expect(calculateRoot(siblingHashes, queries, 1).toString('hex')).toEqual(rootHash);
+		});
+
+		it('should calculate correct root hash for mix proof of inclusion and exclusion', () => {
+			const siblingHashes = [
+				'60a8e2b790e91ca7e05c6eb758a694e42635772b2fa23c0706df4c3423d92a11',
+				'ae63f64dd16496628e978c8f8f8659f65de41850be64db2a54ec24f4d5893ffd',
+				'ecb4e7940250348fcbd38c3eb7982ce7d0a748fd832f48a0154b4ff7ded6fe04',
+				'7ef9d01187c522f5d7198874a28cdb495abefe4fc5b3fa4fb235ba21633928a6',
+			].map(h => Buffer.from(h, 'hex'));
+
+			const queries = [
+				createQueryObject({
+					key: '76',
+					value: '4c94485e0c21ae6c41ce1dfe7b6bfaceea5ab68e40a2476f50208e526f506080',
+					bitmap: '1f',
+				}),
+				createQueryObject({
+					key: '7e',
+					value: '7ace431cb61584cb9b8dc7ec08cf38ac0a2d649660be86d349fb43108b542fa4',
+					bitmap: '1f',
+				}),
+				createQueryObject({
+					key: '6c',
+					value: 'acac86c0e609ca906f632b0e2dacccb2b77d22b0621f20ebece1a4835b93f6f0',
+					bitmap: '1f',
+				}),
+				createQueryObject({
+					key: '1b',
+					value: '77adfc95029e73b173f60e556f915b0cd8850848111358b1c370fb7c154e61fd',
+					bitmap: '07',
+				}),
+			];
+			const rootHash = '21ecda9db382eff32c9ec899fc7090cf58858e8c22a2af82510cd4d9c9a42c2f';
 
 			expect(calculateRoot(siblingHashes, queries, 1).toString('hex')).toEqual(rootHash);
 		});

--- a/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
+++ b/elements/lisk-tree/test/sparse_merkle_tree/utils.spec.ts
@@ -21,7 +21,6 @@ import {
 	filterQueries,
 	calculateRoot,
 } from '../../src/sparse_merkle_tree/utils';
-import { ProofQuery } from '../../src/sparse_merkle_tree/types';
 
 const binarySampleData = [
 	{ str: '101', buf: '05' },
@@ -40,7 +39,7 @@ const createQueryObject = ({
 	key: string;
 	value: string;
 	bitmap: string;
-}): ProofQuery => ({
+}) => ({
 	key: Buffer.from(key, 'hex'),
 	value: Buffer.from(value, 'hex'),
 	bitmap: Buffer.from(bitmap, 'hex'),


### PR DESCRIPTION
### What was the problem?

This PR resolves #6496 

**There are two functions `leafNode` and `branchHash` for which fake implementation is used.**

### How was it solved?

- Added utils functions defined in issue

### How was it tested?

- Added unit tests 
