### PR TITLE
Add BFT utils - Closes #6747

### DIFF
--- a/framework/src/modules/bft/errors.ts
+++ b/framework/src/modules/bft/errors.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export class BFTParameterNotFoundError extends Error {}

--- a/framework/src/modules/bft/utils.ts
+++ b/framework/src/modules/bft/utils.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { BlockHeader } from '@liskhq/lisk-chain';
+import { codec } from '@liskhq/lisk-codec';
+import { BIG_ENDIAN, intToBuffer } from '@liskhq/lisk-cryptography';
+import { ImmutableSubStore } from '../../node/state_machine';
+import { BFTParameterNotFoundError } from './errors';
+import { BFTVotesBlockInfo, BFTParameters, bftParametersSchema } from './schemas';
+
+interface BFTHeader {
+	height: number;
+	generatorAddress: Buffer;
+	maxHeightGenerated: number;
+	maxHeightPrevoted: number;
+}
+
+export const areDistinctHeadersContradicting = (b1: BFTHeader, b2: BFTHeader): boolean => {
+	let earlierBlock = b1;
+	let laterBlock = b2;
+	const higherMaxHeightPreviouslyForged =
+		earlierBlock.maxHeightGenerated > laterBlock.maxHeightGenerated;
+	const sameMaxHeightPreviouslyForged =
+		earlierBlock.maxHeightGenerated === laterBlock.maxHeightGenerated;
+	const higherMaxHeightPrevoted = earlierBlock.maxHeightPrevoted > laterBlock.maxHeightPrevoted;
+	const sameMaxHeightPrevoted = earlierBlock.maxHeightPrevoted === laterBlock.maxHeightPrevoted;
+	const higherHeight = earlierBlock.height > laterBlock.height;
+	if (
+		higherMaxHeightPreviouslyForged ||
+		(sameMaxHeightPreviouslyForged && higherMaxHeightPrevoted) ||
+		(sameMaxHeightPreviouslyForged && sameMaxHeightPrevoted && higherHeight)
+	) {
+		[earlierBlock, laterBlock] = [laterBlock, earlierBlock];
+	}
+	// Blocks by different delegates are never contradicting
+	if (!earlierBlock.generatorAddress.equals(laterBlock.generatorAddress)) {
+		return false;
+	}
+	if (
+		earlierBlock.maxHeightPrevoted === laterBlock.maxHeightPrevoted &&
+		earlierBlock.height >= laterBlock.height
+	) {
+		/* Violation of the fork choice rule as validator moved to different chain
+		 without strictly larger maxHeightPreviouslyForged or larger height as
+		 justification. This in particular happens, if a validator is double forging. */
+		return true;
+	}
+
+	if (earlierBlock.height > laterBlock.maxHeightGenerated) {
+		return true;
+	}
+
+	if (earlierBlock.maxHeightPrevoted > laterBlock.maxHeightPrevoted) {
+		return true;
+	}
+	return false;
+};
+
+export const getBlockBFTProperties = (header: BlockHeader): BFTVotesBlockInfo => ({
+	generatorAddress: header.generatorAddress,
+	height: header.height,
+	maxHeightGenerated: header.maxHeightGenerated,
+	maxHeightPrevoted: header.maxHeightPrevoted,
+	precommitWeight: 0,
+	prevoteWeight: 0,
+});
+
+const maxUInt32 = 2 ** 32 - 1;
+
+export const getBFTParameters = async (
+	paramsStore: ImmutableSubStore,
+	height: number,
+): Promise<BFTParameters> => {
+	const start = intToBuffer(height, 4, BIG_ENDIAN);
+	const end = intToBuffer(maxUInt32, 4, BIG_ENDIAN);
+	const results = await paramsStore.iterate({
+		limit: 1,
+		start,
+		end,
+	});
+	if (results.length !== 1) {
+		throw new BFTParameterNotFoundError();
+	}
+	const [result] = results;
+	return codec.decode<BFTParameters>(bftParametersSchema, result.value);
+};

--- a/framework/test/unit/modules/bft/utils.spec.ts
+++ b/framework/test/unit/modules/bft/utils.spec.ts
@@ -100,7 +100,7 @@ describe('bft utils', () => {
 			expect(areDistinctHeadersContradicting(header1, header2)).toBeTrue();
 		});
 
-		it('should false when headers are not contradicting', () => {
+		it('should return false when headers are not contradicting', () => {
 			const header1 = createFakeBlockHeader({
 				generatorAddress,
 				height: 133,

--- a/framework/test/unit/modules/bft/utils.spec.ts
+++ b/framework/test/unit/modules/bft/utils.spec.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { BIG_ENDIAN, getRandomBytes, intToBuffer } from '@liskhq/lisk-cryptography';
+import { InMemoryKVStore, KVStore } from '@liskhq/lisk-db';
+import { StateStore } from '@liskhq/lisk-chain';
+import { codec } from '@liskhq/lisk-codec';
+import { createFakeBlockHeader } from '../../../../src/testing';
+import {
+	areDistinctHeadersContradicting,
+	getBFTParameters,
+	getBlockBFTProperties,
+} from '../../../../src/modules/bft/utils';
+import { MODULE_ID_BFT, STORE_PREFIX_BFT_PARAMETERS } from '../../../../src/modules/bft/constants';
+import { BFTParameters, bftParametersSchema } from '../../../../src/modules/bft/schemas';
+import { BFTParameterNotFoundError } from '../../../../src/modules/bft/errors';
+
+describe('bft utils', () => {
+	const generatorAddress = getRandomBytes(20);
+
+	it('should return false when generatorAddress does not match', () => {
+		const header1 = createFakeBlockHeader({
+			generatorAddress,
+		});
+		const header2 = createFakeBlockHeader({
+			generatorAddress: getRandomBytes(20),
+		});
+
+		expect(areDistinctHeadersContradicting(header1, header2)).toBeFalse();
+	});
+
+	describe('areDistinctHeadersContradicting', () => {
+		it('should return true when first height is equal to second height but equal maxHeightPrevoted', () => {
+			const header1 = createFakeBlockHeader({
+				height: 10999,
+				maxHeightPrevoted: 1099,
+				generatorAddress,
+			});
+			const header2 = createFakeBlockHeader({
+				height: 10999,
+				maxHeightPrevoted: 1099,
+				generatorAddress,
+			});
+
+			expect(areDistinctHeadersContradicting(header1, header2)).toBeTrue();
+		});
+
+		it('should return true when first height is greater than the second height but equal maxHeightPrevoted', () => {
+			const header1 = createFakeBlockHeader({
+				height: 10999,
+				maxHeightPrevoted: 1099,
+				generatorAddress,
+			});
+			const header2 = createFakeBlockHeader({
+				height: 11999,
+				maxHeightPrevoted: 1099,
+				generatorAddress,
+			});
+
+			expect(areDistinctHeadersContradicting(header1, header2)).toBeTrue();
+		});
+
+		it("should return true when height is greater than the second header's maxHeightGenerated", () => {
+			const header1 = createFakeBlockHeader({
+				generatorAddress,
+				height: 120,
+			});
+			const header2 = createFakeBlockHeader({
+				generatorAddress,
+				height: 123,
+				maxHeightGenerated: 98,
+			});
+
+			expect(areDistinctHeadersContradicting(header1, header2)).toBeTrue();
+		});
+
+		it('should return true when maxHeightPrevoted is greater than the second maxHeightPrevoted', () => {
+			const header1 = createFakeBlockHeader({
+				generatorAddress,
+				height: 133,
+				maxHeightPrevoted: 101,
+			});
+			const header2 = createFakeBlockHeader({
+				generatorAddress,
+				height: 123,
+				maxHeightPrevoted: 98,
+			});
+
+			expect(areDistinctHeadersContradicting(header1, header2)).toBeTrue();
+		});
+
+		it('should false when headers are not contradicting', () => {
+			const header1 = createFakeBlockHeader({
+				generatorAddress,
+				height: 133,
+				maxHeightGenerated: 50,
+				maxHeightPrevoted: 101,
+			});
+			const header2 = createFakeBlockHeader({
+				generatorAddress,
+				height: 153,
+				maxHeightPrevoted: 121,
+				maxHeightGenerated: 133,
+			});
+			expect(areDistinctHeadersContradicting(header1, header2)).toBeFalse();
+		});
+	});
+
+	describe('getBlockBFTProperties', () => {
+		it('should return new bft block properties', () => {
+			const header = createFakeBlockHeader();
+			const bftProps = getBlockBFTProperties(header);
+
+			expect(bftProps.generatorAddress).toEqual(header.generatorAddress);
+			expect(bftProps.maxHeightGenerated).toEqual(header.maxHeightGenerated);
+			expect(bftProps.maxHeightPrevoted).toEqual(header.maxHeightPrevoted);
+			expect(bftProps.maxHeightPrevoted).toEqual(0);
+			expect(bftProps.precommitWeight).toEqual(0);
+		});
+	});
+
+	describe('getBFTParameters', () => {
+		let db: KVStore;
+		let stateStore: StateStore;
+		let bftParams1: BFTParameters;
+		let bftParams2: BFTParameters;
+
+		beforeEach(async () => {
+			db = new InMemoryKVStore() as never;
+			const rootStore = new StateStore(db);
+			const paramsStore = rootStore.getStore(MODULE_ID_BFT, STORE_PREFIX_BFT_PARAMETERS);
+			const height1Bytes = intToBuffer(309, 4, BIG_ENDIAN);
+			bftParams1 = {
+				prevoteThreshold: BigInt(20),
+				precommitThreshold: BigInt(30),
+				certificateThreshold: BigInt(40),
+				validators: [
+					{
+						address: getRandomBytes(20),
+						bftWeight: BigInt(10),
+					},
+				],
+				validatorsHash: getRandomBytes(32),
+			};
+			await paramsStore.set(height1Bytes, codec.encode(bftParametersSchema, bftParams1));
+			const height2Bytes = intToBuffer(515, 4, BIG_ENDIAN);
+			bftParams2 = {
+				prevoteThreshold: BigInt(40),
+				precommitThreshold: BigInt(50),
+				certificateThreshold: BigInt(60),
+				validators: [
+					{
+						address: getRandomBytes(20),
+						bftWeight: BigInt(5),
+					},
+				],
+				validatorsHash: getRandomBytes(32),
+			};
+			await paramsStore.set(height2Bytes, codec.encode(bftParametersSchema, bftParams2));
+			const batch = db.batch();
+			rootStore.finalize(batch);
+			await batch.write();
+
+			stateStore = new StateStore(db);
+		});
+
+		it('should throw if BFT parameters greater than the height does not exist', async () => {
+			const paramsStore = stateStore.getStore(MODULE_ID_BFT, STORE_PREFIX_BFT_PARAMETERS);
+
+			await expect(getBFTParameters(paramsStore, 1014)).rejects.toThrow(BFTParameterNotFoundError);
+		});
+
+		it('should return if BFT parameters equal to the input height exist', async () => {
+			const paramsStore = stateStore.getStore(MODULE_ID_BFT, STORE_PREFIX_BFT_PARAMETERS);
+
+			await expect(getBFTParameters(paramsStore, 515)).resolves.toEqual(bftParams2);
+		});
+
+		it('should return if BFT parameters greater than the input height exist', async () => {
+			const paramsStore = stateStore.getStore(MODULE_ID_BFT, STORE_PREFIX_BFT_PARAMETERS);
+
+			await expect(getBFTParameters(paramsStore, 330)).resolves.toEqual(bftParams2);
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6747 

### How was it solved?

- Copy logic from `lisk-bft` areHeadersContradicting for `areDistinctHeadersContradicting` except id check is removed
- Add 2 new util functions

### How was it tested?

- Add unit test
- `areDistinctHeadersContradicting` tests is copied from DPoS PoM transaction
