### PR TITLE
Multi selector for event subscriber is unable to adjust to multi row - Closes #6437

### DIFF
--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/input/SelectInput.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/input/SelectInput.tsx
@@ -36,7 +36,7 @@ type Props = SingleSelectProps | MultiSelectProps;
 const customSelectStyles: StylesConfig<SelectInputOptionType, boolean> = {
 	container: (currentStyles, _state) => ({
 		...currentStyles,
-		height: '40px',
+		minHeight: '40px',
 		boxSizing: 'border-box',
 		fontStyle: 'normal',
 		fontWeight: 'normal',
@@ -44,7 +44,7 @@ const customSelectStyles: StylesConfig<SelectInputOptionType, boolean> = {
 	}),
 	valueContainer: (currentStyles, _state) => ({
 		...currentStyles,
-		height: '40px',
+		minHeight: '40px',
 	}),
 	option: (currentStyles, state) => ({
 		...currentStyles,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6437

### How was it solved?

- Made the strict height to min height 

### How was it tested?

- Tested visually 

![image](https://user-images.githubusercontent.com/112468/130440177-0a4e286e-1470-46d8-a4ca-54b7619dd197.png)
