### PR TITLE
Update forger plugin to consider genesis height - #6582

### DIFF
--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -109,6 +109,7 @@ export class Chain {
 	};
 
 	private _lastBlock: Block;
+	private readonly _genesisHeight: number;
 	private readonly _networkIdentifier: Buffer;
 	private readonly _blockRewardArgs: BlockRewardOptions;
 	private readonly _accountSchema: Schema;
@@ -170,6 +171,7 @@ export class Chain {
 			genesisBlockTimestamp: genesisBlock.header.timestamp,
 			interval: blockTime,
 		});
+		this._genesisHeight = genesisBlock.header.height;
 		this._blockRewardArgs = {
 			distance: rewardDistance,
 			rewardOffset,
@@ -185,6 +187,10 @@ export class Chain {
 			minFeePerByte,
 			baseFees,
 		};
+	}
+
+	public get genesisHeight(): number {
+		return this._genesisHeight;
 	}
 
 	public get lastBlock(): Block {

--- a/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
+++ b/framework-plugins/lisk-framework-http-api-plugin/test/functional/node.spec.ts
@@ -47,6 +47,7 @@ describe('Node', () => {
 			const nodeStatusAndConstantFixture = {
 				version: appInstance._node._options.version,
 				networkVersion: appInstance._node._options.networkVersion,
+				genesisHeight: appInstance._node._chain.genesisHeight,
 				networkIdentifier: appInstance._node.networkIdentifier.toString('hex'),
 				lastBlockID: appInstance._node._chain.lastBlock.header.id.toString('hex'),
 				height: appInstance._node._chain.lastBlock.header.height,

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -503,6 +503,7 @@ export class Node {
 				networkIdentifier: this._networkIdentifier.toString('hex'),
 				lastBlockID: this._chain.lastBlock.header.id.toString('hex'),
 				height: this._chain.lastBlock.header.height,
+				genesisHeight: this._chain.genesisHeight,
 				finalizedHeight: this._bft.finalityManager.finalizedHeight,
 				syncing: this._synchronizer.isActive,
 				unconfirmedTransactions: this._transactionPool.getAll().length,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6582 

### How was it solved?

- Update lisk-chain to maintain genesis height
- Update nodeInfo to include `genesisHeight` as response
- Update forger plugin to consider genesis height as the initial point before syncing

### How was it tested?

- Run forger plugin with testnet data
