### PR TITLE
Update lisk.io to lisk.com - Closes #6554

### DIFF
--- a/commander/README.md
+++ b/commander/README.md
@@ -58,13 +58,13 @@ $ npm test
 
 ## Get Involved
 
-| Reason                          | How                                                                                            |
-| ------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                               |
-| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk/issues/new)                                  |
-| Found a security issue          | [See our bounty program](https://blog.lisk.io/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
-| Want to share your research     | [Propose your research](https://research.lisk.io)                                              |
-| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk/fork)                                           |
+| Reason                          | How                                                                                             |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                                |
+| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk/issues/new)                                   |
+| Found a security issue          | [See our bounty program](https://blog.lisk.com/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
+| Want to share your research     | [Propose your research](https://research.lisk.com)                                              |
+| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk/fork)                                            |
 
 ## License
 

--- a/commander/package.json
+++ b/commander/package.json
@@ -2,7 +2,7 @@
 	"name": "lisk-commander",
 	"version": "5.1.5",
 	"description": "A command line interface for Lisk",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/commander/src/constants.ts
+++ b/commander/src/constants.ts
@@ -23,4 +23,4 @@ export enum NETWORK {
 	DEVNET = 'devnet',
 }
 export const DEFAULT_NETWORK = NETWORK.DEFAULT;
-export const RELEASE_URL = 'https://downloads.lisk.io/lisk';
+export const RELEASE_URL = 'https://downloads.lisk.com/lisk';

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [info@lisk.io](mailto:info@lisk.io). All
+reported by contacting the project team at [info@lisk.com](mailto:info@lisk.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,34 +11,34 @@ The following is a set of guidelines for contributing to Lisk SDK, which are hos
 1. [Help! I don't want to read this whole thing, I just have one question. :mag_right:](#help!-i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
 
 1. [How Can I Contribute?](#how-can-i-contribute)
-	1. [Reporting Bugs](#reporting-bugs)
-	1. [Suggesting Enhancements](#suggesting-enhancements)
-	1. [Pull Requests](#pull-requests)
+
+   1. [Reporting Bugs](#reporting-bugs)
+   1. [Suggesting Enhancements](#suggesting-enhancements)
+   1. [Pull Requests](#pull-requests)
 
 1. [Styleguides](#styleguides)
-	1. [Git Commit Messages](#git-commit-messages)
-	1. [JavaScript Styleguide](#javascript-styleguide)
+   1. [Git Commit Messages](#git-commit-messages)
+   1. [JavaScript Styleguide](#javascript-styleguide)
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Lisk SDK Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [info@lisk.io](mailto:info@lisk.io).
+This project and everyone participating in it is governed by the [Lisk SDK Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [info@lisk.com](mailto:info@lisk.com).
 
 ## Project License
 
 Every repository within LiskHQ comes with a LICENSE file. Please read it carefully before commiting your code to one of the repositories.
 
-
 ## Help! I don't want to read this whole thing, I just have a question. :mag_right:
 
 Lisk is an open-source decentralized project, there are many ways and platforms to get help. These are some of them:
 
-* [Discuss and Ask on Reddit](https://www.reddit.com/r/Lisk/)
-* [Lisk FAQ](https://docs.lisk.io/docs/faq)
+- [Discuss and Ask on Reddit](https://www.reddit.com/r/Lisk/)
+- [Lisk FAQ](https://docs.lisk.com/docs/faq)
 
 If you prefer to chat with LiskHQ and other developers directly:
 
-* [Join the LiskHQ Discord](https://discordapp.com/invite/7EKWJ7b)
-* Even though Discord is a chat service, sometimes it takes several hours for community members to respond &mdash; please be patient!
+- [Join the LiskHQ Discord](https://discordapp.com/invite/7EKWJ7b)
+- Even though Discord is a chat service, sometimes it takes several hours for community members to respond &mdash; please be patient!
 
 ## How Can I Contribute?
 
@@ -54,7 +54,7 @@ Broadly speaking, we conform to the git flow branching model. For a description 
 
 In case you've never submitted a pull request (PR) via GitHub before, please read [this short tutorial](https://help.github.com/articles/creating-a-pull-request). If you've submitted a PR before, there should be nothing surprising about our procedures for Lisk.
 
-*Before* submitting a pull request, please make sure the following is done:
+_Before_ submitting a pull request, please make sure the following is done:
 
 1. Fork the repo.
 1. If you are creating a pull request that addresses a specific issue, take a look at the projects that issue is a part of (in the right-hand sidebar). Most issues will be a part of a project for a specific version, such as "Version 1.0.0". If this is the case, create your branch from the relevant version branch, e.g. `1.0.0`, and submit your pull request against that branch as a base. Otherwise, create your branch from master.
@@ -73,9 +73,9 @@ Before creating bug reports, please check [this list](#before-submitting-a-bug-r
 
 #### Before Submitting A Bug Report
 
-* **Check the [FAQs](https://docs.lisk.io/docs/faq)** for a list of common questions and problems.
-* **Determine [which repository the problem should be reported in](https://github.com/LiskHQ)**.
-* **Perform a [cursory search](https://github.com/search?utf8=%E2%9C%93&q=+is%3Aissue+org%3ALiskHQ&type=)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+- **Check the [FAQs](https://docs.lisk.com/docs/faq)** for a list of common questions and problems.
+- **Determine [which repository the problem should be reported in](https://github.com/LiskHQ)**.
+- **Perform a [cursory search](https://github.com/search?utf8=%E2%9C%93&q=+is%3Aissue+org%3ALiskHQ&type=)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 
 #### How Do I Submit A (Good) Bug Report?
 
@@ -83,63 +83,63 @@ Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
-* **Use a clear and descriptive title** for the issue to identify the problem.
-* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started Lisk SDK, e.g. with Node.js or in the Browser (which one? which version?), or how you started Lisk SDK otherwise. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you have used an API model provide the configuration you have chosen and the functions you have executed. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
-* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
-* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
-* **Explain which behavior you expected to see instead and why.**
-* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/cgoodrich/byzanz) on Linux.
-* **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
+- **Use a clear and descriptive title** for the issue to identify the problem.
+- **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started Lisk SDK, e.g. with Node.js or in the Browser (which one? which version?), or how you started Lisk SDK otherwise. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you have used an API model provide the configuration you have chosen and the functions you have executed. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
+- **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+- **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+- **Explain which behavior you expected to see instead and why.**
+- **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/cgoodrich/byzanz) on Linux.
+- **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
 
-* **Did the problem start happening recently** (e.g. after updating to a new version of Lisk SDK, Lisk or any other repository) or was this always a problem?
-* If the problem started happening recently, **can you reproduce the problem in an older version of Lisk SDK?** What's the most recent version in which the problem doesn't happen? You can download older versions of Lisk SDK from [the releases page](https://github.com/LiskHQ/lisk-elements/releases).
-* **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
+- **Did the problem start happening recently** (e.g. after updating to a new version of Lisk SDK, Lisk or any other repository) or was this always a problem?
+- If the problem started happening recently, **can you reproduce the problem in an older version of Lisk SDK?** What's the most recent version in which the problem doesn't happen? You can download older versions of Lisk SDK from [the releases page](https://github.com/LiskHQ/lisk-elements/releases).
+- **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 ### Suggesting Enhancements
 
 This section guides you through submitting an enhancement suggestion for Lisk SDK, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
- When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](../.github/ISSUE_TEMPLATE/feature-request.md), including the steps that you imagine you would take if the feature you're requesting existed.
+When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](../.github/ISSUE_TEMPLATE/feature-request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
 #### How Do I Submit A (Good) Enhancement Suggestion?
 
 Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined [which repository](https://github.com/LiskHQ) your enhancement suggestion is related to, create an issue on that repository and provide the following information:
 
-* **Use a clear and descriptive title** for the issue to identify the suggestion.
-* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
-* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
-* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
-* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk SDK which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/cgoodrich/byzanz) on Linux.
-* **Explain why this enhancement would be useful** to most Lisk and Lisk SDK users.
-* **Specify which version of Lisk and Lisk SDK you're using.**
-* **Specify the name and version of the OS you're using.**
+- **Use a clear and descriptive title** for the issue to identify the suggestion.
+- **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+- **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+- **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk SDK which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/cgoodrich/byzanz) on Linux.
+- **Explain why this enhancement would be useful** to most Lisk and Lisk SDK users.
+- **Specify which version of Lisk and Lisk SDK you're using.**
+- **Specify the name and version of the OS you're using.**
 
 ## Styleguides
 
 ### Git Commit Messages
 
-* Use the present tense ("Add feature" not "Added feature")
-* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
-* Limit the first line to 72 characters or less
-* Reference issues and pull requests liberally after the first line
-* Consider starting the commit message with an applicable emoji:
-	* :seedling: `:seedling:` when adding a new feature
-	* :bug: `:bug:` when fixing a bug
-	* :books: `:books:` when adding or updating documentation
-	* :nail_care: `:nail_care:` when making changes to code style (e.g. lint settings)
-	* :recycle: `:recycle:` when refactoring code
-	* :fire: `:fire:` when removing code or files (including dependencies)
-	* :racehorse: `:racehorse:` when improving performance
-	* :white_check_mark: `:white_check_mark:` when adding or updating tests
-	* :construction_worker: `:construction_worker:` when updating the build process
-	* :bowtie: `:bowtie:` when updating CI
-	* :house: `:house:` when performing chores
-	* :new: `:new:` when adding a new dependency
-	* :arrow_up: `:arrow_up:` when upgrading a dependency
-	* :arrow_down: `:arrow_down:` when downgrading a dependency
-	* :back: `:back:` when reverting changes
+- Use the present tense ("Add feature" not "Added feature")
+- Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+- Limit the first line to 72 characters or less
+- Reference issues and pull requests liberally after the first line
+- Consider starting the commit message with an applicable emoji:
+  - :seedling: `:seedling:` when adding a new feature
+  - :bug: `:bug:` when fixing a bug
+  - :books: `:books:` when adding or updating documentation
+  - :nail_care: `:nail_care:` when making changes to code style (e.g. lint settings)
+  - :recycle: `:recycle:` when refactoring code
+  - :fire: `:fire:` when removing code or files (including dependencies)
+  - :racehorse: `:racehorse:` when improving performance
+  - :white_check_mark: `:white_check_mark:` when adding or updating tests
+  - :construction_worker: `:construction_worker:` when updating the build process
+  - :bowtie: `:bowtie:` when updating CI
+  - :house: `:house:` when performing chores
+  - :new: `:new:` when adding a new dependency
+  - :arrow_up: `:arrow_up:` when upgrading a dependency
+  - :arrow_down: `:arrow_down:` when downgrading a dependency
+  - :back: `:back:` when reverting changes
 
 ### JavaScript Styleguide
 

--- a/elements/README.md
+++ b/elements/README.md
@@ -47,13 +47,13 @@ $ npm install --save @liskhq/lisk-cryptography
 
 ## Get Involved
 
-| Reason                          | How                                                                                            |
-| ------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                               |
-| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk-sdk/issues/new)                              |
-| Found a security issue          | [See our bounty program](https://blog.lisk.io/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
-| Want to share your research     | [Propose your research](https://research.lisk.io)                                              |
-| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk-sdk/fork)                                       |
+| Reason                          | How                                                                                             |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                                |
+| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk-sdk/issues/new)                               |
+| Found a security issue          | [See our bounty program](https://blog.lisk.com/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
+| Want to share your research     | [Propose your research](https://research.lisk.com)                                              |
+| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk-sdk/fork)                                        |
 
 ## License
 

--- a/elements/lisk-api-client/package.json
+++ b/elements/lisk-api-client/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-api-client",
 	"version": "5.1.3",
 	"description": "An API client for the Lisk network",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-bft/package.json
+++ b/elements/lisk-bft/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-bft",
 	"version": "0.3.2",
 	"description": "Byzantine fault tolerance implementation according to the Lisk protocol",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-chain/package.json
+++ b/elements/lisk-chain/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-chain",
 	"version": "0.3.2",
 	"description": "Blocks and state management implementation that are used for block processing according to the Lisk protocol",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-client/README.md
+++ b/elements/lisk-client/README.md
@@ -37,13 +37,13 @@ const { transactions } = require('@liskhq/lisk-client');
 Include the following script using the following HTML. The `lisk` variable will be exposed.
 
 ```html
-<script src="https://js.lisk.io/lisk-client-5.0.0.js"></script>
+<script src="https://js.lisk.com/lisk-client-5.0.0.js"></script>
 ```
 
 Or minified:
 
 ```html
-<script src="https://js.lisk.io/lisk-client-5.0.0.min.js"></script>
+<script src="https://js.lisk.com/lisk-client-5.0.0.min.js"></script>
 ```
 
 ## Packages

--- a/elements/lisk-client/package.json
+++ b/elements/lisk-client/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-client",
 	"version": "5.1.3",
 	"description": "A default set of Elements for use by clients of the Lisk network",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-codec/package.json
+++ b/elements/lisk-codec/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-codec",
 	"version": "0.2.0",
 	"description": "Implementation of decoder and encoder using Lisk JSON schema according to the Lisk protocol",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-cryptography/package.json
+++ b/elements/lisk-cryptography/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-cryptography",
 	"version": "3.1.0",
 	"description": "General cryptographic functions for use with Lisk-related software",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-db/package.json
+++ b/elements/lisk-db/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-db",
 	"version": "0.2.0",
 	"description": "A database access implementation for use with Lisk-related software",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-elements/package.json
+++ b/elements/lisk-elements/package.json
@@ -2,7 +2,7 @@
 	"name": "lisk-elements",
 	"version": "5.1.4",
 	"description": "Elements for building blockchain applications in the Lisk network",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-genesis/package.json
+++ b/elements/lisk-genesis/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-genesis",
 	"version": "0.2.2",
 	"description": "Library containing genesis block creation functions according to the Lisk protocol",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-p2p/package.json
+++ b/elements/lisk-p2p/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-p2p",
 	"version": "0.7.1",
 	"description": "Unstructured P2P library for use with Lisk-related software",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-passphrase/package.json
+++ b/elements/lisk-passphrase/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-passphrase",
 	"version": "3.1.0",
 	"description": "Mnemonic passphrase helpers for use with Lisk-related software",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-transaction-pool/package.json
+++ b/elements/lisk-transaction-pool/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-transaction-pool",
 	"version": "0.5.0",
 	"description": "Transaction pool library for use with Lisk-related software",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-transactions/package.json
+++ b/elements/lisk-transactions/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-transactions",
 	"version": "5.1.1",
 	"description": "Utility functions related to transactions according to the Lisk protocol",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-tree/package.json
+++ b/elements/lisk-tree/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-tree",
 	"version": "0.2.0",
 	"description": "Library containing Merkle tree implementations for use with Lisk-related software",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-utils/package.json
+++ b/elements/lisk-utils/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-utils",
 	"version": "0.2.0",
 	"description": "Library containing generic utility functions for use with Lisk-related software",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-validator/package.json
+++ b/elements/lisk-validator/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-validator",
 	"version": "0.6.0",
 	"description": "Validation library according to the Lisk protocol",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/elements/lisk-validator/src/lisk_meta_schema.ts
+++ b/elements/lisk-validator/src/lisk_meta_schema.ts
@@ -14,13 +14,13 @@
 
 export const liskMetaSchema = {
 	$schema: 'http://json-schema.org/draft-07/schema#',
-	$id: 'http://lisk.io/lisk-schema/schema#',
+	$id: 'http://lisk.com/lisk-schema/schema#',
 	title: 'Lisk Schema',
 	type: 'object',
 	properties: {
 		$schema: {
 			type: 'string',
-			const: 'http://lisk.io/lisk-schema/schema#',
+			const: 'http://lisk.com/lisk-schema/schema#',
 			format: 'uri',
 		},
 		$id: {

--- a/elements/lisk-validator/test/lisk_validator.spec.ts
+++ b/elements/lisk-validator/test/lisk_validator.spec.ts
@@ -21,7 +21,7 @@ describe('validator', () => {
 	describe('validateSchema', () => {
 		const validSchema = {
 			$id: '/my-schema',
-			$schema: 'http://lisk.io/lisk-schema/schema#',
+			$schema: 'http://lisk.com/lisk-schema/schema#',
 			type: 'object',
 			properties: {
 				myProp: {
@@ -41,7 +41,7 @@ describe('validator', () => {
 			// Arrange
 			const invalidSchema = {
 				$id: '/my-invalid-schema',
-				$schema: 'http://lisk.io/lisk-schema/schema#',
+				$schema: 'http://lisk.com/lisk-schema/schema#',
 				type: 'string',
 				properties: {},
 			};

--- a/elements/lisk-validator/test/lisk_validator_errors.spec.ts
+++ b/elements/lisk-validator/test/lisk_validator_errors.spec.ts
@@ -21,7 +21,7 @@ describe('LiskValidationError formatter', () => {
 	// Arrange
 	const validSchema = {
 		$id: '/my-schema',
-		$schema: 'http://lisk.io/lisk-schema/schema#',
+		$schema: 'http://lisk.com/lisk-schema/schema#',
 		type: 'object',
 		properties: {
 			myProp: {
@@ -105,7 +105,7 @@ describe('LiskValidationError formatter', () => {
 	it('should format additional property errors', () => {
 		const schema = {
 			$id: '/my-schema',
-			$schema: 'http://lisk.io/lisk-schema/schema#',
+			$schema: 'http://lisk.com/lisk-schema/schema#',
 			type: 'object',
 			properties: {
 				myProp: {

--- a/elements/lisk-validator/test/lisk_validator_keywords.spec.ts
+++ b/elements/lisk-validator/test/lisk_validator_keywords.spec.ts
@@ -25,7 +25,7 @@ describe('validator keywords', () => {
 	// Arrange
 	const validSchema = {
 		$id: '/my-schema',
-		$schema: 'http://lisk.io/lisk-schema/schema#',
+		$schema: 'http://lisk.com/lisk-schema/schema#',
 		type: 'object',
 		properties: {
 			myProp: {

--- a/framework-plugins/lisk-framework-dashboard-plugin/package.json
+++ b/framework-plugins/lisk-framework-dashboard-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-framework-dashboard-plugin",
 	"version": "0.1.4",
 	"description": "A plugin for interacting with a newly developed blockchain application.",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/framework-plugins/lisk-framework-faucet-plugin/package.json
+++ b/framework-plugins/lisk-framework-faucet-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-framework-faucet-plugin",
 	"version": "0.1.4",
 	"description": "A plugin for distributing testnet tokens from a newly developed blockchain application.",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/framework-plugins/lisk-framework-forger-plugin/package.json
+++ b/framework-plugins/lisk-framework-forger-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-framework-forger-plugin",
 	"version": "0.2.4",
 	"description": "A plugin for lisk-framework that monitors configured delegates forging activity and voters information.",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/framework-plugins/lisk-framework-http-api-plugin/package.json
+++ b/framework-plugins/lisk-framework-http-api-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-framework-http-api-plugin",
 	"version": "0.2.4",
 	"description": "A plugin for lisk-framework that provides basic HTTP API endpoints to get running node information.",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
+++ b/framework-plugins/lisk-framework-http-api-plugin/swagger.yml
@@ -41,7 +41,7 @@ info:
     Click on an endpoint to show the descriptions, details and examples.
   version: '1.0.32'
   contact:
-    email: admin@lisk.io
+    email: admin@lisk.com
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0

--- a/framework-plugins/lisk-framework-monitor-plugin/package.json
+++ b/framework-plugins/lisk-framework-monitor-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-framework-monitor-plugin",
 	"version": "0.2.4",
 	"description": "A plugin for lisk-framework that provides network statistics of the running node",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/package.json
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/package.json
@@ -2,7 +2,7 @@
 	"name": "@liskhq/lisk-framework-report-misbehavior-plugin",
 	"version": "0.2.4",
 	"description": "A plugin for lisk-framework that provides automatic detection of delegate misbehavior and sends a reportDelegateMisbehaviorTransaction to the running node",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/framework/README.md
+++ b/framework/README.md
@@ -49,13 +49,13 @@ If you want to test the changes in `lisk-sdk/elements` to reflect in `lisk-sdk/f
 
 ## Get Involved
 
-| Reason                          | How                                                                                            |
-| ------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                               |
-| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk/issues/new)                                  |
-| Found a security issue          | [See our bounty program](https://blog.lisk.io/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
-| Want to share your research     | [Propose your research](https://research.lisk.io)                                              |
-| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk/fork)                                           |
+| Reason                          | How                                                                                             |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                                |
+| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk/issues/new)                                   |
+| Found a security issue          | [See our bounty program](https://blog.lisk.com/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
+| Want to share your research     | [Propose your research](https://research.lisk.com)                                              |
+| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk/fork)                                            |
 
 ## License
 

--- a/framework/package.json
+++ b/framework/package.json
@@ -2,7 +2,7 @@
 	"name": "lisk-framework",
 	"version": "0.8.4",
 	"description": "Lisk blockchain application platform",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"cryptocurrency",

--- a/framework/test/unit/node/network/peers.json
+++ b/framework/test/unit/node/network/peers.json
@@ -2,7 +2,7 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "testnet-seed-01.lisk.io",
+				"ip": "testnet-seed-01.lisk.com",
 				"port": 7001
 			},
 			{
@@ -10,7 +10,7 @@
 				"port": 7001
 			},
 			{
-				"ip": "testnet-seed-03.lisk.io",
+				"ip": "testnet-seed-03.lisk.com",
 				"port": 7001
 			},
 			{
@@ -18,7 +18,7 @@
 				"port": 7001
 			},
 			{
-				"ip": "testnet-seed-05.lisk.io",
+				"ip": "testnet-seed-05.lisk.com",
 				"port": 7001
 			}
 		]

--- a/framework/test/unit/node/network/peers.json
+++ b/framework/test/unit/node/network/peers.json
@@ -2,7 +2,7 @@
 	"peers": {
 		"list": [
 			{
-				"ip": "testnet-seed-01.lisk.com",
+				"ip": "testnet-seed-01.lisk.io",
 				"port": 7001
 			},
 			{
@@ -10,7 +10,7 @@
 				"port": 7001
 			},
 			{
-				"ip": "testnet-seed-03.lisk.com",
+				"ip": "testnet-seed-03.lisk.io",
 				"port": 7001
 			},
 			{
@@ -18,7 +18,7 @@
 				"port": 7001
 			},
 			{
-				"ip": "testnet-seed-05.lisk.com",
+				"ip": "testnet-seed-05.lisk.io",
 				"port": 7001
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"version": "0.1.0",
 	"description": "Reusable packages for use with the Lisk ecosystem",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/protocol-specs/package.json
+++ b/protocol-specs/package.json
@@ -11,7 +11,7 @@
 		"generate-all-specs": "node scripts/generate.js",
 		"validate-all-specs": "node scripts/validate.js"
 	},
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"engines": {
 		"node": ">=12.13.0 <=12",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -142,13 +142,13 @@ The Lisk SDK operates on the NodeJS runtime and consists primarily of an applica
 
 ## Get Involved
 
-| Reason                          | How                                                                                            |
-| ------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                               |
-| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk/issues/new)                                  |
-| Found a security issue          | [See our bounty program](https://blog.lisk.io/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
-| Want to share your research     | [Propose your research](https://research.lisk.io)                                              |
-| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk/fork)                                           |
+| Reason                          | How                                                                                             |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Want to chat with our community | [Reach them on Discord](https://discord.gg/lisk)                                                |
+| Found a bug                     | [Open a new issue](https://github.com/LiskHQ/lisk/issues/new)                                   |
+| Found a security issue          | [See our bounty program](https://blog.lisk.com/announcing-lisk-bug-bounty-program-5895bdd46ed4) |
+| Want to share your research     | [Propose your research](https://research.lisk.com)                                              |
+| Want to develop with us         | [Create a fork](https://github.com/LiskHQ/lisk/fork)                                            |
 
 ## How to Contribute
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -2,7 +2,7 @@
 	"name": "lisk-sdk",
 	"version": "5.1.4",
 	"description": "Official SDK for the Lisk blockchain application platform",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",

--- a/templates/package.json.tmpl
+++ b/templates/package.json.tmpl
@@ -2,7 +2,7 @@
 	"name": "@liskhq/{PACKAGE}",
 	"version": "0.1.0",
 	"description": "Library according to the Lisk protocol",
-	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
+	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"keywords": [
 		"lisk",


### PR DESCRIPTION
### What was the problem?

This PR resolves #6802

### How was it solved?

💅 Update lisk.io -> lisk.com ea736a9

### How was it tested?

search for `lisk.io` on this branch and ignore https://jenkins.lisk.io/ domain