### PR TITLE
Add asset root on block generation - Closes #6750

### DIFF
--- a/elements/lisk-chain/src/block.ts
+++ b/elements/lisk-chain/src/block.ts
@@ -78,7 +78,7 @@ export class Block {
 			tx.validate();
 		}
 
-		const assets = this.assets.getAllAssets();
+		const assets = this.assets.getAll();
 		let last = assets[0];
 		let i = 0;
 		for (const asset of assets) {

--- a/elements/lisk-chain/src/block_assets.ts
+++ b/elements/lisk-chain/src/block_assets.ts
@@ -13,6 +13,7 @@
  */
 
 import { codec } from '@liskhq/lisk-codec';
+import { MerkleTree } from '@liskhq/lisk-tree';
 import { blockAssetSchema } from './schema';
 
 export interface BlockAsset {
@@ -22,6 +23,7 @@ export interface BlockAsset {
 
 export class BlockAssets {
 	private readonly _assets: BlockAsset[] = [];
+	private _assetRoot!: Buffer;
 
 	public constructor(assets: BlockAsset[] = []) {
 		this._assets = assets;
@@ -36,6 +38,12 @@ export class BlockAssets {
 	public static fromJSON(values: Record<string, unknown>[]): BlockAssets {
 		const assets = values.map(val => codec.fromJSON<BlockAsset>(blockAssetSchema, val));
 		return new BlockAssets(assets);
+	}
+
+	public async getRoot(): Promise<Buffer> {
+		this._assetRoot = await this._calculateRoot();
+
+		return this._assetRoot;
 	}
 
 	public getBytes(): Buffer[] {
@@ -61,5 +69,12 @@ export class BlockAssets {
 
 	public sort(): void {
 		this._assets.sort((a1, a2) => a1.moduleID - a2.moduleID);
+	}
+
+	private async _calculateRoot(): Promise<Buffer> {
+		const merkleTree = new MerkleTree();
+		await merkleTree.init(this.getBytes());
+
+		return merkleTree.root;
 	}
 }

--- a/elements/lisk-chain/src/block_assets.ts
+++ b/elements/lisk-chain/src/block_assets.ts
@@ -54,7 +54,7 @@ export class BlockAssets {
 		return this._assets.find(a => a.moduleID === moduleID)?.data;
 	}
 
-	public getAllAssets(): BlockAsset[] {
+	public getAll(): BlockAsset[] {
 		return [...this._assets];
 	}
 

--- a/elements/lisk-chain/src/block_assets.ts
+++ b/elements/lisk-chain/src/block_assets.ts
@@ -46,6 +46,10 @@ export class BlockAssets {
 		return this._assets.find(a => a.moduleID === moduleID)?.data;
 	}
 
+	public getAllAssets(): BlockAsset[] {
+		return [...this._assets];
+	}
+
 	public setAsset(moduleID: number, value: Buffer): void {
 		const asset = this.getAsset(moduleID);
 		if (asset) {

--- a/elements/lisk-chain/src/constants.ts
+++ b/elements/lisk-chain/src/constants.ts
@@ -28,3 +28,6 @@ export const GENESIS_BLOCK_TRANSACTION_ROOT = EMPTY_HASH;
 
 export const TAG_BLOCK_HEADER = createMessageTag('BH');
 export const TAG_TRANSACTION = createMessageTag('TX');
+
+// TODO: Actual size TBD
+export const MAX_ASSET_DATA_SIZE_BYTES = 64;

--- a/elements/lisk-chain/test/unit/block.spec.ts
+++ b/elements/lisk-chain/test/unit/block.spec.ts
@@ -11,7 +11,9 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { Block, Transaction } from '../../src';
+import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { Block, BlockAsset, BlockAssets, Transaction } from '../../src';
+import { MAX_ASSET_DATA_SIZE_BYTES } from '../../src/constants';
 import { createValidDefaultBlock } from '../utils/block';
 import { getTransaction } from '../utils/transaction';
 
@@ -19,15 +21,31 @@ describe('block', () => {
 	describe('validate', () => {
 		let block: Block;
 		let tx: Transaction;
+		let assetList: BlockAsset[];
+		let blockAssets: BlockAssets;
 
 		beforeEach(() => {
+			assetList = [
+				{
+					moduleID: 6,
+					data: getRandomBytes(64),
+				},
+				{
+					moduleID: 3,
+					data: getRandomBytes(64),
+				},
+			];
+			blockAssets = new BlockAssets(assetList);
 			tx = getTransaction();
 		});
 
 		describe('when previousBlockID is empty', () => {
 			it('should throw error', async () => {
 				// Arrange
-				block = await createValidDefaultBlock({ header: { previousBlockID: Buffer.alloc(0) } });
+				block = await createValidDefaultBlock({
+					header: { previousBlockID: Buffer.alloc(0) },
+					assets: blockAssets,
+				});
 				// Act & assert
 				expect(() => block.validate()).toThrow('Previous block id must not be empty');
 			});
@@ -51,6 +69,128 @@ describe('block', () => {
 				block = await createValidDefaultBlock({ payload: txs });
 				// Act & assert
 				expect(() => block.validate()).not.toThrow();
+			});
+		});
+
+		describe('when an asset data has size more than the limit', () => {
+			it(`should throw error when asset data lenght is greater than ${MAX_ASSET_DATA_SIZE_BYTES}`, async () => {
+				// Arrange
+				const assets = [
+					{
+						moduleID: 3,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 4,
+						data: getRandomBytes(128),
+					},
+				];
+				block = await createValidDefaultBlock({ assets: new BlockAssets(assets) });
+				// Act & assert
+				expect(() => block.validate()).toThrow(
+					`Module with ID ${assets[1].moduleID} has data size more than ${MAX_ASSET_DATA_SIZE_BYTES} bytes.`,
+				);
+			});
+
+			it(`should pass when asset data lenght is equal or less than ${MAX_ASSET_DATA_SIZE_BYTES}`, async () => {
+				// Arrange
+				const assets = [
+					{
+						moduleID: 3,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 4,
+						data: getRandomBytes(64),
+					},
+				];
+				block = await createValidDefaultBlock({ assets: new BlockAssets(assets) });
+				// Act & assert
+				expect(block.validate()).toBeUndefined();
+			});
+		});
+
+		describe('when the assets are not sorted by moduleID', () => {
+			it('should throw error when assets are not sorted by moduleID', async () => {
+				// Arrange
+				const assets = [
+					{
+						moduleID: 4,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 3,
+						data: getRandomBytes(64),
+					},
+				];
+				block = await createValidDefaultBlock({ assets: new BlockAssets(assets) });
+				// Act & assert
+				expect(() => block.validate()).toThrow(
+					'Assets are not sorted in the increasing values of moduleID.',
+				);
+			});
+
+			it('should pass when assets are sorted by moduleID', async () => {
+				// Arrange
+				const assets = [
+					{
+						moduleID: 2,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 3,
+						data: getRandomBytes(64),
+					},
+				];
+				block = await createValidDefaultBlock({ assets: new BlockAssets(assets) });
+				// Act & assert
+				expect(block.validate()).toBeUndefined();
+			});
+		});
+
+		describe('when there are multiple asset entries for a moduleID', () => {
+			it('should throw error when there are more than 1 assets for a module', async () => {
+				// Arrange
+				const assets = [
+					{
+						moduleID: 2,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 3,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 3,
+						data: getRandomBytes(64),
+					},
+				];
+				block = await createValidDefaultBlock({ assets: new BlockAssets(assets) });
+				// Act & assert
+				expect(() => block.validate()).toThrow(
+					`Module with ID ${assets[1].moduleID} has duplicate entries.`,
+				);
+			});
+
+			it('should pass when there is atmost 1 asset for a module', async () => {
+				// Arrange
+				const assets = [
+					{
+						moduleID: 2,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 3,
+						data: getRandomBytes(64),
+					},
+					{
+						moduleID: 4,
+						data: getRandomBytes(64),
+					},
+				];
+				block = await createValidDefaultBlock({ assets: new BlockAssets(assets) });
+				// Act & assert
+				expect(block.validate()).toBeUndefined();
 			});
 		});
 	});

--- a/elements/lisk-chain/test/unit/block.spec.ts
+++ b/elements/lisk-chain/test/unit/block.spec.ts
@@ -73,7 +73,7 @@ describe('block', () => {
 		});
 
 		describe('when an asset data has size more than the limit', () => {
-			it(`should throw error when asset data lenght is greater than ${MAX_ASSET_DATA_SIZE_BYTES}`, async () => {
+			it(`should throw error when asset data length is greater than ${MAX_ASSET_DATA_SIZE_BYTES}`, async () => {
 				// Arrange
 				const assets = [
 					{
@@ -92,7 +92,7 @@ describe('block', () => {
 				);
 			});
 
-			it(`should pass when asset data lenght is equal or less than ${MAX_ASSET_DATA_SIZE_BYTES}`, async () => {
+			it(`should pass when asset data length is equal or less than ${MAX_ASSET_DATA_SIZE_BYTES}`, async () => {
 				// Arrange
 				const assets = [
 					{

--- a/elements/lisk-chain/test/unit/block_assets.spec.ts
+++ b/elements/lisk-chain/test/unit/block_assets.spec.ts
@@ -87,7 +87,7 @@ describe('block assets', () => {
 
 	describe('getAllAsset', () => {
 		it('should return list of all assets', () => {
-			expect(assets.getAllAssets()).toContainAllValues(assetList);
+			expect(assets.getAll()).toContainAllValues(assetList);
 		});
 	});
 });

--- a/elements/lisk-chain/test/unit/block_assets.spec.ts
+++ b/elements/lisk-chain/test/unit/block_assets.spec.ts
@@ -12,13 +12,15 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
-import { BlockAssets } from '../../src';
+import { MerkleTree } from '@liskhq/lisk-tree';
+import { BlockAsset, BlockAssets } from '../../src';
 
 describe('block assets', () => {
 	let assets: BlockAssets;
+	let assetList: BlockAsset[];
 
 	beforeEach(() => {
-		assets = new BlockAssets([
+		assetList = [
 			{
 				moduleID: 6,
 				data: getRandomBytes(64),
@@ -27,7 +29,8 @@ describe('block assets', () => {
 				moduleID: 3,
 				data: getRandomBytes(64),
 			},
-		]);
+		];
+		assets = new BlockAssets(assetList);
 	});
 
 	describe('sort', () => {
@@ -70,6 +73,21 @@ describe('block assets', () => {
 			]);
 			expect(assets['_assets']).toHaveLength(1);
 			expect(assets.getAsset(4)).toBeInstanceOf(Buffer);
+		});
+	});
+
+	describe('getRoot', () => {
+		it('should calculate and return asset root', async () => {
+			const root = await assets.getRoot();
+			const merkleT = new MerkleTree();
+			await merkleT.init(assets.getBytes());
+			await expect(assets.getRoot()).resolves.toEqual(root);
+		});
+	});
+
+	describe('getAllAsset', () => {
+		it('should return list of all assets', () => {
+			expect(assets.getAllAssets()).toContainAllValues(assetList);
 		});
 	});
 });

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -634,7 +634,7 @@ export class Consensus {
 	}
 
 	private _validateBlockAsset(block: Block): void {
-		for (const asset of block.assets.getAllAssets()) {
+		for (const asset of block.assets.getAll()) {
 			if (!this._stateMachine.getAllModuleIDs().includes(asset.moduleID)) {
 				throw new Error(`Module with ID: ${asset.moduleID} is not registered.`);
 			}

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -484,8 +484,17 @@ export class Consensus {
 
 		// verify Block signature
 		await this._verifyBlockSignature(apiContext, block);
+
 		// Verify validatorsHash
 		await this._verifyValidatorsHash(apiContext, block);
+
+		// Validate a block
+		block.validate();
+		for (const asset of block.assets.getAllAssets()) {
+			if (!this._stateMachine.getAllModuleIDs().includes(asset.moduleID)) {
+				throw new Error(`Module with ID: ${asset.moduleID} is not registered.`);
+			}
+		}
 	}
 
 	private async _verifyTimestamp(apiContext: APIContext, block: Block): Promise<void> {

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -490,6 +490,7 @@ export class Consensus {
 
 		// Validate a block
 		block.validate();
+		// Check if moduleID is registered
 		for (const asset of block.assets.getAllAssets()) {
 			if (!this._stateMachine.getAllModuleIDs().includes(asset.moduleID)) {
 				throw new Error(`Module with ID: ${asset.moduleID} is not registered.`);

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -490,12 +490,9 @@ export class Consensus {
 
 		// Validate a block
 		block.validate();
+
 		// Check if moduleID is registered
-		for (const asset of block.assets.getAllAssets()) {
-			if (!this._stateMachine.getAllModuleIDs().includes(asset.moduleID)) {
-				throw new Error(`Module with ID: ${asset.moduleID} is not registered.`);
-			}
-		}
+		this._validateBlockAsset(block);
 	}
 
 	private async _verifyTimestamp(apiContext: APIContext, block: Block): Promise<void> {
@@ -631,6 +628,14 @@ export class Consensus {
 					'hex',
 				)} of the block with id: ${block.header.id.toString('hex')}`,
 			);
+		}
+	}
+
+	private _validateBlockAsset(block: Block): void {
+		for (const asset of block.assets.getAllAssets()) {
+			if (!this._stateMachine.getAllModuleIDs().includes(asset.moduleID)) {
+				throw new Error(`Module with ID: ${asset.moduleID} is not registered.`);
+			}
 		}
 	}
 

--- a/framework/src/node/generator/generator.ts
+++ b/framework/src/node/generator/generator.ts
@@ -498,8 +498,7 @@ export class Generator {
 		await txTree.init(transactions.map(tx => tx.id));
 		const transactionRoot = txTree.root;
 		blockHeader.transactionRoot = transactionRoot;
-		// TODO: Update the assetsRoot with proper calculation
-		blockHeader.assetsRoot = hash(Buffer.concat(blockAssets.getBytes()));
+		blockHeader.assetsRoot = await blockAssets.getRoot();
 		// TODO: Update the stateRoot with proper calculation
 		blockHeader.stateRoot = hash(Buffer.alloc(0));
 		// Set validatorsHash

--- a/framework/src/node/state_machine/state_machine.ts
+++ b/framework/src/node/state_machine/state_machine.ts
@@ -51,15 +51,24 @@ export interface StateMachineModule {
 export class StateMachine {
 	private readonly _modules: StateMachineModule[] = [];
 	private readonly _systemModules: StateMachineModule[] = [];
+	private readonly _moduleIDs: number[] = [];
 
 	public registerModule(mod: StateMachineModule): void {
 		this._validateExistingModuleID(mod.id);
 		this._modules.push(mod);
+		this._moduleIDs.push(mod.id);
+		this._moduleIDs.sort((a, b) => a - b);
 	}
 
 	public registerSystemModule(mod: StateMachineModule): void {
 		this._validateExistingModuleID(mod.id);
 		this._systemModules.push(mod);
+		this._moduleIDs.push(mod.id);
+		this._moduleIDs.sort((a, b) => a - b);
+	}
+
+	public getAllModuleIDs() {
+		return this._moduleIDs;
 	}
 
 	public async executeGenesisBlock(ctx: GenesisBlockContext): Promise<void> {

--- a/framework/test/fixtures/blocks.ts
+++ b/framework/test/fixtures/blocks.ts
@@ -82,7 +82,7 @@ export const createFakeBlockHeader = (header?: Partial<BlockHeaderAttrs>): Block
  * Calculates the signature, transactionRoot etc. internally. Facilitating the creation of block with valid signature and other properties
  */
 export const createValidDefaultBlock = async (
-	block?: { header?: Partial<BlockHeaderAttrs>; payload?: Transaction[] },
+	block?: { header?: Partial<BlockHeaderAttrs>; payload?: Transaction[]; assets?: BlockAssets },
 	networkIdentifier: Buffer = defaultNetworkIdentifier,
 ): Promise<Block> => {
 	const keypair = getKeyPair();
@@ -115,5 +115,5 @@ export const createValidDefaultBlock = async (
 	// Assigning the id ahead
 	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	blockHeader.id;
-	return new Block(blockHeader, payload, new BlockAssets());
+	return new Block(blockHeader, payload, block?.assets ?? new BlockAssets());
 };

--- a/framework/test/unit/node/consensus/consensus.spec.ts
+++ b/framework/test/unit/node/consensus/consensus.spec.ts
@@ -84,6 +84,7 @@ describe('consensus', () => {
 			executeGenesisBlock: jest.fn(),
 			verifyBlock: jest.fn(),
 			executeBlock: jest.fn(),
+			getAllModuleIDs: jest.fn(),
 		} as unknown) as StateMachine;
 		bftAPI = {
 			getBFTHeights: jest
@@ -785,6 +786,66 @@ describe('consensus', () => {
 					await expect(
 						consensus['_verifyValidatorsHash'](apiContext, block as any),
 					).resolves.toBeUndefined();
+				});
+			});
+
+			describe('validateBlockAsset', () => {
+				it('should throw error if a module is not registered', async () => {
+					const assetList = [
+						{
+							moduleID: 1,
+							data: cryptography.getRandomBytes(64),
+						},
+						{
+							moduleID: 2,
+							data: cryptography.getRandomBytes(64),
+						},
+						{
+							moduleID: 3,
+							data: cryptography.getRandomBytes(64),
+						},
+						{
+							moduleID: 4,
+							data: cryptography.getRandomBytes(64),
+						},
+					];
+
+					const invalidBlock = await createValidDefaultBlock({
+						assets: new BlockAssets(assetList),
+					});
+					jest.spyOn(stateMachine, 'getAllModuleIDs').mockReturnValue([1, 2, 3]);
+
+					expect(() => consensus['_validateBlockAsset'](invalidBlock as any)).toThrow(
+						'Module with ID: 4 is not registered.',
+					);
+				});
+
+				it('should be success if a module is registered', async () => {
+					const assetList = [
+						{
+							moduleID: 1,
+							data: cryptography.getRandomBytes(64),
+						},
+						{
+							moduleID: 2,
+							data: cryptography.getRandomBytes(64),
+						},
+						{
+							moduleID: 3,
+							data: cryptography.getRandomBytes(64),
+						},
+						{
+							moduleID: 4,
+							data: cryptography.getRandomBytes(64),
+						},
+					];
+
+					const invalidBlock = await createValidDefaultBlock({
+						assets: new BlockAssets(assetList),
+					});
+					jest.spyOn(stateMachine, 'getAllModuleIDs').mockReturnValue([1, 2, 3, 4]);
+
+					expect(consensus['_validateBlockAsset'](invalidBlock as any)).toBeUndefined();
 				});
 			});
 		});

--- a/framework/test/unit/node/consensus/consensus.spec.ts
+++ b/framework/test/unit/node/consensus/consensus.spec.ts
@@ -622,7 +622,7 @@ describe('consensus', () => {
 			});
 
 			describe('generatorAddress', () => {
-				it('should throw error if [generatorAddress.lenght !== 20]', async () => {
+				it('should throw error if [generatorAddress.length !== 20]', async () => {
 					const invalidBlock = { ...block };
 					(invalidBlock.header as any).generatorAddress = cryptography.getRandomBytes(64);
 					await expect(

--- a/framework/test/unit/node/generator/generator.spec.ts
+++ b/framework/test/unit/node/generator/generator.spec.ts
@@ -11,7 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { Chain, Transaction } from '@liskhq/lisk-chain';
+import { BlockAssets, Chain, Transaction } from '@liskhq/lisk-chain';
 import { getAddressFromPublicKey, getRandomBytes, hash } from '@liskhq/lisk-cryptography';
 import { InMemoryKVStore, KVStore } from '@liskhq/lisk-db';
 import { codec } from '@liskhq/lisk-codec';
@@ -449,6 +449,7 @@ describe('generator', () => {
 		};
 		const currentTime = Math.floor(Date.now() / 1000);
 		const validatorsHash = hash(getRandomBytes(32));
+		const assetHash = hash(getRandomBytes(32));
 
 		beforeEach(async () => {
 			mod1 = {
@@ -490,6 +491,13 @@ describe('generator', () => {
 			const block = await generator['_generateBlock'](generatorAddress, keypair, currentTime);
 
 			expect(block.header.validatorsHash).toEqual(validatorsHash);
+		});
+
+		it('should assign assetRoot to the block', async () => {
+			jest.spyOn(BlockAssets.prototype, 'getRoot').mockResolvedValue(assetHash);
+			const block = await generator['_generateBlock'](generatorAddress, keypair, currentTime);
+
+			expect(block.header.assetsRoot).toEqual(assetHash);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #6750

### How was it solved?

🌱 Add block asset validation https://github.com/LiskHQ/lisk-sdk/commit/004e232749f795f7bb97a4ee200f6badb9c76914

- Expose registered module ids from state machine
- Check the size of data of an asset not exceeding the limit
- Check a module asset is not duplicated
- Check a module assets are sorted by id and are registered in state machine
  
🌱 Calculate asset root and add it to block header on block generation https://github.com/LiskHQ/lisk-sdk/commit/f9337ec686a9f12a00cdfae5b3d72fe4b092269c
  
♻️ Add _validateBlockAsset https://github.com/LiskHQ/lisk-sdk/commit/d810783965a107b45ad4f472d1091932bf85a743
  
✅ Add Block and BlockAssets validation tests https://github.com/LiskHQ/lisk-sdk/commit/89778d62fecd4df99279d9d810b811f7c9440550
  
✅ Add tests for BlockAssets validation in consensus and generator https://github.com/LiskHQ/lisk-sdk/commit/b9dea4f7a37f1f31accde2a2b5effa9a712e5dc4
  

### How was it tested?

Under `framework`,
`npm run test:unit consensus.spec`
`npm run test:unit generator.spec`

Under `lisk-chain`,
`npm run test block_asset.spec`
`npm run test block.spec`