### PR TITLE
Fix random module to use random hashOnion when config is not set - Closes #7072

### DIFF
--- a/framework/src/modules/random/module.ts
+++ b/framework/src/modules/random/module.ts
@@ -256,6 +256,12 @@ export class RandomModule extends BaseModule {
 			return prev;
 		}, undefined);
 		const hashOnionConfig = this._getHashOnionConfig(address);
+		if (!hashOnionConfig) {
+			return {
+				hash: generateHashOnionSeed(),
+				count: 0,
+			};
+		}
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		if (!usedHashOnion) {
 			return {
@@ -288,10 +294,10 @@ export class RandomModule extends BaseModule {
 		};
 	}
 
-	private _getHashOnionConfig(address: Buffer): HashOnionConfig {
+	private _getHashOnionConfig(address: Buffer): HashOnionConfig | undefined {
 		const hashOnionConfig = this._generatorConfig.find(d => d.address.equals(address));
 		if (!hashOnionConfig?.hashOnion) {
-			throw new Error(`Account ${address.toString('hex')} does not have hash onion in the config`);
+			return undefined;
 		}
 
 		return hashOnionConfig.hashOnion;

--- a/framework/test/unit/modules/random/random_module.spec.ts
+++ b/framework/test/unit/modules/random/random_module.spec.ts
@@ -382,6 +382,33 @@ describe('RandomModule', () => {
 				'All of the hash onion has been used already. Please update to the new hash onion.',
 			);
 		});
+
+		it('should use random seedReveal when there is no associated generator config', async () => {
+			// Arrange
+			const loggerMock = {
+				warn: jest.fn(),
+			};
+
+			const blockGenerateContext: BlockGenerateContext = testing.createBlockGenerateContext({
+				assets: assetStub,
+				logger: loggerMock as any,
+				networkIdentifier: defaultNetworkIdentifier,
+				getAPIContext: jest.fn() as any,
+				getStore: jest.fn() as any,
+				header: { height: 15, generatorAddress: Buffer.from(targetDelegate.address, 'hex') } as any,
+			});
+
+			// Act
+			await randomModule.init({
+				generatorConfig: { hashOnions: [] },
+				genesisConfig: {} as GenesisConfig,
+				moduleConfig: {},
+			});
+			await expect(randomModule.initBlock(blockGenerateContext)).toResolve();
+
+			// Assert
+			expect(assetStub.setAsset).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe('initGenesisState', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #7072 

### How was it solved?

- Update to return undefined when hash onion config does not exist
- Update to use random seed reveal when hash onion is not set to the config

### How was it tested?

- Update unit test to check this case
