### PR TITLE
Fix module generator and plugin generator templates broken since 185d8acb - Closes #6909

### DIFF
--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/module_generator.ts
@@ -90,7 +90,7 @@ export default class ModuleGenerator extends Generator {
 			.getInitializerIfKindOrThrow(SyntaxKind.ArrowFunction);
 
 		registerFunction.setBodyText(
-			`${registerFunction.getBodyText()}\napp.registerModule(${this._moduleClass});`,
+			`${registerFunction.getBodyText()}\n_app.registerModule(${this._moduleClass});`,
 		);
 
 		modulesFile.organizeImports();

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/plugin_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/plugin_generator.ts
@@ -113,7 +113,7 @@ export default class PluginGenerator extends Generator {
 			.getInitializerIfKindOrThrow(SyntaxKind.ArrowFunction);
 
 		registerFunction.setBodyText(
-			`${registerFunction.getBodyText()}\napp.registerPlugin(${this._className});`,
+			`${registerFunction.getBodyText()}\n_app.registerPlugin(${this._className});`,
 		);
 
 		pluginsFile.organizeImports();


### PR DESCRIPTION
### What was the problem?

This PR resolves #6909

### How was it solved?

Commit 185d8acb232e14c44629b837f7e74121e4bc7809 changed the `app` argument to `_app` in `modules.ts` and `plugins.ts`. This updates the generator templates to use the new `_app` variable.

### How was it tested?

I ran `lisk generate:module hello 1000` and was able to start my app.
