### PR TITLE
Update domain lisk.io to lisk.com

### DIFF
--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/README.md
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/README.md
@@ -30,4 +30,4 @@ lisk generate:plugin httpAPI
 
 ## Learn More
 
-You can learn more in the [documentation](https://lisk.com/documentation/lisk-sdk/index.html).
+You can learn more in the [documentation](https://lisk.com/documentation/lisk-sdk/).

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/README.md
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/README.md
@@ -30,4 +30,4 @@ lisk generate:plugin httpAPI
 
 ## Learn More
 
-You can learn more in the [documentation](https://lisk.io/documentation/lisk-sdk/index.html).
+You can learn more in the [documentation](https://lisk.com/documentation/lisk-sdk/index.html).

--- a/elements/README.md
+++ b/elements/README.md
@@ -6,7 +6,7 @@
 
 ## What is Lisk Elements
 
-Lisk Elements is a collection of libraries, each of them implementing some form of blockchain application functionality such as cryptography, transactions, p2p, etc. Each library is designed to be compatible with the [Lisk Protocol](https://lisk.io/documentation/lisk-protocol).
+Lisk Elements is a collection of libraries, each of them implementing some form of blockchain application functionality such as cryptography, transactions, p2p, etc. Each library is designed to be compatible with the [Lisk Protocol](https://research.lisk.com/).
 
 Lisk Elements supports the modular architecture of the Lisk SDK, where libraries can be created or modified to suit individual blockchain application requirements.
 

--- a/elements/README.md
+++ b/elements/README.md
@@ -6,7 +6,7 @@
 
 ## What is Lisk Elements
 
-Lisk Elements is a collection of libraries, each of them implementing some form of blockchain application functionality such as cryptography, transactions, p2p, etc. Each library is designed to be compatible with the [Lisk Protocol](https://research.lisk.com/).
+Lisk Elements is a collection of libraries, each of them implementing some form of blockchain application functionality such as cryptography, transactions, p2p, etc. Each library is designed to be compatible with the [Lisk Protocol](https://lisk.com/documentation/lisk-sdk/protocol).
 
 Lisk Elements supports the modular architecture of the Lisk SDK, where libraries can be created or modified to suit individual blockchain application requirements.
 

--- a/elements/lisk-api-client/README.md
+++ b/elements/lisk-api-client/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/api-client.html

--- a/elements/lisk-api-client/README.md
+++ b/elements/lisk-api-client/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-api-client/README.md
+++ b/elements/lisk-api-client/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-bft/README.md
+++ b/elements/lisk-bft/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-bft/README.md
+++ b/elements/lisk-bft/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/bft.html

--- a/elements/lisk-bft/README.md
+++ b/elements/lisk-bft/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-chain/README.md
+++ b/elements/lisk-chain/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-chain/README.md
+++ b/elements/lisk-chain/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/chain.html

--- a/elements/lisk-chain/README.md
+++ b/elements/lisk-chain/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-client/README.md
+++ b/elements/lisk-client/README.md
@@ -76,4 +76,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-client/README.md
+++ b/elements/lisk-client/README.md
@@ -76,4 +76,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/client.html

--- a/elements/lisk-client/README.md
+++ b/elements/lisk-client/README.md
@@ -76,4 +76,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-codec/README.md
+++ b/elements/lisk-codec/README.md
@@ -40,4 +40,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-codec/README.md
+++ b/elements/lisk-codec/README.md
@@ -40,4 +40,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/codec.html

--- a/elements/lisk-codec/README.md
+++ b/elements/lisk-codec/README.md
@@ -40,4 +40,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-cryptography/README.md
+++ b/elements/lisk-cryptography/README.md
@@ -50,4 +50,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/cryptography.html

--- a/elements/lisk-cryptography/README.md
+++ b/elements/lisk-cryptography/README.md
@@ -50,4 +50,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-cryptography/README.md
+++ b/elements/lisk-cryptography/README.md
@@ -50,4 +50,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-db/README.md
+++ b/elements/lisk-db/README.md
@@ -85,4 +85,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-db/README.md
+++ b/elements/lisk-db/README.md
@@ -85,4 +85,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-db/README.md
+++ b/elements/lisk-db/README.md
@@ -85,4 +85,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/db.html

--- a/elements/lisk-elements/README.md
+++ b/elements/lisk-elements/README.md
@@ -69,4 +69,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-elements/README.md
+++ b/elements/lisk-elements/README.md
@@ -69,4 +69,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-genesis/README.md
+++ b/elements/lisk-genesis/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/genesis.html

--- a/elements/lisk-genesis/README.md
+++ b/elements/lisk-genesis/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-genesis/README.md
+++ b/elements/lisk-genesis/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-p2p/README.md
+++ b/elements/lisk-p2p/README.md
@@ -128,4 +128,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-p2p/README.md
+++ b/elements/lisk-p2p/README.md
@@ -128,4 +128,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/p2p.html

--- a/elements/lisk-p2p/README.md
+++ b/elements/lisk-p2p/README.md
@@ -128,4 +128,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-passphrase/README.md
+++ b/elements/lisk-passphrase/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/passphrase.html

--- a/elements/lisk-passphrase/README.md
+++ b/elements/lisk-passphrase/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-passphrase/README.md
+++ b/elements/lisk-passphrase/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-transaction-pool/README.md
+++ b/elements/lisk-transaction-pool/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-transaction-pool/README.md
+++ b/elements/lisk-transaction-pool/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/transaction-pool.html

--- a/elements/lisk-transaction-pool/README.md
+++ b/elements/lisk-transaction-pool/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-transactions/README.md
+++ b/elements/lisk-transactions/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-transactions/README.md
+++ b/elements/lisk-transactions/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/transactions.html

--- a/elements/lisk-transactions/README.md
+++ b/elements/lisk-transactions/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-tree/README.md
+++ b/elements/lisk-tree/README.md
@@ -44,4 +44,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-tree/README.md
+++ b/elements/lisk-tree/README.md
@@ -44,4 +44,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-tree/README.md
+++ b/elements/lisk-tree/README.md
@@ -44,4 +44,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/tree.html

--- a/elements/lisk-utils/README.md
+++ b/elements/lisk-utils/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/utils.html

--- a/elements/lisk-utils/README.md
+++ b/elements/lisk-utils/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-utils/README.md
+++ b/elements/lisk-utils/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/elements/lisk-validator/README.md
+++ b/elements/lisk-validator/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/validator.html

--- a/elements/lisk-validator/README.md
+++ b/elements/lisk-validator/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/elements/lisk-validator/README.md
+++ b/elements/lisk-validator/README.md
@@ -25,4 +25,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/framework-plugins/lisk-framework-dashboard-plugin/README.md
+++ b/framework-plugins/lisk-framework-dashboard-plugin/README.md
@@ -35,4 +35,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-framework/dashboard-plugin.html

--- a/framework-plugins/lisk-framework-dashboard-plugin/README.md
+++ b/framework-plugins/lisk-framework-dashboard-plugin/README.md
@@ -35,4 +35,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/framework-plugins/lisk-framework-dashboard-plugin/README.md
+++ b/framework-plugins/lisk-framework-dashboard-plugin/README.md
@@ -35,4 +35,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/framework-plugins/lisk-framework-faucet-plugin/README.md
+++ b/framework-plugins/lisk-framework-faucet-plugin/README.md
@@ -39,4 +39,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/framework-plugins/lisk-framework-faucet-plugin/README.md
+++ b/framework-plugins/lisk-framework-faucet-plugin/README.md
@@ -39,4 +39,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-framework/faucet-plugin.html

--- a/framework-plugins/lisk-framework-faucet-plugin/README.md
+++ b/framework-plugins/lisk-framework-faucet-plugin/README.md
@@ -39,4 +39,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/framework-plugins/lisk-framework-forger-plugin/README.md
+++ b/framework-plugins/lisk-framework-forger-plugin/README.md
@@ -33,4 +33,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/framework-plugins/lisk-framework-forger-plugin/README.md
+++ b/framework-plugins/lisk-framework-forger-plugin/README.md
@@ -33,4 +33,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/framework-plugins/lisk-framework-forger-plugin/README.md
+++ b/framework-plugins/lisk-framework-forger-plugin/README.md
@@ -33,4 +33,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-framework/forger-plugin.html

--- a/framework-plugins/lisk-framework-http-api-plugin/README.md
+++ b/framework-plugins/lisk-framework-http-api-plugin/README.md
@@ -46,4 +46,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/framework-plugins/lisk-framework-http-api-plugin/README.md
+++ b/framework-plugins/lisk-framework-http-api-plugin/README.md
@@ -46,4 +46,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-framework/http-api-plugin.html

--- a/framework-plugins/lisk-framework-http-api-plugin/README.md
+++ b/framework-plugins/lisk-framework-http-api-plugin/README.md
@@ -46,4 +46,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/framework-plugins/lisk-framework-monitor-plugin/README.md
+++ b/framework-plugins/lisk-framework-monitor-plugin/README.md
@@ -46,4 +46,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/framework-plugins/lisk-framework-monitor-plugin/README.md
+++ b/framework-plugins/lisk-framework-monitor-plugin/README.md
@@ -46,4 +46,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/framework-plugins/lisk-framework-monitor-plugin/README.md
+++ b/framework-plugins/lisk-framework-monitor-plugin/README.md
@@ -46,4 +46,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-framework/monitor-plugin.html

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/README.md
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/README.md
@@ -36,4 +36,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/README.md
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/README.md
@@ -36,4 +36,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-framework/report-misbehavior-plugin.html

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/README.md
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/README.md
@@ -36,4 +36,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 [lisk core github]: https://github.com/LiskHQ/lisk
-[lisk documentation site]: https://lisk.io/documentation/lisk-elements
+[lisk documentation site]: https://lisk.com/documentation/lisk-sdk/references/lisk-elements/index.html

--- a/framework/test/unit/node/network/lookup_peers_ips.spec.ts
+++ b/framework/test/unit/node/network/lookup_peers_ips.spec.ts
@@ -32,11 +32,11 @@ describe('init_steps/lookup_peers_ips', () => {
 		});
 
 		it('should throw error when failed to resolve hostname', async () => {
-			await lookupPeersIPs([{ ip: 'https://lisk.io/', port: 4000 }], true);
+			await lookupPeersIPs([{ ip: 'https://lisk.com/', port: 4000 }], true);
 
 			expect(spyConsoleError).toHaveBeenCalledTimes(1);
 			return expect(spyConsoleError).toHaveBeenCalledWith(
-				'Failed to resolve peer domain name https://lisk.io/ to an IP address',
+				'Failed to resolve peer domain name https://lisk.com/ to an IP address',
 			);
 		});
 

--- a/protocol-specs/schema/lisk_protocol_specs.schema.json
+++ b/protocol-specs/schema/lisk_protocol_specs.schema.json
@@ -1,7 +1,7 @@
 {
 	"title": "LiskProtocolSpec",
 	"description": "Schema specification for JSON specs output",
-	"$id": "https://lisk.io/schemas/protocol_specs",
+	"$id": "https://lisk.com/schemas/protocol_specs",
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"type": "object",
 	"additionalProperties": false,

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -20,13 +20,13 @@ We strictly discourage anyone from using the beta release of the Lisk SDK for an
 
 The only application built using the Lisk SDK currently feasible for production usage is [Lisk Core](https://github.com/liskhq/lisk-core), the client of the Lisk network itself.
 
-Please be advised, although we have stabilized the architecture of SDK, we cannot guarantee blockchain created with the beta release of the Lisk SDK will remain compatible with our planned release candidates.
+Please be advised, although we have stabilized the architecture of SDK, we cannot guarantee a blockchain application created with the beta release of the Lisk SDK will remain compatible with our planned release candidates.
 
 We hope you enjoy building your proof-of-concept blockchain applications using the Lisk SDK, and shall look forward to receiving your feedback and contributions during the beta phase.
 
 ## What is the Lisk SDK?
 
-The Lisk SDK aims to provide an easy and reliable software development kit for building blockchain applications which are compatible with the [Lisk Protocol](https://research.lisk.com/). The architecture of the Lisk SDK has been designed so that it can be extended to meet the requirements of a wide variety of blockchain application use-cases. The codebase is written entirely in JavaScript, which means for a majority of developers, no significant change of tools or mindset is required to get started. The Lisk SDK makes every effort to allow developers to focus simply and purely on writing the code that matters to their own blockchain application, and nothing more.
+The Lisk SDK aims to provide an easy and reliable software development kit for building blockchain applications which are compatible with the [Lisk Protocol](https://lisk.com/documentation/lisk-sdk/protocol). The architecture of the Lisk SDK has been designed so that it can be extended to meet the requirements of a wide variety of blockchain application use-cases. The codebase is written entirely in JavaScript, which means for a majority of developers, no significant change of tools or mindset is required to get started. The Lisk SDK makes every effort to allow developers to focus simply and purely on writing the code that matters to their own blockchain application, and nothing more.
 
 ## Usage
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -20,19 +20,19 @@ We strictly discourage anyone from using the beta release of the Lisk SDK for an
 
 The only application built using the Lisk SDK currently feasible for production usage is [Lisk Core](https://github.com/liskhq/lisk-core), the client of the Lisk network itself.
 
-Please be advised, although we have stabilised the architecture of SDK, we cannot guarantee blockchains created with the beta release of the Lisk SDK will remain compatible with our planned release candidates.
+Please be advised, although we have stabilized the architecture of SDK, we cannot guarantee blockchain created with the beta release of the Lisk SDK will remain compatible with our planned release candidates.
 
 We hope you enjoy building your proof-of-concept blockchain applications using the Lisk SDK, and shall look forward to receiving your feedback and contributions during the beta phase.
 
 ## What is the Lisk SDK?
 
-The Lisk SDK aims to provide an easy and reliable software development kit for building blockchain applications which are compatible with the [Lisk Protocol](https://lisk.io/documentation/lisk-protocol). The architecture of the Lisk SDK has been designed so that it can be extended to meet the requirements of a wide variety of blockchain application use-cases. The codebase is written entirely in JavaScript, which means for a majority of developers, no significant change of tools or mindset is required to get started. The Lisk SDK makes every effort to allow developers to focus simply and purely on writing the code that matters to their own blockchain application, and nothing more.
+The Lisk SDK aims to provide an easy and reliable software development kit for building blockchain applications which are compatible with the [Lisk Protocol](https://research.lisk.com/). The architecture of the Lisk SDK has been designed so that it can be extended to meet the requirements of a wide variety of blockchain application use-cases. The codebase is written entirely in JavaScript, which means for a majority of developers, no significant change of tools or mindset is required to get started. The Lisk SDK makes every effort to allow developers to focus simply and purely on writing the code that matters to their own blockchain application, and nothing more.
 
 ## Usage
 
 ### Documentation
 
-For more detailed documentation, see the [official Lisk SDK documentation](https://lisk.io/documentation/lisk-sdk).
+For more detailed documentation, see the [official Lisk SDK documentation](https://lisk.com/documentation/lisk-sdk).
 
 #### Dependencies
 


### PR DESCRIPTION
### What was the problem?

- The lisk domain was changed from lisk.io to lisk.com, which was not reflected in codebase

### How was it solved?

- Updated all the domain references

### How was it tested?

- Click on new domain links and check if they navigate to correct page