### PR TITLE
Add networkIdentifier to module endpoint context - Closes #6792

### DIFF
--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -213,6 +213,7 @@ export class Application {
 				blockchainDB: this._blockchainDB,
 				endpoints: this._rootEndpoints(),
 				events: this._rootEvents(),
+				networkIdentifier: this.networkIdentifier,
 			});
 
 			if (!this._genesisBlock) {

--- a/framework/src/controller/channels/in_memory_channel.ts
+++ b/framework/src/controller/channels/in_memory_channel.ts
@@ -26,6 +26,7 @@ import { Logger } from '../../logger';
 export class InMemoryChannel extends BaseChannel {
 	private bus!: Bus;
 	private readonly _db: KVStore;
+	private readonly _networkIdentifier: Buffer | undefined;
 
 	public constructor(
 		logger: Logger,
@@ -33,9 +34,13 @@ export class InMemoryChannel extends BaseChannel {
 		namespace: string,
 		events: ReadonlyArray<string>,
 		endpoints: EndpointHandlers,
+		networkIdentifier?: Buffer,
 	) {
 		super(logger, namespace, events, endpoints);
 		this._db = db;
+		if (networkIdentifier) {
+			this._networkIdentifier = networkIdentifier;
+		}
 	}
 
 	public async registerToBus(bus: Bus): Promise<void> {
@@ -107,6 +112,7 @@ export class InMemoryChannel extends BaseChannel {
 					const stateStore = new StateStore(this._db);
 					return stateStore.getStore(moduleID, storePrefix);
 				},
+				...(this._networkIdentifier && { networkIdentifier: this._networkIdentifier }),
 			}) as Promise<T>;
 		}
 

--- a/framework/src/controller/controller.ts
+++ b/framework/src/controller/controller.ts
@@ -39,6 +39,7 @@ interface ControllerInitArg {
 	readonly logger: Logger;
 	readonly endpoints: EndpointHandlers;
 	readonly events: string[];
+	readonly networkIdentifier: Buffer;
 }
 
 interface ControllerConfig {
@@ -72,6 +73,7 @@ export class Controller {
 	// Injected at init
 	private _logger!: Logger;
 	private _blockchainDB!: KVStore;
+	private _networkIdentifier!: Buffer;
 
 	// Assigned at init
 	private _channel?: InMemoryChannel;
@@ -150,6 +152,7 @@ export class Controller {
 	}
 
 	public init(arg: ControllerInitArg): void {
+		this._networkIdentifier = arg.networkIdentifier;
 		this._blockchainDB = arg.blockchainDB;
 		this._logger = arg.logger;
 		// Create root channel
@@ -201,6 +204,7 @@ export class Controller {
 				namespace,
 				[],
 				handlers,
+				this._networkIdentifier,
 			);
 			await channel.registerToBus(this._bus);
 		}

--- a/framework/src/node/generator/endpoint.ts
+++ b/framework/src/node/generator/endpoint.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { Chain, Transaction } from '@liskhq/lisk-chain';
+import { Transaction } from '@liskhq/lisk-chain';
 import { StateStore } from '@liskhq/lisk-chain/dist-node/state_store';
 import {
 	decryptPassphraseWithPassword,
@@ -52,7 +52,6 @@ interface EndpointArgs {
 	keypair: dataStructures.BufferMap<Keypair>;
 	generators: Generator[];
 	consensus: Consensus;
-	chain: Chain;
 	stateMachine: StateMachine;
 	pool: TransactionPool;
 	broadcaster: Broadcaster;
@@ -72,7 +71,6 @@ export class Endpoint {
 	private readonly _stateMachine: StateMachine;
 	private readonly _pool: TransactionPool;
 	private readonly _broadcaster: Broadcaster;
-	private readonly _chain: Chain;
 
 	private _logger!: Logger;
 	private _generatorDB!: KVStore;
@@ -82,7 +80,6 @@ export class Endpoint {
 		this._keypairs = args.keypair;
 		this._generators = args.generators;
 		this._consensus = args.consensus;
-		this._chain = args.chain;
 		this._stateMachine = args.stateMachine;
 		this._pool = args.pool;
 		this._broadcaster = args.broadcaster;
@@ -104,7 +101,7 @@ export class Endpoint {
 		const txContext = new TransactionContext({
 			eventQueue: new EventQueue(),
 			logger: this._logger,
-			networkIdentifier: this._chain.networkIdentifier,
+			networkIdentifier: ctx.networkIdentifier,
 			stateStore: new StateStore(this._blockchainDB),
 			transaction,
 		});

--- a/framework/src/node/generator/generator.ts
+++ b/framework/src/node/generator/generator.ts
@@ -135,7 +135,6 @@ export class Generator {
 		this._endpoint = new Endpoint({
 			generators: this._config.generators,
 			keypair: this._keypairs,
-			chain: this._chain,
 			consensus: this._consensus,
 			broadcaster: this._broadcaster,
 			pool: this._pool,

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -191,6 +191,7 @@ export interface PluginEndpointContext {
 
 export interface ModuleEndpointContext extends PluginEndpointContext {
 	getStore: (moduleID: number, storePrefix: number) => ImmutableSubStore;
+	networkIdentifier: Buffer;
 }
 
 export type EndpointHandler = (

--- a/framework/test/unit/controller/channels/in_memory_channel.spec.ts
+++ b/framework/test/unit/controller/channels/in_memory_channel.spec.ts
@@ -35,6 +35,7 @@ describe('InMemoryChannel Channel', () => {
 			action3: jest.fn(),
 		},
 		options: {},
+		networkIdentifier: Buffer.alloc(0),
 	};
 	const config: any = {};
 	let inMemoryChannel: InMemoryChannel;
@@ -193,6 +194,51 @@ describe('InMemoryChannel Channel', () => {
 
 			// Assert
 			expect(inMemoryChannel['bus'].invoke).toHaveBeenCalled();
+		});
+	});
+
+	describe('with networkIdentifier', () => {
+		beforeEach(() => {
+			// Act & Assign
+			inMemoryChannel = new InMemoryChannel(
+				params.logger,
+				params.db,
+				params.namespace,
+				params.events,
+				params.endpoints,
+				params.networkIdentifier,
+			);
+		});
+
+		describe('#constructor', () => {
+			it('should create the instance with given arguments.', () => {
+				// Assert
+				expect(inMemoryChannel).toHaveProperty('_networkIdentifier');
+				expect(inMemoryChannel).toHaveProperty('_db');
+				expect(inMemoryChannel).toHaveProperty('namespace');
+				expect(inMemoryChannel).toHaveProperty('eventsList');
+				expect(inMemoryChannel).toHaveProperty('endpointsList');
+			});
+		});
+
+		describe('#invoke', () => {
+			const actionName = 'action1';
+
+			it('should module endpoint have been called with networkIdentifier in its context', async () => {
+				// Arrange
+				const actionFullName = `${inMemoryChannel.namespace}_${actionName}`;
+
+				// Act
+				await inMemoryChannel.invoke(actionFullName);
+
+				// Assert
+				expect(params.endpoints.action1).toHaveBeenCalledWith({
+					networkIdentifier: params.networkIdentifier,
+					getStore: expect.anything(),
+					logger: expect.anything(),
+					params: expect.anything(),
+				});
+			});
 		});
 	});
 });

--- a/framework/test/unit/controller/controller.spec.ts
+++ b/framework/test/unit/controller/controller.spec.ts
@@ -109,6 +109,7 @@ describe('Controller Class', () => {
 		endpoints: {
 			getBlockByID: jest.fn(),
 		} as EndpointHandlers,
+		networkIdentifier: Buffer.alloc(0),
 	};
 
 	let controller: controllerModule.Controller;

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -30,6 +30,7 @@ describe('RewardModuleEndpoint', () => {
 		tokenIDReward: { chainID: 0, localID: 0 },
 	};
 	const generatorConfig: any = {};
+	const networkIdentifier = Buffer.alloc(0);
 
 	const logger: Logger = fakeLogger;
 	let rewardModule: RewardModule;
@@ -61,6 +62,7 @@ describe('RewardModuleEndpoint', () => {
 				params: {
 					height: currentHeight,
 				},
+				networkIdentifier,
 			});
 			expect(rewardFromEndpoint).toEqual({ reward: rewardFromConfig.toString() });
 		});
@@ -73,6 +75,7 @@ describe('RewardModuleEndpoint', () => {
 			params: {
 				height: offset - 1,
 			},
+			networkIdentifier,
 		});
 		expect(rewardFromEndpoint).toEqual({ reward: '0' });
 	});
@@ -85,6 +88,7 @@ describe('RewardModuleEndpoint', () => {
 				params: {
 					height: 'Not a number',
 				},
+				networkIdentifier,
 			}),
 		).toThrow('Parameter height must be a number.');
 	});
@@ -97,6 +101,7 @@ describe('RewardModuleEndpoint', () => {
 				params: {
 					height: -1,
 				},
+				networkIdentifier,
 			}),
 		).toThrow('Parameter height cannot be smaller than 0.');
 	});

--- a/framework/test/unit/modules/validators/endpoint.spec.ts
+++ b/framework/test/unit/modules/validators/endpoint.spec.ts
@@ -26,6 +26,7 @@ describe('ValidatorsModuleEndpoint', () => {
 	const proof = getRandomBytes(48);
 	const getStore1 = jest.fn();
 	const subStore = (new InMemoryKVStore() as unknown) as KVStore;
+	const networkIdentifier = Buffer.alloc(0);
 
 	beforeAll(async () => {
 		validatorsModule = new ValidatorsModule();
@@ -47,6 +48,7 @@ describe('ValidatorsModuleEndpoint', () => {
 							proofOfPossession: proof.toString('hex'),
 							blsKey: pk.toString('hex'),
 						},
+						networkIdentifier,
 					}),
 				).resolves.toStrictEqual({ valid: false });
 			});
@@ -61,6 +63,7 @@ describe('ValidatorsModuleEndpoint', () => {
 							proofOfPossession: proof.toString('hex'),
 							blsKey: pk.toString('hex'),
 						},
+						networkIdentifier,
 					}),
 				).resolves.toStrictEqual({ valid: false });
 			});
@@ -76,6 +79,7 @@ describe('ValidatorsModuleEndpoint', () => {
 							blsKey:
 								'b301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81',
 						},
+						networkIdentifier,
 					}),
 				).resolves.toStrictEqual({ valid: true });
 			});
@@ -90,6 +94,7 @@ describe('ValidatorsModuleEndpoint', () => {
 						params: {
 							invalid: 'schema',
 						},
+						networkIdentifier,
 					}),
 				).rejects.toThrow();
 			});
@@ -103,6 +108,7 @@ describe('ValidatorsModuleEndpoint', () => {
 							proofOfPossession: 'xxxx',
 							blsKey: 'xxxx',
 						},
+						networkIdentifier,
 					}),
 				).rejects.toThrow();
 			});

--- a/framework/test/unit/node/generator/endpoint.spec.ts
+++ b/framework/test/unit/node/generator/endpoint.spec.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { Chain, Transaction } from '@liskhq/lisk-chain';
+import { Transaction } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import { InMemoryKVStore, KVStore } from '@liskhq/lisk-db';
@@ -51,10 +51,10 @@ describe('generator endpoint', () => {
 		address: 'aaaaaaaaaa4a3846c988f3c15306796f8eae5c1c',
 	};
 	const defaultPassword = 'elephant tree paris dragon chair galaxy';
+	const networkIdentifier = Buffer.alloc(0);
 
 	let endpoint: Endpoint;
 	let broadcaster: Broadcaster;
-	let chain: Chain;
 	let consensus: Consensus;
 	let pool: TransactionPool;
 	let stateMachine: StateMachine;
@@ -62,14 +62,6 @@ describe('generator endpoint', () => {
 	beforeEach(() => {
 		broadcaster = {
 			enqueueTransactionId: jest.fn(),
-		} as never;
-		chain = {
-			dataAccess: {
-				decodeTransaction: jest.fn().mockReturnValue(tx),
-			},
-			constants: {
-				networkIdentifier: Buffer.from('networkIdentifier'),
-			},
 		} as never;
 		consensus = {
 			isSynced: jest.fn().mockResolvedValue(true),
@@ -85,7 +77,6 @@ describe('generator endpoint', () => {
 		} as never;
 		endpoint = new Endpoint({
 			broadcaster,
-			chain,
 			consensus,
 			pool,
 			stateMachine,
@@ -109,6 +100,7 @@ describe('generator endpoint', () => {
 						params: {
 							invalid: 'schema',
 						},
+						networkIdentifier,
 					}),
 				).rejects.toThrow(LiskValidationError);
 			});
@@ -121,6 +113,7 @@ describe('generator endpoint', () => {
 						params: {
 							transaction: 'xxxx',
 						},
+						networkIdentifier,
 					}),
 				).rejects.toThrow();
 			});
@@ -138,6 +131,7 @@ describe('generator endpoint', () => {
 						params: {
 							transaction: tx.getBytes().toString('hex'),
 						},
+						networkIdentifier,
 					}),
 				).rejects.toThrow(InvalidTransactionError);
 			});
@@ -153,6 +147,7 @@ describe('generator endpoint', () => {
 						params: {
 							transaction: tx.getBytes().toString('hex'),
 						},
+						networkIdentifier,
 					}),
 				).resolves.toEqual({
 					transactionId: tx.id.toString('hex'),
@@ -172,6 +167,7 @@ describe('generator endpoint', () => {
 						params: {
 							transaction: tx.getBytes().toString('hex'),
 						},
+						networkIdentifier,
 					}),
 				).rejects.toThrow(InvalidTransactionError);
 			});
@@ -186,6 +182,7 @@ describe('generator endpoint', () => {
 						params: {
 							transaction: tx.getBytes().toString('hex'),
 						},
+						networkIdentifier,
 					}),
 				).resolves.toEqual({
 					transactionId: tx.id.toString('hex'),
@@ -213,6 +210,7 @@ describe('generator endpoint', () => {
 						overwrite: true,
 						...bftProps,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow(LiskValidationError);
 		});
@@ -229,6 +227,7 @@ describe('generator endpoint', () => {
 						overwrite: true,
 						...bftProps,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow('Generator with address:');
 		});
@@ -245,6 +244,7 @@ describe('generator endpoint', () => {
 						overwrite: true,
 						...bftProps,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow('Invalid password and public key combination');
 		});
@@ -261,6 +261,7 @@ describe('generator endpoint', () => {
 						overwrite: true,
 						...bftProps,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow('Invalid keypair');
 		});
@@ -278,6 +279,7 @@ describe('generator endpoint', () => {
 						overwrite: true,
 						...bftProps,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow('Failed to enable forging as the node is not synced to the network.');
 		});
@@ -298,6 +300,7 @@ describe('generator endpoint', () => {
 						overwrite: true,
 						...bftProps,
 					},
+					networkIdentifier,
 				}),
 			).resolves.toEqual({
 				address: config.address,
@@ -318,6 +321,7 @@ describe('generator endpoint', () => {
 						overwrite: true,
 						...bftProps,
 					},
+					networkIdentifier,
 				}),
 			).resolves.toEqual({
 				address: config.address,
@@ -346,6 +350,7 @@ describe('generator endpoint', () => {
 						maxHeightPrevoted: 0,
 						maxHeightGenerated: 0,
 					},
+					networkIdentifier,
 				}),
 			).resolves.toEqual({
 				address: config.address,
@@ -373,6 +378,7 @@ describe('generator endpoint', () => {
 						maxHeightPrevoted: 40,
 						maxHeightGenerated: 3,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow('Last generated information does not exist.');
 		});
@@ -408,6 +414,7 @@ describe('generator endpoint', () => {
 						maxHeightPrevoted: 0,
 						maxHeightGenerated: 0,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow('Request does not match last generated information.');
 		});
@@ -443,6 +450,7 @@ describe('generator endpoint', () => {
 						maxHeightPrevoted: 40,
 						maxHeightGenerated: 3,
 					},
+					networkIdentifier,
 				}),
 			).rejects.toThrow('Request does not match last generated information.');
 		});
@@ -475,6 +483,7 @@ describe('generator endpoint', () => {
 						maxHeightPrevoted: 40,
 						maxHeightGenerated: 3,
 					},
+					networkIdentifier,
 				}),
 			).resolves.toEqual({
 				address: config.address,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6792 

### How was it solved?

- Passed `Node`'s `networkIdentifier` to `controller.init()`
- That `networkIdentifier` set in `controller.init()` is used to append `networkIdentifier` to module endpoints
- `networkIdentifier` is passed to module enpoint context via `InMemoryChannel.invoke()`
- Made `networkIdentifier` optional in `InMemoryChannel` because we don't provide `networkIdentifier` in plugin context so `loadInMemoryPlugin()` function doesn't need it.

### How was it tested?

- Added and modified unit tests, then `yarn test`
