### PR TITLE
Implement static genesis block validation - Closes #6894

### DIFF
--- a/elements/lisk-chain/src/block_header.ts
+++ b/elements/lisk-chain/src/block_header.ts
@@ -183,6 +183,16 @@ export class BlockHeader {
 		const header = this._getBlockHeaderProps();
 		const errors = validator.validate(blockHeaderSchema, header);
 
+		if (header.previousBlockID.length !== 32) {
+			errors.push({
+				message: 'Genesis block header previousBlockID must be 32 bytes',
+				keyword: 'const',
+				dataPath: 'header.previousBlockID',
+				schemaPath: 'properties.previousBlockID',
+				params: {},
+			});
+		}
+
 		if (!header.transactionRoot.equals(EMPTY_HASH)) {
 			errors.push({
 				message: 'Genesis block header transaction root must be empty hash',

--- a/elements/lisk-chain/src/block_header.ts
+++ b/elements/lisk-chain/src/block_header.ts
@@ -203,7 +203,7 @@ export class BlockHeader {
 			});
 		}
 
-		if (!(header.maxHeightPrevoted === header.height)) {
+		if (header.maxHeightPrevoted !== header.height) {
 			errors.push({
 				message: 'Genesis block header maxHeightPrevoted must equal height',
 				keyword: 'const',
@@ -213,7 +213,7 @@ export class BlockHeader {
 			});
 		}
 
-		if (!(header.maxHeightGenerated === 0)) {
+		if (header.maxHeightGenerated !== 0) {
 			errors.push({
 				message: 'Genesis block header maxHeightGenerated must equal 0',
 				keyword: 'const',
@@ -223,7 +223,7 @@ export class BlockHeader {
 			});
 		}
 
-		if (!(header.aggregateCommit.height === 0)) {
+		if (header.aggregateCommit.height !== 0) {
 			errors.push({
 				message: 'Genesis block header aggregateCommit.height must equal 0',
 				keyword: 'const',

--- a/elements/lisk-chain/src/block_header.ts
+++ b/elements/lisk-chain/src/block_header.ts
@@ -15,7 +15,7 @@
 import { signDataWithPrivateKey, hash, verifyData } from '@liskhq/lisk-cryptography';
 import { codec } from '@liskhq/lisk-codec';
 import { validator, LiskValidationError } from '@liskhq/lisk-validator';
-import { TAG_BLOCK_HEADER } from './constants';
+import { EMPTY_BUFFER, EMPTY_HASH, TAG_BLOCK_HEADER } from './constants';
 import { blockHeaderSchema, blockHeaderSchemaWithId, signingBlockHeaderSchema } from './schema';
 
 export interface BlockHeaderAttrs {
@@ -176,6 +176,95 @@ export class BlockHeader {
 		}
 		if (this.previousBlockID.length === 0) {
 			throw new Error('Previous block id must not be empty.');
+		}
+	}
+
+	public validateGenesis(): void {
+		const header = this._getBlockHeaderProps();
+		const errors = validator.validate(blockHeaderSchema, header);
+
+		if (!header.transactionRoot.equals(EMPTY_HASH)) {
+			errors.push({
+				message: 'Genesis block header transaction root must be empty hash',
+				keyword: 'const',
+				dataPath: 'header.transactionRoot',
+				schemaPath: 'properties.transactionRoot',
+				params: { allowedValue: EMPTY_HASH },
+			});
+		}
+
+		if (!header.generatorAddress.equals(EMPTY_BUFFER)) {
+			errors.push({
+				message: 'Genesis block header generatorAddress must be empty bytes',
+				keyword: 'const',
+				dataPath: 'header.generatorAddress',
+				schemaPath: 'properties.generatorAddress',
+				params: { allowedValue: EMPTY_BUFFER },
+			});
+		}
+
+		if (!(header.maxHeightPrevoted === header.height)) {
+			errors.push({
+				message: 'Genesis block header maxHeightPrevoted must equal height',
+				keyword: 'const',
+				dataPath: 'header.maxHeightPrevoted',
+				schemaPath: 'properties.maxHeightPrevoted',
+				params: { allowedValue: header.height },
+			});
+		}
+
+		if (!(header.maxHeightGenerated === 0)) {
+			errors.push({
+				message: 'Genesis block header maxHeightGenerated must equal 0',
+				keyword: 'const',
+				dataPath: 'header.maxHeightGenerated',
+				schemaPath: 'properties.maxHeightGenerated',
+				params: { allowedValue: 0 },
+			});
+		}
+
+		if (!(header.aggregateCommit.height === 0)) {
+			errors.push({
+				message: 'Genesis block header aggregateCommit.height must equal 0',
+				keyword: 'const',
+				dataPath: 'aggregateCommit.height',
+				schemaPath: 'properties.aggregateCommit.height',
+				params: { allowedValue: 0 },
+			});
+		}
+
+		if (!header.aggregateCommit.certificateSignature.equals(EMPTY_BUFFER)) {
+			errors.push({
+				message: 'Genesis block header aggregateCommit.certificateSignature must be empty bytes',
+				keyword: 'const',
+				dataPath: 'aggregateCommit.certificateSignature',
+				schemaPath: 'properties.aggregateCommit.certificateSignature',
+				params: { allowedValue: EMPTY_BUFFER },
+			});
+		}
+
+		if (!header.aggregateCommit.aggregationBits.equals(EMPTY_BUFFER)) {
+			errors.push({
+				message: 'Genesis block header aggregateCommit.aggregationBits must be empty bytes',
+				keyword: 'const',
+				dataPath: 'aggregateCommit.aggregationBits',
+				schemaPath: 'properties.aggregateCommit.aggregationBits',
+				params: { allowedValue: EMPTY_BUFFER },
+			});
+		}
+
+		if (!header.signature.equals(EMPTY_BUFFER)) {
+			errors.push({
+				message: 'Genesis block header signature must be empty bytes',
+				keyword: 'const',
+				dataPath: 'header.signature',
+				schemaPath: 'properties.signature',
+				params: { allowedValue: EMPTY_BUFFER },
+			});
+		}
+
+		if (errors.length) {
+			throw new LiskValidationError(errors);
 		}
 	}
 

--- a/elements/lisk-chain/src/schema.ts
+++ b/elements/lisk-chain/src/schema.ts
@@ -98,16 +98,6 @@ export const blockHeaderSchema = {
 	},
 };
 
-export const genesisBlockHeaderSchema = {
-	...blockHeaderSchema,
-	$id: '/block/header/4',
-	required: [...blockHeaderSchema.required],
-	properties: {
-		...blockHeaderSchema.properties,
-		signature: { dataType: 'bytes', fieldNumber: 13 },
-	},
-};
-
 export const blockHeaderSchemaWithId = {
 	...blockHeaderSchema,
 	$id: '/block/header/3',

--- a/elements/lisk-chain/src/schema.ts
+++ b/elements/lisk-chain/src/schema.ts
@@ -44,7 +44,7 @@ export const signingBlockHeaderSchema = {
 		version: { dataType: 'uint32', fieldNumber: 1 },
 		timestamp: { dataType: 'uint32', fieldNumber: 2 },
 		height: { dataType: 'uint32', fieldNumber: 3 },
-		previousBlockID: { dataType: 'bytes', fieldNumber: 4 },
+		previousBlockID: { dataType: 'bytes', fieldNumber: 4, minLength: 32, maxLength: 32 },
 		generatorAddress: { dataType: 'bytes', fieldNumber: 5 },
 		transactionRoot: { dataType: 'bytes', fieldNumber: 6 },
 		assetsRoot: { dataType: 'bytes', fieldNumber: 7 },

--- a/elements/lisk-chain/src/schema.ts
+++ b/elements/lisk-chain/src/schema.ts
@@ -44,7 +44,7 @@ export const signingBlockHeaderSchema = {
 		version: { dataType: 'uint32', fieldNumber: 1 },
 		timestamp: { dataType: 'uint32', fieldNumber: 2 },
 		height: { dataType: 'uint32', fieldNumber: 3 },
-		previousBlockID: { dataType: 'bytes', fieldNumber: 4, minLength: 32, maxLength: 32 },
+		previousBlockID: { dataType: 'bytes', fieldNumber: 4 },
 		generatorAddress: { dataType: 'bytes', fieldNumber: 5 },
 		transactionRoot: { dataType: 'bytes', fieldNumber: 6 },
 		assetsRoot: { dataType: 'bytes', fieldNumber: 7 },

--- a/elements/lisk-chain/src/schema.ts
+++ b/elements/lisk-chain/src/schema.ts
@@ -98,6 +98,16 @@ export const blockHeaderSchema = {
 	},
 };
 
+export const genesisBlockHeaderSchema = {
+	...blockHeaderSchema,
+	$id: '/block/header/4',
+	required: [...blockHeaderSchema.required],
+	properties: {
+		...blockHeaderSchema.properties,
+		signature: { dataType: 'bytes', fieldNumber: 13 },
+	},
+};
+
 export const blockHeaderSchemaWithId = {
 	...blockHeaderSchema,
 	$id: '/block/header/3',

--- a/elements/lisk-chain/test/unit/block_header.spec.ts
+++ b/elements/lisk-chain/test/unit/block_header.spec.ts
@@ -44,7 +44,7 @@ const getGenesisBlockAttrs = () => ({
 	version: 1,
 	timestamp: 1009988,
 	height: 1009988,
-	previousBlockID: Buffer.from('4a462ea57a8c9f72d866c09770e5ec70cef18727', 'hex'),
+	previousBlockID: getRandomBytes(32),
 	stateRoot: Buffer.from('7f9d96a09a3fd17f3478eb7bef3a8bda00e1238b', 'hex'),
 	transactionRoot: EMPTY_HASH,
 	assetsRoot: EMPTY_HASH,
@@ -196,6 +196,15 @@ describe('block_header', () => {
 		});
 
 		describe('validateGenesis', () => {
+			it('should throw error if previousBlockID is not 32 bytes', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({ ...block, previousBlockID: getRandomBytes(31) });
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header previousBlockID must be 32 bytes',
+				);
+			});
+
 			it('should throw error if transactionRoot is not empty hash', () => {
 				const block = getGenesisBlockAttrs();
 				const blockHeader = new BlockHeader({ ...block, transactionRoot: getRandomBytes(32) });

--- a/elements/lisk-chain/test/unit/block_header.spec.ts
+++ b/elements/lisk-chain/test/unit/block_header.spec.ts
@@ -11,8 +11,9 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { hash } from '@liskhq/lisk-cryptography';
+import { hash, getRandomBytes } from '@liskhq/lisk-cryptography';
 import { BlockHeader } from '../../src/block_header';
+import { EMPTY_BUFFER, EMPTY_HASH } from '../../src/constants';
 import {
 	blockHeaderSchema,
 	blockHeaderSchemaWithId,
@@ -37,6 +38,26 @@ const getBlockAttrs = () => ({
 		certificateSignature: Buffer.alloc(0),
 	},
 	signature: Buffer.from('6da88e2fd4435e26e02682435f108002ccc3ddd5', 'hex'),
+});
+
+const getGenesisBlockAttrs = () => ({
+	version: 1,
+	timestamp: 1009988,
+	height: 1009988,
+	previousBlockID: Buffer.from('4a462ea57a8c9f72d866c09770e5ec70cef18727', 'hex'),
+	stateRoot: Buffer.from('7f9d96a09a3fd17f3478eb7bef3a8bda00e1238b', 'hex'),
+	transactionRoot: EMPTY_HASH,
+	assetsRoot: EMPTY_HASH,
+	generatorAddress: EMPTY_BUFFER,
+	maxHeightPrevoted: 1009988,
+	maxHeightGenerated: 0,
+	validatorsHash: hash(Buffer.alloc(0)),
+	aggregateCommit: {
+		height: 0,
+		aggregationBits: Buffer.alloc(0),
+		certificateSignature: EMPTY_BUFFER,
+	},
+	signature: EMPTY_BUFFER,
 });
 
 const blockId = Buffer.from(
@@ -171,6 +192,80 @@ describe('block_header', () => {
 				const blockHeader = new BlockHeader(data);
 
 				expect(blockHeader.id).toEqual(blockId);
+			});
+		});
+
+		describe('validateGenesis', () => {
+			it('should throw error if transactionRoot is not empty hash', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({ ...block, transactionRoot: getRandomBytes(32) });
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header transaction root must be empty hash',
+				);
+			});
+
+			it('should throw error if generatorAddress is not empty buffer', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({ ...block, generatorAddress: getRandomBytes(32) });
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header generatorAddress must be empty bytes',
+				);
+			});
+
+			it('should throw error if maxHeightPrevoted is not equal to header.height', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({ ...block, maxHeightPrevoted: 10 });
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header maxHeightPrevoted must equal height',
+				);
+			});
+
+			it('should throw error if aggregateCommit.height is not equal to 0', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({
+					...block,
+					aggregateCommit: { ...block.aggregateCommit, height: 10 },
+				});
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header aggregateCommit.height must equal 0',
+				);
+			});
+
+			it('should throw error if aggregateCommit.certificateSignature is not empty buffer', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({
+					...block,
+					aggregateCommit: { ...block.aggregateCommit, certificateSignature: getRandomBytes(32) },
+				});
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header aggregateCommit.certificateSignature must be empty bytes',
+				);
+			});
+
+			it('should throw error if aggregateCommit.aggregationBits is not empty buffer', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({
+					...block,
+					aggregateCommit: { ...block.aggregateCommit, aggregationBits: getRandomBytes(32) },
+				});
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header aggregateCommit.aggregationBits must be empty bytes',
+				);
+			});
+
+			it('should throw error if signature is not empty buffer', () => {
+				const block = getGenesisBlockAttrs();
+				const blockHeader = new BlockHeader({ ...block, signature: getRandomBytes(32) });
+
+				expect(() => blockHeader.validateGenesis()).toThrow(
+					'Genesis block header signature must be empty bytes',
+				);
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #6894 

### How was it solved?

- 🌱 Added static genesis block validation in `lisk-chain` 1be559bc1bb27f6ff2d38cba4783c1c77200b57e
- 🌱 Added unit tests for static genesis block validation 939a3ff69c6985e9ab718dbc9e825b8e1ad2bea3

### How was it tested?

Added relevant unit test
