### PR TITLE
Fixes typeerror in pid file creation

### DIFF
--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -514,7 +514,7 @@ export class Application {
 				throw new DuplicateAppInstanceError(this.config.label, pidPath);
 			}
 		}
-		await fs.writeFile(pidPath, process.pid);
+		await fs.writeFile(pidPath, process.pid.toString());
 	}
 
 	private _clearControllerPidFile() {


### PR DESCRIPTION

### What was the problem?

```
12:23:39 INFO lisk-framework: Booting the application with Lisk Framework(0.1.0) (module=lisk:app)
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (32264)
    at writeFile (fs.js:1487:5)
   ......
```

### How was it solved?

Added toString() in pid file creation.

### How was it tested?

Got application running with `./bin/run start` after the change. It fixed the issue.
