### PR TITLE
Make dpos-mainchain example private - Closes #7092

### DIFF
--- a/examples/dpos-mainchain/package.json
+++ b/examples/dpos-mainchain/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "dpos-mainchain",
+	"private": true,
 	"version": "0.1.0",
 	"description": "Lisk-SDK Application",
 	"author": "Lisk Foundation &lt;admin@lisk.com&gt;, lightcurve GmbH &lt;admin@lightcurve.io&gt;",


### PR DESCRIPTION
### What was the problem?

This PR resolves #7092 

### How was it solved?

- Set `dpos-mainchain` package private

### How was it tested?

On publish it will ignore `dpos-mainchain`
