### PR TITLE
Fix handling of genesis block - Closes #6573

### DIFF
--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -25,6 +25,8 @@ import {
 	EVENT_NEW_BLOCK,
 	EVENT_VALIDATORS_CHANGED,
 	CONSENSUS_STATE_VALIDATORS_KEY,
+	GENESIS_BLOCK_VERSION,
+	CONSENSUS_STATE_GENESIS_INFO,
 } from './constants';
 import { DataAccess } from './data_access';
 import { Slots } from './slots';
@@ -36,6 +38,7 @@ import {
 	GenesisBlock,
 	AccountSchema,
 	Validator,
+	GenesisInfo,
 } from './types';
 import { getAccountSchemaWithDefault } from './utils/account';
 import {
@@ -58,6 +61,7 @@ import {
 	stateDiffSchema,
 	getRegisteredBlockAssetSchema,
 	validatorsSchema,
+	genesisInfoSchema,
 } from './schema';
 import { Transaction } from './transaction';
 
@@ -107,7 +111,6 @@ export class Chain {
 	private _lastBlock: Block;
 	private readonly _networkIdentifier: Buffer;
 	private readonly _blockRewardArgs: BlockRewardOptions;
-	private readonly _genesisBlock: GenesisBlock;
 	private readonly _accountSchema: Schema;
 	private readonly _blockAssetSchema: {
 		readonly [key: number]: Schema;
@@ -163,7 +166,6 @@ export class Chain {
 
 		this._lastBlock = (genesisBlock as unknown) as Block;
 		this._networkIdentifier = networkIdentifier;
-		this._genesisBlock = genesisBlock;
 		this.slots = new Slots({
 			genesisBlockTimestamp: genesisBlock.header.timestamp,
 			interval: blockTime,
@@ -193,10 +195,6 @@ export class Chain {
 		return this._numberOfValidators;
 	}
 
-	public get genesisBlock(): GenesisBlock {
-		return this._genesisBlock;
-	}
-
 	public get accountSchema(): Schema {
 		return this._accountSchema;
 	}
@@ -205,7 +203,7 @@ export class Chain {
 		return this._blockAssetSchema;
 	}
 
-	public async init(): Promise<void> {
+	public async init(genesisBlock: GenesisBlock): Promise<void> {
 		let storageLastBlock: Block;
 		try {
 			storageLastBlock = await this.dataAccess.getLastBlock();
@@ -213,8 +211,21 @@ export class Chain {
 			throw new Error('Failed to load last block');
 		}
 
-		if (storageLastBlock.header.height !== this.genesisBlock.header.height) {
+		if (storageLastBlock.header.height !== genesisBlock.header.height) {
 			await this._cacheBlockHeaders(storageLastBlock);
+		}
+		// TODO: remove on next version.
+		// If there is no genesis block info stored, saves on consensus state
+		// However, this should be done in apply genesis block hook below for fresh node
+		const genesisInfo = await this._getGenesisInfo();
+		if (!genesisInfo) {
+			await this.dataAccess.setConsensusState(
+				CONSENSUS_STATE_GENESIS_INFO,
+				codec.encode(genesisInfoSchema, {
+					height: genesisBlock.header.height,
+					initRounds: genesisBlock.header.asset.initRounds,
+				}),
+			);
 		}
 
 		const validators = await this.getValidators();
@@ -238,8 +249,9 @@ export class Chain {
 	}
 
 	public async newStateStore(skipLastHeights = 0): Promise<StateStore> {
+		const genesisInfo = await this._getGenesisInfo();
 		const fromHeight = Math.max(
-			0,
+			genesisInfo?.height ?? 0,
 			this._lastBlock.header.height - this.numberOfValidators * 3 - skipLastHeights,
 		);
 		const toHeight = Math.max(this._lastBlock.header.height - skipLastHeights, 1);
@@ -262,14 +274,7 @@ export class Chain {
 	}
 
 	public async genesisBlockExist(genesisBlock: GenesisBlock): Promise<boolean> {
-		let matchingGenesisBlock: BlockHeader | undefined;
-		try {
-			matchingGenesisBlock = await this.dataAccess.getBlockHeaderByID(genesisBlock.header.id);
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
-		}
+		const matchingGenesisBlock = await this.dataAccess.blockHeaderExists(genesisBlock.header.id);
 		let lastBlockHeader: BlockHeader | undefined;
 		try {
 			lastBlockHeader = await this.dataAccess.getLastBlockHeader();
@@ -308,6 +313,13 @@ export class Chain {
 		await stateStore.consensus.set(
 			CONSENSUS_STATE_VALIDATORS_KEY,
 			codec.encode(validatorsSchema, { validators: initialValidators }),
+		);
+		await stateStore.consensus.set(
+			CONSENSUS_STATE_GENESIS_INFO,
+			codec.encode(genesisInfoSchema, {
+				height: block.header.height,
+				initRounds: block.header.asset.initRounds,
+			}),
 		);
 		this._numberOfValidators = block.header.asset.initDelegates.length;
 	}
@@ -385,7 +397,7 @@ export class Chain {
 		stateStore: StateStore,
 		{ saveTempBlock } = { saveTempBlock: false },
 	): Promise<void> {
-		if (block.header.version === this.genesisBlock.header.version) {
+		if (block.header.version === GENESIS_BLOCK_VERSION) {
 			throw new Error('Cannot delete genesis block');
 		}
 		let secondLastBlock: Block;
@@ -431,11 +443,10 @@ export class Chain {
 		stateStore: StateStore,
 		blockHeader: BlockHeader,
 	): Promise<void> {
-		if (this._getLastBootstrapHeight() > blockHeader.height) {
+		const lastBootstrapHeight = await this._getLastBootstrapHeight();
+		if (lastBootstrapHeight > blockHeader.height) {
 			debug(
-				`Skipping updating validator since current height ${
-					blockHeader.height
-				} is lower than last bootstrap height ${this._getLastBootstrapHeight()}`,
+				`Skipping updating validator since current height ${blockHeader.height} is lower than last bootstrap height ${lastBootstrapHeight}`,
 			);
 			return;
 		}
@@ -481,10 +492,19 @@ export class Chain {
 		}
 	}
 
-	private _getLastBootstrapHeight(): number {
-		return (
-			this._numberOfValidators * this._genesisBlock.header.asset.initRounds +
-			this._genesisBlock.header.height
-		);
+	private async _getLastBootstrapHeight(): Promise<number> {
+		const genesisInfo = await this._getGenesisInfo();
+		if (!genesisInfo) {
+			throw new Error('genesis info not stored');
+		}
+		return this._numberOfValidators * genesisInfo.initRounds + genesisInfo.height;
+	}
+
+	private async _getGenesisInfo(): Promise<GenesisInfo | undefined> {
+		const genesisInfoBytes = await this.dataAccess.getConsensusState(CONSENSUS_STATE_GENESIS_INFO);
+		if (!genesisInfoBytes) {
+			return undefined;
+		}
+		return codec.decode<GenesisInfo>(genesisInfoSchema, genesisInfoBytes);
 	}
 }

--- a/elements/lisk-chain/src/constants.ts
+++ b/elements/lisk-chain/src/constants.ts
@@ -17,6 +17,7 @@ import { hash } from '@liskhq/lisk-cryptography';
 export const CHAIN_STATE_BURNT_FEE = 'burntFee';
 export const CONSENSUS_STATE_FINALIZED_HEIGHT_KEY = 'finalizedHeight';
 export const CONSENSUS_STATE_VALIDATORS_KEY = 'validators';
+export const CONSENSUS_STATE_GENESIS_INFO = 'genesisInfo';
 
 export const DEFAULT_MIN_BLOCK_HEADER_CACHE = 309;
 export const DEFAULT_MAX_BLOCK_HEADER_CACHE = 515;

--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -13,7 +13,6 @@
  */
 import { KVStore, NotFoundError } from '@liskhq/lisk-db';
 import { codec, Schema } from '@liskhq/lisk-codec';
-import { hash } from '@liskhq/lisk-cryptography';
 import { Transaction } from '../transaction';
 import { BlockHeader, Block, RawBlock, Account, BlockHeaderAsset } from '../types';
 
@@ -114,7 +113,7 @@ export class DataAccess {
 			return true;
 		}
 		try {
-			// if header does not exist, it will through not found error
+			// if header does not exist, it will throw not found error
 			await this._storage.getBlockHeaderByID(id);
 			return true;
 		} catch (error) {
@@ -472,11 +471,10 @@ export class DataAccess {
 			return cachedBlock;
 		}
 		const blockHeaderBuffer = await this._storage.getBlockHeaderByID(id);
-		const blockID = hash(blockHeaderBuffer);
 
 		return {
 			...codec.decode(blockHeaderSchema, blockHeaderBuffer),
-			id: blockID,
+			id,
 		};
 	}
 }

--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -13,6 +13,7 @@
  */
 import { KVStore, NotFoundError } from '@liskhq/lisk-db';
 import { codec, Schema } from '@liskhq/lisk-codec';
+import { hash } from '@liskhq/lisk-cryptography';
 import { Transaction } from '../transaction';
 import { BlockHeader, Block, RawBlock, Account, BlockHeaderAsset } from '../types';
 
@@ -20,7 +21,7 @@ import { BlockCache } from './cache';
 import { Storage as StorageAccess } from './storage';
 import { StateStore } from '../state_store';
 import { BlockHeaderInterfaceAdapter } from './block_header_interface_adapter';
-import { blockSchema } from '../schema';
+import { blockHeaderSchema, blockSchema } from '../schema';
 import { DB_KEY_ACCOUNTS_ADDRESS } from './constants';
 
 interface DAConstructor {
@@ -107,6 +108,20 @@ export class DataAccess {
 		return this._blockHeaderAdapter.decode(blockHeaderBuffer);
 	}
 
+	public async blockHeaderExists(id: Buffer): Promise<boolean> {
+		const cachedBlock = this._blocksCache.getByID(id);
+		if (cachedBlock) {
+			return true;
+		}
+		try {
+			// if header does not exist, it will through not found error
+			await this._storage.getBlockHeaderByID(id);
+			return true;
+		} catch (error) {
+			return false;
+		}
+	}
+
 	public async getBlockHeadersByIDs(
 		arrayOfBlockIds: ReadonlyArray<Buffer>,
 	): Promise<BlockHeader[]> {
@@ -173,22 +188,23 @@ export class DataAccess {
 		return this._blockHeaderAdapter.decode(block);
 	}
 
-	public async getHighestCommonBlockHeader(
+	public async getHighestCommonBlockID(
 		arrayOfBlockIds: ReadonlyArray<Buffer>,
-	): Promise<BlockHeader | undefined> {
+	): Promise<Buffer | undefined> {
 		const headers = this._blocksCache.getByIDs(arrayOfBlockIds);
 		headers.sort((a, b) => b.height - a.height);
 		const cachedBlockHeader = headers[0];
 
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		if (cachedBlockHeader) {
-			return cachedBlockHeader;
+			return cachedBlockHeader.id;
 		}
 
 		const storageBlockHeaders = [];
 		for (const id of arrayOfBlockIds) {
 			try {
-				const blockHeader = await this.getBlockHeaderByID(id);
+				// it should not decode the asset since it might include the genesis block
+				const blockHeader = await this._getRawBlockHeaderByID(id);
 				storageBlockHeaders.push(blockHeader);
 			} catch (error) {
 				if (!(error instanceof NotFoundError)) {
@@ -198,7 +214,7 @@ export class DataAccess {
 		}
 		storageBlockHeaders.sort((a, b) => b.height - a.height);
 
-		return storageBlockHeaders[0];
+		return storageBlockHeaders[0]?.id;
 	}
 
 	/** End: BlockHeaders */
@@ -267,6 +283,9 @@ export class DataAccess {
 	/** Begin ConsensusState */
 	public async getConsensusState(key: string): Promise<Buffer | undefined> {
 		return this._storage.getConsensusState(key);
+	}
+	public async setConsensusState(key: string, val: Buffer): Promise<void> {
+		return this._storage.setConsensusState(key, val);
 	}
 	/** End: ConsensusState */
 
@@ -443,6 +462,21 @@ export class DataAccess {
 		return {
 			header,
 			payload,
+		};
+	}
+
+	private async _getRawBlockHeaderByID(id: Buffer): Promise<BlockHeader> {
+		const cachedBlock = this._blocksCache.getByID(id);
+
+		if (cachedBlock) {
+			return cachedBlock;
+		}
+		const blockHeaderBuffer = await this._storage.getBlockHeaderByID(id);
+		const blockID = hash(blockHeaderBuffer);
+
+		return {
+			...codec.decode(blockHeaderSchema, blockHeaderBuffer),
+			id: blockID,
 		};
 	}
 }

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -292,6 +292,12 @@ export class Storage {
 		}
 	}
 
+	// Warning: This function should never be used. This exist only for migration purpose.
+	// Specifically, only to set genesis state between 5.1.2 => 5.1.3
+	public async setConsensusState(key: string, val: Buffer): Promise<void> {
+		await this._db.put(`${DB_KEY_CONSENSUS_STATE}:${key}`, val);
+	}
+
 	/*
 		Accounts
 	*/

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -292,6 +292,7 @@ export class Storage {
 		}
 	}
 
+	// TODO: Remove in next version
 	// Warning: This function should never be used. This exist only for migration purpose.
 	// Specifically, only to set genesis state between 5.1.2 => 5.1.3
 	public async setConsensusState(key: string, val: Buffer): Promise<void> {

--- a/elements/lisk-chain/src/schema.ts
+++ b/elements/lisk-chain/src/schema.ts
@@ -203,6 +203,22 @@ export const validatorsSchema = {
 	},
 };
 
+export const genesisInfoSchema = {
+	$id: '/state/genesisInfo',
+	type: 'object',
+	properties: {
+		height: {
+			dataType: 'uint32',
+			fieldNumber: 1,
+		},
+		initRounds: {
+			dataType: 'uint32',
+			fieldNumber: 2,
+		},
+	},
+	required: ['height', 'initRounds'],
+};
+
 export const getGenesisBlockHeaderAssetSchema = (accountSchema: Schema): Schema =>
 	objects.mergeDeep({}, baseGenesisBlockHeaderAssetSchema, {
 		properties: {

--- a/elements/lisk-chain/src/types.ts
+++ b/elements/lisk-chain/src/types.ts
@@ -107,3 +107,9 @@ export interface Validator {
 	minActiveHeight: number;
 	isConsensusParticipant: boolean;
 }
+
+export interface GenesisInfo {
+	height: number;
+	timestamp: number;
+	initRounds: number;
+}

--- a/elements/lisk-chain/src/types.ts
+++ b/elements/lisk-chain/src/types.ts
@@ -110,6 +110,5 @@ export interface Validator {
 
 export interface GenesisInfo {
 	height: number;
-	timestamp: number;
 	initRounds: number;
 }

--- a/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
+++ b/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
@@ -243,12 +243,12 @@ describe('dataAccess.blocks', () => {
 
 	describe('getLastCommonBlockHeader', () => {
 		it('should return highest block header which exist in the list and non-existent should not throw', async () => {
-			const header = await dataAccess.getHighestCommonBlockHeader([
+			const header = await dataAccess.getHighestCommonBlockID([
 				blocks[3].header.id,
 				Buffer.from('random-id'),
 				blocks[1].header.id,
 			]);
-			expect(header).toEqual(blocks[3].header);
+			expect(header).toEqual(blocks[3].header.id);
 		});
 	});
 

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -11,7 +11,8 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import {
 	Chain,
 	events as chainEvents,
@@ -27,12 +28,14 @@ import {
 	getAccountSchemaWithDefault,
 	getRegisteredBlockAssetSchema,
 	AccountDefaultProps,
+	RawBlockHeader,
 } from '@liskhq/lisk-chain';
 import { EVENT_BFT_BLOCK_FINALIZED, BFT } from '@liskhq/lisk-bft';
-import { getNetworkIdentifier } from '@liskhq/lisk-cryptography';
+import { getNetworkIdentifier, hash } from '@liskhq/lisk-cryptography';
 import { TransactionPool, events as txPoolEvents } from '@liskhq/lisk-transaction-pool';
 import { KVStore, NotFoundError } from '@liskhq/lisk-db';
 import { jobHandlers } from '@liskhq/lisk-utils';
+import { codec } from '@liskhq/lisk-codec';
 import {
 	APP_EVENT_BLOCK_DELETE,
 	APP_EVENT_BLOCK_NEW,
@@ -77,11 +80,12 @@ const MINIMUM_MODULE_ID = 2;
 export type NodeOptions = Omit<ApplicationConfig, 'plugins'>;
 
 interface NodeConstructor {
-	readonly genesisBlockJSON: Record<string, unknown>;
 	readonly options: NodeOptions;
 }
 
 interface NodeInitInput {
+	readonly dataPath: string;
+	readonly genesisBlockJSON: Record<string, unknown>;
 	readonly logger: Logger;
 	readonly channel: InMemoryChannel;
 	readonly forgerDB: KVStore;
@@ -94,10 +98,11 @@ interface ForgingStatusResponse extends Omit<ForgingStatus, 'address'> {
 	readonly address: string;
 }
 
+const compiledGenesisBlockFileName = 'genesis_block_compiled';
+
 export class Node {
 	private readonly _options: NodeOptions;
 	private readonly _registeredModules: BaseModule[] = [];
-	private readonly _genesisBlockJSON: Record<string, unknown>;
 	private _bus!: Bus;
 	private _channel!: InMemoryChannel;
 	private _logger!: Logger;
@@ -105,7 +110,6 @@ export class Node {
 	private _forgerDB!: KVStore;
 	private _blockchainDB!: KVStore;
 	private _networkIdentifier!: Buffer;
-	private _genesisBlock!: GenesisBlock;
 	private _registeredAccountSchemas: { [moduleName: string]: AccountSchema } = {};
 	private _networkModule!: Network;
 	private _chain!: Chain;
@@ -117,9 +121,8 @@ export class Node {
 	private _forger!: Forger;
 	private _forgingJob!: jobHandlers.Scheduler<void>;
 
-	public constructor({ options, genesisBlockJSON }: NodeConstructor) {
+	public constructor({ options }: NodeConstructor) {
 		this._options = options;
-		this._genesisBlockJSON = genesisBlockJSON;
 		if (this._options.forging.waitThreshold >= this._options.genesisConfig.blockTime) {
 			throw Error(
 				`forging.waitThreshold=${this._options.forging.waitThreshold} is greater or equal to genesisConfig.blockTime=${this._options.genesisConfig.blockTime}. It impacts the forging and propagation of blocks. Please use a smaller value for forging.waitThreshold`,
@@ -222,6 +225,8 @@ export class Node {
 	}
 
 	public async init({
+		genesisBlockJSON,
+		dataPath: configPath,
 		bus,
 		channel,
 		blockchainDB,
@@ -236,17 +241,15 @@ export class Node {
 		this._nodeDB = nodeDB;
 		this._bus = bus;
 
-		this._genesisBlock = readGenesisBlockJSON(
-			this._genesisBlockJSON,
-			this._registeredAccountSchemas,
-		);
+		// read from compiled genesis block if exist
+		const genesisBlock = this._readGenesisBlock(genesisBlockJSON, configPath);
 
 		this._networkIdentifier = getNetworkIdentifier(
-			this._genesisBlock.header.id,
+			genesisBlock.header.id,
 			this._options.genesisConfig.communityIdentifier,
 		);
 
-		this._initModules();
+		this._initModules(genesisBlock);
 
 		for (const customModule of this._registeredModules) {
 			this._processor.register(customModule);
@@ -292,7 +295,7 @@ export class Node {
 		// Start subscribing to events, so that genesis block will also be included in event
 		this._subscribeToEvents();
 		// After binding, it should immediately load blockchain
-		await this._processor.init(this._genesisBlock);
+		await this._processor.init(genesisBlock);
 		// Check if blocks are left in temp_blocks table
 		await this._synchronizer.init();
 
@@ -536,7 +539,7 @@ export class Node {
 		await this._networkModule.cleanup();
 	}
 
-	private _initModules(): void {
+	private _initModules(genesisBlock: GenesisBlock): void {
 		this._networkModule = new Network({
 			networkVersion: this._options.networkVersion,
 			options: this._options.network,
@@ -547,7 +550,7 @@ export class Node {
 
 		this._chain = new Chain({
 			db: this._blockchainDB,
-			genesisBlock: this._genesisBlock,
+			genesisBlock,
 			networkIdentifier: this._networkIdentifier,
 			maxPayloadLength: this._options.genesisConfig.maxPayloadLength,
 			rewardDistance: this._options.genesisConfig.rewards.distance,
@@ -562,7 +565,7 @@ export class Node {
 		this._bft = new BFT({
 			chain: this._chain,
 			threshold: this._options.genesisConfig.bftThreshold,
-			genesisHeight: this._genesisBlock.header.height,
+			genesisHeight: genesisBlock.header.height,
 		});
 
 		this._processor = new Processor({
@@ -823,5 +826,46 @@ export class Node {
 
 	private _unsubscribeToEvents(): void {
 		this._bft.removeAllListeners(EVENT_BFT_BLOCK_FINALIZED);
+	}
+
+	private _readGenesisBlock(
+		genesisBlockJSON: Record<string, unknown>,
+		configPath: string,
+	): GenesisBlock {
+		const compiledGenesisPath = path.join(configPath, compiledGenesisBlockFileName);
+		const { default: defaultAccount, ...schema } = getAccountSchemaWithDefault(
+			this._registeredAccountSchemas,
+		);
+		const genesisAssetSchema = getRegisteredBlockAssetSchema(schema)[0];
+		// check local file for compiled
+		const compiled = fs.existsSync(compiledGenesisPath);
+		if (compiled) {
+			const genesisBlockBytes = fs.readFileSync(compiledGenesisPath);
+			// cannot use chain yet, so manually decode genesis block
+			const blockHeader = codec.decode<RawBlockHeader>(blockHeaderSchema, genesisBlockBytes);
+			const asset = codec.decode<GenesisBlock['header']['asset']>(
+				genesisAssetSchema,
+				blockHeader.asset,
+			);
+			const id = hash(genesisBlockBytes);
+			return {
+				header: {
+					...blockHeader,
+					asset,
+					id,
+				},
+				payload: [],
+			};
+		}
+		// decode from JSON file and store the encoded genesis block
+		const genesisBlock = readGenesisBlockJSON(genesisBlockJSON, this._registeredAccountSchemas);
+		const assetBytes = codec.encode(genesisAssetSchema, genesisBlock.header.asset);
+		const headerBytes = codec.encode(blockHeaderSchema, {
+			...genesisBlock.header,
+			asset: assetBytes,
+		});
+		fs.writeFileSync(compiledGenesisPath, headerBytes);
+		// encode genesis block and
+		return genesisBlock;
 	}
 }

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -286,7 +286,7 @@ export class Node {
 			this._transport.handleRPCGetBlocksFromId(data, peerId),
 		);
 		this._networkModule.registerEndpoint('getHighestCommonBlock', async ({ data, peerId }) =>
-			this._transport.handleRPCGetHighestCommonBlock(data, peerId),
+			this._transport.handleRPCGetHighestCommonBlockID(data, peerId),
 		);
 
 		// Network needs to be initialized first to call events

--- a/framework/src/node/processor/processor.ts
+++ b/framework/src/node/processor/processor.ts
@@ -108,7 +108,7 @@ export class Processor {
 			// TODO: saveBlock should accept both genesis and normal block
 			await this._chain.saveBlock((genesisBlock as unknown) as Block, stateStore, 0);
 		}
-		await this._chain.init();
+		await this._chain.init(genesisBlock);
 		await this._bft.init(stateStore);
 		this._logger.info('Blockchain ready');
 	}

--- a/framework/src/node/transport/schemas.ts
+++ b/framework/src/node/transport/schemas.ts
@@ -58,6 +58,21 @@ export const getHighestCommonBlockRequestSchema = {
 	},
 };
 
+export const getHighestCommonBlockResponseSchema = {
+	$id: 'lisk/getHighestCommonBlockResponse',
+	title: 'Get Highest Common Block Response',
+	type: 'object',
+	required: ['id'],
+	properties: {
+		id: {
+			dataType: 'bytes',
+			fieldNumber: 1,
+			minLength: 32,
+			maxLength: 32,
+		},
+	},
+};
+
 export const transactionIdsSchema = {
 	$id: 'lisk/transactionIds',
 	title: 'Broadcast Transactions',

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -197,7 +197,7 @@ export class Transport {
 		return codec.encode(getBlocksFromIdResponseSchema, { blocks: encodedBlocks });
 	}
 
-	public async handleRPCGetHighestCommonBlock(data: unknown, peerId: string): Promise<Buffer> {
+	public async handleRPCGetHighestCommonBlockID(data: unknown, peerId: string): Promise<Buffer> {
 		this._addRateLimit('getHighestCommonBlock', peerId, DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY);
 		const blockIds = codec.decode<RPCHighestCommonBlockData>(
 			getHighestCommonBlockRequestSchema,

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -24,6 +24,7 @@ import {
 	transactionIdsSchema,
 	postBlockEventSchema,
 	getHighestCommonBlockRequestSchema,
+	getHighestCommonBlockResponseSchema,
 	getBlocksFromIdRequestSchema,
 	getBlocksFromIdResponseSchema,
 	transactionsSchema,
@@ -196,10 +197,7 @@ export class Transport {
 		return codec.encode(getBlocksFromIdResponseSchema, { blocks: encodedBlocks });
 	}
 
-	public async handleRPCGetHighestCommonBlock(
-		data: unknown,
-		peerId: string,
-	): Promise<Buffer | undefined> {
+	public async handleRPCGetHighestCommonBlock(data: unknown, peerId: string): Promise<Buffer> {
 		this._addRateLimit('getHighestCommonBlock', peerId, DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY);
 		const blockIds = codec.decode<RPCHighestCommonBlockData>(
 			getHighestCommonBlockRequestSchema,
@@ -224,13 +222,11 @@ export class Transport {
 			throw error;
 		}
 
-		const commonBlockHeader = await this._chainModule.dataAccess.getHighestCommonBlockHeader(
-			blockIds.ids,
-		);
+		const commonBlockID = await this._chainModule.dataAccess.getHighestCommonBlockID(blockIds.ids);
 
-		return commonBlockHeader
-			? this._chainModule.dataAccess.encodeBlockHeader(commonBlockHeader)
-			: undefined;
+		return codec.encode(getHighestCommonBlockResponseSchema, {
+			id: commonBlockID ?? Buffer.alloc(0),
+		});
 	}
 
 	public async handleEventPostBlock(data: Buffer | undefined, peerId: string): Promise<void> {

--- a/framework/src/testing/app_env.ts
+++ b/framework/src/testing/app_env.ts
@@ -45,10 +45,9 @@ export class ApplicationEnv {
 	private _application!: Application;
 	private _dataPath!: string;
 	private _ipcClient!: APIClient;
-	private _genesisBlock: Record<string, unknown>;
+	private _genesisBlock!: Record<string, unknown>;
 
 	public constructor(appConfig: ApplicationEnvConfig) {
-		this._genesisBlock = appConfig.genesisBlockJSON as Record<string, unknown>;
 		this._initApplication(appConfig);
 	}
 
@@ -119,6 +118,7 @@ export class ApplicationEnv {
 		// so we need to make sure existing schemas are already clear
 		codec.clearCache();
 		const { genesisBlockJSON } = createGenesisBlock({ modules: appConfig.modules });
+		this._genesisBlock = genesisBlockJSON;
 		// In order for application to start forging, update force to true
 		const config = objects.mergeDeep({}, defaultConfig, appConfig.config ?? {});
 		const { label } = config;

--- a/framework/src/testing/app_env.ts
+++ b/framework/src/testing/app_env.ts
@@ -118,15 +118,12 @@ export class ApplicationEnv {
 		// so we need to make sure existing schemas are already clear
 		codec.clearCache();
 		const { genesisBlockJSON } = createGenesisBlock({ modules: appConfig.modules });
-		this._genesisBlock = genesisBlockJSON;
+		this._genesisBlock = appConfig.genesisBlockJSON ?? genesisBlockJSON;
 		// In order for application to start forging, update force to true
 		const config = objects.mergeDeep({}, defaultConfig, appConfig.config ?? {});
 		const { label } = config;
 
-		const application = new Application(
-			appConfig.genesisBlockJSON ?? genesisBlockJSON,
-			config as PartialApplicationConfig,
-		);
+		const application = new Application(this._genesisBlock, config as PartialApplicationConfig);
 		appConfig.modules.map(module => application.registerModule(module));
 		appConfig.plugins?.map(plugin => application.registerPlugin(plugin));
 		this._dataPath = join(application.config.rootPath, label);

--- a/framework/src/testing/app_env.ts
+++ b/framework/src/testing/app_env.ts
@@ -45,8 +45,10 @@ export class ApplicationEnv {
 	private _application!: Application;
 	private _dataPath!: string;
 	private _ipcClient!: APIClient;
+	private _genesisBlock: Record<string, unknown>;
 
 	public constructor(appConfig: ApplicationEnvConfig) {
+		this._genesisBlock = appConfig.genesisBlockJSON as Record<string, unknown>;
 		this._initApplication(appConfig);
 	}
 
@@ -72,6 +74,8 @@ export class ApplicationEnv {
 	}
 
 	public async startApplication(): Promise<void> {
+		// eslint-disable-next-line dot-notation
+		this._application['_genesisBlock'] = this._genesisBlock;
 		await Promise.race([
 			this._application.run(),
 			new Promise(resolve => setTimeout(resolve, 3000)),

--- a/framework/test/functional/actions/blocks.spec.ts
+++ b/framework/test/functional/actions/blocks.spec.ts
@@ -28,30 +28,29 @@ describe('Block related actions', () => {
 
 	describe('getBlockByID', () => {
 		it('should return valid encoded block', async () => {
+			const expectedBlock = app['_node']['_chain'].lastBlock;
 			const encodedBlock = await app['_channel'].invoke('app:getBlockByID', {
-				id: app['_node']['_chain'].genesisBlock.header.id.toString('hex'),
+				id: expectedBlock.header.id.toString('hex'),
 			});
 			expect(encodedBlock).toBeString();
 			const block = app['_node']['_chain'].dataAccess.decode(
 				Buffer.from(encodedBlock as string, 'hex'),
 			);
-			expect(block.header.version).toEqual(0);
-			expect(block.header.height).toEqual(0);
+			expect(block.header.version).toEqual(expectedBlock.header.version);
+			expect(block.header.height).toEqual(expectedBlock.header.height);
 		});
 	});
 
 	describe('getBlocksByIDs', () => {
 		it('should return valid encoded blocks', async () => {
+			const expectedBlock = app['_node']['_chain'].lastBlock;
 			const encodedBlocks: string[] = await app['_channel'].invoke('app:getBlocksByIDs', {
-				ids: [
-					app['_node']['_chain'].genesisBlock.header.id.toString('hex'),
-					app['_node']['_chain'].lastBlock.header.id.toString('hex'),
-				],
+				ids: [expectedBlock.header.id.toString('hex')],
 			});
-			expect(encodedBlocks).toHaveLength(2);
+			expect(encodedBlocks).toHaveLength(1);
 			const block = app['_node']['_chain'].dataAccess.decode(Buffer.from(encodedBlocks[0], 'hex'));
-			expect(block.header.version).toEqual(0);
-			expect(block.header.height).toEqual(0);
+			expect(block.header.version).toEqual(expectedBlock.header.version);
+			expect(block.header.height).toEqual(expectedBlock.header.height);
 		});
 	});
 

--- a/framework/test/integration/node/processor/delete_block.spec.ts
+++ b/framework/test/integration/node/processor/delete_block.spec.ts
@@ -164,7 +164,7 @@ describe('Delete block', () => {
 		describe('when the deleteLastBlock is called', () => {
 			it('should rollback validators to the previous state', async () => {
 				// Arrange
-				const lastBootstrapHeight = processEnv.getChain()['_getLastBootstrapHeight']();
+				const lastBootstrapHeight = await processEnv.getChain()['_getLastBootstrapHeight']();
 				while (processEnv.getLastBlock().header.height !== lastBootstrapHeight - 1) {
 					const newBlock = await processEnv.createBlock([]);
 					await processEnv.process(newBlock);

--- a/framework/test/unit/node/node.spec.ts
+++ b/framework/test/unit/node/node.spec.ts
@@ -29,6 +29,7 @@ import { createMockBus } from '../../utils/channel';
 import { createGenesisBlock } from '../../../src/testing/create_genesis_block';
 
 jest.mock('@liskhq/lisk-db');
+jest.mock('fs-extra');
 
 describe('Node', () => {
 	let node: Node;
@@ -89,7 +90,6 @@ describe('Node', () => {
 
 		node = new Node({
 			options: nodeOptions,
-			genesisBlockJSON,
 		});
 
 		codec.clearCache();
@@ -116,7 +116,6 @@ describe('Node', () => {
 				() =>
 					new Node({
 						options: invalidChainOptions as any,
-						genesisBlockJSON,
 					}),
 			).toThrow('forging.waitThreshold=5 is greater or equal to genesisConfig.blockTime=4');
 		});
@@ -137,7 +136,6 @@ describe('Node', () => {
 				() =>
 					new Node({
 						options: invalidChainOptions as any,
-						genesisBlockJSON,
 					}),
 			).toThrow('forging.waitThreshold=5 is greater or equal to genesisConfig.blockTime=5');
 		});
@@ -154,6 +152,8 @@ describe('Node', () => {
 
 			// Act
 			await node.init({
+				genesisBlockJSON,
+				dataPath: `/tmp/.lisk/${Date.now()}`,
 				bus: createMockBus() as any,
 				channel: stubs.channel,
 				blockchainDB,
@@ -259,6 +259,8 @@ describe('Node', () => {
 		beforeEach(async () => {
 			// Arrange
 			await node.init({
+				genesisBlockJSON,
+				dataPath: `/tmp/.lisk/${Date.now()}`,
 				bus: createMockBus() as any,
 				channel: stubs.channel,
 				blockchainDB,
@@ -290,6 +292,8 @@ describe('Node', () => {
 	describe('#_forgingTask', () => {
 		beforeEach(async () => {
 			await node.init({
+				genesisBlockJSON,
+				dataPath: `/tmp/.lisk/${Date.now()}`,
 				bus: createMockBus() as any,
 				channel: stubs.channel,
 				blockchainDB,
@@ -336,6 +340,8 @@ describe('Node', () => {
 	describe('#_startForging', () => {
 		beforeEach(async () => {
 			await node.init({
+				genesisBlockJSON,
+				dataPath: `/tmp/.lisk/${Date.now()}`,
 				bus: createMockBus() as any,
 				channel: stubs.channel,
 				blockchainDB,

--- a/framework/test/unit/node/synchronizer/synchronizer.spec.ts
+++ b/framework/test/unit/node/synchronizer/synchronizer.spec.ts
@@ -90,6 +90,7 @@ describe('Synchronizer', () => {
 
 		dataAccessMock = {
 			getConsensusState: jest.fn(),
+			setConsensusState: jest.fn(),
 			getTempBlocks: jest.fn(),
 			getBlockHeadersWithHeights: jest.fn(),
 			getBlockByID: jest.fn(),
@@ -230,7 +231,7 @@ describe('Synchronizer', () => {
 						};
 					});
 
-				await chainModule.init();
+				await chainModule.init(genesisBlock);
 
 				// Act
 				await synchronizer.init();
@@ -277,7 +278,7 @@ describe('Synchronizer', () => {
 					.calledWith()
 					.mockResolvedValue(initialLastBlock as never);
 
-				await chainModule.init();
+				await chainModule.init(genesisBlock);
 
 				// Act
 				await synchronizer.init();
@@ -316,7 +317,7 @@ describe('Synchronizer', () => {
 					.calledWith()
 					.mockResolvedValue(initialLastBlock as never);
 
-				await chainModule.init();
+				await chainModule.init(genesisBlock);
 
 				// Act
 				await synchronizer.init();
@@ -367,7 +368,7 @@ describe('Synchronizer', () => {
 			const error = new Error('error while deleting last block');
 			(processorModule.processValidated as jest.Mock).mockRejectedValue(error);
 
-			await chainModule.init();
+			await chainModule.init(genesisBlock);
 
 			// Act
 			await synchronizer.init();

--- a/framework/test/unit/node/transport/transport.spec.ts
+++ b/framework/test/unit/node/transport/transport.spec.ts
@@ -312,7 +312,7 @@ describe('Transport', () => {
 		});
 	});
 
-	describe('handleRPCGetHighestCommonBlock', () => {
+	describe('handleRPCGetHighestCommonBlockID', () => {
 		const defaultPeerId = 'peer-id';
 
 		describe('when commonBlock has not been found', () => {
@@ -326,7 +326,7 @@ describe('Transport', () => {
 				const blockIds = codec.encode(getHighestCommonBlockRequestSchema, { ids });
 
 				// Act
-				const result = await transport.handleRPCGetHighestCommonBlock(blockIds, defaultPeerId);
+				const result = await transport.handleRPCGetHighestCommonBlockID(blockIds, defaultPeerId);
 
 				// Assert
 				expect(chainStub.dataAccess.getHighestCommonBlockID).toHaveBeenCalledWith(ids);
@@ -348,7 +348,7 @@ describe('Transport', () => {
 				const blockIds = codec.encode(getHighestCommonBlockRequestSchema, { ids });
 
 				// Act
-				const result = await transport.handleRPCGetHighestCommonBlock(blockIds, defaultPeerId);
+				const result = await transport.handleRPCGetHighestCommonBlockID(blockIds, defaultPeerId);
 
 				// Assert
 				expect(chainStub.dataAccess.getHighestCommonBlockID).toHaveBeenCalledWith(ids);
@@ -809,7 +809,7 @@ describe('Transport', () => {
 			it('should apply penalty when called ', async () => {
 				// Arrange
 				[...new Array(DEFAULT_COMMON_BLOCK_RATE_LIMIT_FREQUENCY + 1)].map(async () =>
-					transport.handleRPCGetHighestCommonBlock(blockIds, defaultPeerId),
+					transport.handleRPCGetHighestCommonBlockID(blockIds, defaultPeerId),
 				);
 				jest.advanceTimersByTime(defaultRateLimit);
 

--- a/framework/test/utils/node/node.ts
+++ b/framework/test/utils/node/node.ts
@@ -24,6 +24,7 @@ import { Logger, createLogger } from '../../../src/logger';
 import { InMemoryChannel } from '../../../src/controller/channels';
 import { ApplicationConfig } from '../../../src/types';
 import { TokenModule, SequenceModule, KeysModule, DPoSModule } from '../../../src/modules';
+import { defaultPath } from '../kv_store';
 
 const { plugins, ...rootConfigs } = config;
 
@@ -33,7 +34,6 @@ export const createNode = ({ options = {} }: { options?: Partial<NodeOptions> })
 	}) as ApplicationConfig;
 	const node = new Node({
 		options: mergedConfig,
-		genesisBlockJSON,
 	});
 	node.registerModule(new TokenModule(mergedConfig.genesisConfig));
 	node.registerModule(new SequenceModule(mergedConfig.genesisConfig));
@@ -67,6 +67,8 @@ export const createAndLoadNode = async (
 		put: jest.fn(),
 	} as unknown) as KVStore;
 	await chainModule.init({
+		genesisBlockJSON,
+		dataPath: defaultPath,
 		bus: createMockBus() as any,
 		channel: channel ?? (createMockChannel() as any),
 		logger,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6573 

### How was it solved?

- Update not to hold genesis block in memory
- Update getHighestCommonBlock to getHighestCommonBlockID


### How was it tested?

Run 2 nodes with heavy genesis block (modified mainnet snapshot etc)
- Check 2 nodes will sync even after 500 blocks. (after 500 blocks, genesis block will not be on cache)
- Restart one of the node and check the starting time is significantly faster than 1st time
