### PR TITLE
Fix command exec context - Closes #6814

### DIFF
--- a/framework/src/node/state_machine/transaction_context.ts
+++ b/framework/src/node/state_machine/transaction_context.ts
@@ -106,6 +106,12 @@ export class TransactionContext {
 	public createCommandExecuteContext<T = Record<string, unknown>>(
 		paramsSchema: Schema,
 	): CommandExecuteContext<T> {
+		if (!this._header) {
+			throw new Error('Transaction Execution requires block header in the context.');
+		}
+		if (!this._assets) {
+			throw new Error('Transaction Execution requires block assets in the context.');
+		}
 		return {
 			logger: this._logger,
 			networkIdentifier: this._networkIdentifier,
@@ -113,7 +119,9 @@ export class TransactionContext {
 				createAPIContext({ stateStore: this._stateStore, eventQueue: this._eventQueue }),
 			getStore: (moduleID: number, storePrefix: number) =>
 				this._stateStore.getStore(moduleID, storePrefix),
+			header: this._header,
 			transaction: this._transaction,
+			assets: this._assets,
 			params: codec.decode(paramsSchema, this._transaction.params),
 		};
 	}

--- a/framework/src/node/state_machine/types.ts
+++ b/framework/src/node/state_machine/types.ts
@@ -92,6 +92,8 @@ export interface CommandVerifyContext<T> {
 export interface CommandExecuteContext<T> {
 	logger: Logger;
 	networkIdentifier: Buffer;
+	header: BlockHeader;
+	assets: BlockAssets;
 	transaction: Transaction; // without decoding params
 	params: T;
 	getAPIContext: () => APIContext;


### PR DESCRIPTION
### What was the problem?

This PR resolves #6814

### How was it solved?

- Add header and assets to the execution context for command

### How was it tested?

- Command should have access to the header and asset on execute function
