### PR TITLE
Add stateRoot when generating a block - Closes #6752

### DIFF
--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -11,6 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+
 import { KVStore, NotFoundError } from '@liskhq/lisk-db';
 import { Transaction } from '../transaction';
 import { RawBlock } from '../types';
@@ -20,7 +21,7 @@ import { Block } from '../block';
 import { BlockCache } from './cache';
 import { Storage as StorageAccess } from './storage';
 import { BlockAssets } from '../block_assets';
-import { CurrentState } from '..';
+import { CurrentState } from '../state_store';
 
 interface DAConstructor {
 	readonly db: KVStore;

--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -19,8 +19,8 @@ import { Block } from '../block';
 
 import { BlockCache } from './cache';
 import { Storage as StorageAccess } from './storage';
-import { StateStore } from '../state_store';
 import { BlockAssets } from '../block_assets';
+import { CurrentState } from '..';
 
 interface DAConstructor {
 	readonly db: KVStore;
@@ -282,13 +282,13 @@ export class DataAccess {
 	*/
 	public async saveBlock(
 		block: Block,
-		stateStore: StateStore,
+		state: CurrentState,
 		finalizedHeight: number,
 		removeFromTemp = false,
 	): Promise<void> {
 		const { id: blockID, height } = block.header;
 		const encodedHeader = block.header.getBytes();
-		const lastBlock = await this.getLastBlock();
+
 		const encodedPayload = [];
 		for (const tx of block.payload) {
 			const txID = tx.id;
@@ -302,20 +302,15 @@ export class DataAccess {
 			encodedHeader,
 			encodedPayload,
 			block.assets.getBytes(),
-			stateStore,
-			lastBlock,
+			state,
 			removeFromTemp,
 		);
 	}
 
-	public async deleteBlock(
-		block: Block,
-		stateStore: StateStore,
-		saveToTemp = false,
-	): Promise<void> {
+	public async deleteBlock(block: Block, state: CurrentState, saveToTemp = false): Promise<void> {
 		const { id: blockID, height } = block.header;
 		const txIDs = block.payload.map(tx => tx.id);
-		const lastBlock = await this.getLastBlock();
+
 		const encodedBlock = block.getBytes();
 		await this._storage.deleteBlock(
 			blockID,
@@ -323,8 +318,7 @@ export class DataAccess {
 			txIDs,
 			block.assets.getBytes(),
 			encodedBlock,
-			stateStore,
-			lastBlock,
+			state,
 			saveToTemp,
 		);
 	}

--- a/elements/lisk-chain/src/data_access/data_access.ts
+++ b/elements/lisk-chain/src/data_access/data_access.ts
@@ -288,6 +288,7 @@ export class DataAccess {
 	): Promise<void> {
 		const { id: blockID, height } = block.header;
 		const encodedHeader = block.header.getBytes();
+		const lastBlock = await this.getLastBlock();
 		const encodedPayload = [];
 		for (const tx of block.payload) {
 			const txID = tx.id;
@@ -302,6 +303,7 @@ export class DataAccess {
 			encodedPayload,
 			block.assets.getBytes(),
 			stateStore,
+			lastBlock,
 			removeFromTemp,
 		);
 	}
@@ -313,6 +315,7 @@ export class DataAccess {
 	): Promise<void> {
 		const { id: blockID, height } = block.header;
 		const txIDs = block.payload.map(tx => tx.id);
+		const lastBlock = await this.getLastBlock();
 		const encodedBlock = block.getBytes();
 		await this._storage.deleteBlock(
 			blockID,
@@ -321,6 +324,7 @@ export class DataAccess {
 			block.assets.getBytes(),
 			encodedBlock,
 			stateStore,
+			lastBlock,
 			saveToTemp,
 		);
 	}

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -54,10 +54,7 @@ const decodeByteArray = (val: Buffer): Buffer[] => {
 	return decoded.list;
 };
 
-const encodeByteArray = (val: Buffer[]): Buffer => {
-	const encoded = codec.encode(bytesArraySchema, { list: val });
-	return codec.encode(bytesArraySchema, encoded);
-};
+const encodeByteArray = (val: Buffer[]): Buffer => codec.encode(bytesArraySchema, { list: val });
 
 export class Storage {
 	private readonly _db: KVStore;

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -407,8 +407,7 @@ export class Storage {
 			updated: updatedStates,
 			deleted: deletedStates,
 		} = codec.decode<StateDiff>(stateDiffSchema, stateDiff);
-		// const smtStore = new SMTStore(this._db);
-		// const smt = new SparseMerkleTree({ db: smtStore, rootHash: lastBlock.header.stateRoot });
+
 		// Delete all the newly created states
 		for (const key of createdStates) {
 			batch.del(key);

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -28,7 +28,7 @@ import {
 } from '../db_keys';
 import { concatDBKeys } from '../utils';
 import { stateDiffSchema } from '../schema';
-import { CurrentState } from '..';
+import { CurrentState } from '../state_store';
 
 const bytesArraySchema = {
 	$id: 'lisk-chain/bytesarray',

--- a/elements/lisk-chain/src/db_keys.ts
+++ b/elements/lisk-chain/src/db_keys.ts
@@ -27,3 +27,6 @@ export const DB_KEY_FINALIZED_HEIGHT = Buffer.from([27]);
 
 // 51-75 for diff state
 export const DB_KEY_DIFF_STATE = Buffer.from([51]);
+
+// 76 for smt of state
+export const DB_KEY_STATE_SMT = Buffer.from([76]);

--- a/elements/lisk-chain/src/index.ts
+++ b/elements/lisk-chain/src/index.ts
@@ -31,7 +31,7 @@ export type { RawBlock } from './types';
 export { Slots } from './slots';
 export { concatDBKeys } from './utils';
 
-export { StateStore, NotFoundError, SMTStore } from './state_store';
+export { StateStore, NotFoundError, CurrentState, SMTStore } from './state_store';
 export { Block } from './block';
 export { BlockAsset, BlockAssets } from './block_assets';
 export { BlockHeader, BlockHeaderAttrs, BlockHeaderJSON } from './block_header';

--- a/elements/lisk-chain/src/index.ts
+++ b/elements/lisk-chain/src/index.ts
@@ -31,7 +31,7 @@ export type { RawBlock } from './types';
 export { Slots } from './slots';
 export { concatDBKeys } from './utils';
 
-export { StateStore, NotFoundError } from './state_store';
+export { StateStore, NotFoundError, SMTStore } from './state_store';
 export { Block } from './block';
 export { BlockAsset, BlockAssets } from './block_assets';
 export { BlockHeader, BlockHeaderAttrs, BlockHeaderJSON } from './block_header';

--- a/elements/lisk-chain/src/state_store/index.ts
+++ b/elements/lisk-chain/src/state_store/index.ts
@@ -14,3 +14,4 @@
 
 export { NotFoundError } from './errors';
 export { StateStore, IterateOptions } from './state_store';
+export { SMTStore } from './smt_store';

--- a/elements/lisk-chain/src/state_store/index.ts
+++ b/elements/lisk-chain/src/state_store/index.ts
@@ -13,5 +13,5 @@
  */
 
 export { NotFoundError } from './errors';
+export { CurrentState, SMTStore } from './smt_store';
 export { StateStore, IterateOptions } from './state_store';
-export { SMTStore } from './smt_store';

--- a/elements/lisk-chain/src/state_store/smt_store.ts
+++ b/elements/lisk-chain/src/state_store/smt_store.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { NotFoundError as DBNotFoundError } from '@liskhq/lisk-db';
+import { dataStructures } from '@liskhq/lisk-utils';
+import { DB_KEY_STATE_SMT } from '../db_keys';
+import { NotFoundError } from './errors';
+import { DatabaseReader, DatabaseWriter } from './types';
+
+export class SMTStore {
+	private readonly _db: DatabaseReader;
+	private readonly _data: dataStructures.BufferMap<Buffer>;
+
+	public constructor(db: DatabaseReader, data?: dataStructures.BufferMap<Buffer>) {
+		this._db = db;
+		this._data = data ?? new dataStructures.BufferMap();
+	}
+
+	public async get(key: Buffer): Promise<Buffer> {
+		const prefixedKey = this._getKey(key);
+		const cachedValue = this._data.get(prefixedKey);
+		if (cachedValue) {
+			return cachedValue;
+		}
+		try {
+			const storedValue = await this._db.get(prefixedKey);
+			this._data.set(prefixedKey, storedValue);
+			return storedValue;
+		} catch (error) {
+			if (error instanceof DBNotFoundError) {
+				throw new NotFoundError(key);
+			}
+			throw error;
+		}
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async set(key: Buffer, value: Buffer): Promise<void> {
+		const prefixedKey = this._getKey(key);
+		this._data.set(prefixedKey, value);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async del(key: Buffer): Promise<void> {
+		const prefixedKey = this._getKey(key);
+		this._data.delete(prefixedKey);
+	}
+
+	public finalize(batch: DatabaseWriter): void {
+		for (const [key, value] of this._data.entries()) {
+			batch.put(key, value);
+		}
+	}
+
+	private _getKey(key: Buffer): Buffer {
+		return Buffer.concat([DB_KEY_STATE_SMT, key]);
+	}
+}

--- a/elements/lisk-chain/src/state_store/smt_store.ts
+++ b/elements/lisk-chain/src/state_store/smt_store.ts
@@ -12,11 +12,22 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { NotFoundError as DBNotFoundError } from '@liskhq/lisk-db';
+import { BatchChain, NotFoundError as DBNotFoundError } from '@liskhq/lisk-db';
+import { SparseMerkleTree } from '@liskhq/lisk-tree';
 import { dataStructures } from '@liskhq/lisk-utils';
+import { StateStore } from './state_store';
 import { DB_KEY_STATE_SMT } from '../db_keys';
+import { StateDiff } from '../types';
 import { NotFoundError } from './errors';
 import { DatabaseReader, DatabaseWriter } from './types';
+
+export interface CurrentState {
+	batch: BatchChain;
+	diff: StateDiff;
+	stateStore: StateStore;
+	smt: SparseMerkleTree;
+	smtStore: SMTStore;
+}
 
 export class SMTStore {
 	private readonly _db: DatabaseReader;

--- a/elements/lisk-chain/src/state_store/state_store.ts
+++ b/elements/lisk-chain/src/state_store/state_store.ts
@@ -14,6 +14,7 @@
 
 import { codec, Schema } from '@liskhq/lisk-codec';
 import { NotFoundError as DBNotFoundError } from '@liskhq/lisk-db';
+import { SparseMerkleTree } from '@liskhq/lisk-tree';
 import { DB_KEY_STATE_STORE } from '../db_keys';
 import { StateDiff } from '../types';
 import { CacheDB } from './cache_db';
@@ -60,6 +61,7 @@ export class StateStore {
 			Buffer.concat([DB_KEY_STATE_STORE, moduleIDBuffer, storePrefixBuffer]),
 			this._cache,
 		);
+
 		return subStore;
 	}
 
@@ -229,8 +231,8 @@ export class StateStore {
 		this._snapshot = undefined;
 	}
 
-	public finalize(batch: DatabaseWriter): StateDiff {
-		return this._cache.finalize(batch);
+	public async finalize(batch: DatabaseWriter, smt: SparseMerkleTree): Promise<StateDiff> {
+		return this._cache.finalize(batch, smt);
 	}
 
 	private async _ensureCache(prefixedKey: Buffer): Promise<boolean> {

--- a/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
+++ b/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
@@ -14,7 +14,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { KVStore, formatInt, NotFoundError } from '@liskhq/lisk-db';
+import { KVStore, formatInt, NotFoundError, InMemoryKVStore } from '@liskhq/lisk-db';
 import { codec } from '@liskhq/lisk-codec';
 import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import { SparseMerkleTree } from '@liskhq/lisk-tree';
@@ -31,6 +31,7 @@ import {
 	DB_KEY_TEMPBLOCKS_HEIGHT,
 	DB_KEY_DIFF_STATE,
 	DB_KEY_TRANSACTIONS_BLOCK_ID,
+	DB_KEY_STATE_STORE,
 } from '../../../src/db_keys';
 import { concatDBKeys } from '../../../src/utils';
 
@@ -511,6 +512,200 @@ describe('dataAccess.blocks', () => {
 			expect(tempBlocks[0].header.toObject()).toStrictEqual(blocks[2].header.toObject());
 			expect(tempBlocks[0].payload[0]).toBeInstanceOf(Transaction);
 			expect(tempBlocks[0].payload[0].id).toStrictEqual(blocks[2].payload[0].id);
+		});
+	});
+
+	describe('State root calculation after save/delete block', () => {
+		const sequenceSchema = {
+			$id: 'modules/seq/',
+			type: 'object',
+			properties: {
+				nonce: {
+					dataType: 'uint32',
+					fieldNumber: 1,
+				},
+			},
+			required: ['nonce'],
+		};
+
+		const MODULE_ID = 14;
+		const STORE_PREFIX = 1;
+		let currentState: CurrentState;
+		let stateStore: StateStore;
+		let tempDB: InMemoryKVStore;
+
+		const prefixedKey = (
+			key: Buffer,
+			moduleID: number = MODULE_ID,
+			storePrefix: number = STORE_PREFIX,
+		) => {
+			const moduleIDBuffer = Buffer.alloc(4);
+			moduleIDBuffer.writeInt32BE(moduleID, 0);
+			const storePrefixBuffer = Buffer.alloc(2);
+			storePrefixBuffer.writeUInt16BE(storePrefix, 0);
+
+			return Buffer.concat([DB_KEY_STATE_STORE, moduleIDBuffer, storePrefixBuffer, key]);
+		};
+
+		beforeEach(async () => {
+			stateStore = new StateStore(db);
+			tempDB = new InMemoryKVStore();
+		});
+
+		afterAll(async () => {
+			await tempDB.clear();
+		});
+
+		it('should return current stateRoot calculated after saveBlock', async () => {
+			const subStore = stateStore.getStore(14, 1);
+
+			// 3 accounts being set with data
+			const address1 = getRandomBytes(20);
+			const address2 = getRandomBytes(20);
+			const address3 = getRandomBytes(20);
+
+			const data1 = codec.encode(sequenceSchema, { nonce: 10 });
+			const data2 = codec.encode(sequenceSchema, { nonce: 17 });
+			const data3 = codec.encode(sequenceSchema, { nonce: 29 });
+
+			// Set 3 accounts in stateStore
+			await subStore.set(address1, data1);
+			await subStore.set(address2, data2);
+			await subStore.set(address3, data3);
+
+			// To calculate SMT root hash from updating each address above manually
+			const smtStoreTemp = new SMTStore(tempDB);
+			const smtTemp = new SparseMerkleTree({ db: smtStoreTemp, keyLength: 27 });
+
+			await smtTemp.update(prefixedKey(address1), data1);
+			await smtTemp.update(prefixedKey(address2), data2);
+			await smtTemp.update(prefixedKey(address3), data3);
+			const { rootHash: expectedStateRoot } = smtTemp;
+
+			// Add the expected state root calculated to a block to be saved
+			const firstBlock = await createValidDefaultBlock({
+				header: { height: 304, stateRoot: expectedStateRoot },
+				payload: [getTransaction({ nonce: BigInt(10) }), getTransaction({ nonce: BigInt(20) })],
+			});
+
+			// Run all the finalizeStore steps: create SMT store, batch, smt and pass it to saveBlock()
+			const smtStore = new SMTStore(db);
+			const batchLocal = db.batch();
+			const smt = new SparseMerkleTree({ db: smtStore, keyLength: 27 });
+			const diff1 = await stateStore.finalize(batchLocal, smt);
+			smtStore.finalize(batchLocal);
+
+			currentState = {
+				smt,
+				smtStore,
+				batch: batchLocal,
+				diff: diff1,
+				stateStore,
+			};
+			await dataAccess.saveBlock(firstBlock, currentState, 100);
+
+			expect(smt.rootHash).toEqual(firstBlock.header.stateRoot);
+
+			// Test another with deleting one of the keys
+			await smtTemp.remove(prefixedKey(address3));
+			// Add the expected state root calculated to a block to be saved
+			const secondBlock = await createValidDefaultBlock({
+				header: { height: 304, stateRoot: smtTemp.rootHash },
+				payload: [getTransaction({ nonce: BigInt(10) })],
+			});
+
+			const secondSubStore = stateStore.getStore(14, 1);
+			await secondSubStore.del(address3);
+			const secondSMTStore = new SMTStore(db);
+			const secondBatch = db.batch();
+			const secondSMT = new SparseMerkleTree({ db: secondSMTStore, keyLength: 27 });
+			const diff2 = await stateStore.finalize(secondBatch, secondSMT);
+			secondSMTStore.finalize(secondBatch);
+
+			const newCurrentState = {
+				smt: secondSMT,
+				smtStore: secondSMTStore,
+				batch: secondBatch,
+				diff: diff2,
+				stateStore,
+			};
+			await dataAccess.saveBlock(secondBlock, newCurrentState, 100);
+			expect(secondSMT.rootHash).toEqual(secondBlock.header.stateRoot);
+		});
+
+		it('should return previous stateRoot calculated after delete', async () => {
+			const subStore = stateStore.getStore(14, 1);
+
+			// 3 accounts being set with data
+			const address1 = getRandomBytes(20);
+			const address2 = getRandomBytes(20);
+			const address3 = getRandomBytes(20);
+
+			const data1 = codec.encode(sequenceSchema, { nonce: 10 });
+			const data2 = codec.encode(sequenceSchema, { nonce: 17 });
+			const data3 = codec.encode(sequenceSchema, { nonce: 29 });
+
+			// Set 3 accounts in stateStore
+			await subStore.set(address1, data1);
+			await subStore.set(address2, data2);
+			await subStore.set(address3, data3);
+
+			// To calculate SMT root hash from updating each address above manually
+			const smtStoreTemp = new SMTStore(tempDB);
+			const smtTemp = new SparseMerkleTree({ db: smtStoreTemp, keyLength: 27 });
+
+			await smtTemp.update(prefixedKey(address1), data1);
+			await smtTemp.update(prefixedKey(address2), data2);
+			await smtTemp.update(prefixedKey(address3), data3);
+			const { rootHash: expectedStateRoot } = smtTemp;
+
+			// Add the expected state root calculated to a block to be saved
+			const firstBlock = await createValidDefaultBlock({
+				header: { height: 304, stateRoot: expectedStateRoot },
+				payload: [getTransaction({ nonce: BigInt(10) }), getTransaction({ nonce: BigInt(20) })],
+			});
+
+			// Run all the finalizeStore steps: create SMT store, batch, smt and pass it to saveBlock()
+			const smtStore = new SMTStore(db);
+			const batchLocal = db.batch();
+			const smt = new SparseMerkleTree({ db: smtStore, keyLength: 27 });
+			const diff1 = await stateStore.finalize(batchLocal, smt);
+			smtStore.finalize(batchLocal);
+
+			currentState = {
+				smt,
+				smtStore,
+				batch: batchLocal,
+				diff: diff1,
+				stateStore,
+			};
+			await dataAccess.saveBlock(firstBlock, currentState, 100);
+
+			expect(smt.rootHash).toEqual(firstBlock.header.stateRoot);
+
+			// Delete all the keys that were added in the last block
+			await smtTemp.remove(prefixedKey(address1));
+			await smtTemp.remove(prefixedKey(address2));
+			await smtTemp.remove(prefixedKey(address3));
+
+			const secondSMTStore = new SMTStore(db);
+			const secondBatch = db.batch();
+			const secondSMT = new SparseMerkleTree({
+				db: secondSMTStore,
+				keyLength: 27,
+				rootHash: firstBlock.header.stateRoot,
+			});
+
+			const newCurrentState = {
+				smt: secondSMT,
+				smtStore: secondSMTStore,
+				batch: secondBatch,
+				diff: { updated: [], created: [], deleted: [] },
+				stateStore,
+			};
+
+			await dataAccess.deleteBlock(firstBlock, newCurrentState);
+			expect(secondSMT.rootHash).toEqual(smtTemp.rootHash);
 		});
 	});
 });

--- a/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
+++ b/elements/lisk-chain/test/integration/data_access/blocks.spec.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { KVStore, formatInt, NotFoundError, InMemoryKVStore } from '@liskhq/lisk-db';
 import { codec } from '@liskhq/lisk-codec';
-import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { getRandomBytes, intToBuffer } from '@liskhq/lisk-cryptography';
 import { SparseMerkleTree } from '@liskhq/lisk-tree';
 import { Storage } from '../../../src/data_access/storage';
 import { createValidDefaultBlock } from '../../utils/block';
@@ -539,10 +539,8 @@ describe('dataAccess.blocks', () => {
 			moduleID: number = MODULE_ID,
 			storePrefix: number = STORE_PREFIX,
 		) => {
-			const moduleIDBuffer = Buffer.alloc(4);
-			moduleIDBuffer.writeInt32BE(moduleID, 0);
-			const storePrefixBuffer = Buffer.alloc(2);
-			storePrefixBuffer.writeUInt16BE(storePrefix, 0);
+			const moduleIDBuffer = intToBuffer(moduleID, 4);
+			const storePrefixBuffer = intToBuffer(storePrefix, 2);
 
 			return Buffer.concat([DB_KEY_STATE_STORE, moduleIDBuffer, storePrefixBuffer, key]);
 		};
@@ -557,7 +555,7 @@ describe('dataAccess.blocks', () => {
 		});
 
 		it('should return current stateRoot calculated after saveBlock', async () => {
-			const subStore = stateStore.getStore(14, 1);
+			const subStore = stateStore.getStore(MODULE_ID, STORE_PREFIX);
 
 			// 3 accounts being set with data
 			const address1 = getRandomBytes(20);

--- a/elements/lisk-chain/test/unit/state_store/state_store.spec.ts
+++ b/elements/lisk-chain/test/unit/state_store/state_store.spec.ts
@@ -328,6 +328,11 @@ describe('state store', () => {
 			return Buffer.concat([moduleIDBuffer, storePrefixBuffer]);
 		};
 
+		const smt = {
+			update: jest.fn(),
+			remove: jest.fn(),
+		};
+
 		let batch: DatabaseWriter;
 		let data: { key: Buffer; value: Buffer }[];
 
@@ -347,23 +352,23 @@ describe('state store', () => {
 			};
 		});
 
-		it('should set all the newly created and updated values', () => {
-			stateStore.finalize(batch);
+		it('should set all the newly created and updated values', async () => {
+			await stateStore.finalize(batch, smt as any);
 
 			expect(batch.put).toHaveBeenCalledTimes(3);
 			expect(batch.del).toHaveBeenCalledTimes(1);
 		});
 
-		it('should return state diff', () => {
-			const diff = stateStore.finalize(batch);
+		it('should return state diff', async () => {
+			const diff = await stateStore.finalize(batch, smt as any);
 			expect(diff.created).toHaveLength(2);
 			expect(diff.updated).toHaveLength(1);
 			expect(diff.deleted).toHaveLength(1);
 		});
 
-		it('should save only account state changes diff', () => {
+		it('should save only account state changes diff', async () => {
 			// Act
-			const diff = stateStore.finalize(batch);
+			const diff = await stateStore.finalize(batch, smt as any);
 
 			// Assert
 			expect(diff).toEqual({
@@ -386,10 +391,10 @@ describe('state store', () => {
 			});
 		});
 
-		it('should save empty diff if state was not changed', () => {
+		it('should save empty diff if state was not changed', async () => {
 			const newState = new StateStore(db);
 			// Act
-			const diff = newState.finalize(batch);
+			const diff = await newState.finalize(batch, smt as any);
 
 			// Assert
 			expect(diff).toStrictEqual({

--- a/elements/lisk-tree/src/index.ts
+++ b/elements/lisk-tree/src/index.ts
@@ -16,6 +16,8 @@ import { verifyProof } from './merkle_tree/verify_proof';
 import { calculateRootFromUpdateData } from './merkle_tree/calculate';
 import { MerkleTree } from './merkle_tree/merkle_tree';
 import { calculateMerkleRoot, calculateMerkleRootWithLeaves } from './merkle_tree/utils';
+import { SparseMerkleTree } from './sparse_merkle_tree/sparse_merkle_tree';
+import { verify, calculateRoot } from './sparse_merkle_tree/utils';
 
 export const regularMerkleTree = {
 	verifyProof,
@@ -25,4 +27,10 @@ export const regularMerkleTree = {
 	MerkleTree,
 };
 
-export { MerkleTree };
+export const sparseMerkleTree = {
+	verify,
+	calculateRoot,
+	SparseMerkleTree,
+};
+
+export { MerkleTree, SparseMerkleTree };

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -181,7 +181,7 @@ export class Consensus {
 				stateStore: (stateStore as unknown) as StateStore,
 			});
 			await this._stateMachine.executeGenesisBlock(ctx);
-			const state = await this._finalizeStore(stateStore);
+			const state = await this._prepareStore(stateStore);
 
 			await this._chain.saveBlock(args.genesisBlock, state, args.genesisBlock.header.height);
 		}
@@ -458,7 +458,7 @@ export class Consensus {
 		// Verify validatorsHash
 		await this._verifyValidatorsHash(apiContext, block);
 		// Verify stateRoot
-		const currentState = await this._finalizeStore(stateStore);
+		const currentState = await this._prepareStore(stateStore);
 		this._verifyStateRoot(block, currentState.smt.rootHash);
 
 		await this._chain.saveBlock(block, currentState, finalizedHeight, {
@@ -663,12 +663,12 @@ export class Consensus {
 
 		// Offset must be set to 1, because lastBlock is still this deleting block
 		const stateStore = new StateStore(this._db);
-		const currentState = await this._finalizeStore(stateStore, false);
+		const currentState = await this._prepareStore(stateStore, false);
 		await this._chain.removeBlock(block, currentState, { saveTempBlock });
 		this.events.emit(CONSENSUS_EVENT_BLOCK_DELETE, block);
 	}
 
-	private async _finalizeStore(stateStore: StateStore, finalize = true): Promise<CurrentState> {
+	private async _prepareStore(stateStore: StateStore, finalize = true): Promise<CurrentState> {
 		const batch = this._db.batch();
 		const smtStore = new SMTStore(this._db);
 		const smt = new SparseMerkleTree({

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -663,7 +663,7 @@ export class Consensus {
 
 		// Offset must be set to 1, because lastBlock is still this deleting block
 		const stateStore = new StateStore(this._db);
-		const currentState = await this._finalizeStore(stateStore);
+		const currentState = await this._finalizeStore(stateStore, false);
 		await this._chain.removeBlock(block, currentState, { saveTempBlock });
 		this.events.emit(CONSENSUS_EVENT_BLOCK_DELETE, block);
 	}
@@ -676,7 +676,7 @@ export class Consensus {
 			rootHash: this._chain.lastBlock.header.stateRoot,
 		});
 
-		// On save use finalize flag to finalize stores
+		// On save, use finalize flag to finalize stores
 		if (finalize) {
 			const diff = await stateStore.finalize(batch, smt);
 			smtStore.finalize(batch);

--- a/framework/src/node/generator/generator.ts
+++ b/framework/src/node/generator/generator.ts
@@ -12,19 +12,25 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { Chain, Block, Transaction, BlockHeader, BlockAssets } from '@liskhq/lisk-chain';
-import { StateStore } from '@liskhq/lisk-chain/dist-node/state_store';
+import {
+	Chain,
+	Block,
+	Transaction,
+	BlockHeader,
+	BlockAssets,
+	StateStore,
+	SMTStore,
+} from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import {
 	decryptPassphraseWithPassword,
 	getAddressFromPublicKey,
 	getPrivateAndPublicKeyFromPassphrase,
-	hash,
 	parseEncryptedPassphrase,
 } from '@liskhq/lisk-cryptography';
 import { KVStore } from '@liskhq/lisk-db';
 import { TransactionPool, events } from '@liskhq/lisk-transaction-pool';
-import { MerkleTree } from '@liskhq/lisk-tree';
+import { MerkleTree, SparseMerkleTree } from '@liskhq/lisk-tree';
 import { dataStructures, jobHandlers } from '@liskhq/lisk-utils';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
 import { APP_EVENT_NETWORK_READY } from '../events';
@@ -492,6 +498,13 @@ export class Generator {
 		}
 
 		await this._stateMachine.afterExecuteBlock(blockCtx);
+		// Create SMT Store to now update SMT by calling finalize
+		const smtStore = new SMTStore(this._blockchainDB);
+		const smt = new SparseMerkleTree({
+			db: smtStore,
+			rootHash: this._chain.lastBlock.header.stateRoot,
+		});
+		await stateStore.finalize(this._blockchainDB.batch(), smt);
 
 		// calculate transaction root
 		const txTree = new MerkleTree();
@@ -499,8 +512,8 @@ export class Generator {
 		const transactionRoot = txTree.root;
 		blockHeader.transactionRoot = transactionRoot;
 		blockHeader.assetsRoot = await blockAssets.getRoot();
-		// TODO: Update the stateRoot with proper calculation
-		blockHeader.stateRoot = hash(Buffer.alloc(0));
+		// Assign root hash calculated in SMT to state root of block header
+		blockHeader.stateRoot = smt.rootHash;
 		// Set validatorsHash
 		const { validatorsHash } = await this._bftAPI.getBFTParameters(apiContext, height);
 		blockHeader.validatorsHash = validatorsHash;

--- a/framework/test/unit/modules/bft/bft_params.spec.ts
+++ b/framework/test/unit/modules/bft/bft_params.spec.ts
@@ -12,10 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { StateStore } from '@liskhq/lisk-chain';
+import { SMTStore, StateStore } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { BIG_ENDIAN, getRandomBytes, intToBuffer } from '@liskhq/lisk-cryptography';
 import { InMemoryKVStore, KVStore } from '@liskhq/lisk-db';
+import { SparseMerkleTree } from '@liskhq/lisk-tree';
 import { MODULE_ID_BFT, STORE_PREFIX_BFT_PARAMETERS } from '../../../../src/modules/bft/constants';
 import { BFTParameterNotFoundError } from '../../../../src/modules/bft/errors';
 import {
@@ -65,7 +66,9 @@ describe('BFT parameters', () => {
 			};
 			await paramsStore.set(height2Bytes, codec.encode(bftParametersSchema, bftParams2));
 			const batch = db.batch();
-			rootStore.finalize(batch);
+			const smtStore = new SMTStore(db);
+			const smt = new SparseMerkleTree({ db: smtStore, keyLength: 11 });
+			await rootStore.finalize(batch, smt);
 			await batch.write();
 
 			stateStore = new StateStore(db);
@@ -129,7 +132,9 @@ describe('BFT parameters', () => {
 			};
 			await paramsStore.set(height2Bytes, codec.encode(bftParametersSchema, bftParams2));
 			const batch = db.batch();
-			rootStore.finalize(batch);
+			const smtStore = new SMTStore(db);
+			const smt = new SparseMerkleTree({ db: smtStore, keyLength: 11 });
+			await rootStore.finalize(batch, smt);
 			await batch.write();
 
 			stateStore = new StateStore(db);
@@ -204,7 +209,9 @@ describe('BFT parameters', () => {
 				};
 				await paramsStore.set(height3Bytes, codec.encode(bftParametersSchema, bftParams3));
 				const batch = db.batch();
-				rootStore.finalize(batch);
+				const smtStore = new SMTStore(db);
+				const smt = new SparseMerkleTree({ db: smtStore, keyLength: 11 });
+				await rootStore.finalize(batch, smt);
 				await batch.write();
 
 				const stateStore = new StateStore(db);

--- a/framework/test/unit/node/consensus/consensus.spec.ts
+++ b/framework/test/unit/node/consensus/consensus.spec.ts
@@ -914,7 +914,7 @@ describe('consensus', () => {
 			});
 		});
 
-		describe('_finalizeStore', () => {
+		describe('_prepareStore', () => {
 			const sampleDiff = {
 				created: [Buffer.from('key1', 'utf-8')],
 				updated: [
@@ -936,7 +936,6 @@ describe('consensus', () => {
 			});
 
 			it('should return current state object with finalized stores', async () => {
-				// const db = new InMemoryKVStore();
 				const batch = consensus['_db'].batch();
 				const smtStore = new SMTStore(consensus['_db']);
 				const smt = new SparseMerkleTree({
@@ -954,9 +953,7 @@ describe('consensus', () => {
 					stateStore,
 				};
 
-				await expect(consensus['_finalizeStore'](stateStore)).resolves.toEqual(
-					expectedCurrentState,
-				);
+				await expect(consensus['_prepareStore'](stateStore)).resolves.toEqual(expectedCurrentState);
 			});
 
 			it('should return current state object without finalized stores when flag is false', async () => {
@@ -978,7 +975,7 @@ describe('consensus', () => {
 					stateStore,
 				};
 
-				await expect(consensus['_finalizeStore'](stateStore, false)).resolves.toEqual(
+				await expect(consensus['_prepareStore'](stateStore, false)).resolves.toEqual(
 					expectedCurrentState,
 				);
 			});

--- a/framework/test/unit/node/consensus/consensus.spec.ts
+++ b/framework/test/unit/node/consensus/consensus.spec.ts
@@ -914,7 +914,7 @@ describe('consensus', () => {
 			});
 		});
 
-		describe('_prepareStore', () => {
+		describe('_prepareFinalizingState', () => {
 			const sampleDiff = {
 				created: [Buffer.from('key1', 'utf-8')],
 				updated: [
@@ -953,7 +953,9 @@ describe('consensus', () => {
 					stateStore,
 				};
 
-				await expect(consensus['_prepareStore'](stateStore)).resolves.toEqual(expectedCurrentState);
+				await expect(consensus['_prepareFinalizingState'](stateStore)).resolves.toEqual(
+					expectedCurrentState,
+				);
 			});
 
 			it('should return current state object without finalized stores when flag is false', async () => {
@@ -975,7 +977,7 @@ describe('consensus', () => {
 					stateStore,
 				};
 
-				await expect(consensus['_prepareStore'](stateStore, false)).resolves.toEqual(
+				await expect(consensus['_prepareFinalizingState'](stateStore, false)).resolves.toEqual(
 					expectedCurrentState,
 				);
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6752 

### How was it solved?

- [x] Define sparse merkle tree database prefix in lisk-chain - https://github.com/LiskHQ/lisk-sdk/commit/c928e8b482ef7ae1d3a300d750e0e5e6d74daddc
- [x] Update state store finalize to update sparse merkle tree - https://github.com/LiskHQ/lisk-sdk/commit/1fe0910e953052a09e65d3658dc1693bc15ce1ce
- [x] Calculate state root at the end of block generation and add it to block header - https://github.com/LiskHQ/lisk-sdk/commit/b8e8a49f84f29f1e7e3182ff3833d5b25966cf37
- [x] Add verification of the state root against block header in consensus - https://github.com/LiskHQ/lisk-sdk/commit/c5be978dac56c32c7634c89d0d1072bed852b86f
- [x] Store SMT at the end of block execution - https://github.com/LiskHQ/lisk-sdk/commit/f1540da91307f6aff035f06b6d0d911faf8706ff
- [x] Add re-calculation of sparse merkle tree for deleting block - https://github.com/LiskHQ/lisk-sdk/commit/f1540da91307f6aff035f06b6d0d911faf8706ff
- [x] Add unit tests https://github.com/LiskHQ/lisk-sdk/pull/6899/commits/673326d9d302a892f75f5dcc01b56c545b29ab9f
- [x] Add integration test to show generation and execution produce the same stateRoot https://github.com/LiskHQ/lisk-sdk/pull/6899/commits/e786c32be70c8e899f01f727b20b3a17a2157db0
- [x] Add integration test to show deletion of the block will revert the state root to the previous block https://github.com/LiskHQ/lisk-sdk/pull/6899/commits/e786c32be70c8e899f01f727b20b3a17a2157db0

### How was it tested?

In framework,
`npm run test:unit generator`
`npm run test:unit consensus`
In lisk-chain,
`npm run test`