### PR TITLE
Update application class - Closes #6629 and #6892

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -15,7 +15,7 @@
 import { TAG_TRANSACTION, NotFoundError } from '@liskhq/lisk-chain';
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import { isHexString } from '@liskhq/lisk-validator';
-import { ModuleEndpointContext } from '../..';
+import { ModuleEndpointContext } from '../../types';
 import { VerifyStatus } from '../../node/state_machine';
 import { BaseEndpoint } from '../base_endpoint';
 import { COMMAND_ID_DELEGATE_REGISTRATION } from '../dpos_v2/constants';

--- a/framework/src/modules/auth/index.ts
+++ b/framework/src/modules/auth/index.ts
@@ -13,3 +13,4 @@
  */
 
 export { AuthModule } from './module';
+export { AuthAPI } from './api';

--- a/framework/src/modules/dpos_v2/commands/vote.ts
+++ b/framework/src/modules/dpos_v2/commands/vote.ts
@@ -50,6 +50,9 @@ export class VoteCommand extends BaseCommand {
 
 	public addDependencies(args: VoteCommandDependencies) {
 		this._tokenAPI = args.tokenAPI;
+	}
+
+	public init(args: { tokenIDDPoS: TokenIDDPoS }) {
 		this._tokenIDDPoS = args.tokenIDDPoS;
 	}
 

--- a/framework/src/modules/dpos_v2/endpoint.ts
+++ b/framework/src/modules/dpos_v2/endpoint.ts
@@ -13,7 +13,7 @@
  */
 
 import { codec } from '@liskhq/lisk-codec';
-import { ModuleEndpointContext } from '../..';
+import { ModuleEndpointContext } from '../../types';
 import { BaseEndpoint } from '../base_endpoint';
 import { STORE_PREFIX_DELEGATE, STORE_PREFIX_VOTER } from './constants';
 import { voterStoreSchema, delegateStoreSchema } from './schemas';

--- a/framework/src/modules/dpos_v2/index.ts
+++ b/framework/src/modules/dpos_v2/index.ts
@@ -13,3 +13,4 @@
  */
 
 export { DPoSModule } from './module';
+export { DPoSAPI } from './api';

--- a/framework/src/modules/dpos_v2/module.ts
+++ b/framework/src/modules/dpos_v2/module.ts
@@ -104,7 +104,6 @@ export class DPoSModule extends BaseModule {
 			throw new Error("'voteCommand' is missing from DPoS module");
 		}
 		voteCommand.addDependencies({
-			tokenIDDPoS: this._moduleConfig.tokenIDDPoS,
 			tokenAPI: this._tokenAPI,
 		});
 	}
@@ -120,6 +119,14 @@ export class DPoSModule extends BaseModule {
 			...moduleConfig,
 			minWeightStandby: BigInt(moduleConfig.minWeightStandby),
 		} as ModuleConfig;
+
+		const voteCommand = this.commands.find(command => command.id === COMMAND_ID_VOTE) as
+			| VoteCommand
+			| undefined;
+		if (!voteCommand) {
+			throw new Error("'voteCommand' is missing from DPoS module");
+		}
+		voteCommand.init({ tokenIDDPoS: this._moduleConfig.tokenIDDPoS });
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
@@ -270,8 +277,8 @@ export class DPoSModule extends BaseModule {
 		) {
 			await this._bftAPI.setBFTParameters(
 				apiContext,
-				this._moduleConfig.bftThreshold,
-				this._moduleConfig.bftThreshold,
+				BigInt(this._moduleConfig.bftThreshold),
+				BigInt(this._moduleConfig.bftThreshold),
 				bftWeight,
 			);
 		}

--- a/framework/src/modules/dpos_v2/types.ts
+++ b/framework/src/modules/dpos_v2/types.ts
@@ -40,8 +40,8 @@ export interface ModuleConfig {
 export interface BFTAPI {
 	setBFTParameters(
 		apiContext: APIContext,
-		precommitThreshold: number,
-		certificateThreshold: number,
+		precommitThreshold: bigint,
+		certificateThreshold: bigint,
 		validators: Validator[],
 	): Promise<void>;
 	getBFTParameters(
@@ -65,7 +65,7 @@ export interface RandomAPI {
 }
 
 export interface ValidatorsAPI {
-	setGeneratorList(apiContext: APIContext, generatorAddresses: Buffer[]): Promise<void>;
+	setGeneratorList(apiContext: APIContext, generatorAddresses: Buffer[]): Promise<boolean>;
 	setValidatorGeneratorKey(
 		apiContext: APIContext,
 		validatorAddress: Buffer,
@@ -184,7 +184,6 @@ export interface VoteTransactionParams {
 }
 
 export interface VoteCommandDependencies {
-	tokenIDDPoS: TokenIDDPoS;
 	tokenAPI: TokenAPI;
 }
 

--- a/framework/src/modules/fee/constants.ts
+++ b/framework/src/modules/fee/constants.ts
@@ -12,5 +12,5 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export const MODULE_ID_FEE = 1;
+export const MODULE_ID_FEE = 14;
 export const NATIVE_TOKEN_CHAIN_ID = 0;

--- a/framework/src/modules/fee/index.ts
+++ b/framework/src/modules/fee/index.ts
@@ -13,3 +13,4 @@
  */
 
 export { FeeModule } from './module';
+export { FeeAPI } from './api';

--- a/framework/src/modules/random/endpoint.ts
+++ b/framework/src/modules/random/endpoint.ts
@@ -13,7 +13,7 @@
  */
 
 import { validator, LiskValidationError } from '@liskhq/lisk-validator';
-import { ModuleEndpointContext } from '../..';
+import { ModuleEndpointContext } from '../../types';
 import { BaseEndpoint } from '../base_endpoint';
 import { STORE_PREFIX_RANDOM, EMPTY_KEY } from './constants';
 import { isSeedRevealValidParamsSchema, seedRevealSchema } from './schemas';

--- a/framework/src/modules/random/index.ts
+++ b/framework/src/modules/random/index.ts
@@ -13,3 +13,4 @@
  */
 
 export { RandomModule } from './module';
+export { RandomAPI } from './api';

--- a/framework/src/modules/reward/api.ts
+++ b/framework/src/modules/reward/api.ts
@@ -41,7 +41,7 @@ export class RewardAPI extends BaseAPI {
 		header: BlockHeader,
 		assets: BlockAssets,
 	): Promise<bigint> {
-		const isValidSeedReveal = await this._randomAPI.isValidSeedReveal(
+		const isValidSeedReveal = await this._randomAPI.isSeedRevealValid(
 			context,
 			header.generatorAddress,
 			assets,

--- a/framework/src/modules/reward/endpoint.ts
+++ b/framework/src/modules/reward/endpoint.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { ModuleEndpointContext } from '../..';
+import { ModuleEndpointContext } from '../../types';
 import { BaseEndpoint } from '../base_endpoint';
 import { calculateDefaultReward } from './calculate_reward';
 import { DefaultReward, EndpointInitArgs } from './types';

--- a/framework/src/modules/reward/index.ts
+++ b/framework/src/modules/reward/index.ts
@@ -13,3 +13,4 @@
  */
 
 export { RewardModule } from './module';
+export { RewardAPI } from './api';

--- a/framework/src/modules/reward/types.ts
+++ b/framework/src/modules/reward/types.ts
@@ -37,7 +37,7 @@ export interface TokenAPI {
 }
 
 export interface RandomAPI {
-	isValidSeedReveal(
+	isSeedRevealValid(
 		apiContext: ImmutableAPIContext,
 		generatorAddress: Buffer,
 		assets: BlockAssets,

--- a/framework/src/modules/token/api.ts
+++ b/framework/src/modules/token/api.ts
@@ -81,7 +81,7 @@ export class TokenAPI extends BaseAPI {
 				lockedBalances: [],
 			};
 		}
-		if (recipient.availableBalance < amount + this._minBalance) {
+		if (recipient.availableBalance + amount < this._minBalance) {
 			throw new Error(
 				`Recipient ${recipientAddress.toString(
 					'hex',
@@ -199,7 +199,7 @@ export class TokenAPI extends BaseAPI {
 				lockedBalances: [],
 			};
 		}
-		if (recipient.availableBalance < amount + this._minBalance) {
+		if (recipient.availableBalance + amount < this._minBalance) {
 			throw new Error(
 				`Recipient ${address.toString(
 					'hex',

--- a/framework/src/modules/token/api.ts
+++ b/framework/src/modules/token/api.ts
@@ -83,11 +83,9 @@ export class TokenAPI extends BaseAPI {
 		}
 		if (recipient.availableBalance + amount < this._minBalance) {
 			throw new Error(
-				`Recipient ${recipientAddress.toString(
-					'hex',
-				)} balance ${recipient.availableBalance.toString()} is not sufficient for min balance ${(
-					amount + this._minBalance
-				).toString()}`,
+				`Recipient ${recipientAddress.toString('hex')} balance ${(
+					recipient.availableBalance + amount
+				).toString()} is not sufficient for min balance ${this._minBalance.toString()}`,
 			);
 		}
 		recipient.availableBalance += amount;
@@ -201,11 +199,9 @@ export class TokenAPI extends BaseAPI {
 		}
 		if (recipient.availableBalance + amount < this._minBalance) {
 			throw new Error(
-				`Recipient ${address.toString(
-					'hex',
-				)} balance ${recipient.availableBalance.toString()} is not sufficient for min balance ${(
-					amount + this._minBalance
-				).toString()}`,
+				`Recipient ${address.toString('hex')} balance ${(
+					recipient.availableBalance + amount
+				).toString()} is not sufficient for min balance ${this._minBalance.toString()}`,
 			);
 		}
 		recipient.availableBalance += amount;

--- a/framework/src/modules/token/index.ts
+++ b/framework/src/modules/token/index.ts
@@ -12,5 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export * from './module';
-export * from './commands/transfer';
+export { TokenModule } from './module';
+export { TransferCommand } from './commands/transfer';
+export { TokenAPI } from './api';

--- a/framework/src/modules/validators/api.ts
+++ b/framework/src/modules/validators/api.ts
@@ -248,12 +248,12 @@ export class ValidatorsAPI extends BaseAPI {
 		apiContext: ImmutableAPIContext,
 		startTimestamp: number,
 		endTimestamp: number,
-	): Promise<Record<string, unknown>> {
+	): Promise<Record<string, number>> {
 		if (endTimestamp < startTimestamp) {
 			throw new Error('End timestamp must be greater than start timestamp.');
 		}
 
-		const result: Record<string, unknown> = {};
+		const result: Record<string, number> = {};
 		const genesisData = await this.getGenesisData(apiContext);
 
 		if (startTimestamp < genesisData.timestamp) {
@@ -269,7 +269,7 @@ export class ValidatorsAPI extends BaseAPI {
 			EMPTY_KEY,
 			generatorListSchema,
 		);
-		const generatorAddresses = generatorList.addresses.map(buf => buf.toString());
+		const generatorAddresses = generatorList.addresses.map(buf => buf.toString('binary'));
 		const baseSlots = Math.floor(totalSlots / generatorAddresses.length);
 
 		if (baseSlots > 0) {
@@ -287,7 +287,7 @@ export class ValidatorsAPI extends BaseAPI {
 			const slotIndex = slotNumber % generatorAddresses.length;
 			const generatorAddress = generatorAddresses[slotIndex];
 			if (Object.prototype.hasOwnProperty.call(result, generatorAddress)) {
-				(result[generatorAddress] as number) += 1;
+				result[generatorAddress] += 1;
 			} else {
 				result[generatorAddress] = 1;
 			}

--- a/framework/src/modules/validators/endpoint.ts
+++ b/framework/src/modules/validators/endpoint.ts
@@ -15,7 +15,7 @@
 import { blsPopVerify } from '@liskhq/lisk-cryptography';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
 import { NotFoundError } from '@liskhq/lisk-db';
-import { ModuleEndpointContext } from '../..';
+import { ModuleEndpointContext } from '../../types';
 import { BaseEndpoint } from '../base_endpoint';
 import { generatorListSchema, ValidateBLSKeyRequest, validateBLSKeyRequestSchema } from './schemas';
 import {

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -181,10 +181,6 @@ export class Node {
 				throw new Error('Custom module contains command with invalid `id` property.');
 			}
 
-			if (typeof command.schema !== 'object') {
-				throw new Error('Custom module contains command with invalid `schema` property.');
-			}
-
 			if (typeof command.execute !== 'function') {
 				throw new Error('Custom module contains command with invalid `execute` property.');
 			}

--- a/framework/test/functional/utils/application.ts
+++ b/framework/test/functional/utils/application.ts
@@ -53,7 +53,7 @@ export const createApplication = async (
 		},
 	} as PartialApplicationConfig;
 
-	const app = Application.defaultApplication(genesisBlockJSON, config);
+	const { app } = Application.defaultApplication(genesisBlockJSON, config);
 
 	// Remove pre-existing data
 	fs.removeSync(path.join(rootPath, label).replace('~', os.homedir()));
@@ -61,7 +61,7 @@ export const createApplication = async (
 	// eslint-disable-next-line @typescript-eslint/no-floating-promises
 	await Promise.race([app.run(), new Promise(resolve => setTimeout(resolve, 3000))]);
 	await new Promise<void>(resolve => {
-		app['_channel'].subscribe(APP_EVENT_BLOCK_NEW, () => {
+		app.channel.subscribe(APP_EVENT_BLOCK_NEW, () => {
 			if (app['_node']['_chain'].lastBlock.header.height === 2) {
 				resolve();
 			}
@@ -98,8 +98,8 @@ export const createApplicationWithHelloPlugin = async ({
 		rpc: rpcConfig,
 	} as PartialApplicationConfig;
 
-	const app = Application.defaultApplication(genesisBlockJSON, config);
-	app.registerPlugin(HelloPlugin, { loadAsChildProcess: pluginChildProcess });
+	const { app } = Application.defaultApplication(genesisBlockJSON, config);
+	app.registerPlugin(new HelloPlugin(), { loadAsChildProcess: pluginChildProcess });
 
 	// Remove pre-existing data
 	fs.removeSync(path.join(rootPath, label).replace('~', os.homedir()));

--- a/framework/test/unit/application.spec.ts
+++ b/framework/test/unit/application.spec.ts
@@ -83,7 +83,7 @@ describe('Application', () => {
 
 	describe('#constructor', () => {
 		it('should be able to start the application with default parameters if config is not provided', () => {
-			const app = Application.defaultApplication(genesisBlockJSON);
+			const { app } = Application.defaultApplication(genesisBlockJSON);
 
 			expect(app.config).toBeDefined();
 		});
@@ -94,13 +94,13 @@ describe('Application', () => {
 			const configWithoutLabel = objects.cloneDeep(config);
 			delete configWithoutLabel.label;
 
-			const app = Application.defaultApplication(genesisBlockJSON, configWithoutLabel);
+			const { app } = Application.defaultApplication(genesisBlockJSON, configWithoutLabel);
 
 			expect(app.config.label).toBe(label);
 		});
 
 		it('should use the same app label if provided', () => {
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 
 			expect(app.config.label).toBe(config.label);
 		});
@@ -112,7 +112,7 @@ describe('Application', () => {
 			delete configWithoutRootPath.rootPath;
 
 			// Act
-			const app = Application.defaultApplication(genesisBlockJSON, configWithoutRootPath);
+			const { app } = Application.defaultApplication(genesisBlockJSON, configWithoutRootPath);
 
 			// Assert
 			expect(app.config.rootPath).toBe(rootPath);
@@ -125,7 +125,7 @@ describe('Application', () => {
 			configWithCustomRootPath.rootPath = customRootPath;
 
 			// Act
-			const app = Application.defaultApplication(genesisBlockJSON, configWithCustomRootPath);
+			const { app } = Application.defaultApplication(genesisBlockJSON, configWithCustomRootPath);
 
 			// Assert
 			expect(app.config.rootPath).toBe(customRootPath);
@@ -137,7 +137,7 @@ describe('Application', () => {
 			configWithoutLogger.logger = {};
 
 			// Act
-			const app = Application.defaultApplication(genesisBlockJSON, configWithoutLogger);
+			const { app } = Application.defaultApplication(genesisBlockJSON, configWithoutLogger);
 
 			// Assert
 			expect(app.config.logger.logFileName).toBe('lisk.log');
@@ -158,14 +158,14 @@ describe('Application', () => {
 				},
 			};
 
-			const app = Application.defaultApplication(genesisBlockJSON, customConfig);
+			const { app } = Application.defaultApplication(genesisBlockJSON, customConfig);
 
 			expect(app.config.genesisConfig.maxPayloadLength).toBe(15 * 1024);
 		});
 
 		it('should set internal variables', () => {
 			// Act
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 
 			// Assert
 			expect(app['_genesisBlock']).toEqual(genesisBlockJSON);
@@ -176,7 +176,7 @@ describe('Application', () => {
 
 		it('should not initialize logger', () => {
 			// Act
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 
 			// Assert
 			expect(app.logger).toBeUndefined();
@@ -219,7 +219,7 @@ describe('Application', () => {
 	describe('#registerPlugin', () => {
 		it('should throw error when plugin name is missing', () => {
 			// Arrange
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 			class MyPlugin extends TestPlugin {
 				public name = '';
 			}
@@ -230,7 +230,7 @@ describe('Application', () => {
 
 		it('should throw error when plugin with same name is already registered', () => {
 			// Arrange
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 			class MyPlugin extends TestPlugin {
 				public name = 'my-plugin';
 			}
@@ -244,7 +244,7 @@ describe('Application', () => {
 
 		it('should call validatePluginSpec function', () => {
 			// Arrange
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 			jest.spyOn(basePluginModule, 'validatePluginSpec').mockReturnValue();
 
 			// Act
@@ -257,7 +257,7 @@ describe('Application', () => {
 
 		it('should throw error when plugin is required to load as child process and not exported', () => {
 			// Arrange
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 			jest.spyOn(basePluginModule, 'getPluginExportPath').mockReturnValue(undefined);
 
 			// Act && Assert
@@ -270,7 +270,7 @@ describe('Application', () => {
 
 		it('should add plugin to the collection', () => {
 			// Arrange
-			const app = Application.defaultApplication(genesisBlockJSON, config);
+			const { app } = Application.defaultApplication(genesisBlockJSON, config);
 			const plugin = new TestPlugin();
 			jest.spyOn(app['_controller'], 'registerPlugin');
 			app.registerPlugin(plugin);
@@ -287,7 +287,7 @@ describe('Application', () => {
 		let dirs: any;
 
 		beforeEach(async () => {
-			app = Application.defaultApplication(genesisBlockJSON, config);
+			({ app } = Application.defaultApplication(genesisBlockJSON, config));
 			jest.spyOn(app['_node']['_network'], 'start').mockResolvedValue();
 			jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
 			// jest.spyOn(IPCServer.prototype, 'start').mockResolvedValue();
@@ -331,7 +331,7 @@ describe('Application', () => {
 		const fakeSocketFiles = ['1.sock' as any, '2.sock' as any];
 
 		beforeEach(async () => {
-			app = Application.defaultApplication(genesisBlockJSON, config);
+			({ app } = Application.defaultApplication(genesisBlockJSON, config));
 			jest.spyOn(app['_node'], 'init').mockResolvedValue();
 			jest.spyOn(app['_node'], 'start').mockResolvedValue();
 			jest.spyOn(app['_node'], 'stop').mockResolvedValue();
@@ -365,7 +365,7 @@ describe('Application', () => {
 
 		beforeEach(async () => {
 			jest.spyOn(Bus.prototype, 'publish').mockResolvedValue(jest.fn() as never);
-			app = Application.defaultApplication(genesisBlockJSON, config);
+			({ app } = Application.defaultApplication(genesisBlockJSON, config));
 			jest.spyOn(app['_node']['_network'], 'start').mockResolvedValue();
 			await app.run();
 			jest.spyOn(fs, 'readdirSync').mockReturnValue(fakeSocketFiles);

--- a/framework/test/unit/modules/dpos_v2/commands/vote.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/commands/vote.spec.ts
@@ -72,6 +72,8 @@ describe('VoteCommand', () => {
 				getMinRemainingBalance: jest.fn(),
 				transfer: jest.fn(),
 			},
+		});
+		command.init({
 			tokenIDDPoS: { chainID: 0, localID: 0 },
 		});
 

--- a/framework/test/unit/modules/reward/api.spec.ts
+++ b/framework/test/unit/modules/reward/api.spec.ts
@@ -57,7 +57,7 @@ describe('RewardModuleAPI', () => {
 		it(`should getBlockReward return full reward for bracket ${nthBracket}`, async () => {
 			rewardModule.addDependencies(
 				{ mint: jest.fn() } as any,
-				{ isValidSeedReveal: jest.fn().mockReturnValue(true) } as any,
+				{ isSeedRevealValid: jest.fn().mockReturnValue(true) } as any,
 				{ impliesMaximalPrevotes: jest.fn().mockReturnValue(true) } as any,
 			);
 			const blockHeader = createBlockHeaderWithDefaults({ height: currentHeight });
@@ -69,7 +69,7 @@ describe('RewardModuleAPI', () => {
 		it(`should getBlockReward return quarter reward for bracket ${nthBracket} due to bft violation`, async () => {
 			rewardModule.addDependencies(
 				{ mint: jest.fn() } as any,
-				{ isValidSeedReveal: jest.fn().mockReturnValue(true) } as any,
+				{ isSeedRevealValid: jest.fn().mockReturnValue(true) } as any,
 				{ impliesMaximalPrevotes: jest.fn().mockReturnValue(false) } as any,
 			);
 			const blockHeader = createBlockHeaderWithDefaults({ height: currentHeight });
@@ -81,7 +81,7 @@ describe('RewardModuleAPI', () => {
 		it(`should getBlockReward return no reward for bracket ${nthBracket} due to seedReveal violation`, async () => {
 			rewardModule.addDependencies(
 				{ mint: jest.fn() } as any,
-				{ isValidSeedReveal: jest.fn().mockReturnValue(false) } as any,
+				{ isSeedRevealValid: jest.fn().mockReturnValue(false) } as any,
 				{ impliesMaximalPrevotes: jest.fn().mockReturnValue(true) } as any,
 			);
 			const blockHeader = createBlockHeaderWithDefaults({ height: currentHeight });
@@ -94,7 +94,7 @@ describe('RewardModuleAPI', () => {
 	it(`should getBlockReward return no reward for the height below offset`, async () => {
 		rewardModule.addDependencies(
 			{ mint: jest.fn() } as any,
-			{ isValidSeedReveal: jest.fn().mockReturnValue(true) } as any,
+			{ isSeedRevealValid: jest.fn().mockReturnValue(true) } as any,
 			{ impliesMaximalPrevotes: jest.fn().mockReturnValue(true) } as any,
 		);
 		const blockHeader = createBlockHeaderWithDefaults({ height: 1 });

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -40,7 +40,7 @@ describe('RewardModuleEndpoint', () => {
 		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
 		rewardModule.addDependencies(
 			{ mint: jest.fn() } as any,
-			{ isValidSeedReveal: jest.fn() } as any,
+			{ isSeedRevealValid: jest.fn() } as any,
 			{ impliesMaximalPrevotes: jest.fn() } as any,
 		);
 	});

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -38,7 +38,7 @@ describe('RewardModule', () => {
 		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
 		rewardModule.addDependencies(
 			{ mint } as any,
-			{ isValidSeedReveal: jest.fn().mockReturnValue(true) } as any,
+			{ isSeedRevealValid: jest.fn().mockReturnValue(true) } as any,
 			{ impliesMaximalPrevotes: jest.fn().mockReturnValue(true) } as any,
 		);
 	});

--- a/framework/test/unit/modules/validators/api.spec.ts
+++ b/framework/test/unit/modules/validators/api.spec.ts
@@ -419,7 +419,7 @@ describe('ValidatorsModuleAPI', () => {
 			);
 			let genWithCountGreaterThanOne = 0;
 			for (const generatorAddress of Object.keys(result)) {
-				if ((result[generatorAddress] as number) > 1) {
+				if (result[generatorAddress] > 1) {
 					genWithCountGreaterThanOne += 1;
 				}
 			}
@@ -452,14 +452,14 @@ describe('ValidatorsModuleAPI', () => {
 
 			let genWithCountGreaterThanOne = 0;
 			for (const generatorAddress of Object.keys(result)) {
-				if ((result[generatorAddress] as number) > 1) {
+				if (result[generatorAddress] > 1) {
 					genWithCountGreaterThanOne += 1;
 				}
 			}
 
 			let genWithCountGreaterThanTwo = 0;
 			for (const generatorAddress of Object.keys(result)) {
-				if ((result[generatorAddress] as number) > 2) {
+				if (result[generatorAddress] > 2) {
 					genWithCountGreaterThanTwo += 1;
 				}
 			}

--- a/framework/test/unit/node/node.spec.ts
+++ b/framework/test/unit/node/node.spec.ts
@@ -224,7 +224,7 @@ describe('Node', () => {
 			);
 		});
 
-		it('should throw an error if asset does not extend BaseCommand', () => {
+		it('should throw an error if command does not extend BaseCommand', () => {
 			// Act
 			class SampleCommand {
 				public name = 'asset';
@@ -245,7 +245,7 @@ describe('Node', () => {
 			);
 		});
 
-		it('should throw an error if asset id is invalid', () => {
+		it('should throw an error if command id is invalid', () => {
 			// Act
 			class SampleCommand extends BaseCommand {
 				public name = 'asset';
@@ -266,7 +266,7 @@ describe('Node', () => {
 			);
 		});
 
-		it('should throw an error if asset name is invalid', () => {
+		it('should throw an error if command name is invalid', () => {
 			// Act
 			class SampleCommand extends BaseCommand {
 				public name = '';
@@ -287,24 +287,7 @@ describe('Node', () => {
 			);
 		});
 
-		it('should throw an error if asset schema is invalid', () => {
-			// Act
-			class SampleCommand extends BaseCommand {
-				public name = 'asset';
-				public id = 0;
-				public schema = undefined as any;
-				public async execute(): Promise<void> {}
-			}
-			sampleModule.name = 'SampleModule';
-			sampleModule.id = 999999;
-			sampleModule.commands.push(new SampleCommand(sampleModule.id));
-			// Assert
-			expect(() => node.registerModule(sampleModule)).toThrow(
-				'Custom module contains command with invalid `schema` property.',
-			);
-		});
-
-		it('should throw an error if asset apply is invalid', () => {
+		it('should throw an error if command execute is invalid', () => {
 			// Act
 			class SampleCommand extends BaseCommand {
 				public name = 'asset';

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -63,7 +63,10 @@ It is quite simple to have a working blockchain application, mirroring the confi
 ```js
 const { Application, genesisBlockDevnet, configDevnet } = require('lisk-sdk');
 
-const app = Application.defaultApplication(genesisBlockDevnet, configDevnet);
+const { app } = Application.defaultApplication(
+	genesisBlockDevnet,
+	configDevnet
+);
 
 app
 	.run()
@@ -85,7 +88,7 @@ node index.js
 You can also define your blockchain application parameters such as `blockTime`, `maxPayloadLength` and more with an optional configurations object.
 
 ```js
-const app = Application.defaultApplication(genesisBlockDevnet, {
+const { app } = Application.defaultApplication(genesisBlockDevnet, {
     genesisConfig: {
       communityIdentifier: 'newChain',
       blockTime: 5,
@@ -112,7 +115,10 @@ const { Application, genesisBlockDevnet, configDevnet } = require('lisk-sdk');
 const MyModule = require('./my_module');
 const MyPlugin = require('./my_plugin');
 
-const app = Application.defaultApplication(genesisBlockDevnet, configDevnet);
+const { app } = Application.defaultApplication(
+	genesisBlockDevnet,
+	configDevnet
+);
 
 app.registerModule(MyModule); // register the custom module
 app.registerPlugin(MyPlugin); // register the custom plugin


### PR DESCRIPTION
### What was the problem?

This PR resolves #6629 and resolves #6892

### How was it solved?

- Update application class to return default application with APIs
- Remove getDefaultModules since it is no longer useful
- Fix #6892 to match type for build
- Expose bftAPI and validatorAPI
- Fix expected interface name `isSeedRevealValid` from `isValidSeedReveal`
- Fix DPoS not to use config in `addDependencies`

### How was it tested?

- Update unit tests
