### PR TITLE
Update p2p block response not to use the decoding data access -  Closes #6573

### DIFF
--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -107,6 +107,10 @@ export class DataAccess {
 		return this._blockHeaderAdapter.decode(blockHeaderBuffer);
 	}
 
+	public async getRawBlockHeaderByID(id: Buffer): Promise<BlockHeader> {
+		return this._getRawBlockHeaderByID(id);
+	}
+
 	public async blockHeaderExists(id: Buffer): Promise<boolean> {
 		const cachedBlock = this._blocksCache.getByID(id);
 		if (cachedBlock) {

--- a/framework/src/node/transport/transport.ts
+++ b/framework/src/node/transport/transport.ts
@@ -180,7 +180,7 @@ export class Transport {
 		const { blockId } = decodedData as RPCBlocksByIdData;
 
 		// Get height of block with supplied ID
-		const lastBlock = await this._chainModule.dataAccess.getBlockHeaderByID(blockId);
+		const lastBlock = await this._chainModule.dataAccess.getRawBlockHeaderByID(blockId);
 
 		const lastBlockHeight = lastBlock.height;
 

--- a/framework/test/unit/node/transport/transport.spec.ts
+++ b/framework/test/unit/node/transport/transport.spec.ts
@@ -75,6 +75,7 @@ describe('Transport', () => {
 				getTransactionsByIDs: jest.fn(),
 				getHighestCommonBlockID: jest.fn(),
 				getBlockHeaderByID: jest.fn().mockReturnValue({ height: 123 }),
+				getRawBlockHeaderByID: jest.fn().mockReturnValue({ height: 123 }),
 				getBlocksByHeightBetween: jest.fn().mockReturnValue([{ height: 123 }]),
 				decodeTransaction: jest.fn(),
 				encodeBlockHeader: jest.fn().mockReturnValue(encodedBlock),

--- a/framework/test/unit/node/transport/transport_private.spec.ts
+++ b/framework/test/unit/node/transport/transport_private.spec.ts
@@ -151,6 +151,7 @@ describe('transport', () => {
 				lastBlock: jest.fn().mockReturnValue({ height: 1, version: 1, timestamp: 1 }) as any,
 				dataAccess: {
 					getBlockHeaderByID: jest.fn().mockReturnValue({ height: 2, version: 1, timestamp: 1 }),
+					getRawBlockHeaderByID: jest.fn().mockReturnValue({ height: 2, version: 1, timestamp: 1 }),
 					getBlocksByHeightBetween: jest.fn().mockReturnValue([
 						{ height: 3, version: 1, timestamp: 1 },
 						{ height: 37, version: 1, timestamp: 1 },
@@ -515,7 +516,7 @@ describe('transport', () => {
 
 							await transportModule.handleRPCGetBlocksFromId(blockIds);
 							expect(
-								transportModule['_chainModule'].dataAccess.getBlockHeaderByID,
+								transportModule['_chainModule'].dataAccess.getRawBlockHeaderByID,
 							).toHaveBeenCalledWith(Buffer.from('6258354802676165798'));
 							return expect(
 								transportModule['_chainModule'].dataAccess.getBlocksByHeightBetween,
@@ -532,7 +533,7 @@ describe('transport', () => {
 							const errorMessage = 'Failed to load blocks...';
 							const loadBlockFailed = new Error(errorMessage);
 
-							transportModule['_chainModule'].dataAccess.getBlockHeaderByID.mockResolvedValue(
+							transportModule['_chainModule'].dataAccess.getRawBlockHeaderByID.mockResolvedValue(
 								Promise.reject(loadBlockFailed),
 							);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6573 

### How was it solved?

- Replace getBlockHeaderByID usage in handleRPCGetBlocksFromId to use  getRawBlockHeaderByID which does  not decode the asset of block

### How was it tested?

- Sync 2  nodes in the  network with large genesis block
