### PR TITLE
Implement afterBlockExecute hook for the reward module - Closes #6690

### DIFF
--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -70,7 +70,7 @@ export class RewardModule extends BaseModule {
 		);
 
 		if (blockReward <= BigInt(0)) {
-			throw new Error('Reward amount to be minted is not valid.');
+			return;
 		}
 
 		await this._tokenAPI.mint(

--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -36,7 +36,7 @@ export class RewardModule extends BaseModule {
 		this._tokenAPI = tokenAPI;
 		this._randomAPI = randomAPI;
 		this._bftAPI = bftAPI;
-		this.api.addDependencies(bftAPI, randomAPI);
+		this.api.addDependencies(this._bftAPI, this._randomAPI);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await

--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -62,9 +62,7 @@ export class RewardModule extends BaseModule {
 		});
 	}
 
-	// eslint-disable-next-line @typescript-eslint/require-await
 	public async afterBlockExecute(context: BlockAfterExecuteContext): Promise<void> {
-		// eslint-disable-next-line no-console
 		const blockReward = await this.api.getBlockReward(
 			context.getAPIContext(),
 			context.header,

--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -63,8 +63,18 @@ export class RewardModule extends BaseModule {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
-	public async afterBlockExecute(_context: BlockAfterExecuteContext): Promise<void> {
+	public async afterBlockExecute(context: BlockAfterExecuteContext): Promise<void> {
 		// eslint-disable-next-line no-console
-		console.log(this._tokenAPI, this._bftAPI, this._randomAPI, this._tokenIDReward);
+		const blockReward = await this.api.getBlockReward(
+			context.getAPIContext(),
+			context.header,
+			context.assets,
+		);
+		await this._tokenAPI.mint(
+			context.getAPIContext(),
+			context.header.generatorAddress,
+			this._tokenIDReward,
+			blockReward,
+		);
 	}
 }

--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -70,6 +70,11 @@ export class RewardModule extends BaseModule {
 			context.header,
 			context.assets,
 		);
+
+		if (blockReward <= BigInt(0)) {
+			throw new Error('Reward amount to be minted is not valid.');
+		}
+
 		await this._tokenAPI.mint(
 			context.getAPIContext(),
 			context.header.generatorAddress,

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -49,23 +49,25 @@ describe('RewardModule', () => {
 		});
 	});
 
-	it(`should call mint in afterBlockExecute hook for a valid bracket`, async () => {
-		const blockHeader = createBlockHeaderWithDefaults({ height: moduleConfig.offset });
-		const blockAfterExecuteContext = createBlockContext({
-			header: blockHeader,
-		}).getBlockAfterExecuteContext();
-		await rewardModule.afterBlockExecute(blockAfterExecuteContext);
+	describe('afterBlockExecute', () => {
+		it(`should call mint for a valid bracket`, async () => {
+			const blockHeader = createBlockHeaderWithDefaults({ height: moduleConfig.offset });
+			const blockAfterExecuteContext = createBlockContext({
+				header: blockHeader,
+			}).getBlockAfterExecuteContext();
+			await rewardModule.afterBlockExecute(blockAfterExecuteContext);
 
-		expect(mint).toHaveBeenCalledTimes(1);
-	});
+			expect(mint).toHaveBeenCalledTimes(1);
+		});
 
-	it('should afterBlockExecute hook not mint reward for reward <= 0', async () => {
-		const blockHeader = createBlockHeaderWithDefaults({ height: 1 });
-		const blockAfterExecuteContext = createBlockContext({
-			header: blockHeader,
-		}).getBlockAfterExecuteContext();
-		await rewardModule.afterBlockExecute(blockAfterExecuteContext);
+		it('should not mint reward for reward <= 0', async () => {
+			const blockHeader = createBlockHeaderWithDefaults({ height: 1 });
+			const blockAfterExecuteContext = createBlockContext({
+				header: blockHeader,
+			}).getBlockAfterExecuteContext();
+			await rewardModule.afterBlockExecute(blockAfterExecuteContext);
 
-		expect(mint).not.toHaveBeenCalled();
+			expect(mint).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -49,29 +49,15 @@ describe('RewardModule', () => {
 		});
 	});
 
-	const { brackets, offset, distance } = moduleConfig as {
-		brackets: ReadonlyArray<bigint>;
-		offset: number;
-		distance: number;
-	};
+	it(`should call mint in afterBlockExecute hook for a valid bracket`, async () => {
+		const blockHeader = createBlockHeaderWithDefaults({ height: moduleConfig.offset });
+		const blockAfterExecuteContext = createBlockContext({
+			header: blockHeader,
+		}).getBlockAfterExecuteContext();
+		await rewardModule.afterBlockExecute(blockAfterExecuteContext);
 
-	describe.each(Object.entries(brackets))(
-		'afterBlockExecute test for brackets',
-		(index, _rewardFromConfig) => {
-			const nthBracket = Number(index);
-			const currentHeight = offset + nthBracket * distance;
-
-			it(`should call mint in afterBlockExecute hook for valid ${nthBracket}th bracket`, async () => {
-				const blockHeader = createBlockHeaderWithDefaults({ height: currentHeight });
-				const blockAfterExecuteContext = createBlockContext({
-					header: blockHeader,
-				}).getBlockAfterExecuteContext();
-				await rewardModule.afterBlockExecute(blockAfterExecuteContext);
-
-				expect(mint).toHaveBeenCalledTimes(1);
-			});
-		},
-	);
+		expect(mint).toHaveBeenCalledTimes(1);
+	});
 
 	it('should afterBlockExecute hook not mint reward for reward <= 0', async () => {
 		const blockHeader = createBlockHeaderWithDefaults({ height: 1 });

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -73,14 +73,13 @@ describe('RewardModule', () => {
 		},
 	);
 
-	it('should afterBlockExecute hook throw an error for 0 reward', async () => {
+	it('should afterBlockExecute hook not mint reward for reward <= 0', async () => {
 		const blockHeader = createBlockHeaderWithDefaults({ height: 1 });
 		const blockAfterExecuteContext = createBlockContext({
 			header: blockHeader,
 		}).getBlockAfterExecuteContext();
+		await rewardModule.afterBlockExecute(blockAfterExecuteContext);
 
-		await expect(async () =>
-			rewardModule.afterBlockExecute(blockAfterExecuteContext),
-		).rejects.toThrow('Reward amount to be minted is not valid.');
+		expect(mint).not.toHaveBeenCalled();
 	});
 });

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { RewardModule } from '../../../../src/modules/reward';
+import { createBlockContext, createBlockHeaderWithDefaults } from '../../../../src/testing';
 
 describe('RewardModule', () => {
 	const genesisConfig: any = {};
@@ -30,14 +31,15 @@ describe('RewardModule', () => {
 	const generatorConfig: any = {};
 
 	let rewardModule: RewardModule;
-
-	beforeAll(async () => {
+	let mint: any;
+	beforeEach(async () => {
+		mint = jest.fn();
 		rewardModule = new RewardModule();
 		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
 		rewardModule.addDependencies(
-			{ mint: jest.fn() } as any,
-			{ isValidSeedReveal: jest.fn() } as any,
-			{ impliesMaximalPrevotes: jest.fn() } as any,
+			{ mint } as any,
+			{ isValidSeedReveal: jest.fn().mockReturnValue(true) } as any,
+			{ impliesMaximalPrevotes: jest.fn().mockReturnValue(true) } as any,
 		);
 	});
 
@@ -45,5 +47,40 @@ describe('RewardModule', () => {
 		it('should set the moduleConfig property', () => {
 			expect(rewardModule['_moduleConfig']).toEqual(moduleConfig);
 		});
+	});
+
+	const { brackets, offset, distance } = moduleConfig as {
+		brackets: ReadonlyArray<bigint>;
+		offset: number;
+		distance: number;
+	};
+
+	describe.each(Object.entries(brackets))(
+		'afterBlockExecute test for brackets',
+		(index, _rewardFromConfig) => {
+			const nthBracket = Number(index);
+			const currentHeight = offset + nthBracket * distance;
+
+			it(`should call mint in afterBlockExecute hook for valid ${nthBracket}th bracket`, async () => {
+				const blockHeader = createBlockHeaderWithDefaults({ height: currentHeight });
+				const blockAfterExecuteContext = createBlockContext({
+					header: blockHeader,
+				}).getBlockAfterExecuteContext();
+				await rewardModule.afterBlockExecute(blockAfterExecuteContext);
+
+				expect(mint).toHaveBeenCalledTimes(1);
+			});
+		},
+	);
+
+	it('should afterBlockExecute hook throw an error for 0 reward', async () => {
+		const blockHeader = createBlockHeaderWithDefaults({ height: 1 });
+		const blockAfterExecuteContext = createBlockContext({
+			header: blockHeader,
+		}).getBlockAfterExecuteContext();
+
+		await expect(async () =>
+			rewardModule.afterBlockExecute(blockAfterExecuteContext),
+		).rejects.toThrow('Reward amount to be minted is not valid.');
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #6690 

### How was it solved?

- Implemented afterBlockExecute hook in the reward module class

### How was it tested?

- It was tested with unit tests
