### PR TITLE
UnlockHeight is not considered on unlockToken transaction during punishment - Closes #6793

### DIFF
--- a/framework/src/modules/dpos/dpos_module.ts
+++ b/framework/src/modules/dpos/dpos_module.ts
@@ -16,7 +16,7 @@ import { Account } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { objects as objectsUtils } from '@liskhq/lisk-utils';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
-import { getMinWaitingHeight, getMinPunishedHeight } from './utils';
+import { getMinWaitingHeight, getUnlockDelayForPunishment } from './utils';
 import { AfterBlockApplyContext, AfterGenesisBlockApplyContext, GenesisConfig } from '../../types';
 import { BaseModule } from '../base_module';
 import { CHAIN_STATE_DELEGATE_USERNAMES } from './constants';
@@ -113,7 +113,7 @@ export class DPoSModule extends BaseModule {
 						delegate.address,
 						unlocking,
 					);
-					const minPunishedHeight = getMinPunishedHeight(account, delegate);
+					const minPunishedHeight = getUnlockDelayForPunishment(account, delegate);
 
 					result.push({
 						delegateAddress: unlocking.delegateAddress.toString('hex'),

--- a/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
@@ -20,7 +20,7 @@ import { BaseAsset } from '../../base_asset';
 import { ApplyAssetContext, ValidateAssetContext } from '../../../types';
 import { MAX_PUNISHABLE_BLOCK_HEIGHT_DIFFERENCE, MAX_POM_HEIGHTS } from '../constants';
 import { DPOSAccountProps, PomTransactionAssetContext } from '../types';
-import { getUnlockDelayPeriod, validateSignature } from '../utils';
+import { getPunishmentPeriod, validateSignature } from '../utils';
 
 const signingBlockHeaderSchema = {
 	$id: 'lisk/dpos/signingBlockHeader',
@@ -155,7 +155,7 @@ export class PomTransactionAsset extends BaseAsset<PomTransactionAssetContext> {
 		}
 
 		if (
-			getUnlockDelayPeriod(
+			getPunishmentPeriod(
 				delegateAccount,
 				delegateAccount,
 				store.chain.lastBlockHeaders[0].height,

--- a/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/pom_transaction_asset.ts
@@ -20,7 +20,7 @@ import { BaseAsset } from '../../base_asset';
 import { ApplyAssetContext, ValidateAssetContext } from '../../../types';
 import { MAX_PUNISHABLE_BLOCK_HEIGHT_DIFFERENCE, MAX_POM_HEIGHTS } from '../constants';
 import { DPOSAccountProps, PomTransactionAssetContext } from '../types';
-import { getPunishmentPeriod, validateSignature } from '../utils';
+import { getUnlockDelayPeriod, validateSignature } from '../utils';
 
 const signingBlockHeaderSchema = {
 	$id: 'lisk/dpos/signingBlockHeader',
@@ -155,7 +155,7 @@ export class PomTransactionAsset extends BaseAsset<PomTransactionAssetContext> {
 		}
 
 		if (
-			getPunishmentPeriod(
+			getUnlockDelayPeriod(
 				delegateAccount,
 				delegateAccount,
 				store.chain.lastBlockHeaders[0].height,

--- a/framework/src/modules/dpos/transaction_assets/unlock_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/unlock_transaction_asset.ts
@@ -125,23 +125,17 @@ export class UnlockTransactionAsset extends BaseAsset<UnlockTransactionAssetCont
 					? undefined
 					: Math.max(...delegate.dpos.delegate.pomHeights);
 
-			if (currentHeight >= this._unlockFixHeight) {
-				if (
-					minUnlockDelay > currentHeight &&
-					lastPomHeight !== undefined &&
-					lastPomHeight < minWaitingHeight
-				) {
-					throw new Error(
-						'Unlocking is not permitted as the delegate is currently being punished.',
-					);
-				}
-				// unlocking condition before hard fork, to be deprecated
-			} else if (currentHeight < this._unlockFixHeight) {
-				if (minUnlockDelay > currentHeight) {
-					throw new Error(
-						'Unlocking is not permitted as the delegate is currently being punished.',
-					);
-				}
+			if (
+				currentHeight >= this._unlockFixHeight &&
+				minUnlockDelay > currentHeight &&
+				lastPomHeight !== undefined &&
+				lastPomHeight < minWaitingHeight
+			) {
+				throw new Error('Unlocking is not permitted as the delegate is currently being punished.');
+			}
+			// unlocking condition before hard fork, to be deprecated
+			if (currentHeight < this._unlockFixHeight && minUnlockDelay > currentHeight) {
+				throw new Error('Unlocking is not permitted as the delegate is currently being punished.');
 			}
 
 			sender.dpos.unlocking.splice(unlockIndex, 1);

--- a/framework/src/modules/dpos/transaction_assets/unlock_transaction_asset.ts
+++ b/framework/src/modules/dpos/transaction_assets/unlock_transaction_asset.ts
@@ -113,9 +113,16 @@ export class UnlockTransactionAsset extends BaseAsset<UnlockTransactionAssetCont
 			}
 
 			const minUnlockDelay = getUnlockDelayForPunishment(sender, delegate);
-			const lastPomHeight = delegate.dpos.delegate.pomHeights.length === 0 ? 0: Math.max(...delegate.dpos.delegate.pomHeights);
+			const lastPomHeight =
+				delegate.dpos.delegate.pomHeights.length === 0
+					? 0
+					: Math.max(...delegate.dpos.delegate.pomHeights);
 
-			if (minUnlockDelay > currentHeight && lastPomHeight != 0 && lastPomHeight < minWaitingHeight) {
+			if (
+				minUnlockDelay > currentHeight &&
+				lastPomHeight !== 0 &&
+				lastPomHeight < minWaitingHeight
+			) {
 				throw new Error('Unlocking is not permitted as the delegate is currently being punished.');
 			}
 

--- a/framework/src/modules/dpos/utils.ts
+++ b/framework/src/modules/dpos/utils.ts
@@ -43,7 +43,7 @@ export const sortUnlocking = (unlocks: UnlockingAccountAsset[]): void => {
 	});
 };
 
-export const getMinPunishedHeight = (
+export const getUnlockDelayForPunishment = (
 	sender: Account<DPOSAccountProps>,
 	delegate: Account<DPOSAccountProps>,
 ): number => {
@@ -59,14 +59,14 @@ export const getMinPunishedHeight = (
 		: lastPomHeight + VOTER_PUNISH_TIME;
 };
 
-export const getPunishmentPeriod = (
+export const getUnlockDelayPeriod = (
 	sender: Account<DPOSAccountProps>,
 	delegateAccount: Account<DPOSAccountProps>,
 	lastBlockHeight: number,
 ): number => {
 	const currentHeight = lastBlockHeight + 1;
-	const minPunishedHeight = getMinPunishedHeight(sender, delegateAccount);
-	const remainingBlocks = minPunishedHeight - currentHeight;
+	const minUnlockDelay = getUnlockDelayForPunishment(sender, delegateAccount);
+	const remainingBlocks = minUnlockDelay - currentHeight;
 
 	return remainingBlocks < 0 ? 0 : remainingBlocks;
 };
@@ -79,18 +79,6 @@ export const getMinWaitingHeight = (
 	unlockObject.unvoteHeight +
 	(senderAddress.equals(delegateAddress) ? WAIT_TIME_SELF_VOTE : WAIT_TIME_VOTE);
 
-export const getWaitingPeriod = (
-	senderAddress: Buffer,
-	delegateAddress: Buffer,
-	lastBlockHeight: number,
-	unlockObject: UnlockingAccountAsset,
-): number => {
-	const currentHeight = lastBlockHeight + 1;
-	const minWaitingHeight = getMinWaitingHeight(senderAddress, delegateAddress, unlockObject);
-	const remainingBlocks = minWaitingHeight - currentHeight;
-
-	return remainingBlocks < 0 ? 0 : remainingBlocks;
-};
 
 export const isNullCharacterIncluded = (input: string): boolean =>
 	new RegExp(/\\0|\\u0000|\\x00/).test(input);

--- a/framework/src/modules/dpos/utils.ts
+++ b/framework/src/modules/dpos/utils.ts
@@ -79,7 +79,6 @@ export const getMinWaitingHeight = (
 	unlockObject.unvoteHeight +
 	(senderAddress.equals(delegateAddress) ? WAIT_TIME_SELF_VOTE : WAIT_TIME_VOTE);
 
-
 export const isNullCharacterIncluded = (input: string): boolean =>
 	new RegExp(/\\0|\\u0000|\\x00/).test(input);
 

--- a/framework/src/modules/dpos/utils.ts
+++ b/framework/src/modules/dpos/utils.ts
@@ -43,7 +43,7 @@ export const sortUnlocking = (unlocks: UnlockingAccountAsset[]): void => {
 	});
 };
 
-export const getUnlockDelayForPunishment = (
+export const getMinPunishedHeight = (
 	sender: Account<DPOSAccountProps>,
 	delegate: Account<DPOSAccountProps>,
 ): number => {
@@ -59,14 +59,14 @@ export const getUnlockDelayForPunishment = (
 		: lastPomHeight + VOTER_PUNISH_TIME;
 };
 
-export const getUnlockDelayPeriod = (
+export const getPunishmentPeriod = (
 	sender: Account<DPOSAccountProps>,
 	delegateAccount: Account<DPOSAccountProps>,
 	lastBlockHeight: number,
 ): number => {
 	const currentHeight = lastBlockHeight + 1;
-	const minUnlockDelay = getUnlockDelayForPunishment(sender, delegateAccount);
-	const remainingBlocks = minUnlockDelay - currentHeight;
+	const minPunishedHeight = getMinPunishedHeight(sender, delegateAccount);
+	const remainingBlocks = minPunishedHeight - currentHeight;
 
 	return remainingBlocks < 0 ? 0 : remainingBlocks;
 };

--- a/framework/test/unit/modules/dpos/transaction_assets/unlock_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/unlock_transaction_asset.spec.ts
@@ -536,7 +536,7 @@ describe('UnlockTransactionAsset', () => {
 				});
 			});
 
-			describe('when asset.unlockObjects contain valid entries, and voter account has waited pomHeight + 260,000 blocks but not waited for unlockHeight + 2,000 blocks', () => {
+			describe('when asset.unlockObjects contain valid entries, and voter account has waited pomHeight + 260,000 blocks but not waited for unvoteHeight + 2,000 blocks', () => {
 				beforeEach(async () => {
 					const pomHeight = 45968;
 					const unVoteHeight = pomHeight + 260000 + 10;
@@ -558,7 +558,7 @@ describe('UnlockTransactionAsset', () => {
 				});
 			});
 
-			describe('when asset.unlockObjects contain valid entries, and voter account has not waited pomHeight + 260,000 blocks but waited unlockHeight + 2000 blocks', () => {
+			describe('when asset.unlockObjects contain valid entries, and voter account has not waited pomHeight + 260,000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is more than unvoteHeight + 2000 blocks', () => {
 				beforeEach(async () => {
 					const unVoteHeight = 45968;
 					const pomHeight = unVoteHeight + 260000 + 10;
@@ -567,6 +567,64 @@ describe('UnlockTransactionAsset', () => {
 						pomHeight,
 						unVoteHeight,
 						lastBlockHeight: unVoteHeight + 260000 + 5,
+						sender,
+						delegate: delegate1,
+						applyContext,
+					});
+				});
+
+				it('should not return error', async () => {
+					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				});
+
+				it('should make account to have correct balance', async () => {
+					await transactionAsset.apply(applyContext);
+
+					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+						address: sender.address,
+						amount: applyContext.asset.unlockObjects[0].amount,
+					});
+				});
+			});
+
+			describe('when asset.unlockObjects contain valid entries, and voter account has not waited pomHeight + 260,000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is equal to unvoteHeight + 2000 blocks', () => {
+				beforeEach(async () => {
+					const unVoteHeight = 45968;
+					const pomHeight = unVoteHeight + 2000;
+
+					applyContext = await setupUnlocks({
+						pomHeight,
+						unVoteHeight,
+						lastBlockHeight: unVoteHeight + 2000,
+						sender,
+						delegate: delegate1,
+						applyContext,
+					});
+				});
+
+				it('should not return error', async () => {
+					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				});
+
+				it('should make account to have correct balance', async () => {
+					await transactionAsset.apply(applyContext);
+
+					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+						address: sender.address,
+						amount: applyContext.asset.unlockObjects[0].amount,
+					});
+				});
+			});
+
+			describe('when asset.unlockObjects contain valid entries, and voter account has not waited pomHeight + 260,000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is less than unvoteHeight + 2000 blocks', () => {
+				beforeEach(async () => {
+					const unVoteHeight = 45968;
+					const pomHeight = unVoteHeight + 2000 - 5;
+
+					applyContext = await setupUnlocks({
+						pomHeight,
+						unVoteHeight,
+						lastBlockHeight: unVoteHeight + 2000 + 5,
 						sender,
 						delegate: delegate1,
 						applyContext,
@@ -602,7 +660,7 @@ describe('UnlockTransactionAsset', () => {
 				});
 			});
 
-			describe('when asset.unlockObjects contain valid entries, and self-voting account has not waited pomHeight + 780,000 blocks but waited unvoteHeight + 260,000 blocks', () => {
+			describe('when asset.unlockObjects contain valid entries, and self-voting account has not waited pomHeight + 780,000 blocks but waited unvoteHeight + 260,000 blocks and pomHeight is more than unvoteHeight + 260,000 blocks', () => {
 				beforeEach(async () => {
 					const unVoteHeight = 45968;
 					const pomHeight = unVoteHeight + 780000 + 10;
@@ -611,6 +669,64 @@ describe('UnlockTransactionAsset', () => {
 						pomHeight,
 						unVoteHeight,
 						lastBlockHeight: unVoteHeight + 780000 + 5,
+						sender,
+						delegate: sender,
+						applyContext,
+					});
+				});
+
+				it('should not return error', async () => {
+					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				});
+
+				it('should make account to have correct balance', async () => {
+					await transactionAsset.apply(applyContext);
+
+					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+						address: sender.address,
+						amount: applyContext.asset.unlockObjects[0].amount,
+					});
+				});
+			});
+
+			describe('when asset.unlockObjects contain valid entries, and self-voting account has not waited pomHeight + 780,000 blocks but waited unvoteHeight + 260,000 blocks and pomHeight is equal to unvoteHeight + 260,000 blocks', () => {
+				beforeEach(async () => {
+					const unVoteHeight = 45968;
+					const pomHeight = unVoteHeight + 260000;
+
+					applyContext = await setupUnlocks({
+						pomHeight,
+						unVoteHeight,
+						lastBlockHeight: unVoteHeight + 260000,
+						sender,
+						delegate: sender,
+						applyContext,
+					});
+				});
+
+				it('should not return error', async () => {
+					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				});
+
+				it('should make account to have correct balance', async () => {
+					await transactionAsset.apply(applyContext);
+
+					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+						address: sender.address,
+						amount: applyContext.asset.unlockObjects[0].amount,
+					});
+				});
+			});
+
+			describe('when asset.unlockObjects contain valid entries, and self-voting account has not waited pomHeight + 780,000 blocks but waited unvoteHeight + 260,000 blocks and pomHeight is less than unvoteHeight + 260,000 blocks', () => {
+				beforeEach(async () => {
+					const unVoteHeight = 45968;
+					const pomHeight = unVoteHeight + 260000 - 5;
+
+					applyContext = await setupUnlocks({
+						pomHeight,
+						unVoteHeight,
+						lastBlockHeight: unVoteHeight + 260000 + 5,
 						sender,
 						delegate: sender,
 						applyContext,

--- a/framework/test/unit/modules/dpos/transaction_assets/unlock_transaction_asset.spec.ts
+++ b/framework/test/unit/modules/dpos/transaction_assets/unlock_transaction_asset.spec.ts
@@ -559,8 +559,10 @@ describe('UnlockTransactionAsset', () => {
 			});
 
 			describe('when asset.unlockObjects contain valid entries, and voter account has not waited pomHeight + 260,000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is more than unvoteHeight + 2000 blocks', () => {
+				let unVoteHeight: number;
+
 				beforeEach(async () => {
-					const unVoteHeight = 45968;
+					unVoteHeight = 45968;
 					const pomHeight = unVoteHeight + 260000 + 10;
 
 					applyContext = await setupUnlocks({
@@ -573,23 +575,37 @@ describe('UnlockTransactionAsset', () => {
 					});
 				});
 
-				it('should not return error', async () => {
-					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				describe('currentHeight >= transactionAsset._unlockFixHeight', () => {
+					it('should not return error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 260000 + 5 - 50);
+						await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+					});
+
+					it('should make account to have correct balance', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 260000 + 5 - 50);
+						await transactionAsset.apply(applyContext);
+
+						expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+							address: sender.address,
+							amount: applyContext.asset.unlockObjects[0].amount,
+						});
+					});
 				});
-
-				it('should make account to have correct balance', async () => {
-					await transactionAsset.apply(applyContext);
-
-					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
-						address: sender.address,
-						amount: applyContext.asset.unlockObjects[0].amount,
+				describe('currentHeight < transactionAsset._unlockFixHeight', () => {
+					it('should throw error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 260000 + 5 + 50);
+						await expect(transactionAsset.apply(applyContext)).rejects.toThrow(
+							'Unlocking is not permitted as the delegate is currently being punished.',
+						);
 					});
 				});
 			});
 
 			describe('when asset.unlockObjects contain valid entries, and voter account has not waited pomHeight + 260,000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is equal to unvoteHeight + 2000 blocks', () => {
+				let unVoteHeight: number;
+
 				beforeEach(async () => {
-					const unVoteHeight = 45968;
+					unVoteHeight = 45968;
 					const pomHeight = unVoteHeight + 2000;
 
 					applyContext = await setupUnlocks({
@@ -602,16 +618,29 @@ describe('UnlockTransactionAsset', () => {
 					});
 				});
 
-				it('should not return error', async () => {
-					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				describe('currentHeight >= transactionAsset._unlockFixHeight', () => {
+					it('should not return error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 2000 - 50);
+						await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+					});
+
+					it('should make account to have correct balance', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 2000 - 50);
+						await transactionAsset.apply(applyContext);
+
+						expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+							address: sender.address,
+							amount: applyContext.asset.unlockObjects[0].amount,
+						});
+					});
 				});
 
-				it('should make account to have correct balance', async () => {
-					await transactionAsset.apply(applyContext);
-
-					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
-						address: sender.address,
-						amount: applyContext.asset.unlockObjects[0].amount,
+				describe('currentHeight < transactionAsset._unlockFixHeight', () => {
+					it('should throw error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 2000 + 50);
+						await expect(transactionAsset.apply(applyContext)).rejects.toThrow(
+							'Unlocking is not permitted as the delegate is currently being punished.',
+						);
 					});
 				});
 			});
@@ -661,8 +690,10 @@ describe('UnlockTransactionAsset', () => {
 			});
 
 			describe('when asset.unlockObjects contain valid entries, and self-voting account has not waited pomHeight + 780,000 blocks but waited unvoteHeight + 260,000 blocks and pomHeight is more than unvoteHeight + 260,000 blocks', () => {
+				let unVoteHeight: number;
+
 				beforeEach(async () => {
-					const unVoteHeight = 45968;
+					unVoteHeight = 45968;
 					const pomHeight = unVoteHeight + 780000 + 10;
 
 					applyContext = await setupUnlocks({
@@ -675,23 +706,38 @@ describe('UnlockTransactionAsset', () => {
 					});
 				});
 
-				it('should not return error', async () => {
-					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				describe('currentHeight >= transactionAsset._unlockFixHeight', () => {
+					it('should not return error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 780000 + 5 - 50);
+						await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+					});
+
+					it('should make account to have correct balance', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 780000 + 5 - 50);
+						await transactionAsset.apply(applyContext);
+
+						expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+							address: sender.address,
+							amount: applyContext.asset.unlockObjects[0].amount,
+						});
+					});
 				});
 
-				it('should make account to have correct balance', async () => {
-					await transactionAsset.apply(applyContext);
-
-					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
-						address: sender.address,
-						amount: applyContext.asset.unlockObjects[0].amount,
+				describe('currentHeight < transactionAsset._unlockFixHeight', () => {
+					it('should throw error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 780000 + 5 + 50);
+						await expect(transactionAsset.apply(applyContext)).rejects.toThrow(
+							'Unlocking is not permitted as the delegate is currently being punished.',
+						);
 					});
 				});
 			});
 
 			describe('when asset.unlockObjects contain valid entries, and self-voting account has not waited pomHeight + 780,000 blocks but waited unvoteHeight + 260,000 blocks and pomHeight is equal to unvoteHeight + 260,000 blocks', () => {
+				let unVoteHeight: number;
+
 				beforeEach(async () => {
-					const unVoteHeight = 45968;
+					unVoteHeight = 45968;
 					const pomHeight = unVoteHeight + 260000;
 
 					applyContext = await setupUnlocks({
@@ -704,16 +750,29 @@ describe('UnlockTransactionAsset', () => {
 					});
 				});
 
-				it('should not return error', async () => {
-					await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+				describe('currentHeight >= transactionAsset._unlockFixHeight', () => {
+					it('should not return error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 260000 - 50);
+						await expect(transactionAsset.apply(applyContext)).resolves.toBeUndefined();
+					});
+
+					it('should make account to have correct balance', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 260000 - 50);
+						await transactionAsset.apply(applyContext);
+
+						expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
+							address: sender.address,
+							amount: applyContext.asset.unlockObjects[0].amount,
+						});
+					});
 				});
 
-				it('should make account to have correct balance', async () => {
-					await transactionAsset.apply(applyContext);
-
-					expect(applyContext.reducerHandler.invoke).toHaveBeenCalledWith('token:credit', {
-						address: sender.address,
-						amount: applyContext.asset.unlockObjects[0].amount,
+				describe('currentHeight < transactionAsset._unlockFixHeight', () => {
+					it('should throw error', async () => {
+						transactionAsset = new UnlockTransactionAsset(unVoteHeight + 260000 + 50);
+						await expect(transactionAsset.apply(applyContext)).rejects.toThrow(
+							'Unlocking is not permitted as the delegate is currently being punished.',
+						);
 					});
 				});
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6793 

### How was it solved?

* Added condition to check `unvoteHeight` as per the [LIP](https://github.com/LiskHQ/lips/blob/master/proposals/lip-0024.md#update-to-validity-of-unlock-transaction)
* Refactor existing code
* Added condition to make the change configurable by hardfork height 


### How was it tested?

Added unit tests
