### PR TITLE
Fix order of bft execution - Closes #7060

### DIFF
--- a/framework/src/modules/bft/bft_votes.ts
+++ b/framework/src/modules/bft/bft_votes.ts
@@ -85,10 +85,14 @@ export const updatePrevotesPrecommits = async (
 		const params = await paramsCache.getParameters(blockBFTInfo.height);
 		if (blockBFTInfo.prevoteWeight >= params.prevoteThreshold) {
 			const bftValidator = params.validators.find(v =>
-				v.address.equals(blockBFTInfo.generatorAddress),
+				v.address.equals(newBlockBFTInfo.generatorAddress),
 			);
 			if (!bftValidator) {
-				continue;
+				throw new Error(
+					`Invalid state. Validator ${newBlockBFTInfo.generatorAddress.toString(
+						'hex',
+					)} must be in the BFT parameters at height ${newBlockBFTInfo.height}`,
+				);
 			}
 			blockBFTInfo.precommitWeight += bftValidator.bftWeight;
 			if (!hasPrecommitted) {
@@ -116,10 +120,14 @@ export const updatePrevotesPrecommits = async (
 		}
 		const params = await paramsCache.getParameters(blockBFTInfo.height);
 		const bftValidator = params.validators.find(v =>
-			v.address.equals(blockBFTInfo.generatorAddress),
+			v.address.equals(newBlockBFTInfo.generatorAddress),
 		);
 		if (!bftValidator) {
-			continue;
+			throw new Error(
+				`Invalid state. Validator ${newBlockBFTInfo.generatorAddress.toString(
+					'hex',
+				)} must be in the BFT parameters at height ${newBlockBFTInfo.height}`,
+			);
 		}
 		blockBFTInfo.prevoteWeight += bftValidator.bftWeight;
 	}

--- a/framework/src/modules/bft/bft_votes.ts
+++ b/framework/src/modules/bft/bft_votes.ts
@@ -88,11 +88,7 @@ export const updatePrevotesPrecommits = async (
 				v.address.equals(blockBFTInfo.generatorAddress),
 			);
 			if (!bftValidator) {
-				throw new Error(
-					`Invalid state. Validator ${blockBFTInfo.generatorAddress.toString(
-						'hex',
-					)} must be in the BFT parameters at height ${blockBFTInfo.height}`,
-				);
+				continue;
 			}
 			blockBFTInfo.precommitWeight += bftValidator.bftWeight;
 			if (!hasPrecommitted) {
@@ -123,11 +119,7 @@ export const updatePrevotesPrecommits = async (
 			v.address.equals(blockBFTInfo.generatorAddress),
 		);
 		if (!bftValidator) {
-			throw new Error(
-				`Invalid state. Validator ${blockBFTInfo.generatorAddress.toString(
-					'hex',
-				)} must be in the BFT parameters at height ${blockBFTInfo.height}`,
-			);
+			continue;
 		}
 		blockBFTInfo.prevoteWeight += bftValidator.bftWeight;
 	}

--- a/framework/src/modules/bft/module.ts
+++ b/framework/src/modules/bft/module.ts
@@ -24,7 +24,7 @@ import {
 	STORE_PREFIX_BFT_VOTES,
 } from './constants';
 import { bftModuleConfig, BFTVotes, bftVotesSchema } from './schemas';
-import { BlockAfterExecuteContext, GenesisBlockExecuteContext } from '../../node/state_machine';
+import { BlockExecuteContext, GenesisBlockExecuteContext } from '../../node/state_machine';
 import { ValidatorsAPI } from './types';
 import {
 	insertBlockBFTInfo,
@@ -76,7 +76,7 @@ export class BFTModule extends BaseModule {
 		);
 	}
 
-	public async afterTransactionsExecute(context: BlockAfterExecuteContext): Promise<void> {
+	public async beforeTransactionsExecute(context: BlockExecuteContext): Promise<void> {
 		const votesStore = context.getStore(this.id, STORE_PREFIX_BFT_VOTES);
 		const paramsStore = context.getStore(this.id, STORE_PREFIX_BFT_PARAMETERS);
 		const paramsCache = new BFTParametersCache(paramsStore);

--- a/framework/test/unit/modules/bft/bft_processing.spec.ts
+++ b/framework/test/unit/modules/bft/bft_processing.spec.ts
@@ -161,7 +161,7 @@ describe('BFT processing', () => {
 						bftVotesSchema,
 					);
 
-					await bftModule.afterTransactionsExecute(context.getBlockAfterExecuteContext());
+					await bftModule.beforeTransactionsExecute(context.getBlockExecuteContext());
 
 					const votesStore = stateStore.getStore(bftModule.id, STORE_PREFIX_BFT_VOTES);
 					const result = await votesStore.getWithSchema<BFTVotes>(EMPTY_KEY, bftVotesSchema);


### PR DESCRIPTION
### What was the problem?

This PR resolves #7060 

### How was it solved?

- Update hook to be executed in `beforeTransactionsExecute`
- replace BFTValidator not exist error with continue. It is possible that generator address is not bft participant but valid generator of a block.

### How was it tested?
- Updated unit tests
- Run application more than 309 blocks from genesis

