### PR TITLE
Implement DPoS unlocking command - Closes #6726 

### DIFF
--- a/framework/src/modules/dpos_v2/commands/unlock.ts
+++ b/framework/src/modules/dpos_v2/commands/unlock.ts
@@ -49,9 +49,9 @@ export class UnlockCommand extends BaseCommand {
 			getAPIContext,
 			header: { height },
 		} = context;
-		const delegateStore = getStore(this.moduleID, STORE_PREFIX_DELEGATE);
-		const voterStore = getStore(this.moduleID, STORE_PREFIX_VOTER);
-		const voterData = await voterStore.getWithSchema<VoterData>(senderAddress, voterStoreSchema);
+		const delegateSubstore = getStore(this.moduleID, STORE_PREFIX_DELEGATE);
+		const voterSubstore = getStore(this.moduleID, STORE_PREFIX_VOTER);
+		const voterData = await voterSubstore.getWithSchema<VoterData>(senderAddress, voterStoreSchema);
 		const unlockIndices: number[] = [];
 
 		if (!voterData) {
@@ -60,7 +60,7 @@ export class UnlockCommand extends BaseCommand {
 
 		for (let i = 0; i < voterData.pendingUnlocks.length; i += 1) {
 			const unlockObject = voterData.pendingUnlocks[i];
-			const { pomHeights } = await delegateStore.getWithSchema<DelegateAccount>(
+			const { pomHeights } = await delegateSubstore.getWithSchema<DelegateAccount>(
 				unlockObject.delegateAddress,
 				delegateStoreSchema,
 			);
@@ -79,11 +79,12 @@ export class UnlockCommand extends BaseCommand {
 				);
 			}
 		}
+
 		if (unlockIndices.length) {
 			voterData.pendingUnlocks = voterData.pendingUnlocks.filter(
 				(_, i) => !unlockIndices.includes(i),
 			);
-			await voterStore.setWithSchema(senderAddress, voterData, voterStoreSchema);
+			await voterSubstore.setWithSchema(senderAddress, voterData, voterStoreSchema);
 		}
 	}
 }

--- a/framework/src/modules/dpos_v2/commands/unlock.ts
+++ b/framework/src/modules/dpos_v2/commands/unlock.ts
@@ -42,7 +42,7 @@ export class UnlockCommand extends BaseCommand {
 		this._tokenIDDPoS = args.tokenIDDPoS;
 	}
 
-	public async execute(context: CommandExecuteContext<Record<string, unknown>>): Promise<void> {
+	public async execute(context: CommandExecuteContext): Promise<void> {
 		const {
 			transaction: { senderAddress },
 			getStore,

--- a/framework/src/modules/dpos_v2/commands/unlock.ts
+++ b/framework/src/modules/dpos_v2/commands/unlock.ts
@@ -52,11 +52,6 @@ export class UnlockCommand extends BaseCommand {
 		const delegateSubstore = getStore(this.moduleID, STORE_PREFIX_DELEGATE);
 		const voterSubstore = getStore(this.moduleID, STORE_PREFIX_VOTER);
 		const voterData = await voterSubstore.getWithSchema<VoterData>(senderAddress, voterStoreSchema);
-
-		if (!voterData) {
-			throw new Error('No voting data exists for sender');
-		}
-
 		const ineligibleUnlocks = [];
 
 		for (const unlockObject of voterData.pendingUnlocks) {
@@ -80,7 +75,9 @@ export class UnlockCommand extends BaseCommand {
 			}
 			ineligibleUnlocks.push(unlockObject);
 		}
-
+		if (voterData.pendingUnlocks.length === ineligibleUnlocks.length) {
+			throw new Error('No eligible voter data was found for unlocking');
+		}
 		voterData.pendingUnlocks = ineligibleUnlocks;
 		await voterSubstore.setWithSchema(senderAddress, voterData, voterStoreSchema);
 	}

--- a/framework/src/modules/dpos_v2/schemas.ts
+++ b/framework/src/modules/dpos_v2/schemas.ts
@@ -272,12 +272,6 @@ export const pomCommandParamsSchema = {
 	},
 };
 
-export const unlockCommandParamsSchema = {
-	$id: '/dpos/command/unlockTokenParams',
-	type: 'object',
-	properties: {},
-};
-
 export const configSchema = {
 	$id: '/dpos/config',
 	type: 'object',

--- a/framework/src/modules/dpos_v2/types.ts
+++ b/framework/src/modules/dpos_v2/types.ts
@@ -76,6 +76,13 @@ export interface TokenAPI {
 		tokenID: TokenIDDPoS,
 		amount: bigint,
 	): Promise<void>;
+	unlock(
+		apiContext: APIContext,
+		address: Buffer,
+		moduleID: number,
+		tokenID: TokenIDDPoS,
+		amount: bigint,
+	): Promise<void>;
 }
 
 export interface UnlockingObject {
@@ -145,6 +152,11 @@ export interface VoteTransactionParams {
 }
 
 export interface VoteCommandDependencies {
+	tokenIDDPoS: TokenIDDPoS;
+	tokenAPI: TokenAPI;
+}
+
+export interface UnlockCommandDependencies {
 	tokenIDDPoS: TokenIDDPoS;
 	tokenAPI: TokenAPI;
 }

--- a/framework/src/modules/dpos_v2/utils.ts
+++ b/framework/src/modules/dpos_v2/utils.ts
@@ -136,6 +136,23 @@ export const getVoterOrDefault = async (voterStore: SubStore, address: Buffer) =
 	}
 };
 
+export const hasWaited = (
+	unlockingObject: UnlockingObject,
+	senderAddress: Buffer,
+	height: number,
+) => {
+	let delayedAvailability: number;
+
+	// If self-vote
+	if (unlockingObject.delegateAddress.equals(senderAddress)) {
+		delayedAvailability = 260000;
+	} else {
+		delayedAvailability = 2000;
+	}
+
+	return !(height - unlockingObject.unvoteHeight < delayedAvailability);
+};
+
 export const isPunished = (
 	unlockingObject: UnlockingObject,
 	pomHeights: ReadonlyArray<number>,

--- a/framework/src/modules/dpos_v2/utils.ts
+++ b/framework/src/modules/dpos_v2/utils.ts
@@ -84,19 +84,26 @@ export const getVoterOrDefault = async (voterStore: SubStore, address: Buffer) =
 	}
 };
 
+export const isCurrentlyPunished = (height: number, pomHeights: ReadonlyArray<number>): boolean => {
+	if (pomHeights.length === 0) {
+		return false;
+	}
+	const lastPomHeight = Math.max(...pomHeights);
+	if (height - lastPomHeight < PUNISHMENT_PERIOD) {
+		return true;
+	}
+
+	return false;
+};
+
 export const hasWaited = (
 	unlockingObject: UnlockingObject,
 	senderAddress: Buffer,
 	height: number,
 ) => {
-	let delayedAvailability: number;
-
-	// If self-vote
-	if (unlockingObject.delegateAddress.equals(senderAddress)) {
-		delayedAvailability = 260000;
-	} else {
-		delayedAvailability = 2000;
-	}
+	const delayedAvailability = unlockingObject.delegateAddress.equals(senderAddress)
+		? WAIT_TIME_SELF_VOTE
+		: WAIT_TIME_VOTE;
 
 	return !(height - unlockingObject.unvoteHeight < delayedAvailability);
 };

--- a/framework/src/modules/dpos_v2/utils.ts
+++ b/framework/src/modules/dpos_v2/utils.ts
@@ -15,13 +15,7 @@
 import { verifyData } from '@liskhq/lisk-cryptography';
 import { NotFoundError } from '@liskhq/lisk-chain';
 import { UnlockingObject, VoterData } from './types';
-import {
-	PUNISHMENT_PERIOD,
-	SELF_VOTE_PUNISH_TIME,
-	VOTER_PUNISH_TIME,
-	WAIT_TIME_SELF_VOTE,
-	WAIT_TIME_VOTE,
-} from './constants';
+import { PUNISHMENT_PERIOD, WAIT_TIME_SELF_VOTE, WAIT_TIME_VOTE } from './constants';
 import { SubStore } from '../../node/state_machine/types';
 import { voterStoreSchema } from './schemas';
 
@@ -43,57 +37,6 @@ export const sortUnlocking = (unlocks: UnlockingObject[]): void => {
 
 		return 0;
 	});
-};
-
-export const getMinPunishedHeight = (
-	senderAddress: Buffer,
-	delegateAddress: Buffer,
-	pomHeights: number[],
-): number => {
-	if (pomHeights.length === 0) {
-		return 0;
-	}
-
-	const lastPomHeight = Math.max(...pomHeights);
-
-	// https://github.com/LiskHQ/lips/blob/master/proposals/lip-0024.md#update-to-validity-of-unlock-transaction
-	return senderAddress.equals(delegateAddress)
-		? lastPomHeight + SELF_VOTE_PUNISH_TIME
-		: lastPomHeight + VOTER_PUNISH_TIME;
-};
-
-export const getPunishmentPeriod = (
-	senderAddress: Buffer,
-	delegateAddress: Buffer,
-	pomHeights: number[],
-	lastBlockHeight: number,
-): number => {
-	const currentHeight = lastBlockHeight + 1;
-	const minPunishedHeight = getMinPunishedHeight(senderAddress, delegateAddress, pomHeights);
-	const remainingBlocks = minPunishedHeight - currentHeight;
-
-	return remainingBlocks < 0 ? 0 : remainingBlocks;
-};
-
-export const getMinWaitingHeight = (
-	senderAddress: Buffer,
-	delegateAddress: Buffer,
-	unlockObject: UnlockingObject,
-): number =>
-	unlockObject.unvoteHeight +
-	(senderAddress.equals(delegateAddress) ? WAIT_TIME_SELF_VOTE : WAIT_TIME_VOTE);
-
-export const getWaitingPeriod = (
-	senderAddress: Buffer,
-	delegateAddress: Buffer,
-	lastBlockHeight: number,
-	unlockObject: UnlockingObject,
-): number => {
-	const currentHeight = lastBlockHeight + 1;
-	const minWaitingHeight = getMinWaitingHeight(senderAddress, delegateAddress, unlockObject);
-	const remainingBlocks = minWaitingHeight - currentHeight;
-
-	return remainingBlocks < 0 ? 0 : remainingBlocks;
 };
 
 export const isNullCharacterIncluded = (input: string): boolean =>

--- a/framework/src/modules/dpos_v2/utils.ts
+++ b/framework/src/modules/dpos_v2/utils.ts
@@ -15,7 +15,12 @@
 import { verifyData } from '@liskhq/lisk-cryptography';
 import { NotFoundError } from '@liskhq/lisk-chain';
 import { UnlockingObject, VoterData } from './types';
-import { PUNISHMENT_PERIOD, WAIT_TIME_SELF_VOTE, WAIT_TIME_VOTE } from './constants';
+import {
+	PUNISHMENT_PERIOD,
+	VOTER_PUNISH_TIME,
+	WAIT_TIME_SELF_VOTE,
+	WAIT_TIME_VOTE,
+} from './constants';
 import { SubStore } from '../../node/state_machine/types';
 import { voterStoreSchema } from './schemas';
 
@@ -117,7 +122,7 @@ export const isPunished = (
 	}
 
 	return (
-		height - lastPomHeight < WAIT_TIME_SELF_VOTE &&
+		height - lastPomHeight < VOTER_PUNISH_TIME &&
 		lastPomHeight < unlockingObject.unvoteHeight + WAIT_TIME_VOTE
 	);
 };

--- a/framework/test/unit/modules/dpos_v2/commands/delegate_registration.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/delegate_registration.spec.ts
@@ -16,21 +16,24 @@ import { StateStore, Transaction } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import { InMemoryKVStore, KVStore } from '@liskhq/lisk-db';
-import * as testing from '../../../../src/testing';
-import { DelegateRegistrationCommand } from '../../../../src/modules/dpos_v2/commands/delegate_registration';
+import * as testing from '../../../../../src/testing';
+import { DelegateRegistrationCommand } from '../../../../../src/modules/dpos_v2/commands/delegate_registration';
 import {
 	COMMAND_ID_DELEGATE_REGISTRATION,
 	MODULE_ID_DPOS,
 	STORE_PREFIX_DELEGATE,
 	STORE_PREFIX_NAME,
-} from '../../../../src/modules/dpos_v2/constants';
+} from '../../../../../src/modules/dpos_v2/constants';
 import {
 	delegateStoreSchema,
 	delegateRegistrationCommandParamsSchema,
 	nameStoreSchema,
-} from '../../../../src/modules/dpos_v2/schemas';
-import { DelegateRegistrationParams, ValidatorsAPI } from '../../../../src/modules/dpos_v2/types';
-import { VerifyStatus } from '../../../../src/node/state_machine';
+} from '../../../../../src/modules/dpos_v2/schemas';
+import {
+	DelegateRegistrationParams,
+	ValidatorsAPI,
+} from '../../../../../src/modules/dpos_v2/types';
+import { VerifyStatus } from '../../../../../src/node/state_machine';
 
 describe('Delegate registration command', () => {
 	let delegateRegistrationCommand: DelegateRegistrationCommand;

--- a/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
@@ -46,7 +46,7 @@ describe('UnlockCommand', () => {
 	let header: BlockHeader;
 	let unlockableObject: UnlockingObject;
 	let nonUnlockableObject: UnlockingObject;
-	let context: CommandExecuteContext<Record<string, unknown>>;
+	let context: CommandExecuteContext;
 	let storedData: VoterData;
 
 	const delegate1 = { name: 'delegate1', address: getRandomBytes(32), amount: liskToBeddows(100) };

--- a/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
@@ -299,4 +299,64 @@ describe('UnlockCommand', () => {
 			expect(storedData.pendingUnlocks).toEqual([unlockObj2]);
 		});
 	});
+
+	describe('when non self-voted punished account has waited pomHeight + 260000 blocks but not waited for unlockHeight + 2000 blocks', () => {
+		beforeEach(async () => {
+			await delegateSubstore.setWithSchema(
+				delegate3.address,
+				{
+					...defaultDelegateInfo,
+					name: 'punisheddelegate',
+					pomHeights: [lastBlockHeight - 260000],
+				},
+				delegateStoreSchema,
+			);
+			unlockObj1 = {
+				delegateAddress: delegate1.address,
+				amount: delegate1.amount,
+				unvoteHeight: lastBlockHeight - 2001,
+			};
+			unlockObj2 = {
+				delegateAddress: delegate2.address,
+				amount: delegate2.amount,
+				unvoteHeight: lastBlockHeight - 2000,
+			};
+			unlockObj3 = {
+				delegateAddress: delegate3.address,
+				amount: delegate3.amount,
+				unvoteHeight: lastBlockHeight - 1000,
+			};
+			await voterSubstore.setWithSchema(
+				transaction.senderAddress,
+				{
+					sentVotes: [
+						{ delegateAddress: unlockObj1.delegateAddress, amount: unlockObj1.amount },
+						{ delegateAddress: unlockObj2.delegateAddress, amount: unlockObj2.amount },
+						{ delegateAddress: unlockObj3.delegateAddress, amount: unlockObj3.amount },
+					],
+					pendingUnlocks: [unlockObj1, unlockObj2, unlockObj3],
+				},
+				voterStoreSchema,
+			);
+			context = testing
+				.createTransactionContext({
+					stateStore,
+					transaction,
+					header,
+					networkIdentifier,
+				})
+				.createCommandExecuteContext();
+		});
+
+		it('should only remove eligible pending unlocks from voter substore', async () => {
+			await unlockCommand.execute(context);
+			const storedData = codec.decode<VoterData>(
+				voterStoreSchema,
+				await voterSubstore.get(transaction.senderAddress),
+			);
+
+			expect(storedData.pendingUnlocks).toHaveLength(1);
+			expect(storedData.pendingUnlocks).toEqual([unlockObj3]);
+		});
+	});
 });

--- a/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
@@ -359,4 +359,64 @@ describe('UnlockCommand', () => {
 			expect(storedData.pendingUnlocks).toEqual([unlockObj3]);
 		});
 	});
+
+	describe('when non self-voted punished account has not waited pomHeight + 260,000 blocks but waited unlockHeight + 2000 blocks', () => {
+		beforeEach(async () => {
+			await delegateSubstore.setWithSchema(
+				delegate3.address,
+				{
+					...defaultDelegateInfo,
+					name: 'punisheddelegate',
+					pomHeights: [lastBlockHeight - 1],
+				},
+				delegateStoreSchema,
+			);
+			unlockObj1 = {
+				delegateAddress: delegate1.address,
+				amount: delegate1.amount,
+				unvoteHeight: lastBlockHeight - 2001,
+			};
+			unlockObj2 = {
+				delegateAddress: delegate2.address,
+				amount: delegate2.amount,
+				unvoteHeight: lastBlockHeight - 2000,
+			};
+			unlockObj3 = {
+				delegateAddress: delegate3.address,
+				amount: delegate3.amount,
+				unvoteHeight: lastBlockHeight - 2000,
+			};
+			await voterSubstore.setWithSchema(
+				transaction.senderAddress,
+				{
+					sentVotes: [
+						{ delegateAddress: unlockObj1.delegateAddress, amount: unlockObj1.amount },
+						{ delegateAddress: unlockObj2.delegateAddress, amount: unlockObj2.amount },
+						{ delegateAddress: unlockObj3.delegateAddress, amount: unlockObj3.amount },
+					],
+					pendingUnlocks: [unlockObj1, unlockObj2, unlockObj3],
+				},
+				voterStoreSchema,
+			);
+			context = testing
+				.createTransactionContext({
+					stateStore,
+					transaction,
+					header,
+					networkIdentifier,
+				})
+				.createCommandExecuteContext();
+		});
+
+		it('should only remove eligible pending unlocks from voter substore', async () => {
+			await unlockCommand.execute(context);
+			const storedData = codec.decode<VoterData>(
+				voterStoreSchema,
+				await voterSubstore.get(transaction.senderAddress),
+			);
+
+			expect(storedData.pendingUnlocks).toHaveLength(1);
+			expect(storedData.pendingUnlocks).toEqual([unlockObj3]);
+		});
+	});
 });

--- a/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/unlock.spec.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { BlockHeader, StateStore, Transaction } from '@liskhq/lisk-chain';
+import { codec } from '@liskhq/lisk-codec';
+import { hash, getRandomBytes } from '@liskhq/lisk-cryptography';
+import { InMemoryKVStore, KVStore } from '@liskhq/lisk-db';
+import * as testing from '../../../../../src/testing';
+import { UnlockCommand } from '../../../../../src/modules/dpos_v2/commands/unlock';
+import {
+	MODULE_ID_DPOS,
+	STORE_PREFIX_DELEGATE,
+	STORE_PREFIX_VOTER,
+	COMMAND_ID_UNLOCK,
+} from '../../../../../src/modules/dpos_v2/constants';
+import { delegateStoreSchema, voterStoreSchema } from '../../../../../src/modules/dpos_v2/schemas';
+import { TokenAPI, UnlockingObject, VoterData } from '../../../../../src/modules/dpos_v2/types';
+import { CommandExecuteContext } from '../../../../../src/node/state_machine/types';
+import { liskToBeddows } from '../../../../utils/assets';
+
+// TODO: Also add 2 test cases from PR:
+// https://github.com/LiskHQ/lisk-sdk/pull/6807/files
+
+describe('UnlockCommand', () => {
+	let unlockCommand: UnlockCommand;
+	let db: KVStore;
+	let stateStore: StateStore;
+	let delegateSubstore: StateStore;
+	let voterSubstore: StateStore;
+	let mockTokenAPI: TokenAPI;
+	let lastBlockHeight: number;
+	let header: BlockHeader;
+	let unlockObj1: UnlockingObject;
+	let unlockObj2: UnlockingObject;
+	let unlockObj3: UnlockingObject;
+	let context: CommandExecuteContext<Record<string, unknown>>;
+
+	const delegate1 = { name: 'delegate1', address: getRandomBytes(32), amount: liskToBeddows(100) };
+	const delegate2 = { name: 'delegate2', address: getRandomBytes(32), amount: liskToBeddows(120) };
+	const delegate3 = { name: 'delegate3', address: getRandomBytes(32), amount: liskToBeddows(80) };
+	const defaultDelegateInfo = {
+		totalVotesReceived: BigInt(100000000),
+		selfVotes: BigInt(0),
+		lastGeneratedHeight: 0,
+		isBanned: false,
+		pomHeights: [],
+		consecutiveMissedBlocks: 0,
+	};
+	const publicKey = getRandomBytes(32);
+	const transaction = new Transaction({
+		moduleID: MODULE_ID_DPOS,
+		commandID: COMMAND_ID_UNLOCK,
+		senderPublicKey: publicKey,
+		nonce: BigInt(0),
+		fee: BigInt(100000000),
+		params: Buffer.alloc(0),
+		signatures: [publicKey],
+	});
+	const networkIdentifier = Buffer.from(
+		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255',
+		'hex',
+	);
+
+	beforeEach(async () => {
+		unlockCommand = new UnlockCommand(MODULE_ID_DPOS);
+		mockTokenAPI = {
+			unlock: jest.fn(),
+			lock: jest.fn(),
+		};
+		unlockCommand.addDependencies({
+			tokenIDDPoS: { chainID: 0, localID: 0 },
+			tokenAPI: mockTokenAPI,
+		});
+		db = new InMemoryKVStore() as never;
+		stateStore = new StateStore(db);
+		delegateSubstore = stateStore.getStore(MODULE_ID_DPOS, STORE_PREFIX_DELEGATE);
+		voterSubstore = stateStore.getStore(MODULE_ID_DPOS, STORE_PREFIX_VOTER);
+		lastBlockHeight = 8760000;
+		header = new BlockHeader({
+			height: lastBlockHeight,
+			generatorAddress: getRandomBytes(20),
+			previousBlockID: Buffer.alloc(0),
+			timestamp: Math.floor(Date.now() / 1000),
+			version: 0,
+			transactionRoot: hash(Buffer.alloc(0)),
+			stateRoot: hash(Buffer.alloc(0)),
+			maxHeightGenerated: 0,
+			maxHeightPrevoted: 0,
+			assetsRoot: hash(Buffer.alloc(0)),
+			aggregateCommit: {
+				height: 0,
+				aggregationBits: Buffer.alloc(0),
+				certificateSignature: Buffer.alloc(0),
+			},
+			validatorsHash: hash(Buffer.alloc(0)),
+		});
+		await delegateSubstore.setWithSchema(
+			delegate1.address,
+			{
+				name: delegate1.name,
+				...defaultDelegateInfo,
+			},
+			delegateStoreSchema,
+		);
+		await delegateSubstore.setWithSchema(
+			delegate2.address,
+			{
+				name: delegate2.name,
+				...defaultDelegateInfo,
+			},
+			delegateStoreSchema,
+		);
+		await delegateSubstore.setWithSchema(
+			delegate3.address,
+			{
+				name: delegate3.name,
+				...defaultDelegateInfo,
+			},
+			delegateStoreSchema,
+		);
+	});
+
+	describe('when non self-voted non punished account waits 2000 blocks', () => {
+		beforeEach(async () => {
+			unlockObj1 = {
+				delegateAddress: delegate1.address,
+				amount: delegate1.amount,
+				unvoteHeight: lastBlockHeight - 2001,
+			};
+			unlockObj2 = {
+				delegateAddress: delegate2.address,
+				amount: delegate2.amount,
+				unvoteHeight: lastBlockHeight - 2000,
+			};
+			unlockObj3 = {
+				delegateAddress: delegate3.address,
+				amount: delegate3.amount,
+				unvoteHeight: lastBlockHeight - 1000,
+			};
+			await voterSubstore.setWithSchema(
+				transaction.senderAddress,
+				{
+					sentVotes: [
+						{ delegateAddress: unlockObj1.delegateAddress, amount: unlockObj1.amount },
+						{ delegateAddress: unlockObj2.delegateAddress, amount: unlockObj2.amount },
+						{ delegateAddress: unlockObj3.delegateAddress, amount: unlockObj3.amount },
+					],
+					pendingUnlocks: [unlockObj1, unlockObj2, unlockObj3],
+				},
+				voterStoreSchema,
+			);
+			context = testing
+				.createTransactionContext({
+					stateStore,
+					transaction,
+					header,
+					networkIdentifier,
+				})
+				.createCommandExecuteContext();
+		});
+
+		it('should only remove eligible pending unlocks from voter substore', async () => {
+			await unlockCommand.execute(context);
+			const storedData = codec.decode<VoterData>(
+				voterStoreSchema,
+				await voterSubstore.get(transaction.senderAddress),
+			);
+
+			expect(storedData.pendingUnlocks).toHaveLength(1);
+			expect(storedData.pendingUnlocks).toEqual([unlockObj3]);
+		});
+	});
+});

--- a/framework/test/unit/modules/dpos_v2/commands/vote.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/vote.spec.ts
@@ -51,7 +51,7 @@ describe('VoteCommand', () => {
 		lockFn = jest.fn();
 		command = new VoteCommand(MODULE_ID_DPOS);
 		command.addDependencies({
-			tokenAPI: { lock: lockFn },
+			tokenAPI: { lock: lockFn, unlock: jest.fn() },
 			tokenIDDPoS: { chainID: 0, localID: 0 },
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6726 

### How was it solved?

Implemented unlock command and test following scenarios:

- [x] When non self-voted non punished account waits 2000 blocks
- [x] When non self-voted non punished account did not wait 2000 blocks
- [x] When self-voted non punished account waits 260000 blocks
- [x] When self-voted non punished account did not wait 260000 blocks
- [x] When non self-voted punished account has waited pomHeight + 260000 and unvoteHeight + 2000 blocks
- [x] When non self-voted punished account has waited pomHeight + 260000 blocks but not waited for unlockHeight + 2000 blocks
- [x] When non self-voted punished account has not waited pomHeight + 260,000 blocks but waited unlockHeight + 2000 blocks
- [x]  When non self-voted punished account has not waited pomHeight + 260,000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is more than unvoteHeight + 2000 blocks
- [x]  When non self-voted punished account has not waited pomHeight + 260000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is equal to unvoteHeight + 2000 blocks
- [x] When self-voted punished account waits 780000 blocks and waits unvoteHeight + 260000 blocks since pomHeight
- [x] When self-voted punished account waits 780000 blocks and but did not wait unvoteHeight + 260000 blocks since pomHeight
- [x] When self-voted punished account has not waited 780000 blocks and waits unvoteHeight + 260000 blocks since pomHeight
- [x] When self-voted punsished account has not waited pomHeight + 260000 blocks but waited unvoteHeight + 2000 blocks and pomHeight is more than unvoteHeight + 2000 blocks

### How was it tested?

Added unit tests
