### PR TITLE
Add websocket RPC event filtering - Closes #6612

### DIFF
--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -431,7 +431,7 @@ export class Bus {
 
 		if (this._wsServer) {
 			try {
-				this._wsServer.broadcast(JSON.stringify(notification));
+				this._wsServer.broadcast(notification);
 			} catch (error) {
 				this.logger.debug(
 					{ err: error as Error },

--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -523,7 +523,7 @@ export class Bus {
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	private async _setupWSServer(): Promise<void> {
-		this._wsServer?.start((socket, message) => {
+		this._wsServer?.start(this.getEvents(), (socket, message) => {
 			this.invoke(message)
 				.then(data => {
 					socket.send(JSON.stringify(data as JSONRPC.ResponseObjectWithResult));

--- a/framework/src/controller/jsonrpc/types.ts
+++ b/framework/src/controller/jsonrpc/types.ts
@@ -25,7 +25,7 @@ export interface RequestObject {
 	readonly id: ID;
 	readonly jsonrpc: string;
 	readonly method: string;
-	readonly params?: object & { source?: string };
+	readonly params?: Record<string, unknown>;
 }
 
 export type NotificationRequest = Omit<RequestObject, 'id'>;

--- a/framework/src/controller/ws/ws_server.ts
+++ b/framework/src/controller/ws/ws_server.ts
@@ -51,7 +51,10 @@ export class WSServer {
 			this._logger.error(error);
 		});
 		this.server.on('listening', () => {
-			this._logger.info({ host: this._host, port: this._port, path: this._path }, 'Websocket Server Ready');
+			this._logger.info(
+				{ host: this._host, port: this._port, path: this._path },
+				'Websocket Server Ready',
+			);
 		});
 
 		this.server.on('close', () => {
@@ -72,7 +75,7 @@ export class WSServer {
 	public broadcast(message: NotificationRequest): void {
 		for (const client of this.server.clients) {
 			if (client.readyState === WebSocket.OPEN) {
-				const subscription = this._subscriptions[client.url]
+				const subscription = this._subscriptions[client.url];
 				if (!subscription) {
 					continue;
 				}
@@ -99,7 +102,7 @@ export class WSServer {
 					return;
 				}
 			} catch (error) {
-				this._logger.error({ err: (error as Error) }, 'Received invalid websocket message');
+				this._logger.error({ err: error as Error }, 'Received invalid websocket message');
 				return;
 			}
 			messageHandler(socket, message);
@@ -107,7 +110,7 @@ export class WSServer {
 		socket.on('pong', () => this._handleHeartbeat(socket));
 		socket.on('close', () => {
 			delete this._subscriptions[socket.url];
-		})
+		});
 		this._logger.info('New web socket client connected');
 	}
 
@@ -148,7 +151,7 @@ export class WSServer {
 	private _handleUnsubscription(socket: WebSocketWithTracking, message: Partial<RequestObject>) {
 		const { params } = message;
 		if (!params || !Array.isArray(params.topics) || !params.topics.length) {
-			throw new Error('Invalid subscription message.');
+			throw new Error('Invalid unsubscription message.');
 		}
 		if (!this._subscriptions[socket.url]) {
 			return;

--- a/framework/src/controller/ws/ws_server.ts
+++ b/framework/src/controller/ws/ws_server.ts
@@ -24,41 +24,41 @@ export type WSMessageHandler = (socket: WebSocketWithTracking, message: string) 
 export class WSServer {
 	public server!: WebSocket.Server;
 
-	private pingTimer!: NodeJS.Timeout;
-	private readonly port: number;
-	private readonly host?: string;
-	private readonly path: string;
-	private readonly logger: Logger;
+	private _pingTimer!: NodeJS.Timeout;
+	private readonly _port: number;
+	private readonly _host?: string;
+	private readonly _path: string;
+	private readonly _logger: Logger;
 	// subscription holds url: event names array
 	private readonly _subscriptions: Record<string, Set<string>> = {};
 
 	public constructor(options: { port: number; host?: string; path: string; logger: Logger }) {
-		this.port = options.port;
-		this.host = options.host;
-		this.path = options.path;
-		this.logger = options.logger;
+		this._port = options.port;
+		this._host = options.host;
+		this._path = options.path;
+		this._logger = options.logger;
 	}
 
 	public start(messageHandler: WSMessageHandler): WebSocket.Server {
 		this.server = new WebSocket.Server({
-			path: this.path,
-			port: this.port,
-			host: this.host,
+			path: this._path,
+			port: this._port,
+			host: this._host,
 			clientTracking: true,
 		});
 		this.server.on('connection', socket => this._handleConnection(socket, messageHandler));
 		this.server.on('error', error => {
-			this.logger.error(error);
+			this._logger.error(error);
 		});
 		this.server.on('listening', () => {
-			this.logger.info({ host: this.host, port: this.port, path: this.path }, 'Websocket Server Ready');
+			this._logger.info({ host: this._host, port: this._port, path: this._path }, 'Websocket Server Ready');
 		});
 
 		this.server.on('close', () => {
-			clearInterval(this.pingTimer);
+			clearInterval(this._pingTimer);
 		});
 
-		this.pingTimer = this._setUpPing();
+		this._pingTimer = this._setUpPing();
 
 		return this.server;
 	}
@@ -99,7 +99,7 @@ export class WSServer {
 					return;
 				}
 			} catch (error) {
-				this.logger.error({ err: (error as Error) }, 'Received invalid websocket message');
+				this._logger.error({ err: (error as Error) }, 'Received invalid websocket message');
 				return;
 			}
 			messageHandler(socket, message);
@@ -108,7 +108,7 @@ export class WSServer {
 		socket.on('close', () => {
 			delete this._subscriptions[socket.url];
 		})
-		this.logger.info('New web socket client connected');
+		this._logger.info('New web socket client connected');
 	}
 
 	private _handleHeartbeat(socket: WebSocketWithTracking) {

--- a/framework/test/integration/controller/ws_server.spec.ts
+++ b/framework/test/integration/controller/ws_server.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import * as WebSocket from 'ws';
+import { WSServer } from "../../../src/controller/ws/ws_server";
+import { fakeLogger } from "../../utils/node";
+
+describe('WSServer', () => {
+	const port = 34567;
+	let server: WSServer;
+	let handler = jest.fn();
+	let timer: NodeJS.Timer;
+
+	beforeAll((() => {
+		server = new WSServer({
+			path: '/ws',
+			port,
+			host: '0.0.0.0',
+			logger: fakeLogger,
+		});
+		server.start((socket, message) => {
+			handler(socket, message);
+		});
+		timer = setInterval(() => {
+			server.broadcast({
+				method: 'app_block',
+				jsonrpc: '2.0',
+				params: { data: 'somehting'},
+			});
+			server.broadcast({
+				method: 'random',
+				jsonrpc: '2.0',
+				params: { data: 'other'},
+			});
+		}, 300);
+	}));
+
+	afterAll(() => {
+		server.stop();
+		clearInterval(timer);
+	});
+
+	beforeEach(() => {
+		handler = jest.fn();
+	});
+
+	describe('topic subscription', () => {
+		it('should not receive any events unless subscribed', async () => {
+			const client = new WebSocket(`ws://localhost:${port}/ws`);
+
+			await expect(new Promise((resolve, reject) => {
+				client.on('message', msg => {
+					reject(msg);
+				});
+				setTimeout(resolve, 1000);
+			})).toResolve();
+		});
+
+		it('should receive only events subscribed', async () => {
+			const client = new WebSocket(`ws://localhost:${port}/ws`);
+			client.on('open', () => {
+				client.send(JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'subscribe',
+					params: { topics: ['app']},
+				}));
+			});
+
+			await expect(new Promise((resolve, reject) => {
+				client.on('message', msg => {
+					try {
+						const parsedMsg = JSON.parse(msg.toString());
+						if (parsedMsg.method === 'app_block') {
+							resolve(parsedMsg);
+							return;
+						}
+						reject(new Error('Invalid message received'));
+					} catch (error) {
+						reject(error);
+					}
+					reject(msg);
+				});
+				setTimeout(resolve, 1000);
+			})).toResolve();
+		});
+
+		it('should not receive unsubscribed events', async () => {
+			const client = new WebSocket(`ws://localhost:${port}/ws`);
+			client.on('open', () => {
+				client.send(JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'subscribe',
+					params: { topics: ['app']},
+				}));
+			});
+
+			await expect(new Promise((resolve, reject) => {
+				client.on('message', msg => {
+					try {
+						const parsedMsg = JSON.parse(msg.toString());
+						if (parsedMsg.method === 'app_block') {
+							resolve(parsedMsg);
+							return;
+						}
+						reject(new Error('Invalid message received'));
+					} catch (error) {
+						reject(error);
+					}
+					reject(msg);
+				});
+				setTimeout(resolve, 1000);
+			})).toResolve();
+
+			client.send(JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'unsubscribe',
+				params: { topics: ['app'] },
+			}));
+
+			await expect(new Promise((resolve, reject) => {
+				client.on('message', msg => {
+					reject(msg);
+				});
+				setTimeout(resolve, 1000);
+			})).toResolve();
+		});
+	});
+});

--- a/framework/test/integration/controller/ws_server.spec.ts
+++ b/framework/test/integration/controller/ws_server.spec.ts
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import * as WebSocket from 'ws';
-import { WSServer } from "../../../src/controller/ws/ws_server";
-import { fakeLogger } from "../../utils/node";
+import { WSServer } from '../../../src/controller/ws/ws_server';
+import { fakeLogger } from '../../utils/node';
 
 describe('WSServer', () => {
 	const port = 34567;
@@ -21,7 +21,7 @@ describe('WSServer', () => {
 	let handler = jest.fn();
 	let timer: NodeJS.Timer;
 
-	beforeAll((() => {
+	beforeAll(() => {
 		server = new WSServer({
 			path: '/ws',
 			port,
@@ -35,15 +35,15 @@ describe('WSServer', () => {
 			server.broadcast({
 				method: 'app_block',
 				jsonrpc: '2.0',
-				params: { data: 'somehting'},
+				params: { data: 'somehting' },
 			});
 			server.broadcast({
 				method: 'random',
 				jsonrpc: '2.0',
-				params: { data: 'other'},
+				params: { data: 'other' },
 			});
 		}, 300);
-	}));
+	});
 
 	afterAll(() => {
 		server.stop();
@@ -58,81 +58,95 @@ describe('WSServer', () => {
 		it('should not receive any events unless subscribed', async () => {
 			const client = new WebSocket(`ws://localhost:${port}/ws`);
 
-			await expect(new Promise((resolve, reject) => {
-				client.on('message', msg => {
-					reject(msg);
-				});
-				setTimeout(resolve, 1000);
-			})).toResolve();
+			await expect(
+				new Promise((resolve, reject) => {
+					client.on('message', msg => {
+						reject(msg);
+					});
+					setTimeout(resolve, 1000);
+				}),
+			).toResolve();
 		});
 
 		it('should receive only events subscribed', async () => {
 			const client = new WebSocket(`ws://localhost:${port}/ws`);
 			client.on('open', () => {
-				client.send(JSON.stringify({
-					jsonrpc: '2.0',
-					method: 'subscribe',
-					params: { topics: ['app']},
-				}));
+				client.send(
+					JSON.stringify({
+						jsonrpc: '2.0',
+						method: 'subscribe',
+						params: { topics: ['app'] },
+					}),
+				);
 			});
 
-			await expect(new Promise((resolve, reject) => {
-				client.on('message', msg => {
-					try {
-						const parsedMsg = JSON.parse(msg.toString());
-						if (parsedMsg.method === 'app_block') {
-							resolve(parsedMsg);
-							return;
+			await expect(
+				new Promise((resolve, reject) => {
+					client.on('message', msg => {
+						try {
+							const parsedMsg = JSON.parse(msg.toString());
+							if (parsedMsg.method === 'app_block') {
+								resolve(parsedMsg);
+								return;
+							}
+							reject(new Error('Invalid message received'));
+						} catch (error) {
+							reject(error);
 						}
-						reject(new Error('Invalid message received'));
-					} catch (error) {
-						reject(error);
-					}
-					reject(msg);
-				});
-				setTimeout(resolve, 1000);
-			})).toResolve();
+						reject(msg);
+					});
+					setTimeout(resolve, 1000);
+				}),
+			).toResolve();
 		});
 
 		it('should not receive unsubscribed events', async () => {
 			const client = new WebSocket(`ws://localhost:${port}/ws`);
 			client.on('open', () => {
-				client.send(JSON.stringify({
-					jsonrpc: '2.0',
-					method: 'subscribe',
-					params: { topics: ['app']},
-				}));
+				client.send(
+					JSON.stringify({
+						jsonrpc: '2.0',
+						method: 'subscribe',
+						params: { topics: ['app'] },
+					}),
+				);
 			});
 
-			await expect(new Promise((resolve, reject) => {
-				client.on('message', msg => {
-					try {
-						const parsedMsg = JSON.parse(msg.toString());
-						if (parsedMsg.method === 'app_block') {
-							resolve(parsedMsg);
-							return;
+			await expect(
+				new Promise((resolve, reject) => {
+					client.on('message', msg => {
+						try {
+							const parsedMsg = JSON.parse(msg.toString());
+							if (parsedMsg.method === 'app_block') {
+								resolve(parsedMsg);
+								return;
+							}
+							reject(new Error('Invalid message received'));
+						} catch (error) {
+							reject(error);
 						}
-						reject(new Error('Invalid message received'));
-					} catch (error) {
-						reject(error);
-					}
-					reject(msg);
-				});
-				setTimeout(resolve, 1000);
-			})).toResolve();
+						reject(msg);
+					});
+					setTimeout(resolve, 1000);
+				}),
+			).toResolve();
 
-			client.send(JSON.stringify({
-				jsonrpc: '2.0',
-				method: 'unsubscribe',
-				params: { topics: ['app'] },
-			}));
+			client.send(
+				JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'unsubscribe',
+					params: { topics: ['app'] },
+				}),
+			);
 
-			await expect(new Promise((resolve, reject) => {
-				client.on('message', msg => {
-					reject(msg);
-				});
-				setTimeout(resolve, 1000);
-			})).toResolve();
+			await expect(
+				new Promise((resolve, reject) => {
+					client.on('message', msg => {
+						reject(msg);
+					});
+					setTimeout(resolve, 1000);
+				}),
+			).toResolve();
 		});
 	});
 });

--- a/framework/test/integration/controller/ws_server.spec.ts
+++ b/framework/test/integration/controller/ws_server.spec.ts
@@ -28,7 +28,7 @@ describe('WSServer', () => {
 			host: '0.0.0.0',
 			logger: fakeLogger,
 		});
-		server.start((socket, message) => {
+		server.start(['app_block', 'random'], (socket, message) => {
 			handler(socket, message);
 		});
 		timer = setInterval(() => {
@@ -75,7 +75,7 @@ describe('WSServer', () => {
 					JSON.stringify({
 						jsonrpc: '2.0',
 						method: 'subscribe',
-						params: { topics: ['app'] },
+						params: { topics: ['app', 'non-existing'] },
 					}),
 				);
 			});

--- a/framework/test/unit/controller/ws/ws_server.spec.ts
+++ b/framework/test/unit/controller/ws/ws_server.spec.ts
@@ -47,7 +47,7 @@ describe('WSServer', () => {
 
 			jest.spyOn(WebSocket.Server.prototype, 'on');
 
-			wsServerInstance.start(wsMessageHandler);
+			wsServerInstance.start(['app_newBlock'], wsMessageHandler);
 		});
 
 		afterEach(() => {
@@ -73,7 +73,7 @@ describe('WSServer', () => {
 	describe('stop()', () => {
 		it('should call stop on the WS server', () => {
 			wsServerInstance = new WSServer(config);
-			wsServerInstance.start(wsMessageHandler);
+			wsServerInstance.start(['app_newBlock'], wsMessageHandler);
 			const stopSpy = jest.spyOn(wsServerInstance.server, 'close');
 			wsServerInstance.stop();
 			expect(stopSpy).toHaveBeenCalled();

--- a/framework/test/unit/controller/ws/ws_server.spec.ts
+++ b/framework/test/unit/controller/ws/ws_server.spec.ts
@@ -35,9 +35,9 @@ describe('WSServer', () => {
 	describe('constructor()', () => {
 		it('should setup class properties based on config', () => {
 			wsServerInstance = new WSServer(config);
-			expect(wsServerInstance['port']).toBe(config.port);
-			expect(wsServerInstance['path']).toBe(config.path);
-			expect(wsServerInstance['logger']).toBe(config.logger);
+			expect(wsServerInstance['_port']).toBe(config.port);
+			expect(wsServerInstance['_path']).toBe(config.path);
+			expect(wsServerInstance['_logger']).toBe(config.logger);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6617 

### How was it solved?

- Add WS server event filtering based on url

### How was it tested?

- Run testapp, and connect to WS server. Check no events are received.
```
{
    "method": "subscribe",
    "params": {
        "topics": ["app", "dpos"]
    }
}
```
Send above message, and it should send app related events