### PR TITLE
Implement delegate productivity for DPoS AfterBlockExecute hook - Closes #6874

### DIFF
--- a/framework/src/modules/dpos_v2/constants.ts
+++ b/framework/src/modules/dpos_v2/constants.ts
@@ -42,3 +42,4 @@ export const MAX_PUNISHABLE_BLOCK_HEIGHT_DIFFERENCE = 260000;
 export const MAX_POM_HEIGHTS = 5;
 export const REPORTING_PUNISHMENT_REWARD = BigInt(100000000);
 export const DELEGATE_LIST_ROUND_OFFSET = 2;
+export const EMPTY_KEY = Buffer.alloc(0);

--- a/framework/src/modules/dpos_v2/schemas.ts
+++ b/framework/src/modules/dpos_v2/schemas.ts
@@ -171,6 +171,7 @@ export const genesisDataStoreSchema = {
 };
 
 export const previousTimestampStoreSchema = {
+	$id: '/dpos/store/previousTimestamp',
 	type: 'object',
 	required: ['timestamp'],
 	properties: {

--- a/framework/src/modules/dpos_v2/types.ts
+++ b/framework/src/modules/dpos_v2/types.ts
@@ -79,6 +79,12 @@ export interface ValidatorsAPI {
 		proofOfPossession: Buffer,
 	): Promise<boolean>;
 	getValidatorAccount(apiContext: ImmutableAPIContext, address: Buffer): Promise<ValidatorKeys>;
+	getGeneratorsBetweenTimestamps(
+		apiContext: ImmutableAPIContext,
+		startTimestamp: number,
+		endTimestamp: number,
+	): Promise<Record<string, number>>;
+	getGeneratorAtTimestamp(apiContext: ImmutableAPIContext, timestamp: number): Promise<Buffer>;
 }
 
 export interface TokenAPI {
@@ -216,4 +222,8 @@ export interface SnapshotStoreData {
 		delegateAddress: Buffer;
 		delegateWeight: bigint;
 	}[];
+}
+
+export interface PreviousTimestampData {
+	timestamp: number;
 }

--- a/framework/test/unit/modules/dpos_v2/commands/delegate_registration.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/delegate_registration.spec.ts
@@ -84,6 +84,8 @@ describe('Delegate registration command', () => {
 			setGeneratorList: jest.fn(),
 			registerValidatorKeys: jest.fn().mockResolvedValue(true),
 			getValidatorAccount: jest.fn(),
+			getGeneratorsBetweenTimestamps: jest.fn(),
+			getGeneratorAtTimestamp: jest.fn(),
 		};
 		delegateRegistrationCommand.addDependencies(mockValidatorsAPI);
 		db = new InMemoryKVStore() as never;

--- a/framework/test/unit/modules/dpos_v2/commands/pom.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/pom.spec.ts
@@ -96,6 +96,8 @@ describe('ReportDelegateMisbehaviorCommand', () => {
 			setValidatorGeneratorKey: jest.fn(),
 			registerValidatorKeys: jest.fn(),
 			getValidatorAccount: jest.fn().mockResolvedValue({ generatorKey: publicKey }),
+			getGeneratorsBetweenTimestamps: jest.fn(),
+			getGeneratorAtTimestamp: jest.fn(),
 		};
 		pomCommand.addDependencies({
 			tokenIDDPoS: { chainID: 0, localID: 0 },


### PR DESCRIPTION
### What was the problem?

This PR resolves #6874 

### How was it solved?

- Created an auxiliary function that sets delegate productivity by new module interfaces

### How was it tested?

- Created unit tests that are based on old DPoS module test cases
