### PR TITLE
Add rate limit reset job in generator and consensus - Closes #6940

### DIFF
--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -308,7 +308,8 @@ export class Consensus {
 		});
 	}
 
-	public start(): void {
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async start(): Promise<void> {
 		this._endpoint.start();
 	}
 

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -128,7 +128,6 @@ export class Consensus {
 			db: this._db,
 		} as EndpointArgs); // TODO: Remove casting in issue where commitPool is added here
 		const blockExecutor = this._createBlockExecutor();
-		this._endpoint.start();
 		const blockSyncMechanism = new BlockSynchronizationMechanism({
 			chain: this._chain,
 			logger: this._logger,
@@ -307,6 +306,10 @@ export class Consensus {
 		await this._mutex.runExclusive(async () => {
 			await this._executeValidated(block);
 		});
+	}
+
+	public start(): void {
+		this._endpoint.start();
 	}
 
 	public async stop(): Promise<void> {

--- a/framework/src/node/consensus/consensus.ts
+++ b/framework/src/node/consensus/consensus.ts
@@ -128,6 +128,7 @@ export class Consensus {
 			db: this._db,
 		} as EndpointArgs); // TODO: Remove casting in issue where commitPool is added here
 		const blockExecutor = this._createBlockExecutor();
+		this._endpoint.start();
 		const blockSyncMechanism = new BlockSynchronizationMechanism({
 			chain: this._chain,
 			logger: this._logger,
@@ -312,6 +313,7 @@ export class Consensus {
 		this._stop = true;
 		// Add mutex to wait for the current mutex to finish
 		await this._mutex.acquire();
+		this._endpoint.stop();
 	}
 
 	public isSynced(height: number, maxHeightPrevoted: number): boolean {

--- a/framework/src/node/generator/generator.ts
+++ b/framework/src/node/generator/generator.ts
@@ -225,6 +225,7 @@ export class Generator {
 	}
 
 	public async start(): Promise<void> {
+		this._networkEndpoint.start();
 		this._pool.events.on(events.EVENT_TRANSACTION_REMOVED, event => {
 			this._logger.debug(event, 'Transaction was removed from the pool.');
 		});
@@ -249,6 +250,7 @@ export class Generator {
 		this._broadcaster.stop();
 		this._pool.stop();
 		this._generationJob.stop();
+		this._networkEndpoint.stop();
 	}
 
 	public onNewBlock(block: Block): void {

--- a/framework/src/node/network/base_network_endpoint.ts
+++ b/framework/src/node/network/base_network_endpoint.ts
@@ -17,13 +17,25 @@ interface RateTracker {
 	[key: string]: { [key: string]: number };
 }
 
+export const DEFAULT_RATE_RESET_TIME = 10000;
 export class BaseNetworkEndpoint {
 	protected network: Network;
 
 	private _rateTracker: RateTracker = {};
+	private _limitResetInterval!: NodeJS.Timeout;
 
 	public constructor(network: Network) {
 		this.network = network;
+	}
+
+	public start() {
+		this._limitResetInterval = setInterval(() => {
+			this._rateTracker = {};
+		}, DEFAULT_RATE_RESET_TIME);
+	}
+
+	public stop() {
+		clearInterval(this._limitResetInterval);
 	}
 
 	protected addRateLimit(procedure: string, peerId: string, limit: number): void {

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -294,7 +294,7 @@ export class Node {
 	public async start() {
 		await this._network.start();
 		await this._generator.start();
-		this._consensus.start();
+		await this._consensus.start();
 	}
 
 	public async stop(): Promise<void> {

--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -294,6 +294,7 @@ export class Node {
 	public async start() {
 		await this._network.start();
 		await this._generator.start();
+		this._consensus.start();
 	}
 
 	public async stop(): Promise<void> {

--- a/framework/test/unit/application.spec.ts
+++ b/framework/test/unit/application.spec.ts
@@ -281,6 +281,7 @@ describe('Application', () => {
 
 		beforeEach(async () => {
 			({ app } = Application.defaultApplication(config));
+			jest.spyOn(app['_node'], 'start').mockResolvedValue();
 			jest.spyOn(app['_node']['_network'], 'start').mockResolvedValue();
 			jest.spyOn(fs, 'readdirSync').mockReturnValue([]);
 			// jest.spyOn(IPCServer.prototype, 'start').mockResolvedValue();
@@ -361,6 +362,7 @@ describe('Application', () => {
 		beforeEach(async () => {
 			jest.spyOn(Bus.prototype, 'publish').mockResolvedValue(jest.fn() as never);
 			({ app } = Application.defaultApplication(config));
+			jest.spyOn(app['_node'], 'start').mockResolvedValue();
 			jest.spyOn(app['_node']['_network'], 'start').mockResolvedValue();
 			jest.spyOn(app['_node']['_stateMachine'], 'executeGenesisBlock').mockResolvedValue();
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #6940 

### How was it solved?

♻️ Add start/stop job for rateLimit reset job 870f9d631b55cb84418287a1e97e0b0c2f492ace

### How was it tested?

`npm run test:unit` under `framework`
