### PR TITLE
Update to use chain validate for static validation - Closes #7056

### DIFF
--- a/elements/lisk-chain/src/chain.ts
+++ b/elements/lisk-chain/src/chain.ts
@@ -168,7 +168,7 @@ export class Chain {
 		}
 		for (const asset of block.assets.getAll()) {
 			if (!inputs.acceptedModuleIDs.includes(asset.moduleID)) {
-				throw new Error(`Block asset from moduleID: ${asset.moduleID} is not accepted.`);
+				throw new Error(`Block asset with moduleID: ${asset.moduleID} is not accepted.`);
 			}
 		}
 		const transactionIDs = [];

--- a/elements/lisk-chain/test/unit/chain.spec.ts
+++ b/elements/lisk-chain/test/unit/chain.spec.ts
@@ -320,6 +320,17 @@ describe('chain', () => {
 	describe('validateBlock', () => {
 		let block: Block;
 
+		it('should not throw error with a valid block', async () => {
+			const txs = new Array(20).fill(0).map(() => getTransaction());
+			block = await createValidDefaultBlock({
+				transactions: txs,
+			});
+			// Act & assert
+			expect(() =>
+				chainInstance.validateBlock(block, { version: 2, acceptedModuleIDs: [] }),
+			).not.toThrow();
+		});
+
 		it('should throw error if transaction root does not match', async () => {
 			const txs = new Array(20).fill(0).map(() => getTransaction());
 			block = await createValidDefaultBlock({
@@ -364,7 +375,7 @@ describe('chain', () => {
 			// Act & assert
 			expect(() =>
 				chainInstance.validateBlock(block, { version: 2, acceptedModuleIDs: [] }),
-			).toThrow('Block asset from moduleID: 1515 is not accepted.');
+			).toThrow('Block asset with moduleID: 1515 is not accepted.');
 		});
 	});
 });

--- a/framework/src/node/consensus/synchronizer/fast_chain_switching_mechanism.ts
+++ b/framework/src/node/consensus/synchronizer/fast_chain_switching_mechanism.ts
@@ -171,6 +171,7 @@ export class FastChainSwitchingMechanism extends BaseSynchronizer {
 					},
 					'Validating block',
 				);
+				this.blockExecutor.validate(block);
 				await this.blockExecutor.verify(block);
 			}
 		} catch (err) {

--- a/framework/src/node/consensus/synchronizer/synchronizer.ts
+++ b/framework/src/node/consensus/synchronizer/synchronizer.ts
@@ -75,7 +75,7 @@ export class Synchronizer {
 			);
 			// Moving to a Different Chain
 			// 1. Step: Validate new tip of chain
-			await this.blockExecutor.verify(receivedBlock);
+			this.blockExecutor.validate(receivedBlock);
 
 			// Choose the right mechanism to sync
 			const validMechanism = await this._determineSyncMechanism(receivedBlock, peerId);

--- a/framework/src/node/consensus/synchronizer/type.ts
+++ b/framework/src/node/consensus/synchronizer/type.ts
@@ -15,6 +15,7 @@
 import { Block } from '@liskhq/lisk-chain';
 
 export interface BlockExecutor {
+	validate: (block: Block) => void;
 	verify: (block: Block) => Promise<void>;
 	getFinalizedHeight: () => number;
 	executeValidated: (

--- a/framework/test/unit/node/consensus/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
+++ b/framework/test/unit/node/consensus/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
@@ -44,6 +44,7 @@ describe('block_synchronization_mechanism', () => {
 
 	let chainModule: any;
 	let blockExecutor: {
+		validate: jest.Mock;
 		verify: jest.Mock;
 		executeValidated: jest.Mock;
 		deleteLastBlock: jest.Mock;
@@ -108,6 +109,7 @@ describe('block_synchronization_mechanism', () => {
 		chainModule.dataAccess = dataAccessMock;
 
 		blockExecutor = {
+			validate: jest.fn(),
 			verify: jest.fn(),
 			executeValidated: jest.fn().mockImplementation(block => {
 				chainModule._lastBlock = block;
@@ -759,8 +761,8 @@ describe('block_synchronization_mechanism', () => {
 					requestedBlocks.findIndex(block => block.header.id.equals(aBlock.header.id)) + 1,
 				);
 
-				// Lastblock is also validated
-				expect(blockExecutor.verify).toHaveBeenCalledTimes(blocksToApply.length + 1);
+				expect(blockExecutor.validate).toHaveBeenCalledTimes(blocksToApply.length - 1);
+				expect(blockExecutor.verify).toHaveBeenCalledTimes(blocksToApply.length);
 				expect(blockExecutor.executeValidated).toHaveBeenCalledTimes(blocksToApply.length);
 				for (const requestedBlock of blocksToApply) {
 					expect(blockExecutor.verify).toHaveBeenCalledWith(requestedBlock);
@@ -798,7 +800,7 @@ describe('block_synchronization_mechanism', () => {
 				expect(networkMock.getConnectedPeers).toHaveBeenCalledTimes(1);
 
 				// Only called for last block validation
-				expect(blockExecutor.verify).toHaveBeenCalledTimes(1);
+				expect(blockExecutor.validate).toHaveBeenCalledTimes(1);
 				expect(blockExecutor.executeValidated).not.toHaveBeenCalled();
 			});
 

--- a/framework/test/unit/node/consensus/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
+++ b/framework/test/unit/node/consensus/synchronizer/block_synchronization_mechanism/block_synchronization_mechanism.spec.ts
@@ -761,7 +761,7 @@ describe('block_synchronization_mechanism', () => {
 					requestedBlocks.findIndex(block => block.header.id.equals(aBlock.header.id)) + 1,
 				);
 
-				expect(blockExecutor.validate).toHaveBeenCalledTimes(blocksToApply.length - 1);
+				expect(blockExecutor.validate).toHaveBeenCalledTimes(blocksToApply.length + 1);
 				expect(blockExecutor.verify).toHaveBeenCalledTimes(blocksToApply.length);
 				expect(blockExecutor.executeValidated).toHaveBeenCalledTimes(blocksToApply.length);
 				for (const requestedBlock of blocksToApply) {

--- a/framework/test/unit/node/consensus/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
+++ b/framework/test/unit/node/consensus/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
@@ -85,6 +85,7 @@ describe('fast_chain_switching_mechanism', () => {
 		chainModule.dataAccess = dataAccessMock;
 
 		blockExecutor = {
+			validate: jest.fn(),
 			verify: jest.fn(),
 			executeValidated: jest.fn(),
 			deleteLastBlock: jest.fn(),

--- a/framework/test/unit/node/consensus/synchronizer/synchronizer.spec.ts
+++ b/framework/test/unit/node/consensus/synchronizer/synchronizer.spec.ts
@@ -75,6 +75,7 @@ describe('Synchronizer', () => {
 		chainModule.dataAccess = dataAccessMock;
 
 		blockExecutor = {
+			validate: jest.fn(),
 			verify: jest.fn(),
 			executeValidated: jest.fn(),
 			deleteLastBlock: jest.fn(),
@@ -423,23 +424,23 @@ describe('Synchronizer', () => {
 		});
 
 		it('should validate the block before sync', async () => {
-			jest.spyOn(blockExecutor, 'verify');
+			jest.spyOn(blockExecutor, 'validate');
 
 			await synchronizer.run(aReceivedBlock, aPeerId);
 
-			expect(blockExecutor.verify).toHaveBeenCalledWith(aReceivedBlock);
+			expect(blockExecutor.validate).toHaveBeenCalledWith(aReceivedBlock);
 		});
 
 		it('should reject with error if block validation failed', async () => {
-			(blockExecutor.verify as jest.Mock).mockRejectedValueOnce(
-				new Error('Invalid block signature'),
-			);
+			(blockExecutor.validate as jest.Mock).mockImplementationOnce(() => {
+				throw new Error('Invalid block version');
+			});
 			aReceivedBlock.header['_signature'] = Buffer.from(
 				'84d95f9a9c02b1b216bc89610961ca886a454c252e0782f8c4c437f5dff7f720fd63461774fbec4622c85c1c15c3f1d55baf7a4ad41e4e0e50589c5c1e4c7301',
 				'hex',
 			);
 			await expect(synchronizer.run(aReceivedBlock, aPeerId)).rejects.toThrow(
-				'Invalid block signature',
+				'Invalid block version',
 			);
 
 			expect(synchronizer.isActive).toBeFalsy();


### PR DESCRIPTION
### What was the problem?

This PR resolves #7056 

### How was it solved?

- Update to use `chain.validateBlock` instead of `Block.validate` in consensus
- Move `version` and `assets` validation to `validateBlock`
- Fix synchronization code to use `validate` when receiving block.
- Fix misuse of `verify` in synchronization. When validating detached block (block which is not consecutive of the current last block), `verify` cannot be used. Therefore, updated to use `validate`

Reference for synchronization: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0014.md#moving-to-a-different-chain

### How was it tested?

- Updated unit tests
