### PR TITLE
Implement sendInternal function for mainchain/sidechain stores - Closes #7040

### DIFF
--- a/framework/src/modules/interoperability/base_interoperability_store.ts
+++ b/framework/src/modules/interoperability/base_interoperability_store.ts
@@ -13,6 +13,7 @@
  */
 
 import { codec } from '@liskhq/lisk-codec';
+import { NotFoundError } from '@liskhq/lisk-chain';
 import { hash } from '@liskhq/lisk-cryptography';
 import { regularMerkleTree } from '@liskhq/lisk-tree';
 import { SubStore } from '../../node/state_machine/types';
@@ -133,6 +134,20 @@ export abstract class BaseInteroperabilityStore {
 	public async getChainAccount(chainID: Buffer): Promise<ChainAccount> {
 		const chainSubstore = this.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHAIN_DATA);
 		return chainSubstore.getWithSchema<ChainAccount>(chainID, chainAccountSchema);
+	}
+
+	public async chainAccountExist(chainID: Buffer): Promise<Boolean> {
+		const chainSubstore = this.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHAIN_DATA);
+		try {
+			await chainSubstore.getWithSchema<ChainAccount>(chainID, chainAccountSchema);
+		} catch (error) {
+			if (!(error instanceof NotFoundError)) {
+				throw error;
+			}
+			return false;
+		}
+
+		return true;
 	}
 
 	public async getTerminatedStateAccount(chainID: Buffer): Promise<TerminatedStateAccount> {

--- a/framework/src/modules/interoperability/constants.ts
+++ b/framework/src/modules/interoperability/constants.ts
@@ -15,6 +15,11 @@
 export const MODULE_ID_INTEROPERABILITY = 64;
 export const MODULE_NAME_INTEROPERABILITY = 'interoperability';
 
+// General constants
+export const MAINCHAIN_ID = 1;
+export const LIVENESS_LIMIT = 2592000; // 30*24*3600
+export const MAX_CCM_SIZE = 10240;
+
 // Store prefixes
 export const STORE_PREFIX_OUTBOX_ROOT = 0x0000;
 export const STORE_PREFIX_CHAIN_DATA = 0x8000;
@@ -25,5 +30,8 @@ export const STORE_PREFIX_TERMINATED_STATE = 0xc000;
 export const STORE_PREFIX_TERMINATED_OUTBOX = 0xd000;
 export const STORE_PREFIX_REGISTERED_NAMES = 0xe000;
 export const STORE_PREFIX_REGISTERED_NETWORK_IDS = 0xf000;
-export const MAINCHAIN_ID = 1;
-export const LIVENESS_LIMIT = 2592000; // 30*24*3600
+
+// Chain status
+export const CHAIN_REGISTERED = 0;
+export const CHAIN_ACTIVE = 1;
+export const CHAIN_TERMINATED = 2;

--- a/framework/src/modules/interoperability/mainchain/store.ts
+++ b/framework/src/modules/interoperability/mainchain/store.ts
@@ -88,7 +88,7 @@ export class MainchainInteroperabilityStore extends BaseInteroperabilityStore {
 		for (const mod of this._interoperableModules.values()) {
 			if (mod?.crossChainAPI?.beforeSendCCM) {
 				try {
-					await mod.crossChainAPI?.beforeSendCCM(sendContext.beforeSendContext);
+					await mod.crossChainAPI.beforeSendCCM(sendContext.beforeSendContext);
 				} catch (error) {
 					return false;
 				}

--- a/framework/src/modules/interoperability/mainchain/store.ts
+++ b/framework/src/modules/interoperability/mainchain/store.ts
@@ -13,8 +13,9 @@
  */
 
 import { BaseInteroperabilityStore } from '../base_interoperability_store';
-import { LIVENESS_LIMIT } from '../constants';
+import { CHAIN_ACTIVE, LIVENESS_LIMIT } from '../constants';
 import { CCMsg, CCUpdateParams, SendInternalContext } from '../types';
+import { getIDAsKeyForStore, validateFormat } from '../utils';
 
 export class MainchainInteroperabilityStore extends BaseInteroperabilityStore {
 	public async isLive(chainID: Buffer, timestamp: number): Promise<boolean> {
@@ -37,10 +38,58 @@ export class MainchainInteroperabilityStore extends BaseInteroperabilityStore {
 		console.log(ccu, ccm);
 	}
 
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async sendInternal(sendContext: SendInternalContext): Promise<void> {
-		// eslint-disable-next-line no-console
-		console.log(sendContext);
+	public async sendInternal(sendContext: SendInternalContext): Promise<boolean> {
+		const receivingChainIDAsStoreKey = getIDAsKeyForStore(sendContext.receivingChainID);
+		let receivingChainAccount;
+		try {
+			// Chain has to exist on mainchain
+			receivingChainAccount = await this.getChainAccount(receivingChainIDAsStoreKey);
+		} catch (error) {
+			return false;
+		}
+
+		// Chain must be live; This check is always on the receivingChainID
+		const isReceivingChainLive = await this.isLive(
+			receivingChainIDAsStoreKey,
+			sendContext.timestamp,
+		);
+		if (!isReceivingChainLive) {
+			return false;
+		}
+		// Chain status must be active
+		if (receivingChainAccount.status !== CHAIN_ACTIVE) {
+			return false;
+		}
+
+		const ownChainAccount = await this.getOwnChainAccount();
+		// Create cross-chain message
+		const ccm: CCMsg = {
+			crossChainCommandID: sendContext.crossChainCommandID,
+			fee: sendContext.fee,
+			moduleID: sendContext.moduleID,
+			nonce: ownChainAccount.nonce,
+			params: sendContext.params,
+			receivingChainID: sendContext.receivingChainID,
+			sendingChainID: ownChainAccount.id,
+			status: sendContext.status,
+		};
+
+		try {
+			validateFormat(ccm);
+		} catch (error) {
+			return false;
+		}
+
+		for (const mod of this._interoperableModules.values()) {
+			if (mod?.crossChainAPI?.beforeSendCCM) {
+				await mod.crossChainAPI?.beforeSendCCM(sendContext.beforeSendContext);
+			}
+		}
+		await this.addToOutbox(receivingChainIDAsStoreKey, ccm);
+		ownChainAccount.nonce += BigInt(1);
+		await this.setOwnChainAccount(ownChainAccount);
+
+		return true;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await

--- a/framework/src/modules/interoperability/schema.ts
+++ b/framework/src/modules/interoperability/schema.ts
@@ -126,6 +126,26 @@ export const chainAccountSchema = {
 	},
 };
 
+export const ownChainAccountSchema = {
+	$id: 'modules/interoperability/ownChainAccount',
+	type: 'object',
+	required: ['name', 'id', 'nonce'],
+	properties: {
+		name: {
+			dataType: 'string',
+			fieldNumber: 1,
+		},
+		id: {
+			dataType: 'uint32',
+			fieldNumber: 2,
+		},
+		nonce: {
+			dataType: 'uint64',
+			fieldNumber: 3,
+		},
+	},
+};
+
 export const outboxRootSchema = {
 	$id: 'modules/interoperability/outbox',
 	type: 'object',

--- a/framework/src/modules/interoperability/sidechain/store.ts
+++ b/framework/src/modules/interoperability/sidechain/store.ts
@@ -44,7 +44,6 @@ export class SidechainInteroperabilityStore extends BaseInteroperabilityStore {
 
 		const partnerChainAccount = await this.getChainAccount(partnerChainIDAsStoreKey);
 		// Chain must be live; This checks is always on the receivingChainID
-		// Chain must be live; This check is always on the receivingChainID
 		const isReceivingChainLive = await this.isLive(receivingChainIDAsStoreKey);
 		if (!isReceivingChainLive) {
 			return false;
@@ -75,7 +74,7 @@ export class SidechainInteroperabilityStore extends BaseInteroperabilityStore {
 		for (const mod of this._interoperableModules.values()) {
 			if (mod?.crossChainAPI?.beforeSendCCM) {
 				try {
-					await mod.crossChainAPI?.beforeSendCCM(sendContext.beforeSendContext);
+					await mod.crossChainAPI.beforeSendCCM(sendContext.beforeSendContext);
 				} catch (error) {
 					return false;
 				}

--- a/framework/src/modules/interoperability/sidechain/store.ts
+++ b/framework/src/modules/interoperability/sidechain/store.ts
@@ -34,7 +34,7 @@ export class SidechainInteroperabilityStore extends BaseInteroperabilityStore {
 		const receivingChainIDAsStoreKey = getIDAsKeyForStore(sendContext.receivingChainID);
 		let partnerChainID;
 		try {
-			partnerChainID = await this.getChainAccount(receivingChainIDAsStoreKey);
+			await this.getChainAccount(receivingChainIDAsStoreKey);
 			partnerChainID = sendContext.receivingChainID;
 		} catch (error) {
 			if (!(error instanceof NotFoundError)) {

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -70,7 +70,7 @@ export interface BeforeApplyCCMsgAPIContext extends CCAPIContext {
 }
 
 export interface BeforeSendCCMsgAPIContext extends CCAPIContext {
-	payFromAddress: Buffer;
+	feeAddress: Buffer;
 }
 
 export interface BeforeRecoverCCMsgAPIContext extends CCAPIContext {
@@ -86,13 +86,14 @@ export interface RecoverCCMsgAPIContext extends CCAPIContext {
 }
 
 export interface SendInternalContext {
-	feeAddress: Buffer;
 	moduleID: number;
 	crossChainCommandID: number;
 	receivingChainID: number;
 	fee: bigint;
 	status: number;
 	params: Buffer;
+	timestamp: number;
+	beforeSendContext: BeforeSendCCMsgAPIContext;
 }
 
 export interface LastCertificate {
@@ -106,6 +107,12 @@ export interface ChainAccount {
 	networkID: Buffer;
 	lastCertificate: LastCertificate;
 	status: number;
+}
+
+export interface OwnChainAccount {
+	name: string;
+	id: number;
+	nonce: bigint;
 }
 
 export interface Inbox {

--- a/framework/src/modules/interoperability/utils.ts
+++ b/framework/src/modules/interoperability/utils.ts
@@ -12,7 +12,25 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { codec } from '@liskhq/lisk-codec';
 import { intToBuffer } from '@liskhq/lisk-cryptography';
+import { LiskValidationError, validator } from '@liskhq/lisk-validator';
+import { MAX_CCM_SIZE } from './constants';
+import { ccmSchema } from './schema';
+import { CCMsg } from './types';
 
 // Returns the big endian uint32 serialization of an integer x, with 0 <= x < 2^32 which is 4 bytes long.
 export const getIDAsKeyForStore = (id: number) => intToBuffer(id, 4);
+
+export const validateFormat = (ccm: CCMsg) => {
+	const errors = validator.validate(ccmSchema, ccm);
+	if (errors.length) {
+		const error = new LiskValidationError(errors);
+
+		throw error;
+	}
+	const serializedCCM = codec.encode(ccmSchema, ccm);
+	if (serializedCCM.byteLength > MAX_CCM_SIZE) {
+		throw new Error(`Cross chain message is over the the max ccm size limit of ${MAX_CCM_SIZE}`);
+	}
+};

--- a/framework/test/unit/modules/interoperability/mainchain/store.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/store.spec.ts
@@ -13,29 +13,42 @@
  */
 
 import { StateStore } from '@liskhq/lisk-chain';
+import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import { InMemoryKVStore } from '@liskhq/lisk-db';
 import { when } from 'jest-when';
+import { testing } from '../../../../../src';
 import {
 	MODULE_ID_INTEROPERABILITY,
 	MAINCHAIN_ID,
 	STORE_PREFIX_TERMINATED_STATE,
 	STORE_PREFIX_CHAIN_DATA,
 	LIVENESS_LIMIT,
+	MAX_CCM_SIZE,
+	STORE_PREFIX_OWN_CHAIN_DATA,
+	STORE_PREFIX_CHANNEL_DATA,
+	STORE_PREFIX_OUTBOX_ROOT,
 } from '../../../../../src/modules/interoperability/constants';
 import { MainchainInteroperabilityStore } from '../../../../../src/modules/interoperability/mainchain/store';
 import {
 	chainAccountSchema,
+	channelSchema,
 	terminatedStateSchema,
 } from '../../../../../src/modules/interoperability/schema';
+import { SendInternalContext } from '../../../../../src/modules/interoperability/types';
+import { getIDAsKeyForStore } from '../../../../../src/modules/interoperability/utils';
 
 describe('Mainchain interoperability store', () => {
 	const chainID = Buffer.from(MAINCHAIN_ID.toString(16), 'hex');
 	const timestamp = 2592000 * 100;
 	let chainAccount: any;
+	let ownChainAccount: any;
 	let stateStore: StateStore;
 	let mainchainInteroperabilityStore: MainchainInteroperabilityStore;
 	let terminatedStateSubstore: StateStore;
 	let chainSubstore: StateStore;
+	let ownChainSubstore: StateStore;
+	let channelSubstore: StateStore;
+	let outboxRootSubstore: StateStore;
 	let mockGetStore: any;
 
 	beforeEach(() => {
@@ -50,8 +63,18 @@ describe('Mainchain interoperability store', () => {
 			},
 			status: 2739,
 		};
+
+		ownChainAccount = {
+			name: 'mainchain',
+			id: MAINCHAIN_ID,
+			nonce: BigInt('0'),
+		};
+
 		stateStore = new StateStore(new InMemoryKVStore());
 		chainSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHAIN_DATA);
+		ownChainSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OWN_CHAIN_DATA);
+		channelSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHANNEL_DATA);
+		outboxRootSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OUTBOX_ROOT);
 		terminatedStateSubstore = stateStore.getStore(
 			MODULE_ID_INTEROPERABILITY,
 			STORE_PREFIX_TERMINATED_STATE,
@@ -63,6 +86,16 @@ describe('Mainchain interoperability store', () => {
 		when(mockGetStore)
 			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_TERMINATED_STATE)
 			.mockReturnValue(terminatedStateSubstore);
+		when(mockGetStore)
+			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OWN_CHAIN_DATA)
+			.mockReturnValue(ownChainSubstore);
+		when(mockGetStore)
+			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHANNEL_DATA)
+			.mockReturnValue(channelSubstore);
+		when(mockGetStore)
+			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OUTBOX_ROOT)
+			.mockReturnValue(outboxRootSubstore);
+
 		mainchainInteroperabilityStore = new MainchainInteroperabilityStore(
 			MODULE_ID_INTEROPERABILITY,
 			mockGetStore,
@@ -93,6 +126,215 @@ describe('Mainchain interoperability store', () => {
 			const isLive = await mainchainInteroperabilityStore.isLive(chainID, timestamp);
 
 			expect(isLive).toBe(true);
+		});
+	});
+
+	describe('sendInternal', () => {
+		const mod1 = {
+			crossChainAPI: {
+				beforeSendCCM: jest.fn(),
+			},
+		};
+		const mod2 = {
+			crossChainAPI: {
+				beforeSendCCM: jest.fn(),
+			},
+		};
+
+		const modsMap = new Map();
+		modsMap.set('1', mod1);
+		modsMap.set('2', mod2);
+
+		const ccm = {
+			nonce: BigInt(0),
+			moduleID: 1,
+			crossChainCommandID: 1,
+			sendingChainID: 2,
+			receivingChainID: 3,
+			fee: BigInt(1),
+			status: 1,
+			params: Buffer.alloc(0),
+		};
+
+		const randomOutboxRoot = getRandomBytes(32);
+		const channelData = {
+			inbox: {
+				appendPath: [],
+				size: 0,
+				root: getRandomBytes(32),
+			},
+			outbox: {
+				appendPath: [],
+				size: 1,
+				root: randomOutboxRoot,
+			},
+			partnerChainOutboxRoot: Buffer.alloc(0),
+			messageFeeTokenID: {
+				chainID: 1,
+				localID: 2,
+			},
+		};
+
+		const activeChainAccount = {
+			name: 'account1',
+			networkID: Buffer.alloc(0),
+			lastCertificate: {
+				height: 567467,
+				timestamp: timestamp - 500000,
+				stateRoot: Buffer.alloc(0),
+				validatorsHash: Buffer.alloc(0),
+			},
+			status: 1,
+		};
+
+		const beforeSendCCMContext = testing.createBeforeSendCCMsgAPIContext({
+			ccm,
+			feeAddress: getRandomBytes(32),
+		});
+
+		const sendInternalContext: SendInternalContext = {
+			beforeSendContext: beforeSendCCMContext,
+			...ccm,
+			timestamp,
+		};
+
+		it('should return false if the receiving chain does not exist', async () => {
+			await expect(
+				mainchainInteroperabilityStore.sendInternal(sendInternalContext),
+			).resolves.toEqual(false);
+		});
+
+		it('should return false if the receiving chain is not live', async () => {
+			jest.spyOn(mainchainInteroperabilityStore, 'isLive');
+			chainAccount.lastCertificate.timestamp = timestamp - LIVENESS_LIMIT - 1;
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				chainAccount,
+				chainAccountSchema,
+			);
+
+			await expect(
+				mainchainInteroperabilityStore.sendInternal(sendInternalContext),
+			).resolves.toEqual(false);
+			expect(mainchainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return false if the receiving chain is not active', async () => {
+			jest.spyOn(mainchainInteroperabilityStore, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				chainAccount,
+				chainAccountSchema,
+			);
+
+			await expect(
+				mainchainInteroperabilityStore.sendInternal(sendInternalContext),
+			).resolves.toEqual(false);
+			expect(mainchainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return false if the created ccm is of invalid size', async () => {
+			const invalidCCM = {
+				nonce: BigInt(0),
+				moduleID: 1,
+				crossChainCommandID: 1,
+				sendingChainID: 2,
+				receivingChainID: 3,
+				fee: BigInt(1),
+				status: 1,
+				params: Buffer.alloc(MAX_CCM_SIZE), // invalid size
+			};
+
+			const beforeSendCCMContextLocal = testing.createBeforeSendCCMsgAPIContext({
+				ccm: invalidCCM,
+				feeAddress: getRandomBytes(32),
+			});
+
+			const sendInternalContextLocal: SendInternalContext = {
+				beforeSendContext: beforeSendCCMContextLocal,
+				...invalidCCM,
+				timestamp,
+			};
+
+			jest.spyOn(mainchainInteroperabilityStore, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await mainchainInteroperabilityStore.setOwnChainAccount(ownChainAccount);
+
+			await expect(
+				mainchainInteroperabilityStore.sendInternal(sendInternalContextLocal),
+			).resolves.toEqual(false);
+			expect(mainchainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return false if the ccm created is invalid schema', async () => {
+			const invalidCCM = {
+				nonce: BigInt(0),
+				moduleID: 1,
+				crossChainCommandID: 1,
+				sendingChainID: 2,
+				receivingChainID: 3,
+				fee: BigInt(1),
+				status: 'ccm', // invalid field
+				params: Buffer.alloc(0),
+			};
+
+			const beforeSendCCMContextLocal = testing.createBeforeSendCCMsgAPIContext({
+				ccm: invalidCCM as any,
+				feeAddress: getRandomBytes(32),
+			});
+
+			const sendInternalContextLocal = {
+				beforeSendContext: beforeSendCCMContextLocal,
+				...invalidCCM,
+				timestamp,
+			};
+
+			jest.spyOn(mainchainInteroperabilityStore, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await mainchainInteroperabilityStore.setOwnChainAccount(ownChainAccount);
+
+			await expect(
+				mainchainInteroperabilityStore.sendInternal(sendInternalContextLocal as any),
+			).resolves.toEqual(false);
+			expect(mainchainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return true and call each module beforeSendCCM crossChainAPI', async () => {
+			const mainchainInteropStoreLocal = new MainchainInteroperabilityStore(
+				MODULE_ID_INTEROPERABILITY,
+				mockGetStore,
+				modsMap,
+			);
+
+			jest.spyOn(mainchainInteropStoreLocal, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await mainchainInteropStoreLocal.setOwnChainAccount(ownChainAccount);
+			await channelSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				channelData,
+				channelSchema,
+			);
+			jest.spyOn(mainchainInteropStoreLocal, 'appendToOutboxTree').mockResolvedValue({} as never);
+
+			await expect(
+				mainchainInteropStoreLocal.sendInternal(sendInternalContext as any),
+			).resolves.toEqual(true);
+			expect(mainchainInteropStoreLocal.isLive).toHaveBeenCalledTimes(1);
+			expect(mainchainInteropStoreLocal.appendToOutboxTree).toHaveBeenCalledTimes(1);
+			expect(mod1.crossChainAPI.beforeSendCCM).toHaveBeenCalledTimes(1);
+			expect(mod2.crossChainAPI.beforeSendCCM).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/framework/test/unit/modules/interoperability/sidechain/store.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/store.spec.ts
@@ -15,20 +15,40 @@
 import { StateStore } from '@liskhq/lisk-chain';
 import { InMemoryKVStore } from '@liskhq/lisk-db';
 import { when } from 'jest-when';
+import { getRandomBytes } from '@liskhq/lisk-cryptography';
 import {
+	LIVENESS_LIMIT,
+	MAINCHAIN_ID,
+	MAX_CCM_SIZE,
 	MODULE_ID_INTEROPERABILITY,
+	STORE_PREFIX_CHAIN_DATA,
+	STORE_PREFIX_CHANNEL_DATA,
+	STORE_PREFIX_OUTBOX_ROOT,
+	STORE_PREFIX_OWN_CHAIN_DATA,
 	STORE_PREFIX_TERMINATED_STATE,
 } from '../../../../../src/modules/interoperability/constants';
 import { SidechainInteroperabilityStore } from '../../../../../src/modules/interoperability/sidechain/store';
-import { terminatedStateSchema } from '../../../../../src/modules/interoperability/schema';
+import {
+	chainAccountSchema,
+	channelSchema,
+	terminatedStateSchema,
+} from '../../../../../src/modules/interoperability/schema';
+import { testing } from '../../../../../src';
+import { SendInternalContext } from '../../../../../src/modules/interoperability/types';
+import { getIDAsKeyForStore } from '../../../../../src/modules/interoperability/utils';
 
 describe('Sidechain interoperability store', () => {
 	const chainID = Buffer.from('54', 'hex');
 	const timestamp = 2592000 * 100;
+	let ownChainAccount: any;
 	let chainAccount: any;
 	let stateStore: StateStore;
 	let sidechainInteroperabilityStore: SidechainInteroperabilityStore;
 	let terminatedStateSubstore: StateStore;
+	let chainSubstore: StateStore;
+	let ownChainSubstore: StateStore;
+	let channelSubstore: StateStore;
+	let outboxRootSubstore: StateStore;
 	let mockGetStore: any;
 
 	beforeEach(() => {
@@ -43,15 +63,39 @@ describe('Sidechain interoperability store', () => {
 			},
 			status: 2739,
 		};
+
+		ownChainAccount = {
+			name: 'mainchain',
+			id: 2,
+			nonce: BigInt('0'),
+		};
+
 		stateStore = new StateStore(new InMemoryKVStore());
+		chainSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHAIN_DATA);
+		ownChainSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OWN_CHAIN_DATA);
+		channelSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHANNEL_DATA);
+		outboxRootSubstore = stateStore.getStore(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OUTBOX_ROOT);
 		terminatedStateSubstore = stateStore.getStore(
 			MODULE_ID_INTEROPERABILITY,
 			STORE_PREFIX_TERMINATED_STATE,
 		);
 		mockGetStore = jest.fn();
 		when(mockGetStore)
+			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHAIN_DATA)
+			.mockReturnValue(chainSubstore);
+		when(mockGetStore)
 			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_TERMINATED_STATE)
 			.mockReturnValue(terminatedStateSubstore);
+		when(mockGetStore)
+			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OWN_CHAIN_DATA)
+			.mockReturnValue(ownChainSubstore);
+		when(mockGetStore)
+			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_CHANNEL_DATA)
+			.mockReturnValue(channelSubstore);
+		when(mockGetStore)
+			.calledWith(MODULE_ID_INTEROPERABILITY, STORE_PREFIX_OUTBOX_ROOT)
+			.mockReturnValue(outboxRootSubstore);
+
 		sidechainInteroperabilityStore = new SidechainInteroperabilityStore(
 			MODULE_ID_INTEROPERABILITY,
 			mockGetStore,
@@ -71,6 +115,271 @@ describe('Sidechain interoperability store', () => {
 			const isLive = await sidechainInteroperabilityStore.isLive(chainID);
 
 			expect(isLive).toBe(true);
+		});
+	});
+
+	describe('sendInternal', () => {
+		const mod1 = {
+			crossChainAPI: {
+				beforeSendCCM: jest.fn(),
+			},
+		};
+		const mod2 = {
+			crossChainAPI: {
+				beforeSendCCM: jest.fn(),
+			},
+		};
+
+		const modsMap = new Map();
+		modsMap.set('1', mod1);
+		modsMap.set('2', mod2);
+
+		const ccm = {
+			nonce: BigInt(0),
+			moduleID: 1,
+			crossChainCommandID: 1,
+			sendingChainID: 2,
+			receivingChainID: 3,
+			fee: BigInt(1),
+			status: 1,
+			params: Buffer.alloc(0),
+		};
+
+		const activeChainAccount = {
+			name: 'account1',
+			networkID: Buffer.alloc(0),
+			lastCertificate: {
+				height: 567467,
+				timestamp: timestamp - 500000,
+				stateRoot: Buffer.alloc(0),
+				validatorsHash: Buffer.alloc(0),
+			},
+			status: 1,
+		};
+
+		const randomOutboxRoot = getRandomBytes(32);
+		const channelData = {
+			inbox: {
+				appendPath: [],
+				size: 0,
+				root: getRandomBytes(32),
+			},
+			outbox: {
+				appendPath: [],
+				size: 1,
+				root: randomOutboxRoot,
+			},
+			partnerChainOutboxRoot: Buffer.alloc(0),
+			messageFeeTokenID: {
+				chainID: 1,
+				localID: 2,
+			},
+		};
+
+		const beforeSendCCMContext = testing.createBeforeSendCCMsgAPIContext({
+			ccm,
+			feeAddress: getRandomBytes(32),
+		});
+
+		const sendInternalContext: SendInternalContext = {
+			beforeSendContext: beforeSendCCMContext,
+			...ccm,
+			timestamp,
+		};
+
+		// Sidechain case
+		it('should return mainchain account if the receiving chain does not exist', async () => {
+			const sidechainInteropStoreLocal = new SidechainInteroperabilityStore(
+				MODULE_ID_INTEROPERABILITY,
+				mockGetStore,
+				modsMap,
+			);
+
+			jest.spyOn(sidechainInteropStoreLocal, 'isLive').mockResolvedValue(true);
+			jest.spyOn(sidechainInteropStoreLocal, 'getChainAccount');
+			jest.spyOn(sidechainInteropStoreLocal, 'appendToOutboxTree').mockResolvedValue();
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(MAINCHAIN_ID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await sidechainInteropStoreLocal.setOwnChainAccount(ownChainAccount);
+			await channelSubstore.setWithSchema(
+				getIDAsKeyForStore(MAINCHAIN_ID),
+				channelData,
+				channelSchema,
+			);
+
+			await expect(sidechainInteropStoreLocal.sendInternal(sendInternalContext)).resolves.toEqual(
+				true,
+			);
+			expect(sidechainInteropStoreLocal.getChainAccount).toBeCalledWith(
+				getIDAsKeyForStore(MAINCHAIN_ID),
+			);
+		});
+
+		// Sidechain case
+		it('should return receiving chain account if the receiving chain exists', async () => {
+			const sidechainInteropStoreLocal = new SidechainInteroperabilityStore(
+				MODULE_ID_INTEROPERABILITY,
+				mockGetStore,
+				modsMap,
+			);
+
+			jest.spyOn(sidechainInteropStoreLocal, 'isLive').mockResolvedValue(true);
+			jest.spyOn(sidechainInteropStoreLocal, 'getChainAccount');
+			jest.spyOn(sidechainInteropStoreLocal, 'appendToOutboxTree').mockResolvedValue();
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await sidechainInteropStoreLocal.setOwnChainAccount(ownChainAccount);
+			await channelSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				channelData,
+				channelSchema,
+			);
+
+			await expect(sidechainInteropStoreLocal.sendInternal(sendInternalContext)).resolves.toEqual(
+				true,
+			);
+			expect(sidechainInteropStoreLocal.getChainAccount).toBeCalledWith(
+				getIDAsKeyForStore(ccm.receivingChainID),
+			);
+		});
+
+		it('should return false if the receiving chain is not live', async () => {
+			jest.spyOn(sidechainInteroperabilityStore, 'isLive');
+			chainAccount.lastCertificate.timestamp = timestamp - LIVENESS_LIMIT - 1;
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				chainAccount,
+				chainAccountSchema,
+			);
+
+			await expect(
+				sidechainInteroperabilityStore.sendInternal(sendInternalContext),
+			).resolves.toEqual(false);
+			expect(sidechainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return false if the receiving chain is not active', async () => {
+			jest.spyOn(sidechainInteroperabilityStore, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				chainAccount,
+				chainAccountSchema,
+			);
+
+			await expect(
+				sidechainInteroperabilityStore.sendInternal(sendInternalContext),
+			).resolves.toEqual(false);
+			expect(sidechainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return false if the created ccm is of invalid size', async () => {
+			const invalidCCM = {
+				nonce: BigInt(0),
+				moduleID: 1,
+				crossChainCommandID: 1,
+				sendingChainID: 2,
+				receivingChainID: 3,
+				fee: BigInt(1),
+				status: 1,
+				params: Buffer.alloc(MAX_CCM_SIZE), // invalid size
+			};
+
+			const beforeSendCCMContextLocal = testing.createBeforeSendCCMsgAPIContext({
+				ccm: invalidCCM,
+				feeAddress: getRandomBytes(32),
+			});
+
+			const sendInternalContextLocal: SendInternalContext = {
+				beforeSendContext: beforeSendCCMContextLocal,
+				...invalidCCM,
+				timestamp,
+			};
+
+			jest.spyOn(sidechainInteroperabilityStore, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await sidechainInteroperabilityStore.setOwnChainAccount(ownChainAccount);
+
+			await expect(
+				sidechainInteroperabilityStore.sendInternal(sendInternalContextLocal),
+			).resolves.toEqual(false);
+			expect(sidechainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return false if the ccm created is invalid schema', async () => {
+			const invalidCCM = {
+				nonce: BigInt(0),
+				moduleID: 1,
+				crossChainCommandID: 1,
+				sendingChainID: 2,
+				receivingChainID: 3,
+				fee: BigInt(1),
+				status: 'ccm', // invalid field
+				params: Buffer.alloc(0),
+			};
+
+			const beforeSendCCMContextLocal = testing.createBeforeSendCCMsgAPIContext({
+				ccm: invalidCCM as any,
+				feeAddress: getRandomBytes(32),
+			});
+
+			const sendInternalContextLocal = {
+				beforeSendContext: beforeSendCCMContextLocal,
+				...invalidCCM,
+				timestamp,
+			};
+
+			jest.spyOn(sidechainInteroperabilityStore, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await sidechainInteroperabilityStore.setOwnChainAccount(ownChainAccount);
+
+			await expect(
+				sidechainInteroperabilityStore.sendInternal(sendInternalContextLocal as any),
+			).resolves.toEqual(false);
+			expect(sidechainInteroperabilityStore.isLive).toHaveBeenCalledTimes(1);
+		});
+
+		it('should return true and call each module beforeSendCCM crossChainAPI', async () => {
+			const sidechainInteropStoreLocal = new SidechainInteroperabilityStore(
+				MODULE_ID_INTEROPERABILITY,
+				mockGetStore,
+				modsMap,
+			);
+
+			jest.spyOn(sidechainInteropStoreLocal, 'isLive');
+			await chainSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				activeChainAccount,
+				chainAccountSchema,
+			);
+			await sidechainInteropStoreLocal.setOwnChainAccount(ownChainAccount);
+			await channelSubstore.setWithSchema(
+				getIDAsKeyForStore(ccm.receivingChainID),
+				channelData,
+				channelSchema,
+			);
+			jest.spyOn(sidechainInteropStoreLocal, 'appendToOutboxTree').mockResolvedValue({} as never);
+
+			await expect(
+				sidechainInteropStoreLocal.sendInternal(sendInternalContext as any),
+			).resolves.toEqual(true);
+			expect(sidechainInteropStoreLocal.isLive).toHaveBeenCalledTimes(1);
+			expect(sidechainInteropStoreLocal.appendToOutboxTree).toHaveBeenCalledTimes(1);
+			expect(mod1.crossChainAPI.beforeSendCCM).toHaveBeenCalledTimes(1);
+			expect(mod2.crossChainAPI.beforeSendCCM).toHaveBeenCalledTimes(1);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #7040 

### How was it solved?

[🌱 Add schema](https://github.com/LiskHQ/lisk-sdk/commit/18aca1deeb4d16aed224ca42417690191d914e06)
  
[✅ Add get/set own account in baseInteroperabilityStore](https://github.com/LiskHQ/lisk-sdk/commit/e5280315d6537aecea78b4e497fe2a3f420b164a)
  
[🌱 Add mainchain sendInternal store function](https://github.com/LiskHQ/lisk-sdk/commit/7838a9bff0a878287f427a81ceb8c1fbd833450b)
  
[🌱 Add sendInternal fucntion for sidechain store](https://github.com/LiskHQ/lisk-sdk/commit/db3a713a0cba72b1ca2be64c9f4ef0063038b8bb)
  
[🌱 Add cross chain context testing utils](https://github.com/LiskHQ/lisk-sdk/commit/ce65096fc45f336087c1f47dbda26e80cd0c00f4)
  
[✅ Add mainchain sendInternal tests](https://github.com/LiskHQ/lisk-sdk/commit/c234563eb977cac7287d0175366facc6bd0a5898)
  
[✅ Add sidechain sendInternal unit tests](https://github.com/LiskHQ/lisk-sdk/commit/e38c31cc0e2a820973c67757a4370af8ca27dca7)

### How was it tested?

`npm run test:unit interoperability` under `framework`
