### PR TITLE
Add getFinalizedHeight to generatorContext - Closes #6836

### DIFF
--- a/framework/src/modules/random/module.ts
+++ b/framework/src/modules/random/module.ts
@@ -99,7 +99,7 @@ export class RandomModule extends BaseModule {
 
 		const updatedUsedHashOnion = this._filterUsedHashOnions(
 			usedHashOnions,
-			0, // TODO:this._bftModule.finalizedHeight, to update after https://github.com/LiskHQ/lisk-sdk/issues/6836
+			context.getFinalizedHeight(),
 		);
 		// Set value in Block Asset
 		context.assets.setAsset(

--- a/framework/src/node/generator/context.ts
+++ b/framework/src/node/generator/context.ts
@@ -25,6 +25,7 @@ interface GenerationContextArgs {
 	assets: BlockAssets;
 	generatorStore: GeneratorStore;
 	networkIdentifier: Buffer;
+	finalizedHeight: number;
 }
 
 export class GenerationContext {
@@ -34,6 +35,7 @@ export class GenerationContext {
 	private readonly _header: BlockHeader;
 	private readonly _assets: BlockAssets;
 	private readonly _generatorStore: GeneratorStore;
+	private readonly _finalizedHeight: number;
 
 	public constructor(args: GenerationContextArgs) {
 		this._logger = args.logger;
@@ -42,6 +44,7 @@ export class GenerationContext {
 		this._stateStore = args.stateStore;
 		this._generatorStore = args.generatorStore;
 		this._assets = args.assets;
+		this._finalizedHeight = args.finalizedHeight;
 	}
 
 	public get blockHeader(): BlockHeader {
@@ -59,6 +62,7 @@ export class GenerationContext {
 			header: this._header,
 			assets: this._assets,
 			networkIdentifier: this._networkIdentifier,
+			getFinalizedHeight: () => this._finalizedHeight,
 		};
 	}
 }

--- a/framework/src/node/generator/generator.ts
+++ b/framework/src/node/generator/generator.ts
@@ -461,6 +461,7 @@ export class Generator {
 			logger: this._logger,
 			networkIdentifier: this._chain.networkIdentifier,
 			stateStore,
+			finalizedHeight: this._chain.finalizedHeight,
 		});
 
 		for (const mod of this._modules) {

--- a/framework/src/node/generator/types.ts
+++ b/framework/src/node/generator/types.ts
@@ -58,6 +58,7 @@ export interface BlockGenerateContext {
 	header: BlockHeader;
 	assets: WritableBlockAssets;
 	getGeneratorStore: (moduleID: number) => GeneratorStore;
+	getFinalizedHeight(): number;
 }
 
 export interface GeneratorModule {

--- a/framework/src/testing/create_contexts.ts
+++ b/framework/src/testing/create_contexts.ts
@@ -121,6 +121,7 @@ export const createBlockGenerateContext = (params: {
 	getAPIContext?: () => APIContext;
 	getStore?: (moduleID: number, storePrefix: number) => ImmutableSubStore;
 	header: BlockHeader;
+	finalizedHeight?: number;
 	networkIdentifier?: Buffer;
 }): BlockGenerateContext => {
 	const db = new InMemoryKVStore();
@@ -158,6 +159,7 @@ export const createBlockGenerateContext = (params: {
 		networkIdentifier: params.networkIdentifier ?? getRandomBytes(32),
 		getAPIContext: params.getAPIContext ?? (() => ({ getStore, eventQueue: new EventQueue() })),
 		getStore: params.getStore ?? getStore,
+		getFinalizedHeight: () => params.finalizedHeight ?? 0,
 		header,
 	};
 

--- a/framework/test/unit/node/generator/generator.spec.ts
+++ b/framework/test/unit/node/generator/generator.spec.ts
@@ -99,6 +99,7 @@ describe('generator', () => {
 				},
 				payload: [],
 			},
+			finalizedHeight: 100,
 			dataAccess: {
 				decodeTransaction: jest.fn().mockReturnValue(tx),
 			},
@@ -485,6 +486,12 @@ describe('generator', () => {
 
 			expect(block.payload).toHaveLength(1);
 			expect(block.header.signature).toHaveLength(64);
+		});
+
+		it('should have finalizedHeight in the context', async () => {
+			await generator['_generateBlock'](generatorAddress, keypair, currentTime);
+			expect((mod1.initBlock as jest.Mock).mock.calls[0][0].getFinalizedHeight()).toEqual(100);
+			expect((mod2.sealBlock as jest.Mock).mock.calls[0][0].getFinalizedHeight()).toEqual(100);
 		});
 
 		it('should assign validatorsHash to the block', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #6836 

### How was it solved?

- Add `getFinalizedHeight()` to generator context
- Update random module `initBlock` to consider finalized height

### How was it tested?

- Update tests for random module
- Add unit test on generator
