### PR TITLE
Remove node version restriction - Closes #6552

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist/index.js",
@@ -147,7 +147,7 @@
 		"@typescript-eslint/parser": "4.19.0",
 		"copyfiles": "2.4.1",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package-template.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/package-template.json
@@ -4,17 +4,11 @@
 	"description": "<%= appDescription %>",
 	"author": "<%= author %>",
 	"license": "<%= license %>",
-	"keywords": [
-		"blockchain",
-		"lisk",
-		"nodejs",
-		"javascript",
-		"typescript"
-	],
+	"keywords": ["blockchain", "lisk", "nodejs", "javascript", "typescript"],
 	"homepage": "",
 	"repository": {},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist/index.js",
@@ -41,10 +35,7 @@
 	"oclif": {
 		"bin": "<%= appName %>",
 		"commands": "./dist/commands",
-		"plugins": [
-			"@oclif/plugin-autocomplete",
-			"@oclif/plugin-help"
-		],
+		"plugins": ["@oclif/plugin-autocomplete", "@oclif/plugin-help"],
 		"topics": {
 			"account": {
 				"description": "Commands relating to <%= appName %> accounts."
@@ -84,14 +75,7 @@
 			}
 		}
 	},
-	"files": [
-		"/bin",
-		"/npm-shrinkwrap.json",
-		"/oclif.manifest.json",
-		"/dist",
-		"/config",
-		"/docs"
-	],
+	"files": ["/bin", "/npm-shrinkwrap.json", "/oclif.manifest.json", "/dist", "/config", "/docs"],
 	"husky": {
 		"hooks": {
 			"pre-commit": "lint-staged"
@@ -122,7 +106,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"globby": "10.0.2",

--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init_plugin/package.json
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init_plugin/package.json
@@ -11,7 +11,7 @@
 		"url": ""
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -38,7 +38,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-api-client/package.json
+++ b/elements/lisk-api-client/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -51,7 +51,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-bft/package.json
+++ b/elements/lisk-bft/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -53,7 +53,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"faker": "4.1.0",

--- a/elements/lisk-chain/package.json
+++ b/elements/lisk-chain/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -55,7 +55,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"faker": "4.1.0",

--- a/elements/lisk-client/package.json
+++ b/elements/lisk-client/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-browser/index.js",
@@ -76,7 +76,7 @@
 		"cypress": "5.6.0",
 		"cypress-jest-adapter": "0.1.1",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-codec/package.json
+++ b/elements/lisk-codec/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -47,7 +47,7 @@
 		"@typescript-eslint/parser": "4.19.0",
 		"benchmark": "2.1.4",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"glob": "7.1.7",

--- a/elements/lisk-cryptography/package.json
+++ b/elements/lisk-cryptography/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -63,7 +63,7 @@
 		"@typescript-eslint/parser": "4.19.0",
 		"benchmark": "2.1.4",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"glob": "7.1.7",

--- a/elements/lisk-db/package.json
+++ b/elements/lisk-db/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -52,7 +52,7 @@
 		"@typescript-eslint/parser": "4.19.0",
 		"benchmark": "2.1.4",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-elements/package.json
+++ b/elements/lisk-elements/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -58,7 +58,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-genesis/package.json
+++ b/elements/lisk-genesis/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -50,7 +50,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-p2p/package.json
+++ b/elements/lisk-p2p/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -64,7 +64,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-passphrase/package.json
+++ b/elements/lisk-passphrase/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -46,7 +46,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-transaction-pool/package.json
+++ b/elements/lisk-transaction-pool/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -49,7 +49,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-transactions/package.json
+++ b/elements/lisk-transactions/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -47,7 +47,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-tree/package.json
+++ b/elements/lisk-tree/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -47,7 +47,7 @@
 		"@typescript-eslint/parser": "4.19.0",
 		"benchmark": "2.1.4",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-utils/package.json
+++ b/elements/lisk-utils/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -46,7 +46,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/elements/lisk-validator/package.json
+++ b/elements/lisk-validator/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -53,7 +53,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/framework-plugins/lisk-framework-dashboard-plugin/package.json
+++ b/framework-plugins/lisk-framework-dashboard-plugin/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -80,7 +80,7 @@
 		"dotenv": "8.2.0",
 		"dotenv-expand": "5.1.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-config-react-app": "^6.0.0",
 		"eslint-plugin-flowtype": "^5.2.0",
 		"eslint-plugin-import": "2.22.1",

--- a/framework-plugins/lisk-framework-faucet-plugin/package.json
+++ b/framework-plugins/lisk-framework-faucet-plugin/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -82,7 +82,7 @@
 		"dotenv": "8.2.0",
 		"dotenv-expand": "5.1.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-config-react-app": "^6.0.0",
 		"eslint-plugin-flowtype": "^5.2.0",
 		"eslint-plugin-import": "2.22.1",

--- a/framework-plugins/lisk-framework-forger-plugin/package.json
+++ b/framework-plugins/lisk-framework-forger-plugin/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -59,7 +59,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"fs-extra": "9.0.0",

--- a/framework-plugins/lisk-framework-http-api-plugin/package.json
+++ b/framework-plugins/lisk-framework-http-api-plugin/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -60,7 +60,7 @@
 		"@typescript-eslint/parser": "4.19.0",
 		"axios": "0.21.2",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"fs-extra": "9.1.0",

--- a/framework-plugins/lisk-framework-monitor-plugin/package.json
+++ b/framework-plugins/lisk-framework-monitor-plugin/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -59,7 +59,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/package.json
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -57,7 +57,7 @@
 		"@typescript-eslint/parser": "4.19.0",
 		"axios": "0.21.2",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/framework/package.json
+++ b/framework/package.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -74,7 +74,7 @@
 		"axios": "0.21.2",
 		"copyfiles": "2.2.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"workspaces": {
@@ -60,7 +60,7 @@
 		"@typescript-eslint/eslint-plugin": "4.19.0",
 		"@typescript-eslint/parser": "4.19.0",
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"husky": "7.0.1",

--- a/protocol-specs/package.json
+++ b/protocol-specs/package.json
@@ -14,20 +14,20 @@
 	"author": "Lisk Foundation <admin@lisk.com>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "Apache-2.0",
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"dependencies": {
 		"@liskhq/bignum": "1.3.1",
-		"@liskhq/lisk-codec": "0.1.0",
-		"@liskhq/lisk-cryptography": "2.4.2",
-		"@liskhq/lisk-passphrase": "3.0.0",
-		"@liskhq/lisk-validator": "0.5.1",
+		"@liskhq/lisk-codec": "0.2.1",
+		"@liskhq/lisk-cryptography": "3.2.0",
+		"@liskhq/lisk-passphrase": "3.1.0",
+		"@liskhq/lisk-validator": "0.6.1",
 		"protobufjs": "6.9.0"
 	},
 	"devDependencies": {
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"prettier": "2.2.1"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -42,6 +42,13 @@ Before running Lisk SDK, the following dependencies need to be installed in orde
 | ------------ | ------- |
 | NodeJS       | 12+     |
 
+For Mac M1 series,
+NodeJS must be above version 16. Additionally, to build `sodium-native` below tools are required.
+
+```
+brew install libtool cmake autoconf automake
+```
+
 ### Installation
 
 The installation of Lisk Beta SDK is straightforward and limited to getting a single NPM package, `lisk-sdk`, to your Node.js project:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",
@@ -51,7 +51,7 @@
 	},
 	"devDependencies": {
 		"eslint": "7.22.0",
-		"eslint-config-lisk-base": "2.0.0",
+		"eslint-config-lisk-base": "2.0.1",
 		"eslint-plugin-import": "2.22.1",
 		"eslint-plugin-jest": "24.3.2",
 		"jest": "26.6.3",

--- a/templates/package.json.tmpl
+++ b/templates/package.json.tmpl
@@ -17,7 +17,7 @@
 		"url": "https://github.com/LiskHQ/lisk-sdk/issues"
 	},
 	"engines": {
-		"node": ">=12.13.0 <=12",
+		"node": ">=12.13.0",
 		"npm": ">=6.12.0"
 	},
 	"main": "dist-node/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2513,73 +2513,6 @@
   dependencies:
     "@types/node" "11.11.2"
 
-"@liskhq/lisk-codec@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-codec/-/lisk-codec-0.1.0.tgz#deea355d1dcbf83432f213a57c4df087b45f091d"
-  integrity sha512-VM5aF23JoLDuRI6pJ76QN3UymcxT6isgfRTtdD0DkUzoYkB1VrM2TvrmJenF7FRApJc0bCh/cGBtVKDTLyto5g==
-  dependencies:
-    "@liskhq/lisk-utils" "^0.1.0"
-    "@liskhq/lisk-validator" "^0.5.0"
-
-"@liskhq/lisk-cryptography@2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-cryptography/-/lisk-cryptography-2.4.2.tgz#77eecaa2d36bfa00bb43ef92bdc4683ecaadff8b"
-  integrity sha512-y3T/Jg/OvSIhieqY7NKpmnkajpbz+JSxWUx6DyebW/jAXZAUVDoh5n64NPNe78op5TXsMIwqPFao6GE+D3MKsA==
-  dependencies:
-    "@liskhq/bignum" "1.3.1"
-    "@types/ed2curve" "0.2.2"
-    "@types/node" "12.12.11"
-    buffer-reverse "1.0.1"
-    ed2curve "0.2.1"
-    tweetnacl "1.0.1"
-    varuint-bitcoin "1.1.0"
-  optionalDependencies:
-    sodium-native "2.4.6"
-
-"@liskhq/lisk-passphrase@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-passphrase/-/lisk-passphrase-3.0.0.tgz#14e5034446d28008a966b90e906bd5ca8ebee28e"
-  integrity sha512-j/+vSCw6UrYb0PTOLJGbdHCHW/oGNWkHqVKzvUMWiQjLUwIF738GwM1l66eppsx2v7RDm+P7hKTTkGuVtqcSGQ==
-  dependencies:
-    "@types/bip39" "2.4.1"
-    "@types/node" "12.12.11"
-    bip39 "2.5.0"
-
-"@liskhq/lisk-utils@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-utils/-/lisk-utils-0.1.0.tgz#b8f31e0bde5a8d0bf2bee9f6f7e6b9bfe2cd45b0"
-  integrity sha512-PR36Rxk6Nhg8Z6vvEIOpbeTuISaw23It6WhVyxEibH2RN2UPpUwDWR60BcIqZtR1FCK5vEcDMTvBXu1FgawbdA==
-  dependencies:
-    lodash.clonedeep "4.5.0"
-
-"@liskhq/lisk-validator@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-validator/-/lisk-validator-0.5.1.tgz#3cb2a83684dfd3c0d729400579e7f015f8e8527d"
-  integrity sha512-mIFRetkasdU7QoaoOmRWxHZaUXvKXWjAgA3wwn8wnSANArSVtWyM23xvfDVBLzPFRnMH9LfvSt66U8uYkGdIPg==
-  dependencies:
-    "@liskhq/lisk-cryptography" "^3.0.1"
-    "@types/node" "12.12.11"
-    "@types/semver" "7.1.0"
-    "@types/validator" "12.0.1"
-    ajv "6.12.0"
-    debug "4.1.1"
-    semver "7.1.3"
-    validator "12.2.0"
-
-"@liskhq/lisk-validator@^0.5.0":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@liskhq/lisk-validator/-/lisk-validator-0.5.2.tgz#64240b6cc51fe1a2e7a1fc29b7f1cad0c43f8c16"
-  integrity sha512-NiIq7vxHBNWcuOyhzImwtGxqstOBKdcFhckkW+ZMlRFZbyEC1eCFbeVd0S7TivBWS3JfHWUeTEbOczavGo669A==
-  dependencies:
-    "@liskhq/lisk-cryptography" "^3.0.2"
-    "@types/node" "12.12.11"
-    "@types/semver" "7.1.0"
-    "@types/validator" "12.0.1"
-    ajv "6.12.0"
-    debug "4.1.1"
-    semver "7.1.3"
-    validator "12.2.0"
-
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -3323,13 +3256,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/bip39@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@types/bip39/-/bip39-2.4.1.tgz#1a47b453b59a50d7b5856819b834c74798915eb3"
-  integrity sha512-QHx0qI6JaTIW/S3zxE/bXrwOWu6Boos+LZ4438xmFAHY5k+qHkExMdAnb/DENEt2RBnOdZ6c5J+SHrnLEhUohQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/bip39@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/bip39/-/bip39-3.0.0.tgz#4b5b9e89196e0c6c3793f1950724b197018daf70"
@@ -3750,11 +3676,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
-"@types/node@12.12.11":
-  version "12.12.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.11.tgz#bec2961975888d964196bf0016a2f984d793d3ce"
-  integrity sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==
-
 "@types/node@12.20.6":
   version "12.20.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.6.tgz#7b73cce37352936e628c5ba40326193443cfba25"
@@ -4040,11 +3961,6 @@
   integrity sha512-sYAF+CF9XZ5cvEBkI7RtrG9g2GtMBkviTnBxYYyq+8BWvO4QtXfwwR6a2LFwCi4evMKZfpv6U43ViYvv17Wz3Q==
   dependencies:
     source-map "^0.6.1"
-
-"@types/validator@12.0.1":
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-12.0.1.tgz#73dbc7f5f730ff7131754bca682824eb3c260b79"
-  integrity sha512-l57fIANZLMe8DArz+SDb+7ATXnDm15P7u2wHBw5mb0aSMd+UuvmvhouBF2hdLgQPDMJ39sh9g2MJO4GkZ0VAdQ==
 
 "@types/validator@13.1.3":
   version "13.1.3"
@@ -4640,16 +4556,6 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
-
-ajv@6.12.0:
-  version "6.12.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
-  integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
 
 ajv@8.1.0, ajv@^8.0.0:
   version "8.1.0"
@@ -5392,17 +5298,6 @@ bip39@*:
     create-hash "^1.1.0"
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
-
-bip39@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.5.0.tgz#51cbd5179460504a63ea3c000db3f787ca051235"
-  integrity sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==
-  dependencies:
-    create-hash "^1.1.0"
-    pbkdf2 "^3.0.9"
-    randombytes "^2.0.1"
-    safe-buffer "^5.0.1"
-    unorm "^1.3.3"
 
 bip39@3.0.3:
   version "3.0.3"
@@ -7278,13 +7173,6 @@ debug@4, debug@4.3.1, debug@^4.0.0, debug@^4.3.1:
   dependencies:
     ms "2.1.2"
 
-debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
 debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -7296,6 +7184,13 @@ debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -7736,13 +7631,6 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-ed2curve@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ed2curve/-/ed2curve-0.2.1.tgz#22e6aaa3569e3c4dbf4eefa29612ec329e58190c"
-  integrity sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw=
-  dependencies:
-    tweetnacl "0.x.x"
-
 ed2curve@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ed2curve/-/ed2curve-0.3.0.tgz#322b575152a45305429d546b071823a93129a05d"
@@ -8065,10 +7953,10 @@ eslint-config-airbnb-base@14.2.1:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
-eslint-config-lisk-base@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-lisk-base/-/eslint-config-lisk-base-2.0.0.tgz#4241a599466ec0345e3447cf492fecaf9837e596"
-  integrity sha512-Y24PBz8jXzqmR/Z20yTWTrzL14qj9CzvLzYlbaOYkxiDxIjhLhnjINuG16jmJOSj77kPdoAZz8sMPgb5X2ZmdQ==
+eslint-config-lisk-base@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-lisk-base/-/eslint-config-lisk-base-2.0.1.tgz#f9886032bafd4643bc3940c129c3fcfe5d684ff1"
+  integrity sha512-A6fK9qOChiRc/7r0QyDIXCStxKQd/TmhOJlZnN/IK5viW5TAs9XBhlFcG1cXVNPYtRBhhNX2nosBTWPwjLfyiQ==
   dependencies:
     "@typescript-eslint/eslint-plugin" "4.19.0"
     "@typescript-eslint/parser" "4.19.0"
@@ -16145,11 +16033,6 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
-  integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
-
 semver@7.3.5, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
@@ -16506,15 +16389,6 @@ socks@^2.3.3:
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
-
-sodium-native@2.4.6:
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-2.4.6.tgz#8a8173095e8cf4f997de393a2ba106c34870cac2"
-  integrity sha512-Ro9lhTjot8M01nwKLXiqLSmjR7B8o+Wg4HmJUjEShw/q6XPlNMzjPkA1VJKaMH8SO8fJ/sggAKVwreTaFszS2Q==
-  dependencies:
-    ini "^1.3.5"
-    nan "^2.14.0"
-    node-gyp-build "^4.1.0"
 
 sodium-native@3.2.1:
   version "3.2.1"
@@ -17736,20 +17610,15 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tweetnacl@0.x.x, tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
-
-tweetnacl@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.1.tgz#2594d42da73cd036bd0d2a54683dd35a6b55ca17"
-  integrity sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A==
-
 tweetnacl@1.0.3, tweetnacl@1.x.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
   integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 tweetnacl@^1.0.0:
   version "1.0.2"
@@ -17980,11 +17849,6 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
-unorm@^1.3.3:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
-  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
-
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -18165,11 +18029,6 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validator@12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-12.2.0.tgz#660d47e96267033fd070096c3b1a6f2db4380a0a"
-  integrity sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ==
-
 validator@13.7.0:
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
@@ -18179,13 +18038,6 @@ value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
-
-varuint-bitcoin@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz#7a343f50537607af6a3059312b9782a170894540"
-  integrity sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==
-  dependencies:
-    safe-buffer "^5.1.1"
 
 varuint-bitcoin@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
### What was the problem?

Mac M1 requires node version to be 16 and above.

This PR resolves #6552 

### How was it solved?

- Update `eslint-config-lisk-base` to 2.0.1 where node version restriction is removed
- Remove Node version restriction to use node 16

### How was it tested?

- Update node to version 16.13.0 and try `yarn` and `yarn build`
- Further testing for all the feature is required before the release for node 14 and 16.
