### PR TITLE
Update token module endpoint - Closes #7123

### DIFF
--- a/framework/src/controller/channels/in_memory_channel.ts
+++ b/framework/src/controller/channels/in_memory_channel.ts
@@ -22,6 +22,7 @@ import { Bus } from '../bus';
 import * as JSONRPC from '../jsonrpc/types';
 import { ChannelType, EndpointHandlers } from '../../types';
 import { Logger } from '../../logger';
+import { createImmutableAPIContext } from '../../node/state_machine';
 
 export class InMemoryChannel extends BaseChannel {
 	private bus!: Bus;
@@ -112,6 +113,7 @@ export class InMemoryChannel extends BaseChannel {
 					const stateStore = new StateStore(this._db);
 					return stateStore.getStore(moduleID, storePrefix);
 				},
+				getImmutableAPIContext: () => createImmutableAPIContext(new StateStore(this._db)),
 				...(this._networkIdentifier && { networkIdentifier: this._networkIdentifier }),
 			}) as Promise<T>;
 		}

--- a/framework/src/controller/channels/ipc_channel.ts
+++ b/framework/src/controller/channels/ipc_channel.ts
@@ -198,6 +198,9 @@ export class IPCChannel extends BaseChannel {
 				getStore: () => {
 					throw new Error('getStore cannot be called on IPC channel');
 				},
+				getImmutableAPIContext: () => {
+					throw new Error('getImmutableAPIContext cannot be called on IPC channel');
+				},
 				params: request.params ?? {},
 				logger: this._logger,
 			}) as Promise<T>;

--- a/framework/src/modules/token/api.ts
+++ b/framework/src/modules/token/api.ts
@@ -71,7 +71,7 @@ export class TokenAPI extends BaseAPI {
 		tokenID: TokenID,
 		amount: bigint,
 	): Promise<void> {
-		const canonicalTokenID = await this._getCanonicalTokenID(apiContext, tokenID);
+		const canonicalTokenID = await this.getCanonicalTokenID(apiContext, tokenID);
 		const userStore = apiContext.getStore(this.moduleID, STORE_PREFIX_USER);
 		const sender = await userStore.getWithSchema<UserStoreData>(
 			getUserStoreKey(senderAddress, canonicalTokenID),
@@ -289,12 +289,12 @@ export class TokenAPI extends BaseAPI {
 	}
 
 	public async isNative(apiContext: ImmutableAPIContext, tokenID: TokenID): Promise<boolean> {
-		const canonicalTokenID = await this._getCanonicalTokenID(apiContext, tokenID);
+		const canonicalTokenID = await this.getCanonicalTokenID(apiContext, tokenID);
 		const [chainID] = splitTokenID(canonicalTokenID);
 		return chainID.equals(CHAIN_ID_ALIAS_NATIVE);
 	}
 
-	private async _getCanonicalTokenID(
+	public async getCanonicalTokenID(
 		apiContext: ImmutableAPIContext,
 		tokenID: TokenID,
 	): Promise<TokenID> {

--- a/framework/src/modules/token/constants.ts
+++ b/framework/src/modules/token/constants.ts
@@ -33,6 +33,7 @@ export const CCM_STATUS_MIN_BALANCE_NOT_REACHED = 66;
 
 export const MIN_BALANCE = BigInt(5000000);
 
+export const ADDRESS_LENGTH = 20;
 export const CHAIN_ID_LENGTH = 4;
 export const LOCAL_ID_LENGTH = 4;
 export const TOKEN_ID_LENGTH = CHAIN_ID_LENGTH + LOCAL_ID_LENGTH;
@@ -48,3 +49,5 @@ export const defaultConfig = {
 	],
 	supportedTokenIDs: [],
 };
+
+export const EMPTY_BYTES = Buffer.alloc(0);

--- a/framework/src/modules/token/endpoint.ts
+++ b/framework/src/modules/token/endpoint.ts
@@ -16,11 +16,65 @@ import { NotFoundError } from '@liskhq/lisk-chain';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
 import { JSONObject, ModuleEndpointContext } from '../../types';
 import { BaseEndpoint } from '../base_endpoint';
-import { STORE_PREFIX_USER } from './constants';
-import { getBalanceRequestSchema, UserStoreData, userStoreSchema } from './schemas';
-import { getUserStoreKey } from './utils';
+import { TokenAPI } from './api';
+import {
+	CHAIN_ID_ALIAS_NATIVE,
+	LOCAL_ID_LENGTH,
+	STORE_PREFIX_ESCROW,
+	STORE_PREFIX_SUPPLY,
+	STORE_PREFIX_USER,
+	TOKEN_ID_LENGTH,
+} from './constants';
+import {
+	EscrowStoreData,
+	escrowStoreSchema,
+	getBalanceRequestSchema,
+	getBalancesRequestSchema,
+	SupplyStoreData,
+	supplyStoreSchema,
+	UserStoreData,
+	userStoreSchema,
+} from './schemas';
+import { getUserStoreKey, splitTokenID } from './utils';
 
 export class TokenEndpoint extends BaseEndpoint {
+	private _tokenAPI!: TokenAPI;
+	private _supportedTokenIDs: string[] = [];
+
+	public init(tokenAPI: TokenAPI, supportedTokenIDs: string[]) {
+		this._tokenAPI = tokenAPI;
+		this._supportedTokenIDs = supportedTokenIDs;
+	}
+
+	public async getBalances(
+		context: ModuleEndpointContext,
+	): Promise<{ balances: JSONObject<UserStoreData & { tokenID: Buffer }>[] }> {
+		const errors = validator.validate(getBalancesRequestSchema, context.params);
+		if (errors.length) {
+			throw new LiskValidationError(errors);
+		}
+		const address = Buffer.from(context.params.address as string, 'hex');
+		const userStore = context.getStore(this.moduleID, STORE_PREFIX_USER);
+		const userData = await userStore.iterateWithSchema<UserStoreData>(
+			{
+				start: Buffer.concat([address, Buffer.alloc(TOKEN_ID_LENGTH, 0)]),
+				end: Buffer.concat([address, Buffer.alloc(TOKEN_ID_LENGTH, 255)]),
+			},
+			userStoreSchema,
+		);
+
+		return {
+			balances: userData.map(({ key, value: user }) => ({
+				tokenID: key.slice(20).toString('hex'),
+				availableBalance: user.availableBalance.toString(),
+				lockedBalances: user.lockedBalances.map(b => ({
+					amount: b.amount.toString(),
+					moduleID: b.moduleID,
+				})),
+			})),
+		};
+	}
+
 	public async getBalance(context: ModuleEndpointContext): Promise<JSONObject<UserStoreData>> {
 		const errors = validator.validate(getBalanceRequestSchema, context.params);
 		if (errors.length) {
@@ -28,10 +82,14 @@ export class TokenEndpoint extends BaseEndpoint {
 		}
 		const address = Buffer.from(context.params.address as string, 'hex');
 		const tokenID = Buffer.from(context.params.tokenID as string, 'hex');
+		const canonicalTokenID = await this._tokenAPI.getCanonicalTokenID(
+			context.getImmutableAPIContext(),
+			tokenID,
+		);
 		const userStore = context.getStore(this.moduleID, STORE_PREFIX_USER);
 		try {
 			const user = await userStore.getWithSchema<UserStoreData>(
-				getUserStoreKey(address, tokenID),
+				getUserStoreKey(address, canonicalTokenID),
 				userStoreSchema,
 			);
 			return {
@@ -50,5 +108,60 @@ export class TokenEndpoint extends BaseEndpoint {
 				lockedBalances: [],
 			};
 		}
+	}
+
+	public async getTotalSupply(
+		context: ModuleEndpointContext,
+	): Promise<{ totalSupply: JSONObject<SupplyStoreData & { tokenID: string }>[] }> {
+		const supplyStore = context.getStore(this.moduleID, STORE_PREFIX_SUPPLY);
+		const supplyData = await supplyStore.iterateWithSchema<SupplyStoreData>(
+			{
+				start: Buffer.concat([Buffer.alloc(LOCAL_ID_LENGTH, 0)]),
+				end: Buffer.concat([Buffer.alloc(LOCAL_ID_LENGTH, 255)]),
+			},
+			supplyStoreSchema,
+		);
+
+		return {
+			totalSupply: supplyData.map(({ key: localID, value: supply }) => ({
+				tokenID: Buffer.concat([CHAIN_ID_ALIAS_NATIVE, localID]).toString('hex'),
+				totalSupply: supply.totalSupply.toString(),
+			})),
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async getSupportedTokens(
+		_context: ModuleEndpointContext,
+	): Promise<{ tokenIDs: string[] }> {
+		return {
+			tokenIDs: this._supportedTokenIDs,
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async getEscrowedAmounts(
+		context: ModuleEndpointContext,
+	): Promise<{
+		escrowedAmounts: JSONObject<EscrowStoreData & { escrowChainID: Buffer; tokenID: Buffer }>[];
+	}> {
+		const escrowStore = context.getStore(this.moduleID, STORE_PREFIX_ESCROW);
+		const escrowData = await escrowStore.iterateWithSchema<EscrowStoreData>(
+			{
+				start: Buffer.concat([Buffer.alloc(TOKEN_ID_LENGTH, 0)]),
+				end: Buffer.concat([Buffer.alloc(TOKEN_ID_LENGTH, 255)]),
+			},
+			escrowStoreSchema,
+		);
+		return {
+			escrowedAmounts: escrowData.map(({ key, value: escrow }) => {
+				const [escrowChainID, localID] = splitTokenID(key);
+				return {
+					escrowChainID: escrowChainID.toString('hex'),
+					amount: escrow.amount.toString(),
+					tokenID: Buffer.concat([CHAIN_ID_ALIAS_NATIVE, localID]).toString('hex'),
+				};
+			}),
+		};
 	}
 }

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -63,6 +63,7 @@ export class TokenModule extends BaseModule {
 			amount: BigInt(mb.amount),
 		}));
 		this.api.init({ minBalances: this._minBalances });
+		this.endpoint.init(this.api, config.supportedTokenIDs);
 		this._transferCommand.init({
 			api: this.api,
 		});

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { TOKEN_ID_LENGTH } from './constants';
+import { ADDRESS_LENGTH, TOKEN_ID_LENGTH } from './constants';
 
 export const configSchema = {
 	$id: '/token/config',
@@ -100,6 +100,10 @@ export const availableLocalIDStoreSchema = {
 	},
 };
 
+export interface EscrowStoreData {
+	amount: bigint;
+}
+
 export const escrowStoreSchema = {
 	$id: '/token/store/escrow',
 	type: 'object',
@@ -110,22 +114,6 @@ export const escrowStoreSchema = {
 			fieldNumber: 1,
 		},
 	},
-};
-
-export const getBalanceRequestSchema = {
-	$id: '/token/endpoint/getBalance',
-	type: 'object',
-	properties: {
-		address: {
-			type: 'string',
-			format: 'hex',
-		},
-		tokenID: {
-			type: 'string',
-			format: 'hex',
-		},
-	},
-	required: ['address', 'tokenID'],
 };
 
 export const transferParamsSchema = {
@@ -147,8 +135,8 @@ export const transferParamsSchema = {
 		recipientAddress: {
 			dataType: 'bytes',
 			fieldNumber: 3,
-			minLength: 20,
-			maxLength: 20,
+			minLength: ADDRESS_LENGTH,
+			maxLength: ADDRESS_LENGTH,
 		},
 		data: {
 			dataType: 'string',
@@ -406,4 +394,38 @@ export const genesisTokenStoreSchema = {
 			},
 		},
 	},
+};
+
+export const getBalanceRequestSchema = {
+	$id: '/token/endpoint/getBalance',
+	type: 'object',
+	properties: {
+		address: {
+			type: 'string',
+			format: 'hex',
+			minLength: ADDRESS_LENGTH * 2,
+			maxLength: ADDRESS_LENGTH * 2,
+		},
+		tokenID: {
+			type: 'string',
+			format: 'hex',
+			minLength: TOKEN_ID_LENGTH * 2,
+			maxLength: TOKEN_ID_LENGTH * 2,
+		},
+	},
+	required: ['address', 'tokenID'],
+};
+
+export const getBalancesRequestSchema = {
+	$id: '/token/endpoint/getBalance',
+	type: 'object',
+	properties: {
+		address: {
+			type: 'string',
+			format: 'hex',
+			minLength: ADDRESS_LENGTH * 2,
+			maxLength: ADDRESS_LENGTH * 2,
+		},
+	},
+	required: ['address'],
 };

--- a/framework/src/node/state_machine/api_context.ts
+++ b/framework/src/node/state_machine/api_context.ts
@@ -15,7 +15,7 @@
 import { StateStore } from '@liskhq/lisk-chain';
 import { InMemoryKVStore, KVStore } from '@liskhq/lisk-db';
 import { EventQueue } from './event_queue';
-import { SubStore } from './types';
+import { SubStore, ImmutableSubStore, ImmutableAPIContext } from './types';
 
 interface Params {
 	stateStore: StateStore;
@@ -26,6 +26,18 @@ export const createAPIContext = (params: Params) => new APIContext(params);
 
 export const createNewAPIContext = (db: KVStore | InMemoryKVStore) =>
 	new APIContext({ stateStore: new StateStore(db), eventQueue: new EventQueue() });
+
+interface ImmutableSubStoreGetter {
+	getStore: (moduleID: number, storePrefix: number) => ImmutableSubStore;
+}
+
+export const createImmutableAPIContext = (
+	immutableSubstoreGetter: ImmutableSubStoreGetter,
+): ImmutableAPIContext => ({
+	eventQueue: new EventQueue(),
+	getStore: (moduleID: number, storePrefix: number) =>
+		immutableSubstoreGetter.getStore(moduleID, storePrefix),
+});
 
 export class APIContext {
 	private readonly _stateStore: StateStore;

--- a/framework/src/node/state_machine/index.ts
+++ b/framework/src/node/state_machine/index.ts
@@ -17,7 +17,7 @@ export { TransactionContext } from './transaction_context';
 export { BlockContext } from './block_context';
 export { GenesisBlockContext } from './genesis_block_context';
 export { EventQueue } from './event_queue';
-export { createAPIContext } from './api_context';
+export { createAPIContext, createImmutableAPIContext } from './api_context';
 export {
 	APIContext,
 	BlockHeader,

--- a/framework/src/testing/block_processing_env.ts
+++ b/framework/src/testing/block_processing_env.ts
@@ -28,7 +28,7 @@ import { ApplicationConfig, GenesisConfig } from '../types';
 import { Consensus } from '../node/consensus';
 import { APIContext } from '../node/state_machine';
 import { Node } from '../node';
-import { createNewAPIContext } from '../node/state_machine/api_context';
+import { createImmutableAPIContext, createNewAPIContext } from '../node/state_machine/api_context';
 import { blockAssetsJSON } from './fixtures/genesis-asset';
 import { ValidatorsAPI } from '../modules/validators';
 import { BFTAPI } from '../modules/bft';
@@ -216,6 +216,7 @@ export const getBlockProcessingEnv = async (
 			const result = await handler({
 				getStore: (moduleID: number, storePrefix: number) =>
 					stateStore.getStore(moduleID, storePrefix),
+				getImmutableAPIContext: () => createImmutableAPIContext(stateStore),
 				logger: node['_logger'],
 				networkIdentifier: node['_chain'].networkIdentifier,
 				params: input,

--- a/framework/src/testing/create_contexts.ts
+++ b/framework/src/testing/create_contexts.ts
@@ -22,6 +22,7 @@ import {
 	APIContext,
 	BlockContext,
 	createAPIContext,
+	createImmutableAPIContext,
 	EventQueue,
 	GenesisBlockContext,
 	ImmutableSubStore,
@@ -233,6 +234,7 @@ export const createTransientModuleEndpointContext = (params: {
 	const networkIdentifier = params.networkIdentifier ?? Buffer.alloc(0);
 	const ctx = {
 		getStore: (moduleID: number, storePrefix: number) => stateStore.getStore(moduleID, storePrefix),
+		getImmutableAPIContext: () => createImmutableAPIContext(stateStore),
 		params: parameters,
 		logger,
 		networkIdentifier,

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -14,7 +14,7 @@
 import { p2pTypes } from '@liskhq/lisk-p2p';
 import { Schema } from '@liskhq/lisk-codec';
 import { Logger } from './logger';
-import { ImmutableSubStore } from './node/state_machine';
+import { ImmutableAPIContext, ImmutableSubStore } from './node/state_machine';
 import { RPC_MODES } from './constants';
 
 export interface SocketPaths {
@@ -184,6 +184,7 @@ export interface PluginEndpointContext {
 
 export interface ModuleEndpointContext extends PluginEndpointContext {
 	getStore: (moduleID: number, storePrefix: number) => ImmutableSubStore;
+	getImmutableAPIContext: () => ImmutableAPIContext;
 	networkIdentifier: Buffer;
 }
 

--- a/framework/test/unit/controller/channels/in_memory_channel.spec.ts
+++ b/framework/test/unit/controller/channels/in_memory_channel.spec.ts
@@ -235,6 +235,7 @@ describe('InMemoryChannel Channel', () => {
 				expect(params.endpoints.action1).toHaveBeenCalledWith({
 					networkIdentifier: params.networkIdentifier,
 					getStore: expect.anything(),
+					getImmutableAPIContext: expect.anything(),
 					logger: expect.anything(),
 					params: expect.anything(),
 				});

--- a/framework/test/unit/modules/dpos_v2/endpoint.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/endpoint.spec.ts
@@ -77,6 +77,7 @@ describe('DposModuleEndpoint', () => {
 				getStore1.mockReturnValue(voterSubStore);
 				const voterDataReturned = await dposEndpoint.getVoter({
 					getStore: getStore1,
+					getImmutableAPIContext: jest.fn(),
 					logger,
 					params: {
 						address: address.toString('hex'),
@@ -92,6 +93,7 @@ describe('DposModuleEndpoint', () => {
 				getStore1.mockReturnValue(voterSubStore);
 				const voterDataReturned = await dposEndpoint.getVoter({
 					getStore: getStore1,
+					getImmutableAPIContext: jest.fn(),
 					logger,
 					params: {
 						address: address.toString('hex'),
@@ -114,6 +116,7 @@ describe('DposModuleEndpoint', () => {
 				getStore1.mockReturnValue(delegateSubStore);
 				const delegateDataReturned = await dposEndpoint.getDelegate({
 					getStore: getStore1,
+					getImmutableAPIContext: jest.fn(),
 					logger,
 					params: {
 						address: address.toString('hex'),
@@ -135,6 +138,7 @@ describe('DposModuleEndpoint', () => {
 				getStore1.mockReturnValue(delegateSubStore);
 				const delegateDataReturned = await dposEndpoint.getDelegate({
 					getStore: getStore1,
+					getImmutableAPIContext: jest.fn(),
 					logger,
 					params: {
 						address: address.toString('hex'),
@@ -156,6 +160,7 @@ describe('DposModuleEndpoint', () => {
 				getStore1.mockReturnValue(delegateSubStore);
 				const delegatesDataReturned = await dposEndpoint.getAllDelegates({
 					getStore: getStore1,
+					getImmutableAPIContext: jest.fn(),
 					logger,
 					params: {},
 					networkIdentifier,
@@ -175,6 +180,7 @@ describe('DposModuleEndpoint', () => {
 				getStore1.mockReturnValue(delegateSubStore);
 				const delegatesDataReturned = await dposEndpoint.getAllDelegates({
 					getStore: getStore1,
+					getImmutableAPIContext: jest.fn(),
 					logger,
 					params: {},
 					networkIdentifier,

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -58,6 +58,7 @@ describe('RewardModuleEndpoint', () => {
 		it(`should getDefaultRewardAtHeight work for the ${nthBracket}th bracket`, () => {
 			const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
 				getStore: jest.fn(),
+				getImmutableAPIContext: jest.fn(),
 				logger,
 				params: {
 					height: currentHeight,
@@ -71,6 +72,7 @@ describe('RewardModuleEndpoint', () => {
 	it('should getDefaultRewardAtHeight work for the height below offset', () => {
 		const rewardFromEndpoint = rewardModule.endpoint.getDefaultRewardAtHeight({
 			getStore: jest.fn(),
+			getImmutableAPIContext: jest.fn(),
 			logger,
 			params: {
 				height: offset - 1,
@@ -84,6 +86,7 @@ describe('RewardModuleEndpoint', () => {
 		expect(() =>
 			rewardModule.endpoint.getDefaultRewardAtHeight({
 				getStore: jest.fn(),
+				getImmutableAPIContext: jest.fn(),
 				logger,
 				params: {
 					height: 'Not a number',
@@ -97,6 +100,7 @@ describe('RewardModuleEndpoint', () => {
 		expect(() =>
 			rewardModule.endpoint.getDefaultRewardAtHeight({
 				getStore: jest.fn(),
+				getImmutableAPIContext: jest.fn(),
 				logger,
 				params: {
 					height: -1,

--- a/framework/test/unit/modules/token/endpoint.spec.ts
+++ b/framework/test/unit/modules/token/endpoint.spec.ts
@@ -40,7 +40,7 @@ describe('token endpoint', () => {
 	const defaultAddress = getRandomBytes(20);
 	const defaultTokenIDAlias = Buffer.alloc(TOKEN_ID_LENGTH, 0);
 	const defaultTokenID = Buffer.from([0, 0, 0, 1, 0, 0, 0, 0]);
-	const defaultForeginTokenID = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
+	const defaultForeignTokenID = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
 	const defaultAccount = {
 		availableBalance: BigInt(10000000000),
 		lockedBalances: [
@@ -80,7 +80,7 @@ describe('token endpoint', () => {
 			userStoreSchema,
 		);
 		await userStore.setWithSchema(
-			getUserStoreKey(defaultAddress, defaultForeginTokenID),
+			getUserStoreKey(defaultAddress, defaultForeignTokenID),
 			defaultAccount,
 			userStoreSchema,
 		);
@@ -105,7 +105,7 @@ describe('token endpoint', () => {
 		const escrowStore = stateStore.getStore(MODULE_ID_TOKEN, STORE_PREFIX_ESCROW);
 		await escrowStore.setWithSchema(
 			Buffer.concat([
-				defaultForeginTokenID.slice(0, CHAIN_ID_LENGTH),
+				defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
 				defaultTokenIDAlias.slice(CHAIN_ID_LENGTH),
 			]),
 			{ amount: defaultEscrowAmount },
@@ -274,7 +274,7 @@ describe('token endpoint', () => {
 				escrowedAmounts: [
 					{
 						tokenID: defaultTokenIDAlias.toString('hex'),
-						escrowChainID: defaultForeginTokenID.slice(0, CHAIN_ID_LENGTH).toString('hex'),
+						escrowChainID: defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH).toString('hex'),
 						amount: defaultEscrowAmount.toString(),
 					},
 				],

--- a/framework/test/unit/modules/token/endpoint.spec.ts
+++ b/framework/test/unit/modules/token/endpoint.spec.ts
@@ -1,0 +1,284 @@
+/*
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { StateStore } from '@liskhq/lisk-chain';
+import { getRandomBytes } from '@liskhq/lisk-cryptography';
+import { InMemoryKVStore } from '@liskhq/lisk-db';
+import { TokenAPI } from '../../../../src/modules/token';
+import {
+	CHAIN_ID_LENGTH,
+	EMPTY_BYTES,
+	MODULE_ID_TOKEN,
+	STORE_PREFIX_AVAILABLE_LOCAL_ID,
+	STORE_PREFIX_ESCROW,
+	STORE_PREFIX_SUPPLY,
+	STORE_PREFIX_USER,
+	TOKEN_ID_LENGTH,
+} from '../../../../src/modules/token/constants';
+import { TokenEndpoint } from '../../../../src/modules/token/endpoint';
+import {
+	availableLocalIDStoreSchema,
+	escrowStoreSchema,
+	supplyStoreSchema,
+	userStoreSchema,
+} from '../../../../src/modules/token/schemas';
+import { getUserStoreKey } from '../../../../src/modules/token/utils';
+import { createTransientModuleEndpointContext } from '../../../../src/testing';
+import { DEFAULT_TOKEN_ID } from '../../../utils/node/transaction';
+
+describe('token endpoint', () => {
+	const defaultAddress = getRandomBytes(20);
+	const defaultTokenIDAlias = Buffer.alloc(TOKEN_ID_LENGTH, 0);
+	const defaultTokenID = Buffer.from([0, 0, 0, 1, 0, 0, 0, 0]);
+	const defaultForeginTokenID = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
+	const defaultAccount = {
+		availableBalance: BigInt(10000000000),
+		lockedBalances: [
+			{
+				moduleID: 12,
+				amount: BigInt(100000000),
+			},
+		],
+	};
+	const defaultTotalSupply = BigInt('100000000000000');
+	const defaultEscrowAmount = BigInt('100000000000');
+	const supportedTokenIDs = ['0000000000000000', '0000000200000000'];
+
+	let endpoint: TokenEndpoint;
+	let stateStore: StateStore;
+
+	beforeEach(async () => {
+		const api = new TokenAPI(MODULE_ID_TOKEN);
+		endpoint = new TokenEndpoint(MODULE_ID_TOKEN);
+		api.init({
+			minBalances: [
+				{
+					tokenID: DEFAULT_TOKEN_ID,
+					amount: BigInt(5000000),
+				},
+			],
+		});
+		api.addDependencies({
+			getOwnChainAccount: jest.fn().mockResolvedValue({ id: Buffer.from([0, 0, 0, 1]) }),
+		});
+		endpoint.init(api, supportedTokenIDs);
+		stateStore = new StateStore(new InMemoryKVStore());
+		const userStore = stateStore.getStore(MODULE_ID_TOKEN, STORE_PREFIX_USER);
+		await userStore.setWithSchema(
+			getUserStoreKey(defaultAddress, defaultTokenIDAlias),
+			defaultAccount,
+			userStoreSchema,
+		);
+		await userStore.setWithSchema(
+			getUserStoreKey(defaultAddress, defaultForeginTokenID),
+			defaultAccount,
+			userStoreSchema,
+		);
+
+		const supplyStore = stateStore.getStore(MODULE_ID_TOKEN, STORE_PREFIX_SUPPLY);
+		await supplyStore.setWithSchema(
+			defaultTokenIDAlias.slice(CHAIN_ID_LENGTH),
+			{ totalSupply: defaultTotalSupply },
+			supplyStoreSchema,
+		);
+
+		const nextAvailableLocalIDStore = stateStore.getStore(
+			MODULE_ID_TOKEN,
+			STORE_PREFIX_AVAILABLE_LOCAL_ID,
+		);
+		await nextAvailableLocalIDStore.setWithSchema(
+			EMPTY_BYTES,
+			{ nextAvailableLocalID: Buffer.from([0, 0, 0, 5]) },
+			availableLocalIDStoreSchema,
+		);
+
+		const escrowStore = stateStore.getStore(MODULE_ID_TOKEN, STORE_PREFIX_ESCROW);
+		await escrowStore.setWithSchema(
+			Buffer.concat([
+				defaultForeginTokenID.slice(0, CHAIN_ID_LENGTH),
+				defaultTokenIDAlias.slice(CHAIN_ID_LENGTH),
+			]),
+			{ amount: defaultEscrowAmount },
+			escrowStoreSchema,
+		);
+	});
+
+	describe('getBalances', () => {
+		it('should reject when input is invalid', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: { address: '1234' },
+			});
+			await expect(endpoint.getBalances(moduleEndpointContext)).rejects.toThrow(
+				".address' must NOT have fewer than 40 characters",
+			);
+		});
+
+		it('should return empty balances if account does not exist', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: { address: getRandomBytes(20).toString('hex') },
+			});
+			const resp = await endpoint.getBalances(moduleEndpointContext);
+			expect(resp).toEqual({ balances: [] });
+		});
+
+		it('should return all the balances', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: { address: defaultAddress.toString('hex') },
+			});
+			const resp = await endpoint.getBalances(moduleEndpointContext);
+			expect(resp).toEqual({
+				balances: [
+					{
+						tokenID: '0000000000000000',
+						availableBalance: defaultAccount.availableBalance.toString(),
+						lockedBalances: defaultAccount.lockedBalances.map(lb => ({
+							...lb,
+							amount: lb.amount.toString(),
+						})),
+					},
+					{
+						tokenID: '0100000000000000',
+						availableBalance: defaultAccount.availableBalance.toString(),
+						lockedBalances: defaultAccount.lockedBalances.map(lb => ({
+							...lb,
+							amount: lb.amount.toString(),
+						})),
+					},
+				],
+			});
+		});
+	});
+
+	describe('getBalance', () => {
+		it('should reject when input has invalid address', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: { address: '1234' },
+			});
+			await expect(endpoint.getBalance(moduleEndpointContext)).rejects.toThrow(
+				".address' must NOT have fewer than 40 characters",
+			);
+		});
+
+		it('should reject when input has invalid tokenID', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: { address: defaultAddress.toString('hex'), tokenID: '00' },
+			});
+			await expect(endpoint.getBalance(moduleEndpointContext)).rejects.toThrow(
+				".tokenID' must NOT have fewer than 16 characters",
+			);
+		});
+
+		it('should return zero balance if account does not exist', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: {
+					address: getRandomBytes(20).toString('hex'),
+					tokenID: defaultTokenID.toString('hex'),
+				},
+			});
+			const resp = await endpoint.getBalance(moduleEndpointContext);
+			expect(resp).toEqual({
+				availableBalance: '0',
+				lockedBalances: [],
+			});
+		});
+
+		it('should return return balance when network tokenID is specified', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: {
+					address: defaultAddress.toString('hex'),
+					tokenID: defaultTokenID.toString('hex'),
+				},
+			});
+			const resp = await endpoint.getBalance(moduleEndpointContext);
+			expect(resp).toEqual({
+				availableBalance: defaultAccount.availableBalance.toString(),
+				lockedBalances: defaultAccount.lockedBalances.map(lb => ({
+					...lb,
+					amount: lb.amount.toString(),
+				})),
+			});
+		});
+
+		it('should return return balance when native tokenID is specified', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: {
+					address: defaultAddress.toString('hex'),
+					tokenID: defaultTokenIDAlias.toString('hex'),
+				},
+			});
+			const resp = await endpoint.getBalance(moduleEndpointContext);
+			expect(resp).toEqual({
+				availableBalance: defaultAccount.availableBalance.toString(),
+				lockedBalances: defaultAccount.lockedBalances.map(lb => ({
+					...lb,
+					amount: lb.amount.toString(),
+				})),
+			});
+		});
+	});
+
+	describe('getTotalSupply', () => {
+		it('should return all total supply', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+			});
+			const resp = await endpoint.getTotalSupply(moduleEndpointContext);
+			expect(resp).toEqual({
+				totalSupply: [
+					{
+						tokenID: defaultTokenIDAlias.toString('hex'),
+						totalSupply: defaultTotalSupply.toString(),
+					},
+				],
+			});
+		});
+	});
+
+	describe('getSupportedTokens', () => {
+		it('should return all supported tokens', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+			});
+			const resp = await endpoint.getSupportedTokens(moduleEndpointContext);
+			expect(resp).toEqual({
+				tokenIDs: supportedTokenIDs,
+			});
+		});
+	});
+
+	describe('getEscrowedAmounts', () => {
+		it('should return all escrowed tokens', async () => {
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+			});
+			const resp = await endpoint.getEscrowedAmounts(moduleEndpointContext);
+			expect(resp).toEqual({
+				escrowedAmounts: [
+					{
+						tokenID: defaultTokenIDAlias.toString('hex'),
+						escrowChainID: defaultForeginTokenID.slice(0, CHAIN_ID_LENGTH).toString('hex'),
+						amount: defaultEscrowAmount.toString(),
+					},
+				],
+			});
+		});
+	});
+});

--- a/framework/test/unit/modules/validators/endpoint.spec.ts
+++ b/framework/test/unit/modules/validators/endpoint.spec.ts
@@ -42,6 +42,7 @@ describe('ValidatorsModuleEndpoint', () => {
 				getStore1.mockReturnValue(subStore);
 				await expect(
 					validatorsModule.endpoint.validateBLSKey({
+						getImmutableAPIContext: jest.fn(),
 						getStore: getStore1,
 						logger,
 						params: {
@@ -58,6 +59,7 @@ describe('ValidatorsModuleEndpoint', () => {
 				await expect(
 					validatorsModule.endpoint.validateBLSKey({
 						getStore: getStore1,
+						getImmutableAPIContext: jest.fn(),
 						logger,
 						params: {
 							proofOfPossession: proof.toString('hex'),
@@ -72,6 +74,7 @@ describe('ValidatorsModuleEndpoint', () => {
 				await expect(
 					validatorsModule.endpoint.validateBLSKey({
 						getStore: getStore1,
+						getImmutableAPIContext: jest.fn(),
 						logger,
 						params: {
 							proofOfPossession:
@@ -90,6 +93,7 @@ describe('ValidatorsModuleEndpoint', () => {
 				await expect(
 					validatorsModule.endpoint.validateBLSKey({
 						getStore: jest.fn(),
+						getImmutableAPIContext: jest.fn(),
 						logger,
 						params: {
 							invalid: 'schema',
@@ -103,6 +107,7 @@ describe('ValidatorsModuleEndpoint', () => {
 				await expect(
 					validatorsModule.endpoint.validateBLSKey({
 						getStore: jest.fn(),
+						getImmutableAPIContext: jest.fn(),
 						logger,
 						params: {
 							proofOfPossession: 'xxxx',

--- a/framework/test/unit/node/generator/endpoint.spec.ts
+++ b/framework/test/unit/node/generator/endpoint.spec.ts
@@ -95,6 +95,7 @@ describe('generator endpoint', () => {
 			it('should reject with validation error', async () => {
 				await expect(
 					endpoint.postTransaction({
+						getImmutableAPIContext: jest.fn(),
 						getStore: jest.fn(),
 						logger,
 						params: {
@@ -108,6 +109,7 @@ describe('generator endpoint', () => {
 			it('should reject with error when transaction bytes is invalid', async () => {
 				await expect(
 					endpoint.postTransaction({
+						getImmutableAPIContext: jest.fn(),
 						getStore: jest.fn(),
 						logger,
 						params: {
@@ -126,6 +128,7 @@ describe('generator endpoint', () => {
 				});
 				await expect(
 					endpoint.postTransaction({
+						getImmutableAPIContext: jest.fn(),
 						getStore: jest.fn(),
 						logger,
 						params: {
@@ -142,6 +145,7 @@ describe('generator endpoint', () => {
 				(pool.contains as jest.Mock).mockReturnValue(true);
 				await expect(
 					endpoint.postTransaction({
+						getImmutableAPIContext: jest.fn(),
 						getStore: jest.fn(),
 						logger,
 						params: {
@@ -162,6 +166,7 @@ describe('generator endpoint', () => {
 				});
 				await expect(
 					endpoint.postTransaction({
+						getImmutableAPIContext: jest.fn(),
 						getStore: jest.fn(),
 						logger,
 						params: {
@@ -178,6 +183,7 @@ describe('generator endpoint', () => {
 				await expect(
 					endpoint.postTransaction({
 						logger,
+						getImmutableAPIContext: jest.fn(),
 						getStore: jest.fn(),
 						params: {
 							transaction: tx.getBytes().toString('hex'),
@@ -204,6 +210,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						enable: true,
 						password: defaultPassword,
@@ -220,6 +227,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: getRandomBytes(20).toString('hex'),
 						enable: true,
@@ -237,6 +245,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,
@@ -254,6 +263,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: invalidConfig.address,
 						enable: true,
@@ -272,6 +282,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,
@@ -294,6 +305,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: false,
@@ -315,6 +327,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,
@@ -342,6 +355,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,
@@ -370,6 +384,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,
@@ -406,6 +421,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,
@@ -442,6 +458,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,
@@ -475,6 +492,7 @@ describe('generator endpoint', () => {
 				endpoint.updateForgingStatus({
 					logger,
 					getStore: jest.fn(),
+					getImmutableAPIContext: jest.fn(),
 					params: {
 						address: config.address,
 						enable: true,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7123

### How was it solved?

- Add token module endpoint as defined in the issue
- Add `getImmutableAPIContext` in the module endpoint context. This is to be able to access the readonly API defined in other modules. For token module, accessing the interoperability chain ID was necessary, and without access to API, it was not possible

### How was it tested?

- Add/update unit test
