### PR TITLE
Fix maxHeightPrevoted calculation - Closes #6594

### DIFF
--- a/elements/lisk-bft/src/bft.ts
+++ b/elements/lisk-bft/src/bft.ts
@@ -200,8 +200,8 @@ export class BFT extends EventEmitter {
 		return true;
 	}
 
-	public async getMaxHeightPrevoted(): Promise<number> {
-		return this.finalityManager.getMaxHeightPrevoted();
+	public async getMaxHeightPrevoted(lastMaxHeightPrevoted: number): Promise<number> {
+		return this.finalityManager.getMaxHeightPrevoted(lastMaxHeightPrevoted);
 	}
 
 	public get finalizedHeight(): number {
@@ -227,6 +227,7 @@ export class BFT extends EventEmitter {
 		const finalityManager = new FinalityManager({
 			chain: this._chain,
 			finalizedHeight,
+			genesisHeight: this.constants.genesisHeight,
 			threshold: this.constants.threshold,
 		});
 

--- a/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_finality_manager_protocol_specs.spec.ts
@@ -96,6 +96,7 @@ describe('FinalityManager', () => {
 
 					finalityManager = new FinalityManager({
 						chain: chainStub,
+						genesisHeight: 0,
 						finalizedHeight: scenario.config.finalizedHeight,
 						threshold: Math.floor((scenario.config.activeDelegates * 2) / 3) + 1,
 					});
@@ -168,7 +169,7 @@ describe('FinalityManager', () => {
 							CONSENSUS_STATE_VALIDATOR_LEDGER_KEY,
 						);
 						const { ledger } = finalityManager['_decodeVotingLedger'](updatedBftLedgers);
-						const preVoted = finalityManager['_calculateMaxHeightPrevoted'](ledger);
+						const preVoted = finalityManager['_calculateMaxHeightPrevoted'](ledger, 0);
 						expect(preVoted).toEqual(testCase.output.preVotedConfirmedHeight);
 					});
 				}

--- a/elements/lisk-bft/test/protocol_specs/bft_invalid_block_headers_protocol_specs.spec.ts
+++ b/elements/lisk-bft/test/protocol_specs/bft_invalid_block_headers_protocol_specs.spec.ts
@@ -71,6 +71,7 @@ describe('FinalityManager', () => {
 
 				const finalityManager = new FinalityManager({
 					chain: chainStub,
+					genesisHeight: 0,
 					finalizedHeight: invalidBlockHeaderSpec.config.finalizedHeight,
 					threshold: invalidBlockHeaderSpec.config.activeDelegates,
 				});

--- a/elements/lisk-bft/test/unit/finality_manager.spec.ts
+++ b/elements/lisk-bft/test/unit/finality_manager.spec.ts
@@ -106,17 +106,17 @@ describe('finality_manager', () => {
 					validators: [],
 					ledger: [
 						{
-							height: 10,
+							height: 610,
 							prevotes: 67,
 							precommits: 0,
 						},
 						{
-							height: 11,
+							height: 611,
 							prevotes: 67,
 							precommits: 0,
 						},
 						{
-							height: 12,
+							height: 612,
 							prevotes: 66,
 							precommits: 0,
 						},

--- a/framework/src/node/forger/forger.ts
+++ b/framework/src/node/forger/forger.ts
@@ -596,7 +596,9 @@ export class Forger {
 		const previousBlockID = previousBlock.header.id;
 		const forgerInfo = previouslyForgedMap.get(delegateAddress);
 		const maxHeightPreviouslyForged = forgerInfo?.height ?? 0;
-		const maxHeightPrevoted = await this._bftModule.getMaxHeightPrevoted();
+		const maxHeightPrevoted = await this._bftModule.getMaxHeightPrevoted(
+			previousBlock.header.asset?.maxHeightPrevoted,
+		);
 		const stateStore = await this._chainModule.newStateStore();
 		const reward = this._chainModule.calculateDefaultReward(height);
 		let size = 0;

--- a/framework/src/testing/block_processing_env.ts
+++ b/framework/src/testing/block_processing_env.ts
@@ -199,7 +199,9 @@ const createProcessableBlock = async (
 	const validator = await processor['_chain'].getValidator(nextTimestamp);
 	const passphrase = getPassphraseFromDefaultConfig(validator.address);
 	const seedReveal = await getHashOnion(processor, previousBlockHeader, passphrase);
-	const maxHeightPrevoted = await processor['_bft'].getMaxHeightPrevoted();
+	const maxHeightPrevoted = await processor['_bft'].getMaxHeightPrevoted(
+		previousBlockHeader.asset.maxHeightPrevoted,
+	);
 	const reward = processor['_chain'].calculateDefaultReward(previousBlockHeader.height + 1);
 	const maxHeightPreviouslyForged = await getMaxHeightPreviouslyForged(
 		processor,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6594

### How was it solved?

- Update to use maxHeightPrevoted from last block in case there is no prevote above threshold in the state
- In case input maxHeightPrevoted does not exist, genesis height is used

### How was it tested?

- Sync with the current testnet and check if it can be synced and generate new block
- Added unit test
