### PR TITLE
Implement afterBlockExecute hook for DPoS Module - Closes #6722

### DIFF
--- a/framework/src/modules/dpos_v2/schemas.ts
+++ b/framework/src/modules/dpos_v2/schemas.ts
@@ -151,6 +151,7 @@ export const snapshotStoreSchema = {
 };
 
 export const genesisDataStoreSchema = {
+	$id: '/dpos/store/genesis',
 	type: 'object',
 	required: ['height', 'initRounds', 'initDelegates'],
 	properties: {

--- a/framework/src/modules/dpos_v2/types.ts
+++ b/framework/src/modules/dpos_v2/types.ts
@@ -226,3 +226,9 @@ export interface SnapshotStoreData {
 export interface PreviousTimestampData {
 	timestamp: number;
 }
+
+export interface GenesisData {
+	heigth: number;
+	initRounds: number;
+	initDelegates: Buffer[];
+}


### PR DESCRIPTION
### What was the problem?

This PR resolves #6722 

### How was it solved?

- Added private DPoS module methods to afterBlockExecute adhering to required control flow.

### How was it tested?

- Unit tests created for the hook
