### PR TITLE
Implement `signMultiSignatureTransactionWithPrivateKey` utility function - Closes #6819

### DIFF
--- a/elements/lisk-transactions/src/sign.ts
+++ b/elements/lisk-transactions/src/sign.ts
@@ -224,3 +224,74 @@ export const signTransactionWithPrivateKey = (
 	transactionObject.signatures = [signature];
 	return { ...transactionObject, id: hash(getBytes(assetSchema, transactionObject)) };
 };
+
+export const signMultiSignatureTransactionWithPrivateKey = (
+	assetSchema: object,
+	transactionObject: Record<string, unknown>,
+	networkIdentifier: Buffer,
+	privateKey: Buffer,
+	keys: MultiSignatureKeys,
+	includeSenderSignature = false,
+): Record<string, unknown> => {
+	if (!networkIdentifier.length) {
+		throw new Error('Network identifier is required to sign a transaction');
+	}
+
+	if (!privateKey.length || privateKey.length !== 64) {
+		throw new Error('Private key must be 64 bytes');
+	}
+
+	if (!Array.isArray(transactionObject.signatures)) {
+		throw new Error('Signatures must be of type array');
+	}
+
+	const validationErrors = validateTransaction(assetSchema, transactionObject);
+	if (validationErrors) {
+		throw validationErrors;
+	}
+
+	const { senderPublicKey: publicKey } = transactionObject;
+
+	// Sort keys
+	keys.mandatoryKeys.sort((publicKeyA, publicKeyB) => publicKeyA.compare(publicKeyB));
+	keys.optionalKeys.sort((publicKeyA, publicKeyB) => publicKeyA.compare(publicKeyB));
+
+	const transactionWithNetworkIdentifierBytes = Buffer.concat([
+		networkIdentifier,
+		getSigningBytes(assetSchema, transactionObject),
+	]);
+
+	const signature = signDataWithPrivateKey(transactionWithNetworkIdentifierBytes, privateKey);
+
+	if (includeSenderSignature && Buffer.isBuffer(transactionObject.senderPublicKey)) {
+		// eslint-disable-next-line no-param-reassign
+		transactionObject.signatures[0] = signature;
+	}
+
+	// Locate where this public key should go in the signatures array
+	const mandatoryKeyIndex = keys.mandatoryKeys.findIndex(aPublicKey =>
+		aPublicKey.equals(publicKey as Buffer),
+	);
+	const optionalKeyIndex = keys.optionalKeys.findIndex(aPublicKey =>
+		aPublicKey.equals(publicKey as Buffer),
+	);
+
+	// If it's a mandatory Public Key find where to add the signature
+	if (mandatoryKeyIndex !== -1) {
+		const signatureOffset = includeSenderSignature ? 1 : 0;
+		// eslint-disable-next-line no-param-reassign
+		transactionObject.signatures[mandatoryKeyIndex + signatureOffset] = signature;
+	}
+
+	if (optionalKeyIndex !== -1) {
+		const signatureOffset = includeSenderSignature ? 1 : 0;
+		// eslint-disable-next-line no-param-reassign
+		transactionObject.signatures[
+			keys.mandatoryKeys.length + optionalKeyIndex + signatureOffset
+		] = signature;
+	}
+
+	sanitizeSignaturesArray(transactionObject, keys, includeSenderSignature);
+
+	return { ...transactionObject, id: hash(getBytes(assetSchema, transactionObject)) };
+};


### PR DESCRIPTION
### What was the problem?

This PR resolves #6819

### How was it solved?

- 🌱  Implement `signMultiSignatureTransactionWithPrivateKey` function in `lisk-transactions` ae1d05c6a017bce055e4fd3e87ee006a09a25b00
- 🌱 Add unit tests 8ec014c50b18c4a131e16263163778f3f6033e2b

### How was it tested?

Added unit tests in `lisk-transactions`
