### PR TITLE
 Expose `GenesisBlockExecuteContext` interface from SDK - Closes #7008 

### DIFF
--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -50,3 +50,4 @@ export {
 export { RewardAPI, RewardModule } from './modules/reward';
 export { FeeAPI, FeeModule } from './modules/fee';
 export { RandomAPI, RandomModule } from './modules/random';
+export { GenesisBlockExecuteContext } from './node/state_machine/types';


### PR DESCRIPTION
### What was the problem?

This PR resolves #7008 

### How was it solved?

Expose interface from framework

### How was it tested?

Manually
