### PR TITLE
Update to hash SMT key - Closes #6924

### DIFF
--- a/elements/lisk-chain/src/constants.ts
+++ b/elements/lisk-chain/src/constants.ts
@@ -31,3 +31,5 @@ export const TAG_TRANSACTION = createMessageTag('TX');
 
 // TODO: Actual size TBD
 export const MAX_ASSET_DATA_SIZE_BYTES = 64;
+
+export const SMT_PREFIX_SIZE = 6;

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -29,6 +29,7 @@ import {
 import { concatDBKeys } from '../utils';
 import { stateDiffSchema } from '../schema';
 import { CurrentState } from '../state_store';
+import { toSMTKey } from '../state_store/utils';
 
 const bytesArraySchema = {
 	$id: 'lisk-chain/bytesarray',
@@ -411,16 +412,16 @@ export class Storage {
 		// Delete all the newly created states
 		for (const key of createdStates) {
 			batch.del(key);
-			await smt.remove(key);
+			await smt.remove(toSMTKey(key));
 		}
 		// Revert all deleted values
 		for (const { key, value: previousValue } of deletedStates) {
 			batch.put(key, previousValue);
-			await smt.update(key, previousValue);
+			await smt.update(toSMTKey(key), previousValue);
 		}
 		for (const { key, value: previousValue } of updatedStates) {
 			batch.put(key, previousValue);
-			await smt.update(key, previousValue);
+			await smt.update(toSMTKey(key), previousValue);
 		}
 
 		smtStore.finalize(batch);

--- a/elements/lisk-chain/src/state_store/cache_db.ts
+++ b/elements/lisk-chain/src/state_store/cache_db.ts
@@ -14,7 +14,7 @@
 
 import { SparseMerkleTree } from '@liskhq/lisk-tree';
 import { StateDiff } from '../types';
-import { copyBuffer } from './utils';
+import { copyBuffer, toSMTKey } from './utils';
 import { DatabaseWriter } from './types';
 
 interface CacheValue {
@@ -167,9 +167,10 @@ export class CacheDB {
 
 		for (const [key, value] of Object.entries(this._data)) {
 			const keyBytes = Buffer.from(key, 'binary');
+			const smtKey = toSMTKey(keyBytes);
 			if (value.init === undefined) {
 				diff.created.push(keyBytes);
-				await smt.update(keyBytes, value.value);
+				await smt.update(smtKey, value.value);
 				batch.put(keyBytes, value.value);
 				continue;
 			}
@@ -178,7 +179,7 @@ export class CacheDB {
 					key: keyBytes,
 					value: value.init,
 				});
-				await smt.remove(keyBytes);
+				await smt.remove(smtKey);
 				batch.del(keyBytes);
 				continue;
 			}
@@ -187,7 +188,7 @@ export class CacheDB {
 					key: keyBytes,
 					value: value.init,
 				});
-				await smt.update(keyBytes, value.value);
+				await smt.update(smtKey, value.value);
 				batch.put(keyBytes, value.value);
 			}
 		}

--- a/elements/lisk-chain/src/state_store/utils.ts
+++ b/elements/lisk-chain/src/state_store/utils.ts
@@ -13,14 +13,13 @@
  */
 
 import { hash } from '@liskhq/lisk-cryptography';
+import { SMT_PREFIX_SIZE } from '../constants';
 
 export const copyBuffer = (value: Buffer): Buffer => {
 	const copiedValue = Buffer.alloc(value.length);
 	value.copy(copiedValue);
 	return copiedValue;
 };
-
-const SMT_PREFIX_SIZE = 6;
 
 export const toSMTKey = (value: Buffer): Buffer =>
 	Buffer.concat([value.slice(0, SMT_PREFIX_SIZE), hash(value.slice(SMT_PREFIX_SIZE))]);

--- a/elements/lisk-chain/src/state_store/utils.ts
+++ b/elements/lisk-chain/src/state_store/utils.ts
@@ -12,8 +12,15 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { hash } from '@liskhq/lisk-cryptography';
+
 export const copyBuffer = (value: Buffer): Buffer => {
 	const copiedValue = Buffer.alloc(value.length);
 	value.copy(copiedValue);
 	return copiedValue;
 };
+
+const SMT_PREFIX_SIZE = 6;
+
+export const toSMTKey = (value: Buffer): Buffer =>
+	Buffer.concat([value.slice(0, SMT_PREFIX_SIZE), hash(value.slice(SMT_PREFIX_SIZE))]);

--- a/framework/test/unit/modules/bft/bft_params.spec.ts
+++ b/framework/test/unit/modules/bft/bft_params.spec.ts
@@ -67,7 +67,7 @@ describe('BFT parameters', () => {
 			await paramsStore.set(height2Bytes, codec.encode(bftParametersSchema, bftParams2));
 			const batch = db.batch();
 			const smtStore = new SMTStore(db);
-			const smt = new SparseMerkleTree({ db: smtStore, keyLength: 11 });
+			const smt = new SparseMerkleTree({ db: smtStore });
 			await rootStore.finalize(batch, smt);
 			await batch.write();
 
@@ -133,7 +133,7 @@ describe('BFT parameters', () => {
 			await paramsStore.set(height2Bytes, codec.encode(bftParametersSchema, bftParams2));
 			const batch = db.batch();
 			const smtStore = new SMTStore(db);
-			const smt = new SparseMerkleTree({ db: smtStore, keyLength: 11 });
+			const smt = new SparseMerkleTree({ db: smtStore });
 			await rootStore.finalize(batch, smt);
 			await batch.write();
 
@@ -210,7 +210,7 @@ describe('BFT parameters', () => {
 				await paramsStore.set(height3Bytes, codec.encode(bftParametersSchema, bftParams3));
 				const batch = db.batch();
 				const smtStore = new SMTStore(db);
-				const smt = new SparseMerkleTree({ db: smtStore, keyLength: 11 });
+				const smt = new SparseMerkleTree({ db: smtStore });
 				await rootStore.finalize(batch, smt);
 				await batch.write();
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6924 

### How was it solved?

- Update SMT key to be hashed except the module id and storage key

### How was it tested?

- Update all unit test to have default key length
