### PR TITLE
Remove deprecated functions from lisk-cryptography - Closes #6660

### DIFF
--- a/commander/src/bootstrapping/commands/account/create.ts
+++ b/commander/src/bootstrapping/commands/account/create.ts
@@ -30,7 +30,7 @@ const createAccount = (prefix: string): AccountInfo => {
 	const generatedPassphrase = passphrase.Mnemonic.generateMnemonic();
 	const { privateKey, publicKey } = cryptography.getKeys(generatedPassphrase);
 	const binaryAddress = cryptography.getAddressFromPublicKey(publicKey);
-	const address = cryptography.getBase32AddressFromPublicKey(publicKey, prefix);
+	const address = cryptography.getLisk32AddressFromPublicKey(publicKey, prefix);
 
 	return {
 		passphrase: generatedPassphrase,

--- a/commander/src/bootstrapping/commands/account/show.ts
+++ b/commander/src/bootstrapping/commands/account/show.ts
@@ -29,7 +29,7 @@ const processInput = (
 } => {
 	const { privateKey, publicKey } = cryptography.getKeys(passphrase);
 	const binaryAddress = cryptography.getAddressFromPublicKey(publicKey);
-	const address = cryptography.getBase32AddressFromPublicKey(publicKey, prefix);
+	const address = cryptography.getLisk32AddressFromPublicKey(publicKey, prefix);
 
 	return {
 		privateKey: privateKey.toString('hex'),

--- a/commander/src/bootstrapping/commands/account/validate.ts
+++ b/commander/src/bootstrapping/commands/account/validate.ts
@@ -39,8 +39,8 @@ export class ValidateCommand extends Command {
 
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-			cryptography.validateBase32Address(address, this.config.pjson.lisk.addressPrefix);
-			const binaryAddress = cryptography.getAddressFromBase32Address(address).toString('hex');
+			cryptography.validateLisk32Address(address, this.config.pjson.lisk.addressPrefix);
+			const binaryAddress = cryptography.getAddressFromLisk32Address(address).toString('hex');
 
 			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 			this.log(

--- a/commander/test/bootstrapping/commands/account/create.spec.ts
+++ b/commander/test/bootstrapping/commands/account/create.spec.ts
@@ -45,7 +45,7 @@ describe('account:create', () => {
 				{
 					publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
 					privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
+					address: cryptography.getLisk32AddressFromPublicKey(
 						cryptography.getKeys(defaultMnemonic).publicKey,
 						'lsk',
 					),
@@ -64,7 +64,7 @@ describe('account:create', () => {
 				{
 					publicKey: cryptography.getKeys(defaultMnemonic).publicKey.toString('hex'),
 					privateKey: cryptography.getKeys(defaultMnemonic).privateKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
+					address: cryptography.getLisk32AddressFromPublicKey(
 						cryptography.getKeys(defaultMnemonic).publicKey,
 						'lsk',
 					),
@@ -74,7 +74,7 @@ describe('account:create', () => {
 				{
 					publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
 					privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
-					address: cryptography.getBase32AddressFromPublicKey(
+					address: cryptography.getLisk32AddressFromPublicKey(
 						cryptography.getKeys(secondDefaultMnemonic).publicKey,
 						'lsk',
 					),

--- a/commander/test/bootstrapping/commands/account/show.spec.ts
+++ b/commander/test/bootstrapping/commands/account/show.spec.ts
@@ -45,7 +45,7 @@ describe('account:show', () => {
 			expect(JSON.parse(stdout[0])).toEqual({
 				privateKey: cryptography.getKeys(passphraseInput).privateKey.toString('hex'),
 				publicKey: cryptography.getKeys(passphraseInput).publicKey.toString('hex'),
-				address: cryptography.getBase32AddressFromPublicKey(
+				address: cryptography.getLisk32AddressFromPublicKey(
 					cryptography.getKeys(passphraseInput).publicKey,
 					'lsk',
 				),
@@ -59,7 +59,7 @@ describe('account:show', () => {
 			expect(JSON.parse(stdout[0])).toEqual({
 				privateKey: cryptography.getKeys(secondDefaultMnemonic).privateKey.toString('hex'),
 				publicKey: cryptography.getKeys(secondDefaultMnemonic).publicKey.toString('hex'),
-				address: cryptography.getBase32AddressFromPublicKey(
+				address: cryptography.getLisk32AddressFromPublicKey(
 					cryptography.getKeys(secondDefaultMnemonic).publicKey,
 					'lsk',
 				),

--- a/elements/lisk-cryptography/src/keys.ts
+++ b/elements/lisk-cryptography/src/keys.ts
@@ -113,11 +113,6 @@ export const getLisk32AddressFromPublicKey = (
 	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
 ): string => `${prefix}${addressToLisk32(getAddressFromPublicKey(publicKey))}`;
 
-/**
- * @deprecated
- */
-export const getBase32AddressFromPublicKey = getLisk32AddressFromPublicKey;
-
 export const getLisk32AddressFromPassphrase = (
 	passphrase: string,
 	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
@@ -125,11 +120,6 @@ export const getLisk32AddressFromPassphrase = (
 	const { publicKey } = getAddressAndPublicKeyFromPassphrase(passphrase);
 	return getLisk32AddressFromPublicKey(publicKey, prefix);
 };
-
-/**
- * @deprecated
- */
-export const getBase32AddressFromPassphrase = getLisk32AddressFromPassphrase;
 
 const LISK32_ADDRESS_LENGTH = 41;
 const LISK32_CHARSET = 'zxvcpmbn3465o978uyrtkqew2adsjhfg';
@@ -167,11 +157,6 @@ export const validateLisk32Address = (
 	return true;
 };
 
-/**
- * @deprecated
- */
-export const validateBase32Address = validateLisk32Address;
-
 export const getAddressFromLisk32Address = (
 	base32Address: string,
 	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
@@ -190,17 +175,7 @@ export const getAddressFromLisk32Address = (
 	return Buffer.from(integerSequence8);
 };
 
-/**
- * @deprecated
- */
-export const getAddressFromBase32Address = getAddressFromLisk32Address;
-
 export const getLisk32AddressFromAddress = (
 	address: Buffer,
 	prefix = DEFAULT_LISK32_ADDRESS_PREFIX,
 ): string => `${prefix}${addressToLisk32(address)}`;
-
-/**
- * @deprecated
- */
-export const getBase32AddressFromAddress = getLisk32AddressFromAddress;

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/pages/MainPage.tsx
@@ -241,7 +241,7 @@ const MainPage: React.FC = () => {
 		const { address, publicKey } = cryptography.getAddressAndPublicKeyFromPassphrase(
 			accountPassphrase,
 		);
-		const lisk32Address = cryptography.getBase32AddressFromAddress(address);
+		const lisk32Address = cryptography.getLisk32AddressFromAddress(address);
 		const newAccount: Account = {
 			passphrase: accountPassphrase,
 			publicKey: publicKey.toString('hex'),

--- a/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/ui/app.tsx
@@ -7,11 +7,11 @@ import logo from './logo.svg';
 import illustration from './illustration.svg';
 import styles from './app.module.scss';
 
-const { validateBase32Address, getAddressFromBase32Address } = cryptography;
+const { validateLisk32Address, getAddressFromLisk32Address } = cryptography;
 
 const validateAddress = (address: string, prefix: string): boolean => {
 	try {
-		return validateBase32Address(address, prefix);
+		return validateLisk32Address(address, prefix);
 	} catch (error) {
 		return false;
 	}
@@ -138,7 +138,7 @@ export const App: React.FC = () => {
 		try {
 			const client = await apiClient.createWSClient(config.applicationUrl);
 			await client.invoke('faucet:fundTokens', {
-				address: getAddressFromBase32Address(input, config.tokenPrefix).toString('hex'),
+				address: getAddressFromLisk32Address(input, config.tokenPrefix).toString('hex'),
 				token,
 			});
 			updateErrorMsg('');


### PR DESCRIPTION
### What was the problem?

This PR resolves #6660

### How was it solved?

- Removed deprecated functions 

### How was it tested?

- Run all unit tests
