### PR TITLE
Rename module alias to module name - Closes #6697

### DIFF
--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/test/integration/cleanup_job.spec.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/test/integration/cleanup_job.spec.ts
@@ -105,7 +105,7 @@ describe('Clean up old blocks', () => {
 		eventsList: [],
 		actionsList: [],
 		actions: {},
-		moduleAlias: '',
+		moduleName: '',
 		options: {},
 	} as any;
 	const blockHeader1 = Buffer.from(

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/test/unit/send_pom_transaction.spec.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/test/unit/send_pom_transaction.spec.ts
@@ -99,7 +99,7 @@ describe('Send PoM transaction', () => {
 		eventsList: [],
 		actionsList: [],
 		actions: {},
-		moduleAlias: '',
+		moduleName: '',
 		options: {},
 	} as any;
 	const blockHeader1 = Buffer.from(

--- a/framework/src/controller/channels/base_channel.ts
+++ b/framework/src/controller/channels/base_channel.ts
@@ -24,19 +24,19 @@ export interface BaseChannelOptions {
 export abstract class BaseChannel {
 	public readonly eventsList: ReadonlyArray<string>;
 	public readonly actionsList: ReadonlyArray<string>;
-	public readonly moduleAlias: string;
+	public readonly moduleName: string;
 
 	protected readonly actions: { [key: string]: Action };
 	protected readonly options: Record<string, unknown>;
 	private _requestId: number;
 
 	public constructor(
-		moduleAlias: string,
+		moduleName: string,
 		events: ReadonlyArray<string>,
 		actions: ActionsDefinition,
 		options: BaseChannelOptions = {},
 	) {
-		this.moduleAlias = moduleAlias;
+		this.moduleName = moduleName;
 		this.options = options;
 
 		this.eventsList = options.skipInternalEvents ? events : [...events, ...INTERNAL_EVENTS];
@@ -47,7 +47,7 @@ export abstract class BaseChannel {
 			const actionData = actions[actionName];
 
 			const handler = typeof actionData === 'object' ? actionData.handler : actionData;
-			const method = `${this.moduleAlias}:${actionName}`;
+			const method = `${this.moduleName}:${actionName}`;
 			this.actions[actionName] = new Action(null, method, undefined, handler);
 		}
 		this.actionsList = Object.keys(this.actions);
@@ -57,7 +57,7 @@ export abstract class BaseChannel {
 		const result = eventWithModuleNameReg.test(name);
 
 		if (throwError && !result) {
-			throw new Error(`[${this.moduleAlias}] Invalid event name ${name}.`);
+			throw new Error(`[${this.moduleName}] Invalid event name ${name}.`);
 		}
 		return result;
 	}
@@ -66,7 +66,7 @@ export abstract class BaseChannel {
 		const result = eventWithModuleNameReg.test(name);
 
 		if (throwError && !result) {
-			throw new Error(`[${this.moduleAlias}] Invalid action name ${name}.`);
+			throw new Error(`[${this.moduleName}] Invalid action name ${name}.`);
 		}
 
 		return result;
@@ -79,16 +79,16 @@ export abstract class BaseChannel {
 
 	// Listen to any event happening in the application
 	// Specified as moduleName:eventName
-	// If its related to your own moduleAlias specify as :eventName
+	// If its related to your own moduleName specify as :eventName
 	abstract subscribe(eventName: string, cb: EventCallback): void;
 	abstract unsubscribe(eventName: string, cb: EventCallback): void;
 
 	// Publish the event on the channel
 	// Specified as moduleName:eventName
-	// If its related to your own moduleAlias specify as :eventName
+	// If its related to your own moduleName specify as :eventName
 	abstract publish(eventName: string, data?: object): void;
 
-	// Call action of any moduleAlias through controller
+	// Call action of any moduleName through controller
 	// Specified as moduleName:actionName
 	abstract invoke<T>(actionName: string, params?: object): Promise<T>;
 

--- a/framework/src/controller/channels/in_memory_channel.ts
+++ b/framework/src/controller/channels/in_memory_channel.ts
@@ -26,7 +26,7 @@ export class InMemoryChannel extends BaseChannel {
 	public async registerToBus(bus: Bus): Promise<void> {
 		this.bus = bus;
 
-		await this.bus.registerChannel(this.moduleAlias, this.eventsList, this.actions, {
+		await this.bus.registerChannel(this.moduleName, this.eventsList, this.actions, {
 			type: ChannelType.InMemory,
 			channel: this,
 		});
@@ -53,8 +53,8 @@ export class InMemoryChannel extends BaseChannel {
 	public publish(eventName: string, data?: Record<string, unknown>): void {
 		const event = new Event(eventName, data);
 
-		if (event.module !== this.moduleAlias) {
-			throw new Error(`Event "${eventName}" not registered in "${this.moduleAlias}" module.`);
+		if (event.module !== this.moduleName) {
+			throw new Error(`Event "${eventName}" not registered in "${this.moduleName}" module.`);
 		}
 
 		this.bus.publish(event.toJSONRPCNotification());
@@ -63,10 +63,10 @@ export class InMemoryChannel extends BaseChannel {
 	public async invoke<T>(actionName: string, params?: Record<string, unknown>): Promise<T> {
 		const action = new Action(this._getNextRequestId(), actionName, params);
 
-		if (action.module === this.moduleAlias) {
+		if (action.module === this.moduleName) {
 			if (this.actions[action.name] === undefined) {
 				throw new Error(
-					`The action '${action.name}' on module '${this.moduleAlias}' does not exist.`,
+					`The action '${action.name}' on module '${this.moduleName}' does not exist.`,
 				);
 			}
 

--- a/framework/src/plugins/README.md
+++ b/framework/src/plugins/README.md
@@ -35,16 +35,6 @@ export class MyPlugin extends BasePlugin {
     /**
     * Required.
     *
-    * A unique plugin identifier, that can be accessed through out the system.
-    * If some plugin already registered with the same alias, it will throw an error.
-    *
-    * @return {string} alias - Return the plugin alias as string.
-    * */
-    static get alias(){ return 'pluginAlias'; },
-
-    /**
-    * Required.
-    *
     * Package meta information.
     *
     * @return {Object} info - JSON object referring the version, plugin name, and plugin author.
@@ -80,7 +70,7 @@ export class MyPlugin extends BasePlugin {
 
     /**
      * List of valid events which this plugin wants to register with the controller.
-     * Each event name will be prefixed by plugin alias, e.g. pluginName:event1.
+     * Each event name will be prefixed by plugin name, e.g. pluginName:event1.
      * Listing an event means to register the event in the application.
      * Any plugin can subscribe or publish that event in the application.
      *
@@ -90,7 +80,7 @@ export class MyPlugin extends BasePlugin {
 
     /**
      * Object of valid actions which this plugin want to register with the controller.
-     * Each action name will be prefixed by plugin alias, e.g. pluginName:action1.
+     * Each action name will be prefixed by plugin name, e.g. pluginName:action1.
      * Source plugin can define the action while others can invoke that action.
      *
      * @return {Object} actions - Contains all available action names as key, and the corresponding function as value.

--- a/framework/src/testing/mocks/channel_mock.ts
+++ b/framework/src/testing/mocks/channel_mock.ts
@@ -25,7 +25,7 @@ export const channelMock = ({
 	eventsList: [],
 	actionsList: [],
 	actions: {},
-	moduleAlias: '',
+	moduleName: '',
 	options: {},
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	once: (_event: string): void => {},

--- a/framework/test/integration/controller/in_memory_channel.spec.ts
+++ b/framework/test/integration/controller/in_memory_channel.spec.ts
@@ -36,7 +36,7 @@ describe('InMemoryChannel', () => {
 	};
 
 	const alpha = {
-		moduleAlias: 'alphaAlias',
+		moduleName: 'alphaName',
 		events: ['alpha1', 'alpha2'],
 		actions: {
 			multiplyByTwo: {
@@ -49,7 +49,7 @@ describe('InMemoryChannel', () => {
 	};
 
 	const beta = {
-		moduleAlias: 'betaAlias',
+		moduleName: 'betaName',
 		events: ['beta1', 'beta2'],
 		actions: {
 			divideByTwo: {
@@ -70,11 +70,11 @@ describe('InMemoryChannel', () => {
 			// Arrange
 			bus = new Bus(logger, config);
 
-			inMemoryChannelAlpha = new InMemoryChannel(alpha.moduleAlias, alpha.events, alpha.actions);
+			inMemoryChannelAlpha = new InMemoryChannel(alpha.moduleName, alpha.events, alpha.actions);
 
 			await inMemoryChannelAlpha.registerToBus(bus);
 
-			inMemoryChannelBeta = new InMemoryChannel(beta.moduleAlias, beta.events, beta.actions);
+			inMemoryChannelBeta = new InMemoryChannel(beta.moduleName, beta.events, beta.actions);
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			await inMemoryChannelBeta.registerToBus(bus);
 		});
@@ -87,14 +87,14 @@ describe('InMemoryChannel', () => {
 
 				const donePromise = new Promise<void>(resolve => {
 					// Act
-					inMemoryChannelAlpha.subscribe(`${beta.moduleAlias}:${eventName}`, data => {
+					inMemoryChannelAlpha.subscribe(`${beta.moduleName}:${eventName}`, data => {
 						// Assert
 						expect(data).toBe(betaEventData);
 						resolve();
 					});
 				});
 
-				inMemoryChannelBeta.publish(`${beta.moduleAlias}:${eventName}`, betaEventData);
+				inMemoryChannelBeta.publish(`${beta.moduleName}:${eventName}`, betaEventData);
 
 				return donePromise;
 			});
@@ -105,14 +105,14 @@ describe('InMemoryChannel', () => {
 				const eventName = beta.events[0];
 				const donePromise = new Promise<void>(resolve => {
 					// Act
-					inMemoryChannelAlpha.once(`${beta.moduleAlias}:${eventName}`, data => {
+					inMemoryChannelAlpha.once(`${beta.moduleName}:${eventName}`, data => {
 						// Assert
 						expect(data).toBe(betaEventData);
 						resolve();
 					});
 				});
 
-				inMemoryChannelBeta.publish(`${beta.moduleAlias}:${eventName}`, betaEventData);
+				inMemoryChannelBeta.publish(`${beta.moduleName}:${eventName}`, betaEventData);
 
 				return donePromise;
 			});
@@ -120,13 +120,13 @@ describe('InMemoryChannel', () => {
 			it('should be able to subscribe to an unregistered event.', async () => {
 				// Arrange
 				const omegaEventName = 'omegaEventName';
-				const omegaAlias = 'omegaAlias';
+				const omegaName = 'omegaName';
 				const dummyData = { data: '#DATA' };
-				const inMemoryChannelOmega = new InMemoryChannel(omegaAlias, [omegaEventName], {});
+				const inMemoryChannelOmega = new InMemoryChannel(omegaName, [omegaEventName], {});
 
 				const donePromise = new Promise<void>(resolve => {
 					// Act
-					inMemoryChannelAlpha.subscribe(`${omegaAlias}:${omegaEventName}`, data => {
+					inMemoryChannelAlpha.subscribe(`${omegaName}:${omegaEventName}`, data => {
 						// Assert
 						expect(data).toBe(dummyData);
 						resolve();
@@ -136,7 +136,7 @@ describe('InMemoryChannel', () => {
 				// eslint-disable-next-line @typescript-eslint/no-floating-promises
 				await inMemoryChannelOmega.registerToBus(bus);
 
-				inMemoryChannelOmega.publish(`${omegaAlias}:${omegaEventName}`, dummyData);
+				inMemoryChannelOmega.publish(`${omegaName}:${omegaEventName}`, dummyData);
 
 				return donePromise;
 			});
@@ -150,14 +150,14 @@ describe('InMemoryChannel', () => {
 
 				const donePromise = new Promise<void>(done => {
 					// Act
-					inMemoryChannelBeta.once(`${alpha.moduleAlias}:${eventName}`, data => {
+					inMemoryChannelBeta.once(`${alpha.moduleName}:${eventName}`, data => {
 						// Assert
 						expect(data).toBe(alphaEventData);
 						done();
 					});
 				});
 
-				inMemoryChannelAlpha.publish(`${alpha.moduleAlias}:${eventName}`, alphaEventData);
+				inMemoryChannelAlpha.publish(`${alpha.moduleName}:${eventName}`, alphaEventData);
 
 				return donePromise;
 			});
@@ -167,11 +167,11 @@ describe('InMemoryChannel', () => {
 			it('should be able to invoke its own actions.', async () => {
 				// Act && Assert
 				await expect(
-					inMemoryChannelAlpha.invoke<number>(`${alpha.moduleAlias}:multiplyByTwo`, { val: 2 }),
+					inMemoryChannelAlpha.invoke<number>(`${alpha.moduleName}:multiplyByTwo`, { val: 2 }),
 				).resolves.toBe(4);
 
 				await expect(
-					inMemoryChannelAlpha.invoke<number>(`${alpha.moduleAlias}:multiplyByThree`, {
+					inMemoryChannelAlpha.invoke<number>(`${alpha.moduleName}:multiplyByThree`, {
 						val: 4,
 					}),
 				).resolves.toBe(12);
@@ -180,11 +180,11 @@ describe('InMemoryChannel', () => {
 			it("should be able to invoke other channels' actions.", async () => {
 				// Act && Assert
 				await expect(
-					inMemoryChannelAlpha.invoke<number>(`${beta.moduleAlias}:divideByTwo`, { val: 4 }),
+					inMemoryChannelAlpha.invoke<number>(`${beta.moduleName}:divideByTwo`, { val: 4 }),
 				).resolves.toBe(2);
 
 				await expect(
-					inMemoryChannelAlpha.invoke<number>(`${beta.moduleAlias}:divideByThree`, { val: 9 }),
+					inMemoryChannelAlpha.invoke<number>(`${beta.moduleName}:divideByThree`, { val: 9 }),
 				).resolves.toBe(3);
 			});
 
@@ -194,9 +194,9 @@ describe('InMemoryChannel', () => {
 
 				// Act && Assert
 				await expect(
-					inMemoryChannelAlpha.invoke(`${beta.moduleAlias}:${invalidActionName}`),
+					inMemoryChannelAlpha.invoke(`${beta.moduleName}:${invalidActionName}`),
 				).rejects.toThrow(
-					`Action name "${beta.moduleAlias}:${invalidActionName}" must be a valid name with module name and action name.`,
+					`Action name "${beta.moduleName}:${invalidActionName}" must be a valid name with module name and action name.`,
 				);
 			});
 		});

--- a/framework/test/integration/controller/ipc_channel_without_bus.spec.ts
+++ b/framework/test/integration/controller/ipc_channel_without_bus.spec.ts
@@ -29,7 +29,7 @@ describe.skip('IPCChannelWithoutBus', () => {
 	};
 
 	const alpha = {
-		moduleAlias: 'alphaAlias',
+		moduleName: 'alphaName',
 		events: ['alpha1', 'alpha2'],
 		actions: {
 			multiplyByTwo: {
@@ -42,7 +42,7 @@ describe.skip('IPCChannelWithoutBus', () => {
 	};
 
 	const beta = {
-		moduleAlias: 'betaAlias',
+		moduleName: 'betaName',
 		events: ['beta1', 'beta2'],
 		actions: {
 			divideByTwo: {
@@ -85,9 +85,9 @@ describe.skip('IPCChannelWithoutBus', () => {
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			Promise.all<void>([listenForRPC(), listenForEvents()]).catch(_ => ({}));
 
-			alphaChannel = new IPCChannel(alpha.moduleAlias, alpha.events, alpha.actions, config);
+			alphaChannel = new IPCChannel(alpha.moduleName, alpha.events, alpha.actions, config);
 
-			betaChannel = new IPCChannel(beta.moduleAlias, beta.events, beta.actions, config);
+			betaChannel = new IPCChannel(beta.moduleName, beta.events, beta.actions, config);
 
 			await alphaChannel.startAndListen();
 			await betaChannel.startAndListen();
@@ -109,14 +109,14 @@ describe.skip('IPCChannelWithoutBus', () => {
 
 				const donePromise = new Promise<void>(resolve => {
 					// Act
-					alphaChannel.subscribe(`${beta.moduleAlias}:${eventName}`, data => {
+					alphaChannel.subscribe(`${beta.moduleName}:${eventName}`, data => {
 						// Assert
 						expect(data).toEqual(betaEventData);
 						resolve();
 					});
 				});
 
-				betaChannel.publish(`${beta.moduleAlias}:${eventName}`, betaEventData);
+				betaChannel.publish(`${beta.moduleName}:${eventName}`, betaEventData);
 
 				return donePromise;
 			});
@@ -127,14 +127,14 @@ describe.skip('IPCChannelWithoutBus', () => {
 				const eventName = beta.events[0];
 				const donePromise = new Promise<void>(resolve => {
 					// Act
-					alphaChannel.once(`${beta.moduleAlias}:${eventName}`, data => {
+					alphaChannel.once(`${beta.moduleName}:${eventName}`, data => {
 						// Assert
 						expect(data).toEqual(betaEventData);
 						resolve();
 					});
 				});
 
-				betaChannel.publish(`${beta.moduleAlias}:${eventName}`, betaEventData);
+				betaChannel.publish(`${beta.moduleName}:${eventName}`, betaEventData);
 
 				return donePromise;
 			});
@@ -148,14 +148,14 @@ describe.skip('IPCChannelWithoutBus', () => {
 
 				const donePromise = new Promise<void>(done => {
 					// Act
-					betaChannel.once(`${alpha.moduleAlias}:${eventName}`, data => {
+					betaChannel.once(`${alpha.moduleName}:${eventName}`, data => {
 						// Assert
 						expect(data).toEqual(alphaEventData);
 						done();
 					});
 				});
 
-				alphaChannel.publish(`${alpha.moduleAlias}:${eventName}`, alphaEventData);
+				alphaChannel.publish(`${alpha.moduleName}:${eventName}`, alphaEventData);
 
 				return donePromise;
 			});

--- a/framework/test/unit/controller/bus.spec.ts
+++ b/framework/test/unit/controller/bus.spec.ts
@@ -121,58 +121,58 @@ describe('Bus', () => {
 	describe('#registerChannel', () => {
 		it('should register events.', async () => {
 			// Arrange
-			const moduleAlias = 'alias';
+			const moduleName = 'name';
 			const events = ['event1', 'event2'];
 
 			// Act
-			await bus.registerChannel(moduleAlias, events, {}, channelOptions);
+			await bus.registerChannel(moduleName, events, {}, channelOptions);
 
 			// Assert
 			expect(Object.keys(bus['events'])).toHaveLength(2);
 			events.forEach(eventName => {
-				expect(bus['events'][`${moduleAlias}:${eventName}`]).toBe(true);
+				expect(bus['events'][`${moduleName}:${eventName}`]).toBe(true);
 			});
 		});
 
 		it('should throw error when trying to register duplicate events', async () => {
 			// Arrange
-			const moduleAlias = 'alias';
+			const moduleName = 'name';
 			const events = ['event1', 'event1'];
 
 			// Act && Assert
-			await expect(bus.registerChannel(moduleAlias, events, {}, channelOptions)).rejects.toThrow(
+			await expect(bus.registerChannel(moduleName, events, {}, channelOptions)).rejects.toThrow(
 				Error,
 			);
 		});
 
 		it('should register actions.', async () => {
 			// Arrange
-			const moduleAlias = 'alias';
+			const moduleName = 'name';
 			const actions: any = {
-				action1: new Action(null, 'alias:action1', {}, jest.fn()),
-				action2: new Action(null, 'alias:action2', {}, jest.fn()),
+				action1: new Action(null, 'name:action1', {}, jest.fn()),
+				action2: new Action(null, 'name:action2', {}, jest.fn()),
 			};
 
 			// Act
-			await bus.registerChannel(moduleAlias, [], actions, channelOptions);
+			await bus.registerChannel(moduleName, [], actions, channelOptions);
 
 			// Assert
 			expect(Object.keys(bus['actions'])).toHaveLength(2);
 			Object.keys(actions).forEach(actionName => {
-				expect(bus['actions'][`${moduleAlias}:${actionName}`]).toBe(actions[actionName]);
+				expect(bus['actions'][`${moduleName}:${actionName}`]).toBe(actions[actionName]);
 			});
 		});
 
 		it('should throw error when trying to register duplicate actions.', async () => {
 			// Arrange
-			const moduleAlias = 'alias';
+			const moduleName = 'name';
 			const actions = {
-				action1: new Action(null, 'alias:action1', {}, jest.fn()),
+				action1: new Action(null, 'name:action1', {}, jest.fn()),
 			};
 
 			// Act && Assert
-			await bus.registerChannel(moduleAlias, [], actions, channelOptions);
-			await expect(bus.registerChannel(moduleAlias, [], actions, channelOptions)).rejects.toThrow(
+			await bus.registerChannel(moduleName, [], actions, channelOptions);
+			await expect(bus.registerChannel(moduleName, [], actions, channelOptions)).rejects.toThrow(
 				Error,
 			);
 		});
@@ -253,17 +253,17 @@ describe('Bus', () => {
 	describe('#publish', () => {
 		it("should call eventemitter2 library's emit method", async () => {
 			// Arrange
-			const moduleAlias = 'alias';
+			const moduleName = 'name';
 			const events = ['registeredEvent'];
-			const eventName = `${moduleAlias}:${events[0]}`;
+			const eventName = `${moduleName}:${events[0]}`;
 			const eventData = { data: '#DATA' };
-			const JSONRPCData = { jsonrpc: '2.0', method: 'alias:registeredEvent', params: eventData };
+			const JSONRPCData = { jsonrpc: '2.0', method: 'name:registeredEvent', params: eventData };
 			const mockIPCServer = {
 				pubSocket: { send: jest.fn().mockResolvedValue(jest.fn()) },
 				stop: jest.fn(),
 			};
 			(bus as any)['_internalIPCServer'] = mockIPCServer;
-			await bus.registerChannel(moduleAlias, events, {}, channelOptions);
+			await bus.registerChannel(moduleName, events, {}, channelOptions);
 
 			// Act
 			bus.publish(JSONRPCData);
@@ -313,16 +313,14 @@ describe('Bus', () => {
 	describe('#getActions', () => {
 		it('should return the registered actions', async () => {
 			// Arrange
-			const moduleAlias = 'alias';
+			const moduleName = 'name';
 			const actions: any = {
-				action1: new Action(null, 'alias:action1', {}, jest.fn()),
-				action2: new Action(null, 'alias:action2', {}, jest.fn()),
+				action1: new Action(null, 'name:action1', {}, jest.fn()),
+				action2: new Action(null, 'name:action2', {}, jest.fn()),
 			};
-			const expectedActions = Object.keys(actions).map(
-				actionName => `${moduleAlias}:${actionName}`,
-			);
+			const expectedActions = Object.keys(actions).map(actionName => `${moduleName}:${actionName}`);
 
-			await bus.registerChannel(moduleAlias, [], actions, channelOptions);
+			await bus.registerChannel(moduleName, [], actions, channelOptions);
 
 			// Act
 			const registeredActions = bus.getActions();
@@ -335,11 +333,11 @@ describe('Bus', () => {
 	describe('#getEvents', () => {
 		it('should return the registered events.', async () => {
 			// Arrange
-			const moduleAlias = 'alias';
+			const moduleName = 'name';
 			const events = ['event1', 'event2'];
-			const expectedEvents = events.map(event => `${moduleAlias}:${event}`);
+			const expectedEvents = events.map(event => `${moduleName}:${event}`);
 
-			await bus.registerChannel(moduleAlias, events, {}, channelOptions);
+			await bus.registerChannel(moduleName, events, {}, channelOptions);
 
 			// Act
 			const registeredEvent = bus.getEvents();

--- a/framework/test/unit/controller/channels/base_channel.spec.ts
+++ b/framework/test/unit/controller/channels/base_channel.spec.ts
@@ -38,7 +38,7 @@ describe('Base Channel', () => {
 	// Arrange
 	const actionHandler = jest.fn();
 	const params = {
-		moduleAlias: 'alias',
+		moduleName: 'name',
 		events: ['event1', 'event2'],
 		actions: {
 			action1: actionHandler,
@@ -51,19 +51,19 @@ describe('Base Channel', () => {
 
 	beforeEach(() => {
 		// Act
-		baseChannel = new MyChannel(params.moduleAlias, params.events, params.actions, params.options);
+		baseChannel = new MyChannel(params.moduleName, params.events, params.actions, params.options);
 	});
 
 	describe('#constructor', () => {
 		it('should create the instance with given arguments.', () => {
 			// Assert
-			expect(baseChannel['moduleAlias']).toBe(params.moduleAlias);
+			expect(baseChannel['moduleName']).toBe(params.moduleName);
 			expect(baseChannel['options']).toBe(params.options);
 
 			Object.keys(params.actions).forEach(action => {
 				expect(Action).toHaveBeenCalledWith(
 					null,
-					`${params.moduleAlias}:${action}`,
+					`${params.moduleName}:${action}`,
 					undefined,
 					actionHandler,
 				);
@@ -90,7 +90,7 @@ describe('Base Channel', () => {
 
 		it('base.eventsList be list of events', () => {
 			// Arrange & Act
-			baseChannel = new MyChannel(params.moduleAlias, params.events, params.actions);
+			baseChannel = new MyChannel(params.moduleName, params.events, params.actions);
 
 			// Assert
 			expect(baseChannel.eventsList).toHaveLength(params.events.length + INTERNAL_EVENTS.length);
@@ -101,7 +101,7 @@ describe('Base Channel', () => {
 
 		it('base.eventsList should contain internal events when skipInternalEvents option was set to FALSE', () => {
 			// Arrange & Act
-			baseChannel = new MyChannel(params.moduleAlias, params.events, params.actions, {
+			baseChannel = new MyChannel(params.moduleName, params.events, params.actions, {
 				skipInternalEvents: false,
 			});
 
@@ -111,7 +111,7 @@ describe('Base Channel', () => {
 
 		it('base.eventsList must NOT contain internal events when skipInternalEvents option was set TRUE', () => {
 			// Arrange & Act
-			baseChannel = new MyChannel(params.moduleAlias, params.events, params.actions, {
+			baseChannel = new MyChannel(params.moduleName, params.events, params.actions, {
 				skipInternalEvents: true,
 			});
 
@@ -136,7 +136,7 @@ describe('Base Channel', () => {
 
 		it('should return true when valid event name was provided.', () => {
 			// Act & Assert
-			expect(baseChannel.isValidEventName(`${params.moduleAlias}:${eventName}`)).toBe(true);
+			expect(baseChannel.isValidEventName(`${params.moduleName}:${eventName}`)).toBe(true);
 		});
 	});
 
@@ -156,7 +156,7 @@ describe('Base Channel', () => {
 
 		it('should return true when valid event name was provided.', () => {
 			// Act & Assert
-			expect(baseChannel.isValidActionName(`${params.moduleAlias}:${actionName}`)).toBe(true);
+			expect(baseChannel.isValidActionName(`${params.moduleName}:${actionName}`)).toBe(true);
 		});
 	});
 });

--- a/framework/test/unit/controller/channels/in_memory_channel.spec.ts
+++ b/framework/test/unit/controller/channels/in_memory_channel.spec.ts
@@ -23,7 +23,7 @@ import { Event } from '../../../../src/controller/event';
 describe('InMemoryChannel Channel', () => {
 	// Arrange
 	const params = {
-		moduleAlias: 'moduleAlias',
+		moduleName: 'moduleName',
 		events: ['event1', 'event2'],
 		actions: {
 			action1: {
@@ -46,7 +46,7 @@ describe('InMemoryChannel Channel', () => {
 	beforeEach(() => {
 		// Act
 		inMemoryChannel = new InMemoryChannel(
-			params.moduleAlias,
+			params.moduleName,
 			params.events,
 			params.actions,
 			params.options,
@@ -63,7 +63,7 @@ describe('InMemoryChannel Channel', () => {
 	describe('#constructor', () => {
 		it('should create the instance with given arguments.', () => {
 			// Assert
-			expect(inMemoryChannel).toHaveProperty('moduleAlias');
+			expect(inMemoryChannel).toHaveProperty('moduleName');
 			expect(inMemoryChannel).toHaveProperty('options');
 		});
 	});
@@ -76,7 +76,7 @@ describe('InMemoryChannel Channel', () => {
 			// Assert
 			expect(inMemoryChannel['bus']).toBe(bus);
 			expect(inMemoryChannel['bus'].registerChannel).toHaveBeenCalledWith(
-				inMemoryChannel['moduleAlias'],
+				inMemoryChannel['moduleName'],
 				inMemoryChannel.eventsList,
 				inMemoryChannel['actions'],
 				{ type: 'inMemory', channel: inMemoryChannel },
@@ -135,18 +135,18 @@ describe('InMemoryChannel Channel', () => {
 			);
 		});
 
-		it('should throw an Error if event module is different than moduleAlias', () => {
+		it('should throw an Error if event module is different than moduleName', () => {
 			const eventName = 'differentModule:eventName';
 			expect(() => {
 				inMemoryChannel.publish(eventName);
 			}).toThrow(
-				`Event "${eventName}" not registered in "${inMemoryChannel['moduleAlias']}" module.`,
+				`Event "${eventName}" not registered in "${inMemoryChannel['moduleName']}" module.`,
 			);
 		});
 
-		it('should call bus.publish if the event module is equal to moduleAlias', async () => {
+		it('should call bus.publish if the event module is equal to moduleName', async () => {
 			// Arrange
-			const eventFullName = `${inMemoryChannel['moduleAlias']}:eventName`;
+			const eventFullName = `${inMemoryChannel['moduleName']}:eventName`;
 			const event = new Event(eventFullName);
 
 			// Act
@@ -163,9 +163,9 @@ describe('InMemoryChannel Channel', () => {
 	describe('#invoke', () => {
 		const actionName = 'action1';
 
-		it('should execute the action straight away if the action module is equal to moduleAlias', async () => {
+		it('should execute the action straight away if the action module is equal to moduleName', async () => {
 			// Arrange
-			const actionFullName = `${inMemoryChannel['moduleAlias']}:${actionName}`;
+			const actionFullName = `${inMemoryChannel['moduleName']}:${actionName}`;
 
 			// Act
 			await inMemoryChannel.invoke(actionFullName);
@@ -174,7 +174,7 @@ describe('InMemoryChannel Channel', () => {
 			expect(params.actions.action1.handler).toHaveBeenCalled();
 		});
 
-		it('should call bus.invoke if the action module is different to moduleAlias', async () => {
+		it('should call bus.invoke if the action module is different to moduleName', async () => {
 			// Arrange
 			const actionFullName = `aDifferentModule:${actionName}`;
 

--- a/framework/test/unit/controller/channels/ipc_channel.spec.ts
+++ b/framework/test/unit/controller/channels/ipc_channel.spec.ts
@@ -29,7 +29,7 @@ const emitterMock = {
 	once: jest.fn(),
 	emit: jest.fn(),
 };
-const jsonrpcRequest = { id: 1, jsonrpc: '2.0', method: 'moduleAlias:action1' };
+const jsonrpcRequest = { id: 1, jsonrpc: '2.0', method: 'moduleName:action1' };
 
 const ipcClientMock = {
 	stop: jest.fn(),
@@ -72,7 +72,7 @@ describe.skip('IPCChannel Channel', () => {
 	// Arrange
 
 	const params = {
-		moduleAlias: 'moduleAlias',
+		moduleName: 'moduleName',
 		events: ['event1', 'event2'],
 		actions: {
 			action1: {
@@ -93,22 +93,22 @@ describe.skip('IPCChannel Channel', () => {
 	const actionsInfo = {
 		action1: {
 			name: 'action1',
-			module: 'moduleAlias',
+			module: 'moduleName',
 		},
 		action2: {
 			name: 'action2',
-			module: 'moduleAlias',
+			module: 'moduleName',
 		},
 		action3: {
 			name: 'action3',
-			module: 'moduleAlias',
+			module: 'moduleName',
 		},
 	};
 
 	let ipcChannel: IPCChannel;
 
 	beforeEach(() => {
-		ipcChannel = new IPCChannel(params.moduleAlias, params.events, params.actions, params.options);
+		ipcChannel = new IPCChannel(params.moduleName, params.events, params.actions, params.options);
 	});
 
 	afterEach(() => {
@@ -156,7 +156,7 @@ describe.skip('IPCChannel Channel', () => {
 			// Assert
 			expect(ipcClientMock.rpcClient.call).toHaveBeenCalledWith(
 				'registerChannel',
-				params.moduleAlias,
+				params.moduleName,
 				[
 					...params.events,
 					'registeredToBus',
@@ -187,7 +187,7 @@ describe.skip('IPCChannel Channel', () => {
 	});
 
 	describe('#subscribe', () => {
-		const validEventName = `${params.moduleAlias}:${params.events[0]}`;
+		const validEventName = `${params.moduleName}:${params.events[0]}`;
 		beforeEach(async () => ipcChannel.registerToBus());
 
 		it('should call _emitter.on', () => {
@@ -200,7 +200,7 @@ describe.skip('IPCChannel Channel', () => {
 	});
 
 	describe('#once', () => {
-		const validEventName = `${params.moduleAlias}:${params.events[0]}`;
+		const validEventName = `${params.moduleName}:${params.events[0]}`;
 
 		beforeEach(async () => ipcChannel.registerToBus());
 
@@ -215,7 +215,7 @@ describe.skip('IPCChannel Channel', () => {
 	});
 
 	describe('#publish', () => {
-		const validEventName = `${params.moduleAlias}:${params.events[0]}`;
+		const validEventName = `${params.moduleName}:${params.events[0]}`;
 
 		beforeEach(async () => ipcChannel.registerToBus());
 
@@ -223,15 +223,15 @@ describe.skip('IPCChannel Channel', () => {
 			const invalidEventName = `invalidModule:${params.events[0]}`;
 
 			expect(() => ipcChannel.publish(invalidEventName, {})).toThrow(
-				`Event "${invalidEventName}" not registered in "${params.moduleAlias}" module.`,
+				`Event "${invalidEventName}" not registered in "${params.moduleName}" module.`,
 			);
 		});
 
 		it('should throw new Error when the event name not registered', () => {
-			const invalidEventName = `${params.moduleAlias}:invalidEvent`;
+			const invalidEventName = `${params.moduleName}:invalidEvent`;
 
 			expect(() => ipcChannel.publish(invalidEventName, {})).toThrow(
-				`Event "${invalidEventName}" not registered in "${params.moduleAlias}" module.`,
+				`Event "${invalidEventName}" not registered in "${params.moduleName}" module.`,
 			);
 		});
 
@@ -249,7 +249,7 @@ describe.skip('IPCChannel Channel', () => {
 	});
 
 	describe('#invoke', () => {
-		const actionName = 'moduleAlias:action1';
+		const actionName = 'moduleName:action1';
 		const actionParams = { myParams: ['param1', 'param2'] };
 
 		it('should execute the action straight away if the plugins are the same and action is a string', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6697 

### How was it solved?

Renamed `moduleAlias` to `moduleName`
Rename `alias` to `name`

### How was it tested?

`yarn build` and run all the tests
