### PR TITLE
Codec fromJSON and toJSON fails on extra properties #5670

### DIFF
--- a/elements/lisk-codec/src/json_wrapper.ts
+++ b/elements/lisk-codec/src/json_wrapper.ts
@@ -12,7 +12,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-
+import { objects } from '@liskhq/lisk-utils';
 import {
 	BaseTypes,
 	IteratableGenericObject,
@@ -56,7 +56,7 @@ const mappers: mappersInterface = {
 /* eslint-enable @typescript-eslint/explicit-function-return-type */
 
 const findObjectByPath = (message: SchemaProps, pathArr: string[]): SchemaProps | undefined => {
-	let result: SchemaProps = message;
+	let result: SchemaProps = objects.cloneDeep(message);
 	for (let i = 0; i < pathArr.length; i += 1) {
 		if (!result.properties && !result.items) {
 			return undefined;
@@ -131,7 +131,9 @@ export const recursiveTypeCast = (
 			} else {
 				for (let i = 0; i < value.length; i += 1) {
 					if (schemaProp === undefined || schemaProp.items === undefined) {
-						throw new Error(`Invalid schema property found. Path: ${dataPath.join(',')}`);
+						delete object[key];
+						dataPath.pop();
+						continue;
 					}
 
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
@@ -144,7 +146,9 @@ export const recursiveTypeCast = (
 			const schemaProp = findObjectByPath(schema, dataPath);
 
 			if (schemaProp === undefined) {
-				throw new Error(`Invalid schema property found. Path: ${dataPath.join(',')}`);
+				delete object[key];
+				dataPath.pop();
+				continue;
 			}
 
 			object[key] = mappers[mode][(schemaProp.dataType as unknown) as string](value);

--- a/elements/lisk-codec/src/json_wrapper.ts
+++ b/elements/lisk-codec/src/json_wrapper.ts
@@ -12,7 +12,6 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { objects } from '@liskhq/lisk-utils';
 import {
 	BaseTypes,
 	IteratableGenericObject,
@@ -56,7 +55,7 @@ const mappers: mappersInterface = {
 /* eslint-enable @typescript-eslint/explicit-function-return-type */
 
 const findObjectByPath = (message: SchemaProps, pathArr: string[]): SchemaProps | undefined => {
-	let result: SchemaProps = objects.cloneDeep(message);
+	let result: SchemaProps = message;
 	for (let i = 0; i < pathArr.length; i += 1) {
 		if (!result.properties && !result.items) {
 			return undefined;

--- a/elements/lisk-codec/test/fromJSON.spec.ts
+++ b/elements/lisk-codec/test/fromJSON.spec.ts
@@ -85,4 +85,57 @@ describe('toJSON', () => {
 		const res = codec.fromJSON(schema, jsonLikeObject);
 		expect(res).toEqual(jsObject);
 	});
+
+	it('should ignore extra properties', () => {
+		const schema = {
+			$id: '/schema',
+			type: 'object',
+			required: ['rootProp', 'objectValue', 'arrayValue'],
+			properties: {
+				rootProp: {
+					dataType: 'uint64',
+					fieldNumber: 1,
+				},
+				objectValue: {
+					type: 'object',
+					fieldNumber: 2,
+					properties: {
+						objectProp: {
+							dataType: 'uint64',
+							fieldNumber: 1,
+						},
+					},
+				},
+				arrayValue: {
+					type: 'array',
+					fieldNumber: 3,
+					items: {
+						type: 'object',
+						properties: {
+							arrayProp: {
+								dataType: 'uint64',
+								fieldNumber: 1,
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const result = codec.fromJSON(schema, {
+			rootProp: '123',
+			extra3: true,
+			objectValue: { objectProp: '456', extra1: 'my-value', extra2: 'my-value' },
+			arrayValue: [
+				{ arrayProp: '999', extra4: true },
+				{ arrayProp: '879', extra5: 987 },
+			],
+		});
+
+		expect(result).toEqual({
+			rootProp: BigInt(123),
+			objectValue: { objectProp: BigInt(456) },
+			arrayValue: [{ arrayProp: BigInt(999) }, { arrayProp: BigInt(879) }],
+		});
+	});
 });

--- a/elements/lisk-codec/test/toJSON.spec.ts
+++ b/elements/lisk-codec/test/toJSON.spec.ts
@@ -85,4 +85,57 @@ describe('toJSON', () => {
 		const res = codec.toJSON(schema, jsObject);
 		expect(res).toEqual(jsonLikeObject);
 	});
+
+	it('should ignore extra properties', () => {
+		const schema = {
+			$id: '/schema',
+			type: 'object',
+			required: ['rootProp', 'objectValue', 'arrayValue'],
+			properties: {
+				rootProp: {
+					dataType: 'uint64',
+					fieldNumber: 1,
+				},
+				objectValue: {
+					type: 'object',
+					fieldNumber: 2,
+					properties: {
+						objectProp: {
+							dataType: 'uint64',
+							fieldNumber: 1,
+						},
+					},
+				},
+				arrayValue: {
+					type: 'array',
+					fieldNumber: 3,
+					items: {
+						type: 'object',
+						properties: {
+							arrayProp: {
+								dataType: 'uint64',
+								fieldNumber: 1,
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const result = codec.toJSON(schema, {
+			rootProp: BigInt('123'),
+			extra3: true,
+			objectValue: { objectProp: BigInt('456'), extra1: 'my-value', extra2: 'my-value' },
+			arrayValue: [
+				{ arrayProp: BigInt('999'), extra4: true },
+				{ arrayProp: BigInt('879'), extra5: 987 },
+			],
+		});
+
+		expect(result).toEqual({
+			rootProp: '123',
+			objectValue: { objectProp: '456' },
+			arrayValue: [{ arrayProp: '999' }, { arrayProp: '879' }],
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5670

### How was it solved?

- Fixed the issue for throwing error on extra attributes 

### How was it tested?

- Added unit tests for ignoring extra attributes on `fromJSON` and `toJSON`
