### PR TITLE
 Missing static block header validation - Closes #7058 

### DIFF
--- a/elements/lisk-chain/src/block_header.ts
+++ b/elements/lisk-chain/src/block_header.ts
@@ -15,7 +15,7 @@
 import { signDataWithPrivateKey, hash, verifyData } from '@liskhq/lisk-cryptography';
 import { codec } from '@liskhq/lisk-codec';
 import { validator, LiskValidationError } from '@liskhq/lisk-validator';
-import { EMPTY_BUFFER, EMPTY_HASH, TAG_BLOCK_HEADER } from './constants';
+import { EMPTY_BUFFER, EMPTY_HASH, SIGNATURE_LENGTH_BYTES, TAG_BLOCK_HEADER } from './constants';
 import { blockHeaderSchema, blockHeaderSchemaWithId, signingBlockHeaderSchema } from './schema';
 import { JSONObject } from './types';
 
@@ -167,6 +167,9 @@ export class BlockHeader {
 		}
 		if (this.previousBlockID.length === 0) {
 			throw new Error('Previous block id must not be empty.');
+		}
+		if (this.signature.length !== SIGNATURE_LENGTH_BYTES) {
+			throw new Error('Signature length must be 64 bytes.');
 		}
 	}
 

--- a/elements/lisk-chain/src/constants.ts
+++ b/elements/lisk-chain/src/constants.ts
@@ -31,5 +31,6 @@ export const TAG_TRANSACTION = createMessageTag('TX');
 
 // TODO: Actual size TBD
 export const MAX_ASSET_DATA_SIZE_BYTES = 64;
+export const SIGNATURE_LENGTH_BYTES = 64;
 
 export const SMT_PREFIX_SIZE = 6;

--- a/elements/lisk-chain/test/unit/block_header.spec.ts
+++ b/elements/lisk-chain/test/unit/block_header.spec.ts
@@ -155,8 +155,12 @@ describe('block_header', () => {
 		});
 
 		describe('validate', () => {
-			it('should validate the block header without error', () => {
+			it('should validate the block header without error if all the properties are valid', () => {
 				const data = getBlockAttrs();
+				data.signature = Buffer.from(
+					'41f7d923c8957664923b49d7a893153476bc60e0392702cf111a26a92d74279a00c41f1999504c9faeee7b3d05393ca04d61a0768c3ae4d324f3097ab0b52201',
+					'hex',
+				);
 				const blockHeader = new BlockHeader(data);
 
 				expect(blockHeader.validate()).toBeUndefined();
@@ -167,6 +171,13 @@ describe('block_header', () => {
 				const blockHeader = new BlockHeader({ ...data, previousBlockID: Buffer.alloc(0) });
 
 				expect(() => blockHeader.validate()).toThrow('Previous block id must not be empty.');
+			});
+
+			it('should throw error if signature length is not correct', () => {
+				const data = getBlockAttrs();
+				const blockHeader = new BlockHeader(data);
+
+				expect(() => blockHeader.validate()).toThrow('Signature length must be 64 bytes.');
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #7058

### How was it solved?

Add signature length validation logic to `header.validate`

### How was it tested?
Added unit test

