### PR TITLE
validateBase32Address(address) doesn't return false value - Closes #6652

### DIFF
--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -137,7 +137,7 @@ const LISK32_CHARSET = 'zxvcpmbn3465o978uyrtkqew2adsjhfg';
 export const validateLisk32Address = (
 	address: string,
 	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
-): boolean => {
+): true | never => {
 	if (address.length !== LISK32_ADDRESS_LENGTH) {
 		throw new Error('Address length does not match requirements. Expected 41 characters.');
 	}

--- a/elements/lisk-cryptography/test/keys.spec.ts
+++ b/elements/lisk-cryptography/test/keys.spec.ts
@@ -163,7 +163,7 @@ describe('keys', () => {
 		describe('Given an address that is too short', () => {
 			const address = 'lsk1';
 			it('should throw an error', () => {
-				return expect(validateLisk32Address.bind(null, address)).toThrow(
+				return expect(() => validateLisk32Address(address)).toThrow(
 					'Address length does not match requirements. Expected 41 characters.',
 				);
 			});
@@ -172,7 +172,7 @@ describe('keys', () => {
 		describe('Given an address that is too long', () => {
 			const address = 'lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmux2ga';
 			it('should throw an error', () => {
-				return expect(validateLisk32Address.bind(null, address)).toThrow(
+				return expect(() => validateLisk32Address(address)).toThrow(
 					'Address length does not match requirements. Expected 41 characters.',
 				);
 			});
@@ -181,7 +181,7 @@ describe('keys', () => {
 		describe('Given an address that is not prefixed with `lsk`', () => {
 			const address = 'LSK24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu';
 			it('should throw an error', () => {
-				return expect(validateLisk32Address.bind(null, address)).toThrow(
+				return expect(() => validateLisk32Address(address)).toThrow(
 					'Invalid address prefix. Actual prefix: LSK, Expected prefix: lsk',
 				);
 			});
@@ -190,7 +190,7 @@ describe('keys', () => {
 		describe('Given an address containing non-lisk32 characters', () => {
 			const address = 'lsk1aknq582o6fw7sp82bm2hnj7pzp47mpmbmux2g';
 			it('should throw an error', () => {
-				return expect(validateLisk32Address.bind(null, address)).toThrow(
+				return expect(() => validateLisk32Address(address)).toThrow(
 					"Invalid character found in address. Only allow characters: 'abcdefghjkmnopqrstuvwxyz23456789'.",
 				);
 			});
@@ -199,7 +199,7 @@ describe('keys', () => {
 		describe('Given an address with invalid checksum', () => {
 			const address = 'lskoaknq582o6fw7sp82bm2hnj7pzp47mpmbmuxgg';
 			it('should throw an error', () => {
-				return expect(validateLisk32Address.bind(null, address)).toThrow(
+				return expect(() => validateLisk32Address(address)).toThrow(
 					'Invalid checksum for address.',
 				);
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6652

### How was it solved?

- Change the return type of the function to be consistent with implementation 

### How was it tested?

- Run unit tests 
