### PR TITLE
Add reward module endpoint - Closes #6689

### DIFF
--- a/framework/src/modules/reward/calculate_reward.ts
+++ b/framework/src/modules/reward/calculate_reward.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.

--- a/framework/src/modules/reward/calculate_reward.ts
+++ b/framework/src/modules/reward/calculate_reward.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { CalculateDefaultRewardArgs } from './types';
+
+export const calculateDefaultReward = (args: CalculateDefaultRewardArgs): bigint => {
+	const { height, distance, offset, brackets } = args;
+
+	if (height < offset) {
+		return BigInt(0);
+	}
+
+	const rewardDistance = Math.floor(distance);
+	const location = Math.trunc((height - offset) / rewardDistance);
+	const lastBracket = brackets[brackets.length - 1];
+
+	const bracket = location > brackets.length - 1 ? brackets.lastIndexOf(lastBracket) : location;
+
+	return brackets[bracket];
+};

--- a/framework/src/modules/reward/endpoint.ts
+++ b/framework/src/modules/reward/endpoint.ts
@@ -32,7 +32,7 @@ export class RewardEndpoint extends BaseEndpoint {
 
 		if (height < this._offset) {
 			return {
-				reward: BigInt(0),
+				reward: '0',
 			};
 		}
 
@@ -48,7 +48,7 @@ export class RewardEndpoint extends BaseEndpoint {
 		}
 
 		return {
-			reward: this._brackets[bracket],
+			reward: this._brackets[bracket].toString(),
 		};
 	}
 }

--- a/framework/src/modules/reward/endpoint.ts
+++ b/framework/src/modules/reward/endpoint.ts
@@ -14,6 +14,7 @@
 
 import { ModuleEndpointContext } from '../..';
 import { BaseEndpoint } from '../base_endpoint';
+import { calculateDefaultReward } from './calculate_reward';
 import { DefaultReward, EndpointInitArgs } from './types';
 
 export class RewardEndpoint extends BaseEndpoint {
@@ -38,21 +39,13 @@ export class RewardEndpoint extends BaseEndpoint {
 			throw new Error('Parameter height cannot be smaller than 0.');
 		}
 
-		if (height < this._offset) {
-			return {
-				reward: '0',
-			};
-		}
+		const reward = calculateDefaultReward({
+			height,
+			brackets: this._brackets,
+			distance: this._distance,
+			offset: this._offset,
+		});
 
-		const distance = Math.floor(this._distance);
-		const location = Math.trunc((height - this._offset) / distance);
-		const lastBracket = this._brackets[this._brackets.length - 1];
-
-		const bracket =
-			location > this._brackets.length - 1 ? this._brackets.lastIndexOf(lastBracket) : location;
-
-		return {
-			reward: this._brackets[bracket].toString(),
-		};
+		return { reward: reward.toString() };
 	}
 }

--- a/framework/src/modules/reward/endpoint.ts
+++ b/framework/src/modules/reward/endpoint.ts
@@ -48,12 +48,8 @@ export class RewardEndpoint extends BaseEndpoint {
 		const location = Math.trunc((height - this._offset) / distance);
 		const lastBracket = this._brackets[this._brackets.length - 1];
 
-		let bracket;
-		if (location > this._brackets.length - 1) {
-			bracket = this._brackets.lastIndexOf(lastBracket);
-		} else {
-			bracket = location;
-		}
+		const bracket =
+			location > this._brackets.length - 1 ? this._brackets.lastIndexOf(lastBracket) : location;
 
 		return {
 			reward: this._brackets[bracket].toString(),

--- a/framework/src/modules/reward/endpoint.ts
+++ b/framework/src/modules/reward/endpoint.ts
@@ -12,6 +12,43 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { ModuleEndpointContext } from '../..';
 import { BaseEndpoint } from '../base_endpoint';
+import { DefaultReward, EndpointInitArgs, GetDefaultRewardParams } from './types';
 
-export class RewardEndpoint extends BaseEndpoint {}
+export class RewardEndpoint extends BaseEndpoint {
+	private _brackets!: ReadonlyArray<bigint>;
+	private _offset!: number;
+	private _distance!: number;
+
+	public init(args: EndpointInitArgs) {
+		this._brackets = args.config.brackets;
+		this._offset = args.config.offset;
+		this._distance = args.config.distance;
+	}
+
+	public getDefaultRewardAtHeight(ctx: ModuleEndpointContext): DefaultReward {
+		const { height } = (ctx.params as unknown) as GetDefaultRewardParams;
+
+		if (height < this._offset) {
+			return {
+				reward: BigInt(0),
+			};
+		}
+
+		const distance = Math.floor(this._distance);
+		const location = Math.trunc((height - this._offset) / distance);
+		const lastBracket = this._brackets[this._brackets.length - 1];
+
+		let bracket;
+		if (location > this._brackets.length - 1) {
+			bracket = this._brackets.lastIndexOf(lastBracket);
+		} else {
+			bracket = location;
+		}
+
+		return {
+			reward: this._brackets[bracket],
+		};
+	}
+}

--- a/framework/src/modules/reward/endpoint.ts
+++ b/framework/src/modules/reward/endpoint.ts
@@ -31,11 +31,11 @@ export class RewardEndpoint extends BaseEndpoint {
 		const { height } = ctx.params;
 
 		if (typeof height !== 'number') {
-			throw new Error('Parameter height must be a number');
+			throw new Error('Parameter height must be a number.');
 		}
 
 		if (height < 0) {
-			throw new Error('Parameter height cannot be smaller than 0');
+			throw new Error('Parameter height cannot be smaller than 0.');
 		}
 
 		if (height < this._offset) {

--- a/framework/src/modules/reward/endpoint.ts
+++ b/framework/src/modules/reward/endpoint.ts
@@ -14,7 +14,7 @@
 
 import { ModuleEndpointContext } from '../..';
 import { BaseEndpoint } from '../base_endpoint';
-import { DefaultReward, EndpointInitArgs, GetDefaultRewardParams } from './types';
+import { DefaultReward, EndpointInitArgs } from './types';
 
 export class RewardEndpoint extends BaseEndpoint {
 	private _brackets!: ReadonlyArray<bigint>;
@@ -28,7 +28,15 @@ export class RewardEndpoint extends BaseEndpoint {
 	}
 
 	public getDefaultRewardAtHeight(ctx: ModuleEndpointContext): DefaultReward {
-		const { height } = (ctx.params as unknown) as GetDefaultRewardParams;
+		const { height } = ctx.params;
+
+		if (typeof height !== 'number') {
+			throw new Error('Parameter height must be a number');
+		}
+
+		if (height < 0) {
+			throw new Error('Parameter height cannot be smaller than 0');
+		}
 
 		if (height < this._offset) {
 			return {

--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -44,6 +44,14 @@ export class RewardModule extends BaseModule {
 		const { moduleConfig } = args;
 		this._moduleConfig = (moduleConfig as unknown) as ModuleConfig;
 		this._tokenIDReward = this._moduleConfig.tokenIDReward;
+
+		this.endpoint.init({
+			config: {
+				brackets: this._moduleConfig.brackets.map(bracket => BigInt(bracket)),
+				offset: this._moduleConfig.offset,
+				distance: this._moduleConfig.distance,
+			},
+		});
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await

--- a/framework/src/modules/reward/schemas.ts
+++ b/framework/src/modules/reward/schemas.ts
@@ -28,6 +28,21 @@ export const configSchema = {
 			},
 			required: ['chainID', 'localID'],
 		},
+		offset: {
+			type: 'integer',
+			minimum: 1,
+		},
+		distance: {
+			type: 'integer',
+			minimum: 1,
+		},
+		brackets: {
+			type: 'array',
+			items: {
+				type: 'string',
+				format: 'uint64',
+			},
+		},
 	},
-	required: ['tokenIDReward'],
+	required: ['tokenIDReward', 'offset', 'distance', 'brackets'],
 };

--- a/framework/src/modules/reward/types.ts
+++ b/framework/src/modules/reward/types.ts
@@ -53,7 +53,7 @@ export interface GetDefaultRewardParams {
 }
 
 export interface DefaultReward {
-	reward: bigint;
+	reward: string;
 }
 
 export interface EndpointInitArgs {

--- a/framework/src/modules/reward/types.ts
+++ b/framework/src/modules/reward/types.ts
@@ -59,3 +59,10 @@ export interface EndpointInitArgs {
 		distance: number;
 	};
 }
+
+export interface CalculateDefaultRewardArgs {
+	brackets: ReadonlyArray<bigint>;
+	offset: number;
+	distance: number;
+	height: number;
+}

--- a/framework/src/modules/reward/types.ts
+++ b/framework/src/modules/reward/types.ts
@@ -48,10 +48,6 @@ export interface LiskBFTAPI {
 	impliesMaximalPrevotes(apiContext: APIContext, blockHeader: BlockHeader): Promise<boolean>;
 }
 
-export interface GetDefaultRewardParams {
-	height: number;
-}
-
 export interface DefaultReward {
 	reward: string;
 }

--- a/framework/src/modules/reward/types.ts
+++ b/framework/src/modules/reward/types.ts
@@ -22,6 +22,9 @@ export interface TokenIDReward {
 
 export interface ModuleConfig {
 	tokenIDReward: TokenIDReward;
+	brackets: ReadonlyArray<string>;
+	offset: number;
+	distance: number;
 }
 
 export interface TokenAPI {
@@ -43,4 +46,20 @@ export interface RandomAPI {
 
 export interface LiskBFTAPI {
 	impliesMaximalPrevotes(apiContext: APIContext, blockHeader: BlockHeader): Promise<boolean>;
+}
+
+export interface GetDefaultRewardParams {
+	height: number;
+}
+
+export interface DefaultReward {
+	reward: bigint;
+}
+
+export interface EndpointInitArgs {
+	config: {
+		brackets: ReadonlyArray<bigint>;
+		offset: number;
+		distance: number;
+	};
 }

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -63,7 +63,7 @@ describe('RewardModule', () => {
 						height: currentHeight,
 					},
 				});
-				expect(rewardFromEndpoint).toEqual({ reward: rewardFromConfig });
+				expect(rewardFromEndpoint).toEqual({ reward: rewardFromConfig.toString() });
 			});
 		}
 
@@ -75,7 +75,7 @@ describe('RewardModule', () => {
 					height: offset - 1,
 				},
 			});
-			expect(rewardFromEndpoint).toEqual({ reward: BigInt(0) });
+			expect(rewardFromEndpoint).toEqual({ reward: '0' });
 		});
 	});
 });

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -87,7 +87,7 @@ describe('RewardModule', () => {
 						height: 'Not a number',
 					},
 				}),
-			).toThrow('Parameter height must be a number');
+			).toThrow('Parameter height must be a number.');
 		});
 
 		it('should throw an error when parameter height is below 0', () => {
@@ -99,7 +99,7 @@ describe('RewardModule', () => {
 						height: -1,
 					},
 				}),
-			).toThrow('Parameter height cannot be smaller than 0');
+			).toThrow('Parameter height cannot be smaller than 0.');
 		});
 	});
 });

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -77,5 +77,29 @@ describe('RewardModule', () => {
 			});
 			expect(rewardFromEndpoint).toEqual({ reward: '0' });
 		});
+
+		it('should throw an error when parameter height is not a number', () => {
+			expect(() =>
+				rewardModule.endpoint.getDefaultRewardAtHeight({
+					getStore: jest.fn(),
+					logger,
+					params: {
+						height: 'Not a number',
+					},
+				}),
+			).toThrow('Parameter height must be a number');
+		});
+
+		it('should throw an error when parameter height is below 0', () => {
+			expect(() =>
+				rewardModule.endpoint.getDefaultRewardAtHeight({
+					getStore: jest.fn(),
+					logger,
+					params: {
+						height: -1,
+					},
+				}),
+			).toThrow('Parameter height cannot be smaller than 0');
+		});
 	});
 });

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { Logger } from '../../../../src/logger';
+import { RewardModule } from '../../../../src/modules/reward';
+import { fakeLogger } from '../../../utils/node';
+
+describe('RewardModule', () => {
+	const genesisConfig: any = {};
+	const moduleConfig: any = {
+		distance: 3000000,
+		offset: 2160,
+		brackets: [
+			BigInt('500000000'), // Initial Reward
+			BigInt('400000000'), // Milestone 1
+			BigInt('300000000'), // Milestone 2
+			BigInt('200000000'), // Milestone 3
+			BigInt('100000000'), // Milestone 4
+		],
+		tokenIDReward: { chainID: 0, localID: 0 },
+	};
+	const generatorConfig: any = {};
+
+	const logger: Logger = fakeLogger;
+	let rewardModule: RewardModule;
+
+	beforeAll(async () => {
+		rewardModule = new RewardModule();
+		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
+		rewardModule.addDependencies(
+			{ mint: jest.fn() } as any,
+			{ isValidSeedReveal: jest.fn() } as any,
+			{ impliesMaximalPrevotes: jest.fn() } as any,
+		);
+	});
+
+	describe('endpoint', () => {
+		const { brackets, offset, distance } = moduleConfig as {
+			brackets: ReadonlyArray<bigint>;
+			offset: number;
+			distance: number;
+		};
+
+		for (const [index, rewardFromConfig] of Object.entries(brackets)) {
+			const nthBracket = +index;
+			const currentHeight = offset + nthBracket * distance;
+			// eslint-disable-next-line no-loop-func
+			it(`should getDefaultRewardAtHeight work for the ${nthBracket}th bracket`, () => {
+				const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
+					getStore: jest.fn(),
+					logger,
+					params: {
+						height: currentHeight,
+					},
+				});
+				expect(rewardFromEndpoint).toEqual({ reward: rewardFromConfig });
+			});
+		}
+
+		it(`should getDefaultRewardAtHeight work for the height below offset`, () => {
+			const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
+				getStore: jest.fn(),
+				logger,
+				params: {
+					height: offset - 1,
+				},
+			});
+			expect(rewardFromEndpoint).toEqual({ reward: BigInt(0) });
+		});
+	});
+});

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -15,7 +15,7 @@ import { Logger } from '../../../../src/logger';
 import { RewardModule } from '../../../../src/modules/reward';
 import { fakeLogger } from '../../../utils/node';
 
-describe('RewardModule', () => {
+describe('RewardModuleEndpoint', () => {
 	const genesisConfig: any = {};
 	const moduleConfig: any = {
 		distance: 3000000,
@@ -44,62 +44,60 @@ describe('RewardModule', () => {
 		);
 	});
 
-	describe('endpoint', () => {
-		const { brackets, offset, distance } = moduleConfig as {
-			brackets: ReadonlyArray<bigint>;
-			offset: number;
-			distance: number;
-		};
+	const { brackets, offset, distance } = moduleConfig as {
+		brackets: ReadonlyArray<bigint>;
+		offset: number;
+		distance: number;
+	};
 
-		for (const [index, rewardFromConfig] of Object.entries(brackets)) {
-			const nthBracket = +index;
-			const currentHeight = offset + nthBracket * distance;
-			// eslint-disable-next-line no-loop-func
-			it(`should getDefaultRewardAtHeight work for the ${nthBracket}th bracket`, () => {
-				const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
-					getStore: jest.fn(),
-					logger,
-					params: {
-						height: currentHeight,
-					},
-				});
-				expect(rewardFromEndpoint).toEqual({ reward: rewardFromConfig.toString() });
-			});
-		}
-
-		it(`should getDefaultRewardAtHeight work for the height below offset`, () => {
+	for (const [index, rewardFromConfig] of Object.entries(brackets)) {
+		const nthBracket = +index;
+		const currentHeight = offset + nthBracket * distance;
+		// eslint-disable-next-line no-loop-func
+		it(`should getDefaultRewardAtHeight work for the ${nthBracket}th bracket`, () => {
 			const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
 				getStore: jest.fn(),
 				logger,
 				params: {
-					height: offset - 1,
+					height: currentHeight,
 				},
 			});
-			expect(rewardFromEndpoint).toEqual({ reward: '0' });
+			expect(rewardFromEndpoint).toEqual({ reward: rewardFromConfig.toString() });
 		});
+	}
 
-		it('should throw an error when parameter height is not a number', () => {
-			expect(() =>
-				rewardModule.endpoint.getDefaultRewardAtHeight({
-					getStore: jest.fn(),
-					logger,
-					params: {
-						height: 'Not a number',
-					},
-				}),
-			).toThrow('Parameter height must be a number.');
+	it(`should getDefaultRewardAtHeight work for the height below offset`, () => {
+		const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
+			getStore: jest.fn(),
+			logger,
+			params: {
+				height: offset - 1,
+			},
 		});
+		expect(rewardFromEndpoint).toEqual({ reward: '0' });
+	});
 
-		it('should throw an error when parameter height is below 0', () => {
-			expect(() =>
-				rewardModule.endpoint.getDefaultRewardAtHeight({
-					getStore: jest.fn(),
-					logger,
-					params: {
-						height: -1,
-					},
-				}),
-			).toThrow('Parameter height cannot be smaller than 0.');
-		});
+	it('should throw an error when parameter height is not a number', () => {
+		expect(() =>
+			rewardModule.endpoint.getDefaultRewardAtHeight({
+				getStore: jest.fn(),
+				logger,
+				params: {
+					height: 'Not a number',
+				},
+			}),
+		).toThrow('Parameter height must be a number.');
+	});
+
+	it('should throw an error when parameter height is below 0', () => {
+		expect(() =>
+			rewardModule.endpoint.getDefaultRewardAtHeight({
+				getStore: jest.fn(),
+				logger,
+				params: {
+					height: -1,
+				},
+			}),
+		).toThrow('Parameter height cannot be smaller than 0.');
 	});
 });

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -66,7 +66,7 @@ describe('RewardModuleEndpoint', () => {
 		});
 	}
 
-	it(`should getDefaultRewardAtHeight work for the height below offset`, () => {
+	it('should getDefaultRewardAtHeight work for the height below offset', () => {
 		const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
 			getStore: jest.fn(),
 			logger,

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { RewardModule } from '../../../../src/modules/reward';
+
+describe('RewardModule', () => {
+	const genesisConfig: any = {};
+	const moduleConfig: any = {
+		distance: 3000000,
+		offset: 2160,
+		brackets: [
+			BigInt('500000000'), // Initial Reward
+			BigInt('400000000'), // Milestone 1
+			BigInt('300000000'), // Milestone 2
+			BigInt('200000000'), // Milestone 3
+			BigInt('100000000'), // Milestone 4
+		],
+		tokenIDReward: { chainID: 0, localID: 0 },
+	};
+	const generatorConfig: any = {};
+
+	let rewardModule: RewardModule;
+
+	beforeAll(async () => {
+		rewardModule = new RewardModule();
+		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
+		rewardModule.addDependencies(
+			{ mint: jest.fn() } as any,
+			{ isValidSeedReveal: jest.fn() } as any,
+			{ impliesMaximalPrevotes: jest.fn() } as any,
+		);
+	});
+
+	describe('init', () => {
+		it('should set the moduleConfig property', () => {
+			expect(rewardModule['_moduleConfig']).toEqual(moduleConfig);
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6689

### How was it solved?

- Added `getDefaultRewardAtHeight` function and injected necessary configs for it

### How was it tested?

- With a unit test that tests every bracket and offset range
- With a unit test that tests module config is properly imported
