### PR TITLE
Add validatorsHash to block on block creation - Closes #6753

### DIFF
--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -484,6 +484,8 @@ export class Consensus {
 
 		// verify Block signature
 		await this._verifyBlockSignature(apiContext, block);
+		// Verify validatorsHash
+		await this._verifyValidatorsHash(apiContext, block);
 	}
 
 	private async _verifyTimestamp(apiContext: APIContext, block: Block): Promise<void> {
@@ -596,6 +598,26 @@ export class Consensus {
 		} catch (error) {
 			throw new Error(
 				`Invalid signature ${block.header.signature.toString(
+					'hex',
+				)} of the block with id: ${block.header.id.toString('hex')}`,
+			);
+		}
+	}
+
+	private async _verifyValidatorsHash(apiContext: APIContext, block: Block): Promise<void> {
+		if (!block.header.validatorsHash) {
+			throw new Error(
+				`Validators hash is "undefined" for the block with id: ${block.header.id.toString('hex')}`,
+			);
+		}
+		const { validatorsHash } = await this._bftAPI.getBFTParameters(
+			apiContext,
+			block.header.height + 1,
+		);
+
+		if (!block.header.validatorsHash.equals(validatorsHash)) {
+			throw new Error(
+				`Invalid validatorsHash ${block.header.validatorsHash?.toString(
 					'hex',
 				)} of the block with id: ${block.header.id.toString('hex')}`,
 			);

--- a/framework/src/node/consensus/types.ts
+++ b/framework/src/node/consensus/types.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { BFTParameters } from '../../modules/bft/schemas';
 import { BFTHeights } from '../../modules/bft/types';
 import { ValidatorKeys } from '../../modules/validators/types';
 import { BlockHeader, ImmutableAPIContext } from '../state_machine';
@@ -42,6 +43,7 @@ export interface ValidatorAPI {
 export interface BFTAPI {
 	getCurrentValidators: (apiContext: ImmutableAPIContext) => Promise<Validator[]>;
 	getBFTHeights: (apiClient: ImmutableAPIContext) => Promise<BFTHeights>;
+	getBFTParameters: (apiContext: ImmutableAPIContext, height: number) => Promise<BFTParameters>;
 	isHeaderContradictingChain: (
 		apiClient: ImmutableAPIContext,
 		header: BlockHeader,

--- a/framework/src/node/generator/generator.ts
+++ b/framework/src/node/generator/generator.ts
@@ -502,8 +502,9 @@ export class Generator {
 		blockHeader.assetsRoot = hash(Buffer.concat(blockAssets.getBytes()));
 		// TODO: Update the stateRoot with proper calculation
 		blockHeader.stateRoot = hash(Buffer.alloc(0));
-		// TODO: Update validatorsHash with proper calculation
-		blockHeader.validatorsHash = hash(Buffer.alloc(0));
+		// Set validatorsHash
+		const { validatorsHash } = await this._bftAPI.getBFTParameters(apiContext, height);
+		blockHeader.validatorsHash = validatorsHash;
 		blockHeader.sign(this._chain.networkIdentifier, keypair.privateKey);
 
 		const generatedBlock = new Block(blockHeader, transactions, blockAssets);

--- a/framework/src/node/generator/types.ts
+++ b/framework/src/node/generator/types.ts
@@ -15,6 +15,7 @@
 import { Block } from '@liskhq/lisk-chain';
 import { Options } from '@liskhq/lisk-db';
 import { Logger } from '../../logger';
+import { BFTParameters } from '../../modules/bft/schemas';
 import { BFTHeights } from '../consensus';
 import { APIContext, BlockHeader, ImmutableAPIContext, ImmutableSubStore } from '../state_machine';
 
@@ -35,6 +36,7 @@ export interface Consensus {
 
 export interface BFTAPI {
 	getBFTHeights: (_apiClient: ImmutableAPIContext) => Promise<BFTHeights>;
+	getBFTParameters: (apiContext: ImmutableAPIContext, height: number) => Promise<BFTParameters>;
 }
 
 export interface ValidatorAPI {

--- a/framework/test/unit/node/consensus/consensus.spec.ts
+++ b/framework/test/unit/node/consensus/consensus.spec.ts
@@ -90,6 +90,7 @@ describe('consensus', () => {
 				.fn()
 				.mockResolvedValue({ maxHeghgtPrevoted: 0, maxHeightPrecommitted: 0 }),
 			isHeaderContradictingChain: jest.fn(),
+			getBFTParameters: jest.fn(),
 		} as never;
 		validatorAPI = {
 			getGeneratorAtTimestamp: jest.fn(),
@@ -735,6 +736,54 @@ describe('consensus', () => {
 
 					await expect(
 						consensus['_verifyBlockSignature'](apiContext, validBlock as any),
+					).resolves.toBeUndefined();
+				});
+			});
+
+			describe('validatorsHash', () => {
+				it('should throw error when validatorsHash is undefined', async () => {
+					when(consensus['_bftAPI'].getBFTParameters as never)
+						.calledWith(apiContext, block.header.height + 1)
+						.mockResolvedValue({
+							validatorsHash: cryptography.hash(cryptography.getRandomBytes(32)),
+						} as never);
+
+					block.header.validatorsHash = undefined;
+					block.header['_signature'] = cryptography.getRandomBytes(64);
+					block.header['_id'] = cryptography.getRandomBytes(64);
+
+					await expect(
+						consensus['_verifyValidatorsHash'](apiContext, block as any),
+					).rejects.toThrow(
+						`Validators hash is "undefined" for the block with id: ${block.header.id.toString(
+							'hex',
+						)}`,
+					);
+				});
+
+				it('should throw error for invalid validatorsHash', async () => {
+					when(consensus['_bftAPI'].getBFTParameters as never)
+						.calledWith(apiContext, block.header.height + 1)
+						.mockResolvedValue({
+							validatorsHash: cryptography.hash(cryptography.getRandomBytes(32)),
+						} as never);
+
+					await expect(
+						consensus['_verifyValidatorsHash'](apiContext, block as any),
+					).rejects.toThrow(
+						`Invalid validatorsHash ${block.header.validatorsHash?.toString(
+							'hex',
+						)} of the block with id: ${block.header.id.toString('hex')}`,
+					);
+				});
+
+				it('should be success for valid validatorsHash', async () => {
+					when(consensus['_bftAPI'].getBFTParameters as never)
+						.calledWith(apiContext, block.header.height + 1)
+						.mockResolvedValue({ validatorsHash: block.header.validatorsHash } as never);
+
+					await expect(
+						consensus['_verifyValidatorsHash'](apiContext, block as any),
 					).resolves.toBeUndefined();
 				});
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6753 

### How was it solved?

🌱 Assign validatorsHash in generator f098fd2
- Get validatorsHash from BFT module and assign it to the block being generated before signing

✅  Add test for assigning validatorsHash to block 8cb76ac

🌱 Add validatorsHash validation for verifying block 13e4e37

✅  Add tests for validatorsHash validation 5f19cca

### How was it tested?

`npm run test:unit consensus.spec`
`npm run test:unit generator.spec`
