### PR TITLE
Identify commits created by generator - Closes #6969

### DIFF
--- a/framework/src/node/consensus/certificate_generation/commit_pool.ts
+++ b/framework/src/node/consensus/certificate_generation/commit_pool.ts
@@ -74,8 +74,11 @@ export class CommitPool {
 
 	public addCommit(commit: SingleCommit, local = false): void {
 		if (!this._nonGossipedCommits.exists(commit) && !this._nonGossipedCommitsLocal.exists(commit)) {
-			// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-			local ? this._nonGossipedCommitsLocal.add(commit) : this._nonGossipedCommits.add(commit);
+			if (local) {
+				this._nonGossipedCommitsLocal.add(commit);
+			} else {
+				this._nonGossipedCommits.add(commit);
+			}
 		}
 	}
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6969 

### How was it solved?

♻️ Add nonGossipedCommitsLocal list to handle generator commits - 581b811417a781fcdab91c05afb16239f9972c0a

### How was it tested?

Run `npm run test:unit commit_pool.spec` under `framework`