### PR TITLE
On update root is saved twice on sparse merkle tree - Closes #6655

### DIFF
--- a/elements/lisk-tree/src/sparse_merkle_tree/sparse_merkle_tree.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/sparse_merkle_tree.ts
@@ -163,10 +163,9 @@ export class SparseMerkleTree {
 			bottomNode = p;
 			h -= 1;
 		}
-		rootNode = bottomNode;
-		this._rootHash = rootNode.hash;
+		this._rootHash = bottomNode.hash;
 
-		return rootNode;
+		return bottomNode;
 	}
 
 	public async remove(key: Buffer): Promise<TreeNode> {

--- a/elements/lisk-tree/src/sparse_merkle_tree/sparse_merkle_tree.ts
+++ b/elements/lisk-tree/src/sparse_merkle_tree/sparse_merkle_tree.ts
@@ -165,7 +165,6 @@ export class SparseMerkleTree {
 		}
 		rootNode = bottomNode;
 		this._rootHash = rootNode.hash;
-		await this._db.set(rootNode.hash, (rootNode as Branch).data);
 
 		return rootNode;
 	}
@@ -255,7 +254,6 @@ export class SparseMerkleTree {
 			h -= 1;
 		}
 		this._rootHash = bottomNode.hash;
-		await this._db.set(bottomNode.hash, (bottomNode as Branch).data);
 
 		return bottomNode;
 	}


### PR DESCRIPTION
### What was the problem?

This PR resolves #6655

### How was it solved?

- Removed the code line which endup calling `db.set` twice. 

### How was it tested?

- Run unit tests
