### PR TITLE
Add moduleID to BaseCommand - Closes #6785

### DIFF
--- a/framework/src/modules/auth/commands/register_multisignature.ts
+++ b/framework/src/modules/auth/commands/register_multisignature.ts
@@ -25,12 +25,6 @@ export class RegisterMultisignatureCommand extends BaseCommand {
 	public id = 0;
 	public name = 'registerMultisignatureGroup';
 	public schema = registerMultisignatureParamsSchema;
-	protected moduleID: number;
-
-	public constructor(moduleID: number) {
-		super();
-		this.moduleID = moduleID;
-	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async verify(

--- a/framework/src/modules/base_command.ts
+++ b/framework/src/modules/base_command.ts
@@ -21,9 +21,14 @@ import {
 } from '../node/state_machine';
 
 export abstract class BaseCommand<T = unknown> {
+	protected moduleID: number;
 	public abstract name: string;
 	public abstract id: number;
 	public abstract schema: Schema;
+
+	public constructor(moduleID: number) {
+		this.moduleID = moduleID;
+	}
 
 	public verify?(context: CommandVerifyContext<T>): Promise<VerificationResult>;
 

--- a/framework/test/unit/node/node.spec.ts
+++ b/framework/test/unit/node/node.spec.ts
@@ -238,7 +238,7 @@ describe('Node', () => {
 			}
 			sampleModule.name = 'SampleModule';
 			sampleModule.id = 999999;
-			sampleModule.commands.push(new SampleCommand());
+			sampleModule.commands.push(new SampleCommand() as any);
 			// Assert
 			expect(() => node.registerModule(sampleModule)).toThrow(
 				'Custom module contains command which does not extend `BaseCommand` class.',
@@ -259,7 +259,7 @@ describe('Node', () => {
 			}
 			sampleModule.name = 'SampleModule';
 			sampleModule.id = 999999;
-			sampleModule.commands.push(new SampleCommand());
+			sampleModule.commands.push(new SampleCommand(sampleModule.id));
 			// Assert
 			expect(() => node.registerModule(sampleModule)).toThrow(
 				'Custom module contains command with invalid `id` property.',
@@ -280,7 +280,7 @@ describe('Node', () => {
 			}
 			sampleModule.name = 'SampleModule';
 			sampleModule.id = 999999;
-			sampleModule.commands.push(new SampleCommand());
+			sampleModule.commands.push(new SampleCommand(sampleModule.id));
 			// Assert
 			expect(() => node.registerModule(sampleModule)).toThrow(
 				'Custom module contains command with invalid `name` property.',
@@ -297,7 +297,7 @@ describe('Node', () => {
 			}
 			sampleModule.name = 'SampleModule';
 			sampleModule.id = 999999;
-			sampleModule.commands.push(new SampleCommand());
+			sampleModule.commands.push(new SampleCommand(sampleModule.id));
 			// Assert
 			expect(() => node.registerModule(sampleModule)).toThrow(
 				'Custom module contains command with invalid `schema` property.',
@@ -318,7 +318,7 @@ describe('Node', () => {
 			}
 			sampleModule.name = 'SampleModule';
 			sampleModule.id = 999999;
-			sampleModule.commands.push(new SampleCommand());
+			sampleModule.commands.push(new SampleCommand(sampleModule.id));
 			// Assert
 			expect(() => node.registerModule(sampleModule)).toThrow(
 				'Custom module contains command with invalid `execute` property.',


### PR DESCRIPTION
### What was the problem?

This PR resolves #6785 

### How was it solved?

- Added `moduleID` to `BaseCommand`
- Removed `moduleID` from `RegisterMultisignatureCommand`
- Fixed `node.spec.ts` tests that contain commands

### How was it tested?

- `yarn test`
