### PR TITLE
 Verify aggregate commit on block verification - Closes #6855 

### DIFF
--- a/framework/src/node/consensus/certificate_generation/commit_pool.ts
+++ b/framework/src/node/consensus/certificate_generation/commit_pool.ts
@@ -18,15 +18,9 @@ import { createAggSig } from '@liskhq/lisk-cryptography';
 import { EMPTY_BUFFER } from './constants';
 import { BFTParameterNotFoundError } from '../../../modules/bft/errors';
 import { APIContext } from '../../state_machine/types';
-import { BFTAPI, PkSigPair, ValidatorAPI } from '../types';
+import { BFTAPI, PkSigPair, ValidatorAPI, AggregateCommit } from '../types';
 import { COMMIT_RANGE_STORED } from './constants';
-import {
-	AggregateCommit,
-	Certificate,
-	CommitPoolConfig,
-	SingleCommit,
-	ValidatorInfo,
-} from './types';
+import { Certificate, CommitPoolConfig, SingleCommit, ValidatorInfo } from './types';
 import {
 	computeCertificateFromBlockHeader,
 	verifyAggregateCertificateSignature,

--- a/framework/src/node/consensus/certificate_generation/types.ts
+++ b/framework/src/node/consensus/certificate_generation/types.ts
@@ -47,9 +47,3 @@ export interface ValidatorInfo {
 	readonly blsPublicKey: Buffer;
 	readonly blsSecretKey: Buffer;
 }
-
-export interface AggregateCommit {
-	readonly height: number;
-	readonly aggregationBits: Buffer;
-	readonly certificateSignature: Buffer;
-}

--- a/framework/src/node/consensus/types.ts
+++ b/framework/src/node/consensus/types.ts
@@ -15,7 +15,7 @@
 import { BFTParameters } from '../../modules/bft/schemas';
 import { BFTHeights } from '../../modules/bft/types';
 import { ValidatorKeys } from '../../modules/validators/types';
-import { BlockHeader, ImmutableAPIContext } from '../state_machine';
+import { BlockHeader, ImmutableAPIContext, APIContext } from '../state_machine';
 
 export interface BFTHeader {
 	id: Buffer;
@@ -55,4 +55,17 @@ export interface BFTAPI {
 export interface PkSigPair {
 	publicKey: Buffer;
 	signature: Buffer;
+}
+
+export interface AggregateCommit {
+	readonly height: number;
+	readonly aggregationBits: Buffer;
+	readonly certificateSignature: Buffer;
+}
+
+export interface CommitPool {
+	verifyAggregateCommit: (
+		apiContext: APIContext,
+		aggregateCommit: AggregateCommit,
+	) => Promise<boolean>;
 }

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -37,6 +37,7 @@ import {
 	APP_EVENT_NETWORK_READY,
 	APP_EVENT_TRANSACTION_NEW,
 } from './events';
+import { CommitPool } from './consensus/types';
 
 const MINIMUM_MODULE_ID = 2;
 
@@ -93,6 +94,7 @@ export class Node {
 			genesisConfig: this._options.genesis,
 			bftAPI: this._bftModule.api,
 			validatorAPI: this._validatorsModule.api,
+			commitPool: {} as CommitPool, // TODO Initialize commit pool
 		});
 		this._generator = new Generator({
 			chain: this._chain,

--- a/framework/test/unit/node/consensus/certificate_generation/commit_pool.spec.ts
+++ b/framework/test/unit/node/consensus/certificate_generation/commit_pool.spec.ts
@@ -32,7 +32,6 @@ import {
 } from '../../../../../src/node/consensus/certificate_generation/constants';
 import { certificateSchema } from '../../../../../src/node/consensus/certificate_generation/schema';
 import {
-	AggregateCommit,
 	Certificate,
 	SingleCommit,
 } from '../../../../../src/node/consensus/certificate_generation/types';
@@ -42,6 +41,7 @@ import {
 	computeCertificateFromBlockHeader,
 	signCertificate,
 } from '../../../../../src/node/consensus/certificate_generation/utils';
+import { AggregateCommit } from '../../../../../src/node/consensus/types';
 
 jest.mock('@liskhq/lisk-cryptography', () => ({
 	__esModule: true,


### PR DESCRIPTION
### What was the problem?

This PR resolves #6855 

### How was it solved?

Added check for `verifyAggregateCommit` under block verification in `consensus.ts`

### How was it tested?
Added unit test
