### PR TITLE
Expose getPublicKey - Closes #6821

### DIFF
--- a/elements/lisk-cryptography/src/index.ts
+++ b/elements/lisk-cryptography/src/index.ts
@@ -22,6 +22,6 @@ export * from './keys';
 export * from './legacy_address';
 export * from './sign';
 export * from './hash_onion';
-export { getRandomBytes } from './nacl';
+export { getRandomBytes, getPublicKey } from './nacl';
 
 export { constants };


### PR DESCRIPTION
### What was the problem?

This PR resolves #6821 

### How was it solved?

- Expose `getPublicKey` from lisk-cryptography

### How was it tested?

Check if the built index has getPublicKey function exposed
