### PR TITLE
Fix transport to encode BigNumber to string - Closes #6609

### DIFF
--- a/framework/src/modules/chain/transport/transport.js
+++ b/framework/src/modules/chain/transport/transport.js
@@ -155,15 +155,15 @@ class Transport {
 		}
 
 		if (block.totalAmount) {
-			block.totalAmount = block.totalAmount.toNumber();
+			block.totalAmount = block.totalAmount.toString();
 		}
 
 		if (block.totalFee) {
-			block.totalFee = block.totalFee.toNumber();
+			block.totalFee = block.totalFee.toString();
 		}
 
 		if (block.reward) {
-			block.reward = block.reward.toNumber();
+			block.reward = block.reward.toString();
 		}
 
 		if (block.transactions) {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6609

### How was it solved?

- Update transport to encode big number to string
- Lock sinon-chai to old version for building

### How was it tested?

Run network with delegate nodes and send transaction with amount `1300262865374292`
