### PR TITLE
Implement cross chain command for interoperability modules - Closes #7038 & #7039

### DIFF
--- a/elements/lisk-tree/src/index.ts
+++ b/elements/lisk-tree/src/index.ts
@@ -14,6 +14,7 @@
 
 import { verifyProof, verifyDataBlock } from './merkle_tree/verify_proof';
 import { calculateRootFromUpdateData } from './merkle_tree/calculate';
+import { calculateRootFromRightWitness, verifyRightWitness } from './merkle_tree/right_witness';
 import { MerkleTree } from './merkle_tree/merkle_tree';
 import { calculateMerkleRoot, calculateMerkleRootWithLeaves } from './merkle_tree/utils';
 import { SparseMerkleTree } from './sparse_merkle_tree/sparse_merkle_tree';
@@ -26,6 +27,8 @@ export const regularMerkleTree = {
 	calculateMerkleRoot,
 	calculateMerkleRootWithLeaves,
 	MerkleTree,
+	calculateRootFromRightWitness,
+	verifyRightWitness,
 };
 
 export const sparseMerkleTree = {

--- a/framework/src/modules/interoperability/constants.ts
+++ b/framework/src/modules/interoperability/constants.ts
@@ -39,7 +39,7 @@ export const MAX_LENGTH_NAME = 40;
 export const MAX_UINT32 = 4294967295;
 export const MAX_UINT64 = BigInt('18446744073709551615'); // BigInt((2 ** 64) - 1) - 1
 export const THRESHOLD_MAINCHAIN = 68;
-export const MESSAGE_TAG_CERTIFICATE = Buffer.from('LSK_CE_', 'utf-8');
+export const MESSAGE_TAG_CERTIFICATE = 'LSK_CE_';
 
 // Store prefixes
 export const STORE_PREFIX_OUTBOX_ROOT = 0x0000;

--- a/framework/src/modules/interoperability/constants.ts
+++ b/framework/src/modules/interoperability/constants.ts
@@ -24,6 +24,8 @@ export const MAINCHAIN_NETWORK_ID = Buffer.from(
 	'03693f3126b9d0df3096c4ebd59e5c42af4a7f0e313cd7c96a07b6e9f8f54924',
 	'hex',
 ); // TBD
+export const VALID_BLS_KEY_LENGTH = 48;
+export const SMT_KEY_LENGTH = 38;
 export const NUMBER_MAINCHAIN_VALIDATORS = 101;
 export const TAG_CHAIN_REG_MESSAGE = 'LSK_CHAIN_REGISTRATION';
 export const LIVENESS_LIMIT = 2592000; // 30*24*3600

--- a/framework/src/modules/interoperability/mainchain/cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/channel_terminated.ts
@@ -25,6 +25,9 @@ export class MainchainCCChannelTerminatedCommand extends BaseInteroperabilityCCC
 
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
+		if (!context.ccm) {
+			throw new Error('CCM is missing to execute channel terminated cross chain command.');
+		}
 		await interoperabilityStore.createTerminatedStateAccount(context.ccm.sendingChainID);
 	}
 

--- a/framework/src/modules/interoperability/mainchain/cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/channel_terminated.ts
@@ -26,7 +26,7 @@ export class MainchainCCChannelTerminatedCommand extends BaseInteroperabilityCCC
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
 		if (!context.ccm) {
-			throw new Error('CCM is missing to execute channel terminated cross chain command.');
+			throw new Error('CCM to execute channel terminated cross chain command is missing.');
 		}
 		await interoperabilityStore.createTerminatedStateAccount(context.ccm.sendingChainID);
 	}

--- a/framework/src/modules/interoperability/mainchain/cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/registration.ts
@@ -34,7 +34,7 @@ export class MainchainCCRegistrationCommand extends BaseInteroperabilityCCComman
 	public async execute(ctx: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = ctx;
 		if (!ccm) {
-			throw new Error('CCM is missing to execute registration cross chain command.');
+			throw new Error('CCM to execute registration cross chain command is missing.');
 		}
 		const decodedParams = codec.decode<CCMRegistrationParams>(
 			registrationCCMParamsSchema,

--- a/framework/src/modules/interoperability/mainchain/cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/registration.ts
@@ -33,6 +33,9 @@ export class MainchainCCRegistrationCommand extends BaseInteroperabilityCCComman
 
 	public async execute(ctx: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = ctx;
+		if (!ccm) {
+			throw new Error('CCM is missing to execute registration cross chain command.');
+		}
 		const decodedParams = codec.decode<CCMRegistrationParams>(
 			registrationCCMParamsSchema,
 			ccm.params,

--- a/framework/src/modules/interoperability/mainchain/cc_commands/sidechain_terminated.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/sidechain_terminated.ts
@@ -33,6 +33,9 @@ export class MainchainCCSidechainTerminatedCommand extends BaseInteroperabilityC
 
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = context;
+		if (!ccm) {
+			throw new Error('CCM is missing to execute sidechain terminated cross chain command.');
+		}
 		const decodedParams = codec.decode<CCMSidechainTerminatedParams>(
 			sidechainTerminatedCCMParamsSchema,
 			ccm.params,

--- a/framework/src/modules/interoperability/mainchain/cc_commands/sidechain_terminated.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/sidechain_terminated.ts
@@ -34,7 +34,7 @@ export class MainchainCCSidechainTerminatedCommand extends BaseInteroperabilityC
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = context;
 		if (!ccm) {
-			throw new Error('CCM is missing to execute sidechain terminated cross chain command.');
+			throw new Error('CCM to execute sidechain terminated cross chain command is missing.');
 		}
 		const decodedParams = codec.decode<CCMSidechainTerminatedParams>(
 			sidechainTerminatedCCMParamsSchema,

--- a/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
@@ -123,6 +123,17 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 			return certificateValidity;
 		}
 
+		const partnerValidatorStore = context.getStore(this.moduleID, STORE_PREFIX_CHAIN_VALIDATORS);
+		const partnerValidators = await partnerValidatorStore.getWithSchema<ChainValidators>(
+			partnerChainIDBuffer,
+			chainValidatorsSchema,
+		);
+		// If params contains a non-empty activeValidatorsUpdate
+		const validatorsHashValidity = checkValidatorsHashWithCertificate(txParams, partnerValidators);
+		if (validatorsHashValidity.error) {
+			return validatorsHashValidity;
+		}
+
 		// If params contains a non-empty activeValidatorsUpdate
 		const activeValidatorsValidity = checkActiveValidatorsUpdate(txParams);
 		if (activeValidatorsValidity.error) {
@@ -175,9 +186,6 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 			decodedCertificate,
 			header,
 		);
-
-		// If params contains a non-empty activeValidatorsUpdate
-		checkValidatorsHashWithCertificate(txParams, decodedCertificate, partnerValidators);
 
 		// CCM execution
 		const beforeSendContext = createCCMsgBeforeSendContext({

--- a/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
@@ -13,7 +13,6 @@
  */
 
 import { codec } from '@liskhq/lisk-codec';
-import { verifyWeightedAggSig } from '@liskhq/lisk-cryptography';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
 import { certificateSchema } from '../../../../node/consensus/certificate_generation/schema';
 import { Certificate } from '../../../../node/consensus/certificate_generation/types';
@@ -31,10 +30,7 @@ import {
 	CHAIN_TERMINATED,
 	COMMAND_ID_MAINCHAIN_CCU,
 	CROSS_CHAIN_COMMAND_ID_REGISTRATION,
-	EMPTY_BYTES,
-	LIVENESS_LIMIT,
 	MAINCHAIN_ID,
-	MESSAGE_TAG_CERTIFICATE,
 	STORE_PREFIX_CHAIN_DATA,
 	STORE_PREFIX_CHAIN_VALIDATORS,
 	STORE_PREFIX_CHANNEL_DATA,
@@ -57,12 +53,14 @@ import {
 } from '../../types';
 import {
 	checkActiveValidatorsUpdate,
+	checkCertificateTimestampAndSignature,
 	checkCertificateValidity,
 	checkInboxUpdateValidity,
 	checkLivenessRequirementFirstCCU,
-	computeValidatorsHash,
+	checkValidatorsHashWithCertificate,
+	checkValidCertificateLiveness,
+	commonCCUExecutelogic,
 	getIDAsKeyForStore,
-	updateActiveValidators,
 	validateFormat,
 } from '../../utils';
 import { MainchainInteroperabilityStore } from '../store';
@@ -148,7 +146,7 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 	public async execute(
 		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
 	): Promise<void> {
-		const { transaction, header, params: txParams } = context;
+		const { header, params: txParams } = context;
 		const chainIDBuffer = getIDAsKeyForStore(txParams.sendingChainID);
 		const partnerChainStore = context.getStore(this.moduleID, STORE_PREFIX_CHAIN_DATA);
 		const partnerChainAccount = await partnerChainStore.getWithSchema<ChainAccount>(
@@ -159,59 +157,25 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
 
 		// if the CCU also contains a non-empty inboxUpdate, check the validity of certificate with liveness check
-		if (
-			txParams.inboxUpdate &&
-			!(header.timestamp - decodedCertificate.timestamp < LIVENESS_LIMIT / 2)
-		) {
-			throw Error(
-				`Certificate is not valid as it passed Liveness limit of ${LIVENESS_LIMIT} seconds.`,
-			);
-		}
+		checkValidCertificateLiveness(txParams, header, decodedCertificate);
 
 		const partnerValidatorStore = context.getStore(this.moduleID, STORE_PREFIX_CHAIN_VALIDATORS);
 		const partnerValidators = await partnerValidatorStore.getWithSchema<ChainValidators>(
 			chainIDBuffer,
 			chainValidatorsSchema,
 		);
-		const { activeValidators, certificateThreshold } = partnerValidators;
 
 		// Certificate and Validators Update Validity
-		if (!txParams.certificate.equals(EMPTY_BYTES)) {
-			const verifySignature = verifyWeightedAggSig(
-				activeValidators.map(v => v.blsKey),
-				decodedCertificate.aggregationBits as Buffer,
-				decodedCertificate.signature as Buffer,
-				MESSAGE_TAG_CERTIFICATE.toString('hex'),
-				partnerChainAccount.networkID,
-				txParams.certificate,
-				activeValidators.map(v => v.bftWeight),
-				certificateThreshold,
-			);
-
-			if (!verifySignature || decodedCertificate.timestamp >= header.timestamp)
-				throw Error(
-					`Certificate is invalid due to invalid last certified height or timestamp or signature.`,
-				);
-		}
+		checkCertificateTimestampAndSignature(
+			txParams,
+			partnerValidators,
+			partnerChainAccount,
+			decodedCertificate,
+			header,
+		);
 
 		// If params contains a non-empty activeValidatorsUpdate
-		if (
-			txParams.activeValidatorsUpdate.length !== 0 ||
-			txParams.newCertificateThreshold > BigInt(0)
-		) {
-			const newActiveValidators = updateActiveValidators(
-				activeValidators,
-				txParams.activeValidatorsUpdate,
-			);
-			const validatorsHash = computeValidatorsHash(
-				newActiveValidators,
-				txParams.newCertificateThreshold || certificateThreshold,
-			);
-
-			if (!decodedCertificate.validatorsHash.equals(validatorsHash)) {
-				throw new Error('Validators hash is incorrect given in the certificate.');
-			}
-		}
+		checkValidatorsHashWithCertificate(txParams, decodedCertificate, partnerValidators);
 
 		// CCM execution
 		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
@@ -304,35 +268,16 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 				);
 			}
 		}
-		// Common ccm execution logic
-		const newActiveValidators = updateActiveValidators(
-			activeValidators,
-			txParams.activeValidatorsUpdate,
-		);
-		partnerValidators.activeValidators = newActiveValidators;
-		if (txParams.newCertificateThreshold !== BigInt(0)) {
-			partnerValidators.certificateThreshold = txParams.newCertificateThreshold;
-		}
-		await partnerValidatorStore.setWithSchema(
+		// Common ccu execution logic
+		await commonCCUExecutelogic({
+			certificate: decodedCertificate,
 			chainIDBuffer,
+			context,
+			partnerChainAccount,
+			partnerChainStore,
+			partnerValidatorStore,
 			partnerValidators,
-			chainValidatorsSchema,
-		);
-		if (!txParams.certificate.equals(EMPTY_BYTES)) {
-			partnerChainAccount.lastCertificate.stateRoot = decodedCertificate.stateRoot;
-			partnerChainAccount.lastCertificate.timestamp = decodedCertificate.timestamp;
-			partnerChainAccount.lastCertificate.height = decodedCertificate.height;
-			partnerChainAccount.lastCertificate.validatorsHash = decodedCertificate.validatorsHash;
-		}
-
-		await partnerChainStore.setWithSchema(chainIDBuffer, partnerChainAccount, chainAccountSchema);
-
-		const partnerChannelStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHANNEL_DATA);
-		const partnerChannelData = await partnerChannelStore.getWithSchema<ChannelData>(
-			chainIDBuffer,
-			channelSchema,
-		);
-		await partnerChainStore.setWithSchema(chainIDBuffer, partnerChannelData, channelSchema);
+		});
 	}
 
 	protected getInteroperabilityStore(getStore: StoreCallback): MainchainInteroperabilityStore {

--- a/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
@@ -138,7 +138,7 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 		}
 		if (
 			txParams.activeValidatorsUpdate &&
-			txParams.activeValidatorsUpdate !== [] &&
+			txParams.activeValidatorsUpdate.length !== 0 &&
 			txParams.newCertificateThreshold > BigInt(0)
 		) {
 			// Non-empty certificate
@@ -181,16 +181,15 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 		let newInboxAppendPath;
 		let newInboxSize;
 		for (const ccm of ccmHashes) {
-			const { appendPath, root, size } = regularMerkleTree.calculateMerkleRoot({
+			const { appendPath, size } = regularMerkleTree.calculateMerkleRoot({
 				value: ccm,
 				appendPath: partnerChannelData.inbox.appendPath,
 				size: partnerChannelData.inbox.size,
 			});
-			newInboxRoot = root;
 			newInboxAppendPath = appendPath;
 			newInboxSize = size;
 		}
-		if (txParams.certificate && txParams.inboxUpdate) {
+		if (txParams.certificate) {
 			// If inboxUpdate contains a non-empty messageWitness, then update newInboxRoot to the output
 			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
 				newInboxSize as number,
@@ -224,7 +223,7 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 					),
 				};
 			}
-		} else if (!txParams.certificate && txParams.inboxUpdate) {
+		} else if (!txParams.certificate) {
 			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
 				newInboxSize as number,
 				newInboxAppendPath as Buffer[],
@@ -339,7 +338,7 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 			serialized: ccm,
 			deserilized: codec.decode<CCMsg>(ccmSchema, ccm),
 		}));
-		if (partnerChainAccount.status === CHAIN_REGISTERED && txParams.inboxUpdate) {
+		if (partnerChainAccount.status === CHAIN_REGISTERED) {
 			// If the first CCM in inboxUpdate is a registration CCM
 			if (
 				decodedCCMs[0].deserilized.crossChainCommandID === CROSS_CHAIN_COMMAND_ID_REGISTRATION &&

--- a/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
@@ -12,18 +12,434 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { CommandExecuteContext } from '../../../../node/state_machine';
-import { BaseCommand } from '../../../base_command';
-import { COMMAND_ID_MAINCHAIN_CCU } from '../../constants';
-import { crossChainUpdateTransactionParams } from '../../schema';
+import { codec } from '@liskhq/lisk-codec';
+import { hash, verifyWeightedAggSig } from '@liskhq/lisk-cryptography';
+import { regularMerkleTree, sparseMerkleTree } from '@liskhq/lisk-tree';
+import { LiskValidationError, validator } from '@liskhq/lisk-validator';
+import { certificateSchema } from '../../../../node/consensus/certificate_generation/schema';
+import { Certificate } from '../../../../node/consensus/certificate_generation/types';
+import {
+	CommandExecuteContext,
+	CommandVerifyContext,
+	VerificationResult,
+	VerifyStatus,
+} from '../../../../node/state_machine';
+import { createBeforeSendCCMsgAPIContext } from '../../../../testing';
+import { BaseInteroperabilityCommand } from '../../base_interoperability_command';
+import {
+	CHAIN_ACTIVE,
+	CHAIN_REGISTERED,
+	CHAIN_TERMINATED,
+	COMMAND_ID_MAINCHAIN_CCU,
+	CROSS_CHAIN_COMMAND_ID_REGISTRATION,
+	LIVENESS_LIMIT,
+	MAINCHAIN_ID,
+	MESSAGE_TAG_CERTIFICATE,
+	SMT_KEY_LENGTH,
+	STORE_PREFIX_CHAIN_DATA,
+	STORE_PREFIX_CHANNEL_DATA,
+	STORE_PREFIX_OUTBOX_ROOT,
+	VALID_BLS_KEY_LENGTH,
+} from '../../constants';
+import { createCCMsgBeforeSendContext } from '../../context';
+import {
+	ccmSchema,
+	chainAccountSchema,
+	channelSchema,
+	crossChainUpdateTransactionParams,
+} from '../../schema';
+import {
+	ActiveValidators,
+	BFTAPI,
+	CCMsg,
+	ChainAccount,
+	ChannelData,
+	CrossChainCommandDependencies,
+	CrossChainUpdateTransactionParams,
+	StoreCallback,
+	ValidatorsAPI,
+} from '../../types';
+import {
+	computeValidatorsHash,
+	getIDAsKeyForStore,
+	rawStateStoreKey,
+	sortValidatorsByBLSKey,
+	updateActiveValidators,
+	validateFormat,
+} from '../../utils';
+import { MainchainInteroperabilityStore } from '../store';
 
-export class MainchainCCUpdateCommand extends BaseCommand {
+export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 	public name = 'mainchainCCUpdate';
 	public id = COMMAND_ID_MAINCHAIN_CCU;
 	public schema = crossChainUpdateTransactionParams;
+	private _bftAPI!: BFTAPI;
+	private _validatorsAPI!: ValidatorsAPI;
 
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async execute(_context: CommandExecuteContext<unknown>): Promise<void> {
-		throw new Error('Method not implemented.');
+	public addDependencies(args: CrossChainCommandDependencies) {
+		this._bftAPI = args.bftAPI;
+		this._validatorsAPI = args.validatorsAPI;
+	}
+	public async verify(
+		context: CommandVerifyContext<CrossChainUpdateTransactionParams>,
+	): Promise<VerificationResult> {
+		const { params: txParams, transaction } = context;
+		const errors = validator.validate(crossChainUpdateTransactionParams, context.params);
+
+		if (errors.length > 0) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new LiskValidationError(errors),
+			};
+		}
+
+		const partnerChainIDBuffer = getIDAsKeyForStore(txParams.sendingChainID);
+		const partnerChainStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHAIN_DATA);
+		const partnerChainAccount = await partnerChainStore.getWithSchema<ChainAccount>(
+			partnerChainIDBuffer,
+			chainAccountSchema,
+		);
+
+		// Liveness of Partner Chain
+		if (partnerChainAccount.status === CHAIN_TERMINATED) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error(`Sending partner chain ${txParams.sendingChainID} is terminated.`),
+			};
+		}
+		const interoperabilityStore = this.getInteroperabilityStore(context.getStore as StoreCallback);
+		const isChainLive = await interoperabilityStore.isLive(partnerChainIDBuffer, Date.now());
+		if (partnerChainAccount.status === CHAIN_ACTIVE && !isChainLive) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error(`Sending partner chain ${txParams.sendingChainID} is not live.`),
+			};
+		}
+
+		// Liveness Requirement for the First CCU
+		if (partnerChainAccount.status === CHAIN_REGISTERED) {
+			// Certificate must not be empty for first CCU
+			if (!txParams.certificate) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error(
+						`Sending partner chain ${txParams.sendingChainID} is in registered status so certificate cannot be empty.`,
+					),
+				};
+			}
+		}
+		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
+		const invalidCertificateErrors = validator.validate(certificateSchema, decodedCertificate);
+		if (invalidCertificateErrors.length > 0) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error('Certificate does not follow valid certificate schema.'),
+			};
+		}
+		if (
+			txParams.activeValidatorsUpdate &&
+			txParams.activeValidatorsUpdate !== [] &&
+			txParams.newCertificateThreshold > BigInt(0)
+		) {
+			// Non-empty certificate
+			if (!txParams.certificate) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error('Certificate cannot be empty.'),
+				};
+			}
+
+			// params.activeValidatorsUpdate has the correct format
+			for (let i = 0; i < txParams.activeValidatorsUpdate.length; i += 1) {
+				const currentValidator = txParams.activeValidatorsUpdate[i];
+				const nextValidator = txParams.activeValidatorsUpdate[i + 1];
+				if (currentValidator.blsKey.byteLength !== VALID_BLS_KEY_LENGTH) {
+					return {
+						status: VerifyStatus.FAIL,
+						error: new Error(`BlsKey length should be equal to ${VALID_BLS_KEY_LENGTH}.`),
+					};
+				}
+				if (currentValidator.blsKey.compare(nextValidator.blsKey) > -1) {
+					return {
+						status: VerifyStatus.FAIL,
+						error: new Error('Validators blsKeys must be unique and lexicographically ordered'),
+					};
+				}
+			}
+		}
+
+		const partnerChannelStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHANNEL_DATA);
+		const partnerChannelData = await partnerChannelStore.getWithSchema<ChannelData>(
+			partnerChainIDBuffer,
+			channelSchema,
+		);
+		// InboxUpdate Validity
+		const { crossChainMessages, messageWitness, outboxRootWitness } = txParams.inboxUpdate;
+		const ccmHashes = crossChainMessages.map(ccm => hash(ccm));
+
+		let newInboxRoot;
+		let newInboxAppendPath;
+		let newInboxSize;
+		for (const ccm of ccmHashes) {
+			const { appendPath, root, size } = regularMerkleTree.calculateMerkleRoot({
+				value: ccm,
+				appendPath: partnerChannelData.inbox.appendPath,
+				size: partnerChannelData.inbox.size,
+			});
+			newInboxRoot = root;
+			newInboxAppendPath = appendPath;
+			newInboxSize = size;
+		}
+		if (txParams.certificate && txParams.inboxUpdate) {
+			// If inboxUpdate contains a non-empty messageWitness, then update newInboxRoot to the output
+			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
+				newInboxSize as number,
+				newInboxAppendPath as Buffer[],
+				messageWitness.siblingHashes,
+			);
+
+			const proof = {
+				siblingHashes: outboxRootWitness.siblingHashes,
+				queries: [
+					{
+						key: partnerChainIDBuffer,
+						value: newInboxRoot,
+						bitmap: outboxRootWitness.bitmap,
+					},
+				],
+			};
+			const outboxKey = rawStateStoreKey(STORE_PREFIX_OUTBOX_ROOT);
+			const querykeys = [outboxKey];
+			const isSMTRootValid = sparseMerkleTree.verify(
+				querykeys,
+				proof,
+				decodedCertificate.stateRoot,
+				SMT_KEY_LENGTH,
+			);
+			if (!isSMTRootValid) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error(
+						'Failed at verifying state root when messageWitness and certificate are non-empty.',
+					),
+				};
+			}
+		} else if (!txParams.certificate && txParams.inboxUpdate) {
+			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
+				newInboxSize as number,
+				newInboxAppendPath as Buffer[],
+				messageWitness.siblingHashes,
+			);
+
+			if (!newInboxRoot.equals(partnerChannelData.partnerChainOutboxRoot)) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error(
+						'Failed at verifying state root when messageWitness is non-empty and certificate is empty.',
+					),
+				};
+			}
+		}
+
+		return {
+			status: VerifyStatus.OK,
+		};
+	}
+
+	public async execute(
+		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
+	): Promise<void> {
+		const { transaction, header, params: txParams } = context;
+		const chainIDBuffer = getIDAsKeyForStore(txParams.sendingChainID);
+		const partnerChainStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHAIN_DATA);
+		const partnerChainAccount = await partnerChainStore.getWithSchema<ChainAccount>(
+			chainIDBuffer,
+			chainAccountSchema,
+		);
+
+		const {
+			validators,
+			certificateThreshold,
+			precommitThreshold,
+		} = await this._bftAPI.getBFTParameters(context.getAPIContext(), header.height);
+
+		const activeValidators: ActiveValidators[] = [];
+		const updatedValidators = [];
+		const keyList: Buffer[] = [];
+		const weights: bigint[] = [];
+		for (const v of validators) {
+			const { blsKey } = await this._validatorsAPI.getValidatorAccount(
+				context.getAPIContext(),
+				v.address,
+			);
+			updatedValidators.push({
+				bftWeight: v.bftWeight,
+				address: v.address,
+			});
+			activeValidators.push({
+				blsKey,
+				bftWeight: v.bftWeight,
+			});
+		}
+		sortValidatorsByBLSKey(activeValidators);
+		for (const v of activeValidators) {
+			keyList.push(v.blsKey);
+			weights.push(v.bftWeight);
+		}
+
+		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
+
+		// if the CCU also contains a non-empty inboxUpdate, the certificate is only valid if it allows the sidechain account to remain live for a reasonable amount of time
+		if (
+			txParams.inboxUpdate &&
+			!(header.timestamp - decodedCertificate.timestamp < LIVENESS_LIMIT / 2)
+		) {
+			throw Error(
+				`Certificate is not valid as it passed Liveness limit of ${LIVENESS_LIMIT} seconds.`,
+			);
+		}
+		// Certificate and Validators Update Validity
+		const verifySignature = verifyWeightedAggSig(
+			keyList,
+			decodedCertificate.aggregationBits as Buffer,
+			decodedCertificate.signature as Buffer,
+			MESSAGE_TAG_CERTIFICATE.toString('hex'),
+			partnerChainAccount.networkID,
+			txParams.certificate,
+			weights,
+			certificateThreshold,
+		);
+
+		if (
+			!(decodedCertificate.height > partnerChainAccount.lastCertificate.height) ||
+			decodedCertificate.timestamp >= header.timestamp ||
+			!verifySignature
+		) {
+			throw Error(
+				`Certificate is invalid due to invalid last certified height or timestamp or signature.`,
+			);
+		}
+
+		const newActiveValidators = updateActiveValidators(
+			activeValidators,
+			txParams.activeValidatorsUpdate,
+		);
+		const validatorsHash = computeValidatorsHash(
+			newActiveValidators,
+			txParams.newCertificateThreshold || certificateThreshold,
+		);
+
+		if (!decodedCertificate.validatorsHash.equals(validatorsHash)) {
+			throw new Error('Validators hash is incorrect given in the certificate.');
+		}
+
+		// CCM execution
+		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
+		const decodedCCMs = txParams.inboxUpdate.crossChainMessages.map(ccm => ({
+			serialized: ccm,
+			deserilized: codec.decode<CCMsg>(ccmSchema, ccm),
+		}));
+		if (partnerChainAccount.status === CHAIN_REGISTERED && txParams.inboxUpdate) {
+			// If the first CCM in inboxUpdate is a registration CCM
+			if (
+				decodedCCMs[0].deserilized.crossChainCommandID === CROSS_CHAIN_COMMAND_ID_REGISTRATION &&
+				decodedCCMs[0].deserilized.receivingChainID === MAINCHAIN_ID
+			) {
+				partnerChainAccount.status = CHAIN_ACTIVE;
+			} else {
+				const beforeSendContext = createBeforeSendCCMsgAPIContext({
+					feeAddress: context.transaction.senderAddress,
+					eventQueue: context.eventQueue,
+					getAPIContext: context.getAPIContext,
+					logger: context.logger,
+					networkIdentifier: context.networkIdentifier,
+				});
+				await interoperabilityStore.terminateChainInternal(
+					txParams.sendingChainID,
+					beforeSendContext,
+				);
+			}
+		}
+
+		for (const ccm of decodedCCMs) {
+			const beforeSendContext = createCCMsgBeforeSendContext({
+				feeAddress: context.transaction.senderAddress,
+				eventQueue: context.eventQueue,
+				getAPIContext: context.getAPIContext,
+				logger: context.logger,
+				networkIdentifier: context.networkIdentifier,
+				getStore: context.getStore,
+			});
+			if (txParams.sendingChainID !== ccm.deserilized.sendingChainID) {
+				await interoperabilityStore.terminateChainInternal(
+					txParams.sendingChainID,
+					beforeSendContext,
+				);
+			}
+			try {
+				validateFormat(ccm.deserilized);
+			} catch (error) {
+				await interoperabilityStore.terminateChainInternal(
+					txParams.sendingChainID,
+					beforeSendContext,
+				);
+			}
+			await interoperabilityStore.appendToInboxTree(
+				getIDAsKeyForStore(txParams.sendingChainID),
+				ccm.serialized,
+			);
+
+			if (ccm.deserilized.receivingChainID !== MAINCHAIN_ID) {
+				await interoperabilityStore.forward({
+					ccm: ccm.deserilized,
+					ccu: txParams,
+					eventQueue: context.eventQueue,
+					feeAddress: context.transaction.senderAddress,
+					getAPIContext: context.getAPIContext,
+					getStore: context.getStore,
+					logger: context.logger,
+					networkIdentifier: context.networkIdentifier,
+				});
+			} else {
+				await interoperabilityStore.apply(
+					{
+						ccm: ccm.deserilized,
+						ccu: txParams,
+						eventQueue: context.eventQueue,
+						feeAddress: context.transaction.senderAddress,
+						getAPIContext: context.getAPIContext,
+						getStore: context.getStore,
+						logger: context.logger,
+						networkIdentifier: context.networkIdentifier,
+					},
+					this.ccCommands,
+				);
+			}
+		}
+
+		// Common ccm execution logic
+		await this._bftAPI.setBFTParameters(
+			context.getAPIContext(),
+			precommitThreshold,
+			txParams.newCertificateThreshold ?? certificateThreshold,
+			updatedValidators,
+		);
+		partnerChainAccount.lastCertificate.stateRoot = decodedCertificate.stateRoot;
+		partnerChainAccount.lastCertificate.timestamp = decodedCertificate.timestamp;
+		partnerChainAccount.lastCertificate.height = decodedCertificate.height;
+		partnerChainAccount.lastCertificate.validatorsHash = decodedCertificate.validatorsHash;
+
+		await partnerChainStore.setWithSchema(chainIDBuffer, partnerChainAccount, chainAccountSchema);
+
+		const partnerChannelStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHANNEL_DATA);
+		const partnerChannelData = await partnerChannelStore.getWithSchema<ChannelData>(
+			chainIDBuffer,
+			channelSchema,
+		);
+		await partnerChainStore.setWithSchema(chainIDBuffer, partnerChannelData, channelSchema);
+	}
+
+	protected getInteroperabilityStore(getStore: StoreCallback): MainchainInteroperabilityStore {
+		return new MainchainInteroperabilityStore(this.moduleID, getStore, this.interoperableCCAPIs);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
@@ -32,11 +32,13 @@ import {
 	CHAIN_TERMINATED,
 	COMMAND_ID_MAINCHAIN_CCU,
 	CROSS_CHAIN_COMMAND_ID_REGISTRATION,
+	EMPTY_BYTES,
 	LIVENESS_LIMIT,
 	MAINCHAIN_ID,
 	MESSAGE_TAG_CERTIFICATE,
 	SMT_KEY_LENGTH,
 	STORE_PREFIX_CHAIN_DATA,
+	STORE_PREFIX_CHAIN_VALIDATORS,
 	STORE_PREFIX_CHANNEL_DATA,
 	STORE_PREFIX_OUTBOX_ROOT,
 	VALID_BLS_KEY_LENGTH,
@@ -45,25 +47,22 @@ import { createCCMsgBeforeSendContext } from '../../context';
 import {
 	ccmSchema,
 	chainAccountSchema,
+	chainValidatorsSchema,
 	channelSchema,
 	crossChainUpdateTransactionParams,
 } from '../../schema';
 import {
-	ActiveValidators,
-	BFTAPI,
 	CCMsg,
 	ChainAccount,
+	ChainValidators,
 	ChannelData,
-	CrossChainCommandDependencies,
 	CrossChainUpdateTransactionParams,
 	StoreCallback,
-	ValidatorsAPI,
 } from '../../types';
 import {
 	computeValidatorsHash,
 	getIDAsKeyForStore,
 	rawStateStoreKey,
-	sortValidatorsByBLSKey,
 	updateActiveValidators,
 	validateFormat,
 } from '../../utils';
@@ -73,13 +72,7 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 	public name = 'mainchainCCUpdate';
 	public id = COMMAND_ID_MAINCHAIN_CCU;
 	public schema = crossChainUpdateTransactionParams;
-	private _bftAPI!: BFTAPI;
-	private _validatorsAPI!: ValidatorsAPI;
 
-	public addDependencies(args: CrossChainCommandDependencies) {
-		this._bftAPI = args.bftAPI;
-		this._validatorsAPI = args.validatorsAPI;
-	}
 	public async verify(
 		context: CommandVerifyContext<CrossChainUpdateTransactionParams>,
 	): Promise<VerificationResult> {
@@ -100,7 +93,7 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 			chainAccountSchema,
 		);
 
-		// Liveness of Partner Chain
+		// Section: Liveness of Partner Chain
 		if (partnerChainAccount.status === CHAIN_TERMINATED) {
 			return {
 				status: VerifyStatus.FAIL,
@@ -116,10 +109,10 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 			};
 		}
 
-		// Liveness Requirement for the First CCU
+		// Section: Liveness Requirement for the First CCU
 		if (partnerChainAccount.status === CHAIN_REGISTERED) {
 			// Certificate must not be empty for first CCU
-			if (!txParams.certificate) {
+			if (txParams.certificate.equals(EMPTY_BYTES)) {
 				return {
 					status: VerifyStatus.FAIL,
 					error: new Error(
@@ -128,24 +121,44 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 				};
 			}
 		}
+		// Section: Certificate and Validators Update Validity
+
+		// Certificate follows the schema
 		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
-		const invalidCertificateErrors = validator.validate(certificateSchema, decodedCertificate);
-		if (invalidCertificateErrors.length > 0) {
-			return {
-				status: VerifyStatus.FAIL,
-				error: new Error('Certificate does not follow valid certificate schema.'),
-			};
+		if (!txParams.certificate.equals(EMPTY_BYTES)) {
+			if (
+				decodedCertificate.blockID.equals(EMPTY_BYTES) ||
+				decodedCertificate.stateRoot.equals(EMPTY_BYTES) ||
+				decodedCertificate.validatorsHash.equals(EMPTY_BYTES) ||
+				decodedCertificate.timestamp === 0
+			) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error('Certificate is missing required values.'),
+				};
+			}
+
+			// Last certificate height should be less than new certificate height
+			if (decodedCertificate.height <= partnerChainAccount.lastCertificate.height) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error('Certificate height should be greater than last certificate height.'),
+				};
+			}
 		}
+
+		// If params contains a non-empty activeValidatorsUpdate
 		if (
-			txParams.activeValidatorsUpdate &&
-			txParams.activeValidatorsUpdate.length !== 0 &&
+			txParams.activeValidatorsUpdate.length !== 0 ||
 			txParams.newCertificateThreshold > BigInt(0)
 		) {
 			// Non-empty certificate
-			if (!txParams.certificate) {
+			if (txParams.certificate.equals(EMPTY_BYTES)) {
 				return {
 					status: VerifyStatus.FAIL,
-					error: new Error('Certificate cannot be empty.'),
+					error: new Error(
+						'Certificate cannot be empty when activeValidatorsUpdate is non-empty or newCertificateThreshold >0.',
+					),
 				};
 			}
 
@@ -173,27 +186,31 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 			partnerChainIDBuffer,
 			channelSchema,
 		);
-		// InboxUpdate Validity
+		// Section: InboxUpdate Validity
 		const { crossChainMessages, messageWitness, outboxRootWitness } = txParams.inboxUpdate;
 		const ccmHashes = crossChainMessages.map(ccm => hash(ccm));
 
 		let newInboxRoot;
-		let newInboxAppendPath;
-		let newInboxSize;
+		let newInboxAppendPath = partnerChannelData.inbox.appendPath;
+		let newInboxSize = partnerChannelData.inbox.size;
 		for (const ccm of ccmHashes) {
 			const { appendPath, size } = regularMerkleTree.calculateMerkleRoot({
 				value: ccm,
-				appendPath: partnerChannelData.inbox.appendPath,
-				size: partnerChannelData.inbox.size,
+				appendPath: newInboxAppendPath,
+				size: newInboxSize,
 			});
 			newInboxAppendPath = appendPath;
 			newInboxSize = size;
 		}
-		if (txParams.certificate) {
-			// If inboxUpdate contains a non-empty messageWitness, then update newInboxRoot to the output
+		// If inboxUpdate contains a non-empty messageWitness, then update newInboxRoot to the output
+		if (
+			!txParams.certificate.equals(EMPTY_BYTES) &&
+			txParams.inboxUpdate.messageWitness.siblingHashes.length !== 0 &&
+			txParams.inboxUpdate.messageWitness.partnerChainOutboxSize > 0
+		) {
 			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
-				newInboxSize as number,
-				newInboxAppendPath as Buffer[],
+				newInboxSize,
+				newInboxAppendPath,
 				messageWitness.siblingHashes,
 			);
 
@@ -223,10 +240,14 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 					),
 				};
 			}
-		} else if (!txParams.certificate) {
+		} else if (
+			txParams.certificate.equals(EMPTY_BYTES) &&
+			txParams.inboxUpdate.messageWitness.siblingHashes.length !== 0 &&
+			txParams.inboxUpdate.messageWitness.partnerChainOutboxSize > 0
+		) {
 			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
-				newInboxSize as number,
-				newInboxAppendPath as Buffer[],
+				newInboxSize,
+				newInboxAppendPath,
 				messageWitness.siblingHashes,
 			);
 
@@ -250,45 +271,15 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 	): Promise<void> {
 		const { transaction, header, params: txParams } = context;
 		const chainIDBuffer = getIDAsKeyForStore(txParams.sendingChainID);
-		const partnerChainStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHAIN_DATA);
+		const partnerChainStore = context.getStore(this.moduleID, STORE_PREFIX_CHAIN_DATA);
 		const partnerChainAccount = await partnerChainStore.getWithSchema<ChainAccount>(
 			chainIDBuffer,
 			chainAccountSchema,
 		);
 
-		const {
-			validators,
-			certificateThreshold,
-			precommitThreshold,
-		} = await this._bftAPI.getBFTParameters(context.getAPIContext(), header.height);
-
-		const activeValidators: ActiveValidators[] = [];
-		const updatedValidators = [];
-		const keyList: Buffer[] = [];
-		const weights: bigint[] = [];
-		for (const v of validators) {
-			const { blsKey } = await this._validatorsAPI.getValidatorAccount(
-				context.getAPIContext(),
-				v.address,
-			);
-			updatedValidators.push({
-				bftWeight: v.bftWeight,
-				address: v.address,
-			});
-			activeValidators.push({
-				blsKey,
-				bftWeight: v.bftWeight,
-			});
-		}
-		sortValidatorsByBLSKey(activeValidators);
-		for (const v of activeValidators) {
-			keyList.push(v.blsKey);
-			weights.push(v.bftWeight);
-		}
-
 		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
 
-		// if the CCU also contains a non-empty inboxUpdate, the certificate is only valid if it allows the sidechain account to remain live for a reasonable amount of time
+		// if the CCU also contains a non-empty inboxUpdate, check the validity of certificate with liveness check
 		if (
 			txParams.inboxUpdate &&
 			!(header.timestamp - decodedCertificate.timestamp < LIVENESS_LIMIT / 2)
@@ -297,39 +288,50 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 				`Certificate is not valid as it passed Liveness limit of ${LIVENESS_LIMIT} seconds.`,
 			);
 		}
-		// Certificate and Validators Update Validity
-		const verifySignature = verifyWeightedAggSig(
-			keyList,
-			decodedCertificate.aggregationBits as Buffer,
-			decodedCertificate.signature as Buffer,
-			MESSAGE_TAG_CERTIFICATE.toString('hex'),
-			partnerChainAccount.networkID,
-			txParams.certificate,
-			weights,
-			certificateThreshold,
-		);
 
-		if (
-			!(decodedCertificate.height > partnerChainAccount.lastCertificate.height) ||
-			decodedCertificate.timestamp >= header.timestamp ||
-			!verifySignature
-		) {
-			throw Error(
-				`Certificate is invalid due to invalid last certified height or timestamp or signature.`,
+		const partnerValidatorStore = context.getStore(this.moduleID, STORE_PREFIX_CHAIN_VALIDATORS);
+		const partnerValidators = await partnerValidatorStore.getWithSchema<ChainValidators>(
+			chainIDBuffer,
+			chainValidatorsSchema,
+		);
+		const { activeValidators, certificateThreshold } = partnerValidators;
+
+		// Certificate and Validators Update Validity
+		if (!txParams.certificate.equals(EMPTY_BYTES)) {
+			const verifySignature = verifyWeightedAggSig(
+				activeValidators.map(v => v.blsKey),
+				decodedCertificate.aggregationBits as Buffer,
+				decodedCertificate.signature as Buffer,
+				MESSAGE_TAG_CERTIFICATE.toString('hex'),
+				partnerChainAccount.networkID,
+				txParams.certificate,
+				activeValidators.map(v => v.bftWeight),
+				certificateThreshold,
 			);
+
+			if (!verifySignature || decodedCertificate.timestamp >= header.timestamp)
+				throw Error(
+					`Certificate is invalid due to invalid last certified height or timestamp or signature.`,
+				);
 		}
 
-		const newActiveValidators = updateActiveValidators(
-			activeValidators,
-			txParams.activeValidatorsUpdate,
-		);
-		const validatorsHash = computeValidatorsHash(
-			newActiveValidators,
-			txParams.newCertificateThreshold || certificateThreshold,
-		);
+		// If params contains a non-empty activeValidatorsUpdate
+		if (
+			txParams.activeValidatorsUpdate.length !== 0 ||
+			txParams.newCertificateThreshold > BigInt(0)
+		) {
+			const newActiveValidators = updateActiveValidators(
+				activeValidators,
+				txParams.activeValidatorsUpdate,
+			);
+			const validatorsHash = computeValidatorsHash(
+				newActiveValidators,
+				txParams.newCertificateThreshold || certificateThreshold,
+			);
 
-		if (!decodedCertificate.validatorsHash.equals(validatorsHash)) {
-			throw new Error('Validators hash is incorrect given in the certificate.');
+			if (!decodedCertificate.validatorsHash.equals(validatorsHash)) {
+				throw new Error('Validators hash is incorrect given in the certificate.');
+			}
 		}
 
 		// CCM execution
@@ -338,9 +340,15 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 			serialized: ccm,
 			deserilized: codec.decode<CCMsg>(ccmSchema, ccm),
 		}));
-		if (partnerChainAccount.status === CHAIN_REGISTERED) {
+		if (
+			partnerChainAccount.status === CHAIN_REGISTERED &&
+			txParams.inboxUpdate.crossChainMessages.length !== 0 &&
+			txParams.inboxUpdate.messageWitness.siblingHashes.length !== 0 &&
+			txParams.inboxUpdate.outboxRootWitness.siblingHashes.length !== 0
+		) {
 			// If the first CCM in inboxUpdate is a registration CCM
 			if (
+				decodedCCMs.length > 0 &&
 				decodedCCMs[0].deserilized.crossChainCommandID === CROSS_CHAIN_COMMAND_ID_REGISTRATION &&
 				decodedCCMs[0].deserilized.receivingChainID === MAINCHAIN_ID
 			) {
@@ -357,6 +365,8 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 					txParams.sendingChainID,
 					beforeSendContext,
 				);
+
+				return; // Exit CCU processing
 			}
 		}
 
@@ -415,18 +425,26 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 				);
 			}
 		}
-
 		// Common ccm execution logic
-		await this._bftAPI.setBFTParameters(
-			context.getAPIContext(),
-			precommitThreshold,
-			txParams.newCertificateThreshold ?? certificateThreshold,
-			updatedValidators,
+		const newActiveValidators = updateActiveValidators(
+			activeValidators,
+			txParams.activeValidatorsUpdate,
 		);
-		partnerChainAccount.lastCertificate.stateRoot = decodedCertificate.stateRoot;
-		partnerChainAccount.lastCertificate.timestamp = decodedCertificate.timestamp;
-		partnerChainAccount.lastCertificate.height = decodedCertificate.height;
-		partnerChainAccount.lastCertificate.validatorsHash = decodedCertificate.validatorsHash;
+		partnerValidators.activeValidators = newActiveValidators;
+		if (txParams.newCertificateThreshold !== BigInt(0)) {
+			partnerValidators.certificateThreshold = txParams.newCertificateThreshold;
+		}
+		await partnerValidatorStore.setWithSchema(
+			chainIDBuffer,
+			partnerValidators,
+			chainValidatorsSchema,
+		);
+		if (!txParams.certificate.equals(EMPTY_BYTES)) {
+			partnerChainAccount.lastCertificate.stateRoot = decodedCertificate.stateRoot;
+			partnerChainAccount.lastCertificate.timestamp = decodedCertificate.timestamp;
+			partnerChainAccount.lastCertificate.height = decodedCertificate.height;
+			partnerChainAccount.lastCertificate.validatorsHash = decodedCertificate.validatorsHash;
+		}
 
 		await partnerChainStore.setWithSchema(chainIDBuffer, partnerChainAccount, chainAccountSchema);
 

--- a/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
@@ -22,7 +22,6 @@ import {
 	VerificationResult,
 	VerifyStatus,
 } from '../../../../node/state_machine';
-import { createBeforeSendCCMsgAPIContext } from '../../../../testing';
 import { BaseInteroperabilityCommand } from '../../base_interoperability_command';
 import {
 	CHAIN_ACTIVE,

--- a/framework/src/modules/interoperability/schema.ts
+++ b/framework/src/modules/interoperability/schema.ts
@@ -128,6 +128,36 @@ export const chainAccountSchema = {
 	},
 };
 
+export const chainValidatorsSchema = {
+	$id: 'modules/interoperability/chainValidators',
+	type: 'object',
+	required: ['activeValidators', 'certificateThreshold'],
+	properties: {
+		activeValidators: {
+			type: 'array',
+			fieldNumber: 1,
+			items: {
+				type: 'object',
+				required: ['blsKey', 'bftWeight'],
+				properties: {
+					blsKey: {
+						dataType: 'bytes',
+						fieldNumber: 1,
+					},
+					bftWeight: {
+						dataType: 'uint64',
+						fieldNumber: 2,
+					},
+				},
+			},
+		},
+		certificateThreshold: {
+			dataType: 'uint64',
+			fieldNumber: 2,
+		},
+	},
+};
+
 export const ownChainAccountSchema = {
 	$id: 'modules/interoperability/ownChainAccount',
 	type: 'object',

--- a/framework/src/modules/interoperability/schema.ts
+++ b/framework/src/modules/interoperability/schema.ts
@@ -143,6 +143,8 @@ export const chainValidatorsSchema = {
 					blsKey: {
 						dataType: 'bytes',
 						fieldNumber: 1,
+						minLength: 48,
+						maxLength: 48,
 					},
 					bftWeight: {
 						dataType: 'uint64',
@@ -400,6 +402,8 @@ export const crossChainUpdateTransactionParams = {
 					blsKey: {
 						dataType: 'bytes',
 						fieldNumber: 1,
+						minLength: 48,
+						maxLength: 48,
 					},
 					bftWeight: {
 						dataType: 'uint64',

--- a/framework/src/modules/interoperability/sidechain/cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/channel_terminated.ts
@@ -25,6 +25,9 @@ export class SidechainCCChannelTerminatedCommand extends BaseInteroperabilityCCC
 
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
+		if (!context.ccm) {
+			throw new Error('CCM is missing to execute channel terminated cross chain command.');
+		}
 		await interoperabilityStore.createTerminatedStateAccount(context.ccm.sendingChainID);
 	}
 

--- a/framework/src/modules/interoperability/sidechain/cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/channel_terminated.ts
@@ -26,7 +26,7 @@ export class SidechainCCChannelTerminatedCommand extends BaseInteroperabilityCCC
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
 		if (!context.ccm) {
-			throw new Error('CCM is missing to execute channel terminated cross chain command.');
+			throw new Error('CCM to execute channel terminated cross chain command is missing.');
 		}
 		await interoperabilityStore.createTerminatedStateAccount(context.ccm.sendingChainID);
 	}

--- a/framework/src/modules/interoperability/sidechain/cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/registration.ts
@@ -33,6 +33,9 @@ export class SidechainCCRegistrationCommand extends BaseInteroperabilityCCComman
 
 	public async execute(ctx: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = ctx;
+		if (!ccm) {
+			throw new Error('CCM is missing to execute registration cross chain command.');
+		}
 		const decodedParams = codec.decode<CCMRegistrationParams>(
 			registrationCCMParamsSchema,
 			ccm.params,

--- a/framework/src/modules/interoperability/sidechain/cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/registration.ts
@@ -34,7 +34,7 @@ export class SidechainCCRegistrationCommand extends BaseInteroperabilityCCComman
 	public async execute(ctx: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = ctx;
 		if (!ccm) {
-			throw new Error('CCM is missing to execute registration cross chain command.');
+			throw new Error('CCM to execute registration cross chain command is missing.');
 		}
 		const decodedParams = codec.decode<CCMRegistrationParams>(
 			registrationCCMParamsSchema,

--- a/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
@@ -34,7 +34,7 @@ export class SidechainCCSidechainTerminatedCommand extends BaseInteroperabilityC
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = context;
 		if (!ccm) {
-			throw new Error('CCM is missing to execute sidechain terminated cross chain command.');
+			throw new Error('CCM to execute sidechain terminated cross chain command is missing.');
 		}
 		const decodedParams = codec.decode<CCMSidechainTerminatedParams>(
 			sidechainTerminatedCCMParamsSchema,

--- a/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
@@ -33,6 +33,9 @@ export class SidechainCCSidechainTerminatedCommand extends BaseInteroperabilityC
 
 	public async execute(context: CCCommandExecuteContext): Promise<void> {
 		const { ccm } = context;
+		if (!ccm) {
+			throw new Error('CCM is missing to execute sidechain terminated cross chain command.');
+		}
 		const decodedParams = codec.decode<CCMSidechainTerminatedParams>(
 			sidechainTerminatedCCMParamsSchema,
 			ccm.params,

--- a/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
@@ -122,6 +122,17 @@ export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 			return certificateValidity;
 		}
 
+		const partnerValidatorStore = context.getStore(this.moduleID, STORE_PREFIX_CHAIN_VALIDATORS);
+		const partnerValidators = await partnerValidatorStore.getWithSchema<ChainValidators>(
+			partnerChainIDBuffer,
+			chainValidatorsSchema,
+		);
+		// If params contains a non-empty activeValidatorsUpdate
+		const validatorsHashValidity = checkValidatorsHashWithCertificate(txParams, partnerValidators);
+		if (validatorsHashValidity.error) {
+			return validatorsHashValidity;
+		}
+
 		// If params contains a non-empty activeValidatorsUpdate
 		const activeValidatorsValidity = checkActiveValidatorsUpdate(txParams);
 		if (activeValidatorsValidity.error) {
@@ -174,9 +185,6 @@ export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 			decodedCertificate,
 			header,
 		);
-
-		// If params contains a non-empty activeValidatorsUpdate
-		checkValidatorsHashWithCertificate(txParams, decodedCertificate, partnerValidators);
 
 		// CCM execution
 		const beforeSendContext = createCCMsgBeforeSendContext({

--- a/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
@@ -60,6 +60,7 @@ import {
 	checkValidCertificateLiveness,
 	commonCCUExecutelogic,
 	getIDAsKeyForStore,
+	isInboxUpdateEmpty,
 	validateFormat,
 } from '../../utils';
 import { SidechainInteroperabilityStore } from '../store';
@@ -177,32 +178,37 @@ export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 		checkValidatorsHashWithCertificate(txParams, decodedCertificate, partnerValidators);
 
 		// CCM execution
+		const beforeSendContext = createCCMsgBeforeSendContext({
+			feeAddress: context.transaction.senderAddress,
+			eventQueue: context.eventQueue,
+			getAPIContext: context.getAPIContext,
+			logger: context.logger,
+			networkIdentifier: context.networkIdentifier,
+			getStore: context.getStore,
+		});
 		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
-		const decodedCCMs = txParams.inboxUpdate.crossChainMessages.map(ccm => ({
-			serialized: ccm,
-			deserilized: codec.decode<CCMsg>(ccmSchema, ccm),
-		}));
-		if (
-			partnerChainAccount.status === CHAIN_REGISTERED &&
-			txParams.inboxUpdate.crossChainMessages.length !== 0 &&
-			txParams.inboxUpdate.messageWitness.siblingHashes.length !== 0 &&
-			txParams.inboxUpdate.outboxRootWitness.siblingHashes.length !== 0
-		) {
+		let decodedCCMs;
+		try {
+			decodedCCMs = txParams.inboxUpdate.crossChainMessages.map(ccm => ({
+				serialized: ccm,
+				deserilized: codec.decode<CCMsg>(ccmSchema, ccm),
+			}));
+		} catch (err) {
+			await interoperabilityStore.terminateChainInternal(
+				txParams.sendingChainID,
+				beforeSendContext,
+			);
+
+			throw err;
+		}
+		if (partnerChainAccount.status === CHAIN_REGISTERED && !isInboxUpdateEmpty) {
 			// If the first CCM in inboxUpdate is a registration CCM
 			if (
-				decodedCCMs.length > 0 &&
 				decodedCCMs[0].deserilized.crossChainCommandID === CROSS_CHAIN_COMMAND_ID_REGISTRATION &&
 				decodedCCMs[0].deserilized.receivingChainID === txParams.sendingChainID
 			) {
 				partnerChainAccount.status = CHAIN_ACTIVE;
 			} else {
-				const beforeSendContext = createBeforeSendCCMsgAPIContext({
-					feeAddress: context.transaction.senderAddress,
-					eventQueue: context.eventQueue,
-					getAPIContext: context.getAPIContext,
-					logger: context.logger,
-					networkIdentifier: context.networkIdentifier,
-				});
 				await interoperabilityStore.terminateChainInternal(
 					txParams.sendingChainID,
 					beforeSendContext,
@@ -213,14 +219,6 @@ export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 		}
 
 		for (const ccm of decodedCCMs) {
-			const beforeSendContext = createCCMsgBeforeSendContext({
-				feeAddress: context.transaction.senderAddress,
-				eventQueue: context.eventQueue,
-				getAPIContext: context.getAPIContext,
-				logger: context.logger,
-				networkIdentifier: context.networkIdentifier,
-				getStore: context.getStore,
-			});
 			if (txParams.sendingChainID !== ccm.deserilized.sendingChainID) {
 				await interoperabilityStore.terminateChainInternal(
 					txParams.sendingChainID,

--- a/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
@@ -13,8 +13,7 @@
  */
 
 import { codec } from '@liskhq/lisk-codec';
-import { hash, verifyWeightedAggSig } from '@liskhq/lisk-cryptography';
-import { regularMerkleTree, sparseMerkleTree } from '@liskhq/lisk-tree';
+import { verifyWeightedAggSig } from '@liskhq/lisk-cryptography';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
 import { certificateSchema } from '../../../../node/consensus/certificate_generation/schema';
 import { Certificate } from '../../../../node/consensus/certificate_generation/types';
@@ -35,12 +34,9 @@ import {
 	EMPTY_BYTES,
 	LIVENESS_LIMIT,
 	MESSAGE_TAG_CERTIFICATE,
-	SMT_KEY_LENGTH,
 	STORE_PREFIX_CHAIN_DATA,
 	STORE_PREFIX_CHAIN_VALIDATORS,
 	STORE_PREFIX_CHANNEL_DATA,
-	STORE_PREFIX_OUTBOX_ROOT,
-	VALID_BLS_KEY_LENGTH,
 } from '../../constants';
 import { createCCMsgBeforeSendContext } from '../../context';
 import {
@@ -59,9 +55,12 @@ import {
 	StoreCallback,
 } from '../../types';
 import {
+	checkActiveValidatorsUpdate,
+	checkCertificateValidity,
+	checkInboxUpdateValidity,
+	checkLivenessRequirementFirstCCU,
 	computeValidatorsHash,
 	getIDAsKeyForStore,
-	rawStateStoreKey,
 	updateActiveValidators,
 	validateFormat,
 } from '../../utils';
@@ -109,75 +108,24 @@ export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 		}
 
 		// Section: Liveness Requirement for the First CCU
-		if (partnerChainAccount.status === CHAIN_REGISTERED) {
-			// Certificate must not be empty for first CCU
-			if (txParams.certificate.equals(EMPTY_BYTES)) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error(
-						`Sending partner chain ${txParams.sendingChainID} is in registered status so certificate cannot be empty.`,
-					),
-				};
-			}
+		const livenessRequirementFirstCCU = checkLivenessRequirementFirstCCU(
+			partnerChainAccount,
+			txParams,
+		);
+		if (livenessRequirementFirstCCU.error) {
+			return livenessRequirementFirstCCU;
 		}
 		// Section: Certificate and Validators Update Validity
+		const certificateValidity = checkCertificateValidity(partnerChainAccount, txParams.certificate);
 
-		// Certificate follows the schema
-		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
-		if (!txParams.certificate.equals(EMPTY_BYTES)) {
-			if (
-				decodedCertificate.blockID.equals(EMPTY_BYTES) ||
-				decodedCertificate.stateRoot.equals(EMPTY_BYTES) ||
-				decodedCertificate.validatorsHash.equals(EMPTY_BYTES) ||
-				decodedCertificate.timestamp === 0
-			) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error('Certificate is missing required values.'),
-				};
-			}
-
-			// Last certificate height should be less than new certificate height
-			if (decodedCertificate.height <= partnerChainAccount.lastCertificate.height) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error('Certificate height should be greater than last certificate height.'),
-				};
-			}
+		if (certificateValidity.error) {
+			return certificateValidity;
 		}
 
 		// If params contains a non-empty activeValidatorsUpdate
-		if (
-			txParams.activeValidatorsUpdate.length !== 0 ||
-			txParams.newCertificateThreshold > BigInt(0)
-		) {
-			// Non-empty certificate
-			if (txParams.certificate.equals(EMPTY_BYTES)) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error(
-						'Certificate cannot be empty when activeValidatorsUpdate is non-empty or newCertificateThreshold >0.',
-					),
-				};
-			}
-
-			// params.activeValidatorsUpdate has the correct format
-			for (let i = 0; i < txParams.activeValidatorsUpdate.length; i += 1) {
-				const currentValidator = txParams.activeValidatorsUpdate[i];
-				const nextValidator = txParams.activeValidatorsUpdate[i + 1];
-				if (currentValidator.blsKey.byteLength !== VALID_BLS_KEY_LENGTH) {
-					return {
-						status: VerifyStatus.FAIL,
-						error: new Error(`BlsKey length should be equal to ${VALID_BLS_KEY_LENGTH}.`),
-					};
-				}
-				if (currentValidator.blsKey.compare(nextValidator.blsKey) > -1) {
-					return {
-						status: VerifyStatus.FAIL,
-						error: new Error('Validators blsKeys must be unique and lexicographically ordered'),
-					};
-				}
-			}
+		const activeValidatorsValidity = checkActiveValidatorsUpdate(txParams);
+		if (activeValidatorsValidity.error) {
+			return activeValidatorsValidity;
 		}
 
 		const partnerChannelStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHANNEL_DATA);
@@ -186,78 +134,9 @@ export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 			channelSchema,
 		);
 		// Section: InboxUpdate Validity
-		const { crossChainMessages, messageWitness, outboxRootWitness } = txParams.inboxUpdate;
-		const ccmHashes = crossChainMessages.map(ccm => hash(ccm));
-
-		let newInboxRoot;
-		let newInboxAppendPath = partnerChannelData.inbox.appendPath;
-		let newInboxSize = partnerChannelData.inbox.size;
-		for (const ccm of ccmHashes) {
-			const { appendPath, size } = regularMerkleTree.calculateMerkleRoot({
-				value: ccm,
-				appendPath: newInboxAppendPath,
-				size: newInboxSize,
-			});
-			newInboxAppendPath = appendPath;
-			newInboxSize = size;
-		}
-		// If inboxUpdate contains a non-empty messageWitness, then update newInboxRoot to the output
-		if (
-			!txParams.certificate.equals(EMPTY_BYTES) &&
-			txParams.inboxUpdate.messageWitness.siblingHashes.length !== 0 &&
-			txParams.inboxUpdate.messageWitness.partnerChainOutboxSize > 0
-		) {
-			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
-				newInboxSize,
-				newInboxAppendPath,
-				messageWitness.siblingHashes,
-			);
-
-			const proof = {
-				siblingHashes: outboxRootWitness.siblingHashes,
-				queries: [
-					{
-						key: partnerChainIDBuffer,
-						value: newInboxRoot,
-						bitmap: outboxRootWitness.bitmap,
-					},
-				],
-			};
-			const outboxKey = rawStateStoreKey(STORE_PREFIX_OUTBOX_ROOT);
-			const querykeys = [outboxKey];
-			const isSMTRootValid = sparseMerkleTree.verify(
-				querykeys,
-				proof,
-				decodedCertificate.stateRoot,
-				SMT_KEY_LENGTH,
-			);
-			if (!isSMTRootValid) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error(
-						'Failed at verifying state root when messageWitness and certificate are non-empty.',
-					),
-				};
-			}
-		} else if (
-			txParams.certificate.equals(EMPTY_BYTES) &&
-			txParams.inboxUpdate.messageWitness.siblingHashes.length !== 0 &&
-			txParams.inboxUpdate.messageWitness.partnerChainOutboxSize > 0
-		) {
-			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
-				newInboxSize,
-				newInboxAppendPath,
-				messageWitness.siblingHashes,
-			);
-
-			if (!newInboxRoot.equals(partnerChannelData.partnerChainOutboxRoot)) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error(
-						'Failed at verifying state root when messageWitness is non-empty and certificate is empty.',
-					),
-				};
-			}
+		const inboxUpdateValidity = checkInboxUpdateValidity(txParams, partnerChannelData);
+		if (inboxUpdateValidity.error) {
+			return inboxUpdateValidity;
 		}
 
 		return {

--- a/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
@@ -22,7 +22,6 @@ import {
 	VerificationResult,
 	VerifyStatus,
 } from '../../../../node/state_machine';
-import { createBeforeSendCCMsgAPIContext } from '../../../../testing';
 import { BaseInteroperabilityCommand } from '../../base_interoperability_command';
 import {
 	CHAIN_ACTIVE,

--- a/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
@@ -12,18 +12,421 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { CommandExecuteContext } from '../../../../node/state_machine';
-import { BaseCommand } from '../../../base_command';
-import { COMMAND_ID_SIDECHAIN_CCU } from '../../constants';
-import { crossChainUpdateTransactionParams } from '../../schema';
+import { codec } from '@liskhq/lisk-codec';
+import { hash, verifyWeightedAggSig } from '@liskhq/lisk-cryptography';
+import { regularMerkleTree, sparseMerkleTree } from '@liskhq/lisk-tree';
+import { LiskValidationError, validator } from '@liskhq/lisk-validator';
+import { certificateSchema } from '../../../../node/consensus/certificate_generation/schema';
+import { Certificate } from '../../../../node/consensus/certificate_generation/types';
+import {
+	CommandExecuteContext,
+	CommandVerifyContext,
+	VerificationResult,
+	VerifyStatus,
+} from '../../../../node/state_machine';
+import { createBeforeSendCCMsgAPIContext } from '../../../../testing';
+import { BaseInteroperabilityCommand } from '../../base_interoperability_command';
+import {
+	CHAIN_ACTIVE,
+	CHAIN_REGISTERED,
+	CHAIN_TERMINATED,
+	COMMAND_ID_SIDECHAIN_CCU,
+	CROSS_CHAIN_COMMAND_ID_REGISTRATION,
+	LIVENESS_LIMIT,
+	MESSAGE_TAG_CERTIFICATE,
+	SMT_KEY_LENGTH,
+	STORE_PREFIX_CHAIN_DATA,
+	STORE_PREFIX_CHANNEL_DATA,
+	STORE_PREFIX_OUTBOX_ROOT,
+	VALID_BLS_KEY_LENGTH,
+} from '../../constants';
+import { createCCMsgBeforeSendContext } from '../../context';
+import {
+	ccmSchema,
+	chainAccountSchema,
+	channelSchema,
+	crossChainUpdateTransactionParams,
+} from '../../schema';
+import {
+	ActiveValidators,
+	BFTAPI,
+	CCMsg,
+	ChainAccount,
+	ChannelData,
+	CrossChainCommandDependencies,
+	CrossChainUpdateTransactionParams,
+	StoreCallback,
+	ValidatorsAPI,
+} from '../../types';
+import {
+	computeValidatorsHash,
+	getIDAsKeyForStore,
+	rawStateStoreKey,
+	sortValidatorsByBLSKey,
+	updateActiveValidators,
+	validateFormat,
+} from '../../utils';
+import { SidechainInteroperabilityStore } from '../store';
 
-export class MainchainCCUpdateCommand extends BaseCommand {
+export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 	public name = 'sidechainCCUpdate';
 	public id = COMMAND_ID_SIDECHAIN_CCU;
 	public schema = crossChainUpdateTransactionParams;
+	private _bftAPI!: BFTAPI;
+	private _validatorsAPI!: ValidatorsAPI;
 
-	// eslint-disable-next-line @typescript-eslint/require-await
-	public async execute(_context: CommandExecuteContext<unknown>): Promise<void> {
-		throw new Error('Method not implemented.');
+	public addDependencies(args: CrossChainCommandDependencies) {
+		this._bftAPI = args.bftAPI;
+		this._validatorsAPI = args.validatorsAPI;
+	}
+	public async verify(
+		context: CommandVerifyContext<CrossChainUpdateTransactionParams>,
+	): Promise<VerificationResult> {
+		const { params: txParams, transaction } = context;
+		const errors = validator.validate(crossChainUpdateTransactionParams, context.params);
+
+		if (errors.length > 0) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new LiskValidationError(errors),
+			};
+		}
+
+		const partnerChainIDBuffer = getIDAsKeyForStore(txParams.sendingChainID);
+		const partnerChainStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHAIN_DATA);
+		const partnerChainAccount = await partnerChainStore.getWithSchema<ChainAccount>(
+			partnerChainIDBuffer,
+			chainAccountSchema,
+		);
+
+		// Liveness of Partner Chain
+		if (partnerChainAccount.status === CHAIN_TERMINATED) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error(`Sending partner chain ${txParams.sendingChainID} is terminated.`),
+			};
+		}
+		const interoperabilityStore = this.getInteroperabilityStore(context.getStore as StoreCallback);
+		const isChainLive = await interoperabilityStore.isLive(partnerChainIDBuffer);
+		if (partnerChainAccount.status === CHAIN_ACTIVE && !isChainLive) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error(`Sending partner chain ${txParams.sendingChainID} is not live.`),
+			};
+		}
+
+		// Liveness Requirement for the First CCU
+		if (partnerChainAccount.status === CHAIN_REGISTERED) {
+			// Certificate must not be empty for first CCU
+			if (!txParams.certificate) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error(
+						`Sending partner chain ${txParams.sendingChainID} is in registered status so certificate cannot be empty.`,
+					),
+				};
+			}
+		}
+		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
+		const invalidCertificateErrors = validator.validate(certificateSchema, decodedCertificate);
+		if (invalidCertificateErrors.length > 0) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error('Certificate does not follow valid certificate schema.'),
+			};
+		}
+		// If params contains a non-empty activeValidatorsUpdate property (with deserialized value not equal to {activeValidatorsUpdate:[]}), or a non-zero newCertificateThreshold
+		if (
+			txParams.activeValidatorsUpdate &&
+			txParams.activeValidatorsUpdate !== [] &&
+			txParams.newCertificateThreshold > BigInt(0)
+		) {
+			// Non-empty certificate
+			if (!txParams.certificate) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error('Certificate cannot be empty.'),
+				};
+			}
+
+			// params.activeValidatorsUpdate has the correct format
+			for (let i = 0; i < txParams.activeValidatorsUpdate.length; i += 1) {
+				const currentValidator = txParams.activeValidatorsUpdate[i];
+				const nextValidator = txParams.activeValidatorsUpdate[i + 1];
+				if (currentValidator.blsKey.byteLength !== VALID_BLS_KEY_LENGTH) {
+					return {
+						status: VerifyStatus.FAIL,
+						error: new Error(`BlsKey length should be equal to ${VALID_BLS_KEY_LENGTH}.`),
+					};
+				}
+				if (currentValidator.blsKey.compare(nextValidator.blsKey) > -1) {
+					return {
+						status: VerifyStatus.FAIL,
+						error: new Error('Validators blsKeys must be unique and lexicographically ordered'),
+					};
+				}
+			}
+		}
+
+		const partnerChannelStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHANNEL_DATA);
+		const partnerChannelData = await partnerChannelStore.getWithSchema<ChannelData>(
+			partnerChainIDBuffer,
+			channelSchema,
+		);
+		// InboxUpdate Validity
+		const { crossChainMessages, messageWitness, outboxRootWitness } = txParams.inboxUpdate;
+		const ccmHashes = crossChainMessages.map(ccm => hash(ccm));
+
+		let newInboxRoot;
+		let newInboxAppendPath;
+		let newInboxSize;
+		for (const ccm of ccmHashes) {
+			const { appendPath, root, size } = regularMerkleTree.calculateMerkleRoot({
+				value: ccm,
+				appendPath: partnerChannelData.inbox.appendPath,
+				size: partnerChannelData.inbox.size,
+			});
+			newInboxRoot = root;
+			newInboxAppendPath = appendPath;
+			newInboxSize = size;
+		}
+		if (txParams.certificate && txParams.inboxUpdate) {
+			// If inboxUpdate contains a non-empty messageWitness, then update newInboxRoot to the output
+			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
+				newInboxSize as number,
+				newInboxAppendPath as Buffer[],
+				messageWitness.siblingHashes,
+			);
+
+			const proof = {
+				siblingHashes: outboxRootWitness.siblingHashes,
+				queries: [
+					{
+						key: partnerChainIDBuffer,
+						value: newInboxRoot,
+						bitmap: outboxRootWitness.bitmap,
+					},
+				],
+			};
+			const outboxKey = rawStateStoreKey(STORE_PREFIX_OUTBOX_ROOT);
+			const querykeys = [outboxKey];
+			const isSMTRootValid = sparseMerkleTree.verify(
+				querykeys,
+				proof,
+				decodedCertificate.stateRoot,
+				SMT_KEY_LENGTH,
+			);
+			if (!isSMTRootValid) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error(
+						'Failed at verifying state root when messageWitness and certificate are non-empty.',
+					),
+				};
+			}
+		} else if (!txParams.certificate && txParams.inboxUpdate) {
+			newInboxRoot = regularMerkleTree.calculateRootFromRightWitness(
+				newInboxSize as number,
+				newInboxAppendPath as Buffer[],
+				messageWitness.siblingHashes,
+			);
+
+			if (!newInboxRoot.equals(partnerChannelData.partnerChainOutboxRoot)) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error(
+						'Failed at verifying state root when messageWitness is non-empty and certificate is empty.',
+					),
+				};
+			}
+		}
+
+		return {
+			status: VerifyStatus.OK,
+		};
+	}
+
+	public async execute(
+		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
+	): Promise<void> {
+		const { transaction, header, params: txParams } = context;
+		const chainIDBuffer = getIDAsKeyForStore(txParams.sendingChainID);
+		const partnerChainStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHAIN_DATA);
+		const partnerChainAccount = await partnerChainStore.getWithSchema<ChainAccount>(
+			chainIDBuffer,
+			chainAccountSchema,
+		);
+
+		const {
+			validators,
+			certificateThreshold,
+			precommitThreshold,
+		} = await this._bftAPI.getBFTParameters(context.getAPIContext(), header.height);
+
+		const activeValidators: ActiveValidators[] = [];
+		const updatedValidators = [];
+		const keyList: Buffer[] = [];
+		const weights: bigint[] = [];
+		for (const v of validators) {
+			const { blsKey } = await this._validatorsAPI.getValidatorAccount(
+				context.getAPIContext(),
+				v.address,
+			);
+			updatedValidators.push({
+				bftWeight: v.bftWeight,
+				address: v.address,
+			});
+			activeValidators.push({
+				blsKey,
+				bftWeight: v.bftWeight,
+			});
+		}
+		sortValidatorsByBLSKey(activeValidators);
+		for (const v of activeValidators) {
+			keyList.push(v.blsKey);
+			weights.push(v.bftWeight);
+		}
+
+		const decodedCertificate = codec.decode<Certificate>(certificateSchema, txParams.certificate);
+
+		// if the CCU also contains a non-empty inboxUpdate, the certificate is only valid if it allows the sidechain account to remain live for a reasonable amount of time
+		if (
+			txParams.inboxUpdate &&
+			!(header.timestamp - decodedCertificate.timestamp < LIVENESS_LIMIT / 2)
+		) {
+			throw Error(
+				`Certificate is not valid as it passed Liveness limit of ${LIVENESS_LIMIT} seconds.`,
+			);
+		}
+		// Certificate and Validators Update Validity
+		const verifySignature = verifyWeightedAggSig(
+			keyList,
+			decodedCertificate.aggregationBits as Buffer,
+			decodedCertificate.signature as Buffer,
+			MESSAGE_TAG_CERTIFICATE.toString('hex'),
+			partnerChainAccount.networkID,
+			txParams.certificate,
+			weights,
+			certificateThreshold,
+		);
+
+		if (
+			!(decodedCertificate.height > partnerChainAccount.lastCertificate.height) ||
+			decodedCertificate.timestamp >= header.timestamp ||
+			!verifySignature
+		) {
+			throw Error(
+				`Certificate is invalid due to invalid last certified height or timestamp or signature.`,
+			);
+		}
+
+		const newActiveValidators = updateActiveValidators(
+			activeValidators,
+			txParams.activeValidatorsUpdate,
+		);
+		const validatorsHash = computeValidatorsHash(
+			newActiveValidators,
+			txParams.newCertificateThreshold || certificateThreshold,
+		);
+
+		if (!decodedCertificate.validatorsHash.equals(validatorsHash)) {
+			throw new Error('Validators hash is incorrect given in the certificate.');
+		}
+
+		// CCM execution
+		const interoperabilityStore = this.getInteroperabilityStore(context.getStore);
+		const decodedCCMs = txParams.inboxUpdate.crossChainMessages.map(ccm => ({
+			serialized: ccm,
+			deserilized: codec.decode<CCMsg>(ccmSchema, ccm),
+		}));
+		if (partnerChainAccount.status === CHAIN_REGISTERED && txParams.inboxUpdate) {
+			// If the first CCM in inboxUpdate is a registration CCM
+			if (
+				decodedCCMs[0].deserilized.crossChainCommandID === CROSS_CHAIN_COMMAND_ID_REGISTRATION &&
+				decodedCCMs[0].deserilized.sendingChainID === txParams.sendingChainID
+			) {
+				partnerChainAccount.status = CHAIN_ACTIVE;
+			} else {
+				const beforeSendContext = createBeforeSendCCMsgAPIContext({
+					feeAddress: context.transaction.senderAddress,
+					eventQueue: context.eventQueue,
+					getAPIContext: context.getAPIContext,
+					logger: context.logger,
+					networkIdentifier: context.networkIdentifier,
+				});
+				await interoperabilityStore.terminateChainInternal(
+					txParams.sendingChainID,
+					beforeSendContext,
+				);
+			}
+		}
+
+		for (const ccm of decodedCCMs) {
+			const beforeSendContext = createCCMsgBeforeSendContext({
+				feeAddress: context.transaction.senderAddress,
+				eventQueue: context.eventQueue,
+				getAPIContext: context.getAPIContext,
+				logger: context.logger,
+				networkIdentifier: context.networkIdentifier,
+				getStore: context.getStore,
+			});
+			if (txParams.sendingChainID !== ccm.deserilized.sendingChainID) {
+				await interoperabilityStore.terminateChainInternal(
+					txParams.sendingChainID,
+					beforeSendContext,
+				);
+			}
+			try {
+				validateFormat(ccm.deserilized);
+			} catch (error) {
+				await interoperabilityStore.terminateChainInternal(
+					txParams.sendingChainID,
+					beforeSendContext,
+				);
+			}
+			await interoperabilityStore.appendToInboxTree(
+				getIDAsKeyForStore(txParams.sendingChainID),
+				ccm.serialized,
+			);
+
+			await interoperabilityStore.apply(
+				{
+					ccm: ccm.deserilized,
+					ccu: txParams,
+					eventQueue: context.eventQueue,
+					feeAddress: context.transaction.senderAddress,
+					getAPIContext: context.getAPIContext,
+					getStore: context.getStore,
+					logger: context.logger,
+					networkIdentifier: context.networkIdentifier,
+				},
+				this.ccCommands,
+			);
+		}
+
+		// Common ccm execution logic
+		await this._bftAPI.setBFTParameters(
+			context.getAPIContext(),
+			precommitThreshold,
+			txParams.newCertificateThreshold ?? certificateThreshold,
+			updatedValidators,
+		);
+		partnerChainAccount.lastCertificate.stateRoot = decodedCertificate.stateRoot;
+		partnerChainAccount.lastCertificate.timestamp = decodedCertificate.timestamp;
+		partnerChainAccount.lastCertificate.height = decodedCertificate.height;
+		partnerChainAccount.lastCertificate.validatorsHash = decodedCertificate.validatorsHash;
+
+		await partnerChainStore.setWithSchema(chainIDBuffer, partnerChainAccount, chainAccountSchema);
+
+		const partnerChannelStore = context.getStore(transaction.moduleID, STORE_PREFIX_CHANNEL_DATA);
+		const partnerChannelData = await partnerChannelStore.getWithSchema<ChannelData>(
+			chainIDBuffer,
+			channelSchema,
+		);
+		await partnerChainStore.setWithSchema(chainIDBuffer, partnerChannelData, channelSchema);
+	}
+
+	protected getInteroperabilityStore(getStore: StoreCallback): SidechainInteroperabilityStore {
+		return new SidechainInteroperabilityStore(this.moduleID, getStore, this.interoperableCCAPIs);
 	}
 }

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -35,7 +35,7 @@ export interface ActiveValidator {
 }
 
 export interface MsgWitness {
-	partnerChainOutboxSize: number;
+	partnerChainOutboxSize: bigint;
 	siblingHashes: Buffer[];
 }
 

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -174,7 +174,7 @@ export interface CCCommandExecuteContext {
 	logger: Logger;
 	networkIdentifier: Buffer;
 	eventQueue: EventQueue;
-	ccm: CCMsg;
+	ccm?: CCMsg;
 	getAPIContext: () => APIContext;
 	getStore: StoreCallback;
 	feeAddress: Buffer;

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -294,3 +294,8 @@ export interface CrossChainUpdateTransactionParams {
 	newCertificateThreshold: bigint;
 	inboxUpdate: InboxUpdate;
 }
+
+export interface ChainValidators {
+	activeValidators: ActiveValidator[];
+	certificateThreshold: bigint;
+}

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -35,7 +35,7 @@ export interface ActiveValidator {
 }
 
 export interface MsgWitness {
-	partnerChainOutboxSize: bigint;
+	partnerChainOutboxSize: number;
 	siblingHashes: Buffer[];
 }
 
@@ -220,6 +220,12 @@ export interface BFTAPI {
 		certificateThreshold: bigint;
 		validators: Validator[];
 	}>;
+	setBFTParameters(
+		apiContext: APIContext,
+		precommitThreshold: bigint,
+		certificateThreshold: bigint,
+		validators: Validator[],
+	): Promise<void>;
 }
 
 export interface ValidatorsAPI {
@@ -227,6 +233,11 @@ export interface ValidatorsAPI {
 }
 
 export interface MainchainRegistrationCommandDependencies {
+	bftAPI: BFTAPI;
+	validatorsAPI: ValidatorsAPI;
+}
+
+export interface CrossChainCommandDependencies {
 	bftAPI: BFTAPI;
 	validatorsAPI: ValidatorsAPI;
 }
@@ -274,4 +285,12 @@ export interface StateRecoveryInitParams {
 	sidechainChainAccount: Buffer;
 	bitmap: Buffer;
 	siblingHashes: Buffer[];
+}
+
+export interface CrossChainUpdateTransactionParams {
+	sendingChainID: number;
+	certificate: Buffer;
+	activeValidatorsUpdate: ActiveValidator[];
+	newCertificateThreshold: bigint;
+	inboxUpdate: InboxUpdate;
 }

--- a/framework/src/modules/interoperability/utils.ts
+++ b/framework/src/modules/interoperability/utils.ts
@@ -39,7 +39,6 @@ import {
 	SMT_KEY_LENGTH,
 	STORE_PREFIX_CHANNEL_DATA,
 	STORE_PREFIX_OUTBOX_ROOT,
-	VALID_BLS_KEY_LENGTH,
 } from './constants';
 import {
 	ccmSchema,
@@ -295,7 +294,7 @@ export const checkActiveValidatorsUpdate = (
 		return {
 			status: VerifyStatus.FAIL,
 			error: new Error(
-				'Certificate cannot be empty when activeValidatorsUpdate is non-empty or newCertificateThreshold >0.',
+				'Certificate cannot be empty when activeValidatorsUpdate is non-empty or newCertificateThreshold > 0.',
 			),
 		};
 	}
@@ -304,12 +303,6 @@ export const checkActiveValidatorsUpdate = (
 	for (let i = 0; i < txParams.activeValidatorsUpdate.length - 1; i += 1) {
 		const currentValidator = txParams.activeValidatorsUpdate[i];
 		const nextValidator = txParams.activeValidatorsUpdate[i + 1];
-		if (currentValidator.blsKey.byteLength !== VALID_BLS_KEY_LENGTH) {
-			return {
-				status: VerifyStatus.FAIL,
-				error: new Error(`BlsKey length should be equal to ${VALID_BLS_KEY_LENGTH}.`),
-			};
-		}
 		if (currentValidator.blsKey.compare(nextValidator.blsKey) > -1) {
 			return {
 				status: VerifyStatus.FAIL,

--- a/framework/src/modules/interoperability/utils.ts
+++ b/framework/src/modules/interoperability/utils.ts
@@ -244,7 +244,7 @@ export const checkLivenessRequirementFirstCCU = (
 		return {
 			status: VerifyStatus.FAIL,
 			error: new Error(
-				`Sending partner chain ${txParams.sendingChainID} is in registered status so certificate cannot be empty.`,
+				`Sending partner chain ${txParams.sendingChainID} has a registered status so certificate cannot be empty.`,
 			),
 		};
 	}
@@ -273,7 +273,7 @@ export const checkCertificateValidity = (
 	}
 
 	// Last certificate height should be less than new certificate height
-	if (partnerChainAccount.lastCertificate.height > decodedCertificate.height) {
+	if (partnerChainAccount.lastCertificate.height >= decodedCertificate.height) {
 		return {
 			status: VerifyStatus.FAIL,
 			error: new Error('Certificate height should be greater than last certificate height.'),
@@ -433,7 +433,7 @@ export const checkCertificateTimestampAndSignature = (
 	certificate: Certificate,
 	header: BlockHeader,
 ) => {
-	// Certificate and Validators Update Validity
+	// Certificate Validity
 	if (txParams.certificate.equals(EMPTY_BYTES)) {
 		return;
 	}
@@ -451,9 +451,7 @@ export const checkCertificateTimestampAndSignature = (
 	);
 
 	if (!verifySignature || certificate.timestamp >= header.timestamp)
-		throw Error(
-			'Certificate is invalid due to invalid last certified height or timestamp or signature.',
-		);
+		throw Error('Certificate is invalid due to invalid certificate timestamp or signature.');
 };
 
 export const checkValidatorsHashWithCertificate = (
@@ -476,7 +474,7 @@ export const checkValidatorsHashWithCertificate = (
 		);
 
 		if (!certificate.validatorsHash.equals(validatorsHash)) {
-			throw new Error('Validators hash is incorrect given in the certificate.');
+			throw new Error('Validators hash given in the certificate is incorrect.');
 		}
 	}
 };

--- a/framework/src/modules/interoperability/utils.ts
+++ b/framework/src/modules/interoperability/utils.ts
@@ -16,7 +16,7 @@ import { regularMerkleTree } from '@liskhq/lisk-tree';
 import { codec } from '@liskhq/lisk-codec';
 import { hash, intToBuffer } from '@liskhq/lisk-cryptography';
 import { LiskValidationError, validator } from '@liskhq/lisk-validator';
-import { CCM_STATUS_OK, MAX_CCM_SIZE } from './constants';
+import { CCM_STATUS_OK, MAX_CCM_SIZE, MODULE_ID_INTEROPERABILITY } from './constants';
 import {
 	ActiveValidators,
 	CCMsg,
@@ -24,6 +24,7 @@ import {
 	MessageRecoveryVerificationParams,
 	TerminatedOutboxAccount,
 } from './types';
+import { DB_KEY_STATE_STORE } from '@liskhq/lisk-chain';
 import { ccmSchema, sidechainTerminatedCCMParamsSchema, validatorsHashInputSchema } from './schema';
 import { VerifyStatus } from '../../node/state_machine/types';
 
@@ -175,3 +176,11 @@ export const swapReceivingAndSendingChainIDs = (ccm: CCMsg) => ({
 	receivingChainID: ccm.sendingChainID,
 	sendingChainID: ccm.receivingChainID,
 });
+export const rawStateStoreKey = (storePrefix: number) => {
+	const moduleIDBuffer = Buffer.alloc(4);
+	moduleIDBuffer.writeInt32BE(MODULE_ID_INTEROPERABILITY, 0);
+	const storePrefixBuffer = Buffer.alloc(2);
+	storePrefixBuffer.writeUInt16BE(storePrefix, 0);
+
+	return Buffer.concat([DB_KEY_STATE_STORE, moduleIDBuffer, storePrefixBuffer]);
+};

--- a/framework/src/testing/create_contexts.ts
+++ b/framework/src/testing/create_contexts.ts
@@ -295,7 +295,7 @@ export const createExecuteCCMsgAPIContext = (params: {
 }): CCCommandExecuteContext => createCCAPIContext(params);
 
 export const createBeforeSendCCMsgAPIContext = (params: {
-	ccm: CCMsg;
+	ccm?: CCMsg;
 	feeAddress: Buffer;
 	logger?: Logger;
 	networkIdentifier?: Buffer;

--- a/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { when } from 'jest-when';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import { codec } from '@liskhq/lisk-codec';
+import { CommandVerifyContext, testing, VerifyStatus } from '../../../../../../src';
+import {
+	ActiveValidator,
+	ChainAccount,
+	ChannelData,
+	CrossChainUpdateTransactionParams,
+} from '../../../../../../src/modules/interoperability/types';
+import { MainchainCCUpdateCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/cc_update';
+import { Certificate } from '../../../../../../src/node/consensus/certificate_generation/types';
+import { certificateSchema } from '../../../../../../src/node/consensus/certificate_generation/schema';
+import * as interopUtils from '../../../../../../src/modules/interoperability/utils';
+import {
+	chainAccountSchema,
+	channelSchema,
+} from '../../../../../../src/modules/interoperability/schema';
+import {
+	CHAIN_ACTIVE,
+	CHAIN_REGISTERED,
+	CHAIN_TERMINATED,
+	EMPTY_BYTES,
+	STORE_PREFIX_CHAIN_DATA,
+	STORE_PREFIX_CHANNEL_DATA,
+} from '../../../../../../src/modules/interoperability/constants';
+import { MainchainInteroperabilityStore } from '../../../../../../src/modules/interoperability/mainchain/store';
+
+describe('CrossChainUpdateCommand', () => {
+	const getAPIContextMock = jest.fn();
+	const getStoreMock = jest.fn();
+	const moduleID = 1;
+	const networkIdentifier = cryptography.getRandomBytes(32);
+	const defaultCertificateValues: Certificate = {
+		blockID: cryptography.getRandomBytes(20),
+		height: 21,
+		stateRoot: cryptography.getRandomBytes(38),
+		timestamp: Date.now(),
+		validatorsHash: cryptography.getRandomBytes(48),
+		aggregationBits: cryptography.getRandomBytes(38),
+		signature: cryptography.getRandomBytes(32),
+	};
+	const defaultNewCertificateThreshold = BigInt(20);
+	const defaultSendingChainID = 20;
+	const defaultSendingChainIDBuffer = interopUtils.getIDAsKeyForStore(defaultSendingChainID);
+	const defaultInboxUpdateValue = {
+		crossChainMessages: [Buffer.alloc(1)],
+		messageWitness: {
+			partnerChainOutboxSize: BigInt(2),
+			siblingHashes: [Buffer.alloc(1)],
+		},
+		outboxRootWitness: {
+			bitmap: Buffer.alloc(1),
+			siblingHashes: [Buffer.alloc(1)],
+		},
+	};
+	const defaultTransaction = { moduleID: 1 };
+
+	const encodedDefaultCertificate = codec.encode(certificateSchema, defaultCertificateValues);
+
+	const partnerChainStore = {
+		getWithSchema: jest.fn(),
+	};
+
+	const partnerChannelStore = {
+		getWithSchema: jest.fn(),
+	};
+
+	let partnerChainAccount: ChainAccount;
+	let partnerChannelAccount: ChannelData;
+	let context: CommandVerifyContext<CrossChainUpdateTransactionParams>;
+	let mainchainCCUUpdateCommand: MainchainCCUpdateCommand;
+	let params: CrossChainUpdateTransactionParams;
+	let activeValidatorsUpdate: ActiveValidator[];
+	let sortedActiveValidatorsUpdate: ActiveValidator[];
+	// let paramCertificate: Certificate;
+
+	beforeEach(async () => {
+		activeValidatorsUpdate = [
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(1) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+		];
+		sortedActiveValidatorsUpdate = [...activeValidatorsUpdate].sort((v1, v2) =>
+			v1.blsKey.compare(v2.blsKey),
+		);
+		partnerChainAccount = {
+			lastCertificate: {
+				height: 10,
+				stateRoot: cryptography.getRandomBytes(38),
+				timestamp: Date.now(),
+				validatorsHash: cryptography.getRandomBytes(48),
+			},
+			name: 'sidechain1',
+			networkID: cryptography.getRandomBytes(32),
+			status: CHAIN_ACTIVE,
+		};
+		partnerChannelAccount = {
+			inbox: {
+				appendPath: [Buffer.alloc(1), Buffer.alloc(1)],
+				root: cryptography.getRandomBytes(38),
+				size: 18,
+			},
+			messageFeeTokenID: { chainID: 1, localID: 0 },
+			outbox: {
+				appendPath: [Buffer.alloc(1), Buffer.alloc(1)],
+				root: cryptography.getRandomBytes(38),
+				size: 18,
+			},
+			partnerChainOutboxRoot: cryptography.getRandomBytes(38),
+		};
+		// paramCertificate = {
+		//     ...defaultCertificateValues,
+		// }
+		params = {
+			activeValidatorsUpdate: sortedActiveValidatorsUpdate,
+			certificate: encodedDefaultCertificate,
+			inboxUpdate: { ...defaultInboxUpdateValue },
+			newCertificateThreshold: defaultNewCertificateThreshold,
+			sendingChainID: defaultSendingChainID,
+		};
+		context = {
+			getAPIContext: getAPIContextMock,
+			getStore: getStoreMock,
+			logger: testing.mocks.loggerMock,
+			networkIdentifier,
+			params,
+			transaction: defaultTransaction as any,
+		};
+		when(partnerChainStore.getWithSchema)
+			.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
+			.mockResolvedValue(partnerChainAccount);
+
+		when(partnerChannelStore.getWithSchema)
+			.calledWith(defaultSendingChainIDBuffer, channelSchema)
+			.mockResolvedValue(partnerChannelAccount);
+
+		when(getStoreMock)
+			.calledWith(defaultTransaction.moduleID, STORE_PREFIX_CHAIN_DATA)
+			.mockReturnValueOnce(partnerChainStore);
+
+		when(getStoreMock)
+			.calledWith(defaultTransaction.moduleID, STORE_PREFIX_CHANNEL_DATA)
+			.mockReturnValueOnce(partnerChannelStore);
+
+		jest
+			.spyOn(interopUtils, 'checkInboxUpdateValidity')
+			.mockReturnValue({ status: VerifyStatus.OK });
+
+		mainchainCCUUpdateCommand = new MainchainCCUpdateCommand(moduleID, new Map(), new Map());
+		jest.spyOn(MainchainInteroperabilityStore.prototype, 'isLive').mockResolvedValue(true);
+	});
+	describe('verify', () => {
+		it('should return error when ccu params validation fails', async () => {
+			const { status, error } = await mainchainCCUUpdateCommand.verify({
+				...context,
+				params: { ...params, sendingChainID: Buffer.alloc(2) } as any,
+			});
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('.sendingChainID');
+		});
+
+		it('should return error when chain has terminated status', async () => {
+			when(partnerChainStore.getWithSchema)
+				.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
+				.mockResolvedValue({ ...partnerChainAccount, status: CHAIN_TERMINATED });
+
+			const { status, error } = await mainchainCCUUpdateCommand.verify(context);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('Sending partner chain 20 is terminated.');
+		});
+
+		it('should return error when chain is active but not live', async () => {
+			jest.spyOn(MainchainInteroperabilityStore.prototype, 'isLive').mockResolvedValue(false);
+			const { status, error } = await mainchainCCUUpdateCommand.verify(context);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('Sending partner chain 20 is not live');
+		});
+
+		it('should return error checkLivenessRequirementFirstCCU fails', async () => {
+			when(partnerChainStore.getWithSchema)
+				.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
+				.mockResolvedValue({ ...partnerChainAccount, status: CHAIN_REGISTERED });
+
+			const { status, error } = await mainchainCCUUpdateCommand.verify({
+				...context,
+				params: { ...params, certificate: EMPTY_BYTES },
+			});
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				`Sending partner chain ${defaultSendingChainID} is in registered status so certificate cannot be empty.`,
+			);
+		});
+
+		it('should return error checkCertificateValidity fails when certificate height is less than lastCertificateHeight', async () => {
+			const encodedDefaultCertificateWithLowerheight = codec.encode(certificateSchema, {
+				...defaultCertificateValues,
+				height: 9,
+			});
+
+			const { status, error } = await mainchainCCUUpdateCommand.verify({
+				...context,
+				params: { ...params, certificate: encodedDefaultCertificateWithLowerheight },
+			});
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				'Certificate height should be greater than last certificate height.',
+			);
+		});
+
+		it('should return error checkActiveValidatorsUpdate fails when Validators blsKeys are not unique and lexicographically ordered', async () => {
+			const { status, error } = await mainchainCCUUpdateCommand.verify({
+				...context,
+				params: { ...params, activeValidatorsUpdate },
+			});
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				'Validators blsKeys must be unique and lexicographically ordered.',
+			);
+		});
+
+		it('should return error checkInboxUpdateValidity fails', async () => {
+			jest.spyOn(interopUtils, 'checkInboxUpdateValidity').mockReturnValue({
+				status: VerifyStatus.FAIL,
+				error: new Error(
+					'Failed at verifying state root when messageWitness is non-empty and certificate is empty.',
+				),
+			});
+
+			const { status, error } = await mainchainCCUUpdateCommand.verify(context);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				'Failed at verifying state root when messageWitness is non-empty and certificate is empty.',
+			);
+		});
+
+		it('should return Verify.OK when all the checks pass', async () => {
+			const { status, error } = await mainchainCCUUpdateCommand.verify(context);
+
+			expect(status).toEqual(VerifyStatus.OK);
+			expect(error).toBeUndefined();
+		});
+	});
+
+	describe('execute', () => {
+		it('should throw error when checkValidCertificateLiveness() throws error', () => {});
+
+		it('should throw error when checkCertificateTimestampAndSignature() throws error', () => {});
+		it('should throw error when checkValidatorsHashWithCertificate() throws error', () => {});
+		it('should throw error and calls terminateChainInternal() if CCM decoding fails', () => {});
+		it('should throw error when chain.status === CHAIN_REGISTERED and inboxUpdate is non-empty and the first CCM is not a registration CCM', () => {});
+		it('should call terminateChainInternal() for a ccm when txParams.sendingChainID !== ccm.deserilized.sendingChainID', () => {});
+		it('should call terminateChainInternal() for a ccm when it fails on validateFormat', () => {});
+		it('should call forward() when ccm.deserilized.receivingChainID !== MAINCHAIN_ID', () => {});
+		it('should call apply() when ccm.deserilized.receivingChainID === MAINCHAIN_ID', () => {});
+	});
+});

--- a/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
@@ -269,7 +269,7 @@ describe('CrossChainUpdateCommand', () => {
 			});
 			expect(status).toEqual(VerifyStatus.FAIL);
 			expect(error?.message).toContain(
-				`Sending partner chain ${defaultSendingChainID} is in registered status so certificate cannot be empty.`,
+				`Sending partner chain ${defaultSendingChainID} has a registered status so certificate cannot be empty.`,
 			);
 		});
 
@@ -389,14 +389,14 @@ describe('CrossChainUpdateCommand', () => {
 					header: { ...blockHeader, timestamp: blockHeaderWithInvalidTimestamp.timestamp },
 				}),
 			).rejects.toThrow(
-				'Certificate is invalid due to invalid last certified height or timestamp or signature.',
+				'Certificate is invalid due to invalid certificate timestamp or signature.',
 			);
 		});
 
 		it('should throw error when checkValidatorsHashWithCertificate() throws error', async () => {
 			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			await expect(mainchainCCUUpdateCommand.execute(executeContext)).rejects.toThrow(
-				'Validators hash is incorrect given in the certificate.',
+				'Validators hash given in the certificate is incorrect.',
 			);
 		});
 

--- a/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
@@ -243,6 +243,7 @@ describe('CrossChainUpdateCommand', () => {
 
 		jest.spyOn(MainchainInteroperabilityStore.prototype, 'isLive').mockResolvedValue(true);
 		jest.spyOn(interopUtils, 'computeValidatorsHash').mockReturnValue(validatorsHash);
+		jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 	});
 
 	describe('verify', () => {
@@ -345,6 +346,18 @@ describe('CrossChainUpdateCommand', () => {
 			);
 		});
 
+		it('should return VerifyStatus.FAIL when verifyCertificateSignature fails', async () => {
+			jest.spyOn(interopUtils, 'verifyCertificateSignature').mockReturnValue({
+				status: VerifyStatus.FAIL,
+				error: new Error('Certificate is invalid due to invalid signature.'),
+			});
+
+			const { status, error } = await mainchainCCUUpdateCommand.verify(verifyContext);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('Certificate is invalid due to invalid signature.');
+		});
+
 		it('should return error checkInboxUpdateValidity fails', async () => {
 			jest.spyOn(interopUtils, 'checkInboxUpdateValidity').mockReturnValue({
 				status: VerifyStatus.FAIL,
@@ -421,7 +434,7 @@ describe('CrossChainUpdateCommand', () => {
 			).rejects.toThrow('Certificate is not valid as it passed Liveness limit of 2592000 seconds.');
 		});
 
-		it('should throw error when checkCertificateTimestampAndSignature() throws error', async () => {
+		it('should throw error when checkCertificateTimestamp() throws error', async () => {
 			const blockHeaderWithInvalidTimestamp = {
 				height: 25,
 				timestamp: Math.floor(Date.now() / 1000) - LIVENESS_LIMIT,
@@ -431,14 +444,11 @@ describe('CrossChainUpdateCommand', () => {
 					...executeContext,
 					header: { ...blockHeader, timestamp: blockHeaderWithInvalidTimestamp.timestamp },
 				}),
-			).rejects.toThrow(
-				'Certificate is invalid due to invalid certificate timestamp or signature.',
-			);
+			).rejects.toThrow('Certificate is invalid due to invalid timestamp.');
 		});
 
 		it('should throw error and calls terminateChainInternal() if CCM decoding fails', async () => {
 			const invalidCCM = Buffer.from([1]);
-			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			jest
 				.spyOn(interopUtils, 'computeValidatorsHash')
 				.mockReturnValue(defaultCertificateValues.validatorsHash);
@@ -463,7 +473,6 @@ describe('CrossChainUpdateCommand', () => {
 				.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
 				.mockResolvedValue({ ...partnerChainAccount, status: CHAIN_REGISTERED });
 
-			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			jest
 				.spyOn(interopUtils, 'computeValidatorsHash')
 				.mockReturnValue(defaultCertificateValues.validatorsHash);
@@ -486,7 +495,6 @@ describe('CrossChainUpdateCommand', () => {
 				sendingChainID: 50,
 				status: CCM_STATUS_OK,
 			});
-			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			jest
 				.spyOn(interopUtils, 'computeValidatorsHash')
 				.mockReturnValue(defaultCertificateValues.validatorsHash);
@@ -518,7 +526,6 @@ describe('CrossChainUpdateCommand', () => {
 				status: CCM_STATUS_OK,
 			};
 			const invalidCCMSerialized = codec.encode(ccmSchema, invalidCCM);
-			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			jest
 				.spyOn(interopUtils, 'computeValidatorsHash')
 				.mockReturnValue(defaultCertificateValues.validatorsHash);
@@ -558,7 +565,6 @@ describe('CrossChainUpdateCommand', () => {
 				status: CCM_STATUS_OK,
 			};
 			const nonMainchainCCMSerialized = codec.encode(ccmSchema, nonMainchainCCM);
-			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			jest
 				.spyOn(interopUtils, 'computeValidatorsHash')
 				.mockReturnValue(defaultCertificateValues.validatorsHash);
@@ -598,7 +604,6 @@ describe('CrossChainUpdateCommand', () => {
 				status: CCM_STATUS_OK,
 			};
 			const mainchainCCMSerialized = codec.encode(ccmSchema, mainchainCCM);
-			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			jest
 				.spyOn(interopUtils, 'computeValidatorsHash')
 				.mockReturnValue(defaultCertificateValues.validatorsHash);

--- a/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/cc_update.spec.ts
@@ -153,7 +153,8 @@ describe('CrossChainUpdateCommand', () => {
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
-		];
+		].sort((v1, v2) => v2.blsKey.compare(v1.blsKey)); // unsorted list
+
 		sortedActiveValidatorsUpdate = [...activeValidatorsUpdate].sort((v1, v2) =>
 			v1.blsKey.compare(v2.blsKey),
 		);

--- a/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
@@ -152,7 +152,8 @@ describe('CrossChainUpdateCommand', () => {
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
-		];
+		].sort((v1, v2) => v2.blsKey.compare(v1.blsKey)); // unsorted list
+
 		sortedActiveValidatorsUpdate = [...activeValidatorsUpdate].sort((v1, v2) =>
 			v1.blsKey.compare(v2.blsKey),
 		);

--- a/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
@@ -268,7 +268,7 @@ describe('CrossChainUpdateCommand', () => {
 			});
 			expect(status).toEqual(VerifyStatus.FAIL);
 			expect(error?.message).toContain(
-				`Sending partner chain ${defaultSendingChainID} is in registered status so certificate cannot be empty.`,
+				`Sending partner chain ${defaultSendingChainID} has a registered status so certificate cannot be empty.`,
 			);
 		});
 
@@ -388,14 +388,14 @@ describe('CrossChainUpdateCommand', () => {
 					header: { ...blockHeader, timestamp: blockHeaderWithInvalidTimestamp.timestamp },
 				}),
 			).rejects.toThrow(
-				'Certificate is invalid due to invalid last certified height or timestamp or signature.',
+				'Certificate is invalid due to invalid certificate timestamp or signature.',
 			);
 		});
 
 		it('should throw error when checkValidatorsHashWithCertificate() throws error', async () => {
 			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
 			await expect(sidechainCCUUpdateCommand.execute(executeContext)).rejects.toThrow(
-				'Validators hash is incorrect given in the certificate.',
+				'Validators hash given in the certificate is incorrect.',
 			);
 		});
 

--- a/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
@@ -54,6 +54,7 @@ import {
 } from '../../../../../../src/modules/interoperability/constants';
 import { BlockHeader, EventQueue } from '../../../../../../src/node/state_machine';
 import { SidechainInteroperabilityStore } from '../../../../../../src/modules/interoperability/sidechain/store';
+import { computeValidatorsHash } from '../../../../../../src/modules/interoperability/utils';
 
 jest.mock('@liskhq/lisk-cryptography', () => ({
 	...jest.requireActual('@liskhq/lisk-cryptography'),
@@ -122,7 +123,6 @@ describe('CrossChainUpdateCommand', () => {
 		},
 	};
 	const defaultTransaction = { moduleID: 1 };
-	const encodedDefaultCertificate = codec.encode(certificateSchema, defaultCertificateValues);
 
 	const partnerChainStore = {
 		getWithSchema: jest.fn(),
@@ -137,6 +137,7 @@ describe('CrossChainUpdateCommand', () => {
 		setWithSchema: jest.fn(),
 	};
 
+	let encodedDefaultCertificate: Buffer;
 	let partnerChainAccount: ChainAccount;
 	let partnerChannelAccount: ChannelData;
 	let verifyContext: CommandVerifyContext<CrossChainUpdateTransactionParams>;
@@ -153,6 +154,25 @@ describe('CrossChainUpdateCommand', () => {
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
 			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
 		].sort((v1, v2) => v2.blsKey.compare(v1.blsKey)); // unsorted list
+		const partnerValidators: any = {
+			certificateThreshold: BigInt(10),
+			activeValidators: activeValidatorsUpdate.map(v => ({
+				blsKey: v.blsKey,
+				bftWeight: v.bftWeight + BigInt(1),
+			})),
+		};
+		const partnerValidatorsData = {
+			activeValidators: [...activeValidatorsUpdate],
+			certificateThreshold: BigInt(10),
+		};
+		const validatorsHash = computeValidatorsHash(
+			activeValidatorsUpdate,
+			partnerValidators.certificateThreshold,
+		);
+		encodedDefaultCertificate = codec.encode(certificateSchema, {
+			...defaultCertificateValues,
+			validatorsHash,
+		});
 
 		sortedActiveValidatorsUpdate = [...activeValidatorsUpdate].sort((v1, v2) =>
 			v1.blsKey.compare(v2.blsKey),
@@ -207,11 +227,21 @@ describe('CrossChainUpdateCommand', () => {
 			.calledWith(defaultTransaction.moduleID, STORE_PREFIX_CHANNEL_DATA)
 			.mockReturnValueOnce(partnerChannelStore);
 
+		when(getStoreMock)
+			.calledWith(moduleID, STORE_PREFIX_CHAIN_VALIDATORS)
+			.mockReturnValueOnce(partnerValidatorStore);
+
+		when(partnerValidatorStore.getWithSchema)
+			.calledWith(defaultSendingChainIDBuffer, chainValidatorsSchema)
+			.mockResolvedValue(partnerValidatorsData);
+
 		jest
 			.spyOn(interopUtils, 'checkInboxUpdateValidity')
 			.mockReturnValue({ status: VerifyStatus.OK });
 
 		jest.spyOn(SidechainInteroperabilityStore.prototype, 'isLive').mockResolvedValue(true);
+
+		jest.spyOn(interopUtils, 'computeValidatorsHash').mockReturnValue(validatorsHash);
 	});
 
 	describe('verify', () => {
@@ -288,6 +318,20 @@ describe('CrossChainUpdateCommand', () => {
 			);
 		});
 
+		it('should return VerifyStatus.FAIL when checkValidatorsHashWithCertificate() throws error', async () => {
+			const certificateWithIncorrectValidatorHash = codec.encode(certificateSchema, {
+				...defaultCertificateValues,
+				validatorsHash: cryptography.getRandomBytes(48),
+			});
+
+			const { status, error } = await sidechainCCUUpdateCommand.verify({
+				...verifyContext,
+				params: { ...params, certificate: certificateWithIncorrectValidatorHash },
+			});
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('Validators hash given in the certificate is incorrect.');
+		});
+
 		it('should return error checkActiveValidatorsUpdate fails when Validators blsKeys are not unique and lexicographically ordered', async () => {
 			const { status, error } = await sidechainCCUUpdateCommand.verify({
 				...verifyContext,
@@ -326,21 +370,20 @@ describe('CrossChainUpdateCommand', () => {
 
 	describe('execute', () => {
 		let blockHeader: any;
-		let partnerValidatorsData: ChainValidators;
-		let activeValidators: ActiveValidator[];
+		let partnerValidatorsDataVerify: ChainValidators;
+		let activeValidatorsVerify: ActiveValidator[];
 
 		beforeEach(async () => {
-			activeValidators = [...activeValidatorsUpdate];
+			activeValidatorsVerify = [...activeValidatorsUpdate];
 			blockHeader = {
 				height: 25,
 				timestamp: Math.floor(Date.now() / 1000) + 100000,
 			};
 
-			partnerValidatorsData = {
-				activeValidators,
+			partnerValidatorsDataVerify = {
+				activeValidators: activeValidatorsVerify,
 				certificateThreshold: BigInt(10),
 			};
-
 			executeContext = {
 				getAPIContext: getAPIContextMock,
 				getStore: getStoreMock,
@@ -353,13 +396,13 @@ describe('CrossChainUpdateCommand', () => {
 				header: blockHeader as BlockHeader,
 			};
 
-			when(partnerValidatorStore.getWithSchema)
-				.calledWith(defaultSendingChainIDBuffer, chainValidatorsSchema)
-				.mockResolvedValue(partnerValidatorsData);
-
 			when(getStoreMock)
 				.calledWith(defaultTransaction.moduleID, STORE_PREFIX_CHAIN_VALIDATORS)
 				.mockReturnValueOnce(partnerValidatorStore);
+
+			when(partnerValidatorStore.getWithSchema)
+				.calledWith(defaultSendingChainIDBuffer, chainValidatorsSchema)
+				.mockResolvedValue(partnerValidatorsDataVerify);
 
 			sidechainCCUUpdateCommand = new SidechainCCUpdateCommand(moduleID, new Map(), new Map());
 		});
@@ -389,13 +432,6 @@ describe('CrossChainUpdateCommand', () => {
 				}),
 			).rejects.toThrow(
 				'Certificate is invalid due to invalid certificate timestamp or signature.',
-			);
-		});
-
-		it('should throw error when checkValidatorsHashWithCertificate() throws error', async () => {
-			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
-			await expect(sidechainCCUUpdateCommand.execute(executeContext)).rejects.toThrow(
-				'Validators hash given in the certificate is incorrect.',
 			);
 		});
 

--- a/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/cc_update.spec.ts
@@ -1,0 +1,555 @@
+/*
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { when } from 'jest-when';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import { codec } from '@liskhq/lisk-codec';
+import { BlockAssets } from '@liskhq/lisk-chain';
+import {
+	CommandExecuteContext,
+	CommandVerifyContext,
+	testing,
+	VerifyStatus,
+} from '../../../../../../src';
+import {
+	ActiveValidator,
+	CCMsg,
+	ChainAccount,
+	ChainValidators,
+	ChannelData,
+	CrossChainUpdateTransactionParams,
+} from '../../../../../../src/modules/interoperability/types';
+import { SidechainCCUpdateCommand } from '../../../../../../src/modules/interoperability/sidechain/commands/cc_update';
+import { Certificate } from '../../../../../../src/node/consensus/certificate_generation/types';
+import { certificateSchema } from '../../../../../../src/node/consensus/certificate_generation/schema';
+import * as interopUtils from '../../../../../../src/modules/interoperability/utils';
+import {
+	ccmSchema,
+	chainAccountSchema,
+	chainValidatorsSchema,
+	channelSchema,
+} from '../../../../../../src/modules/interoperability/schema';
+import {
+	CCM_STATUS_OK,
+	CHAIN_ACTIVE,
+	CHAIN_REGISTERED,
+	CHAIN_TERMINATED,
+	EMPTY_BYTES,
+	LIVENESS_LIMIT,
+	MAX_CCM_SIZE,
+	STORE_PREFIX_CHAIN_DATA,
+	STORE_PREFIX_CHAIN_VALIDATORS,
+	STORE_PREFIX_CHANNEL_DATA,
+} from '../../../../../../src/modules/interoperability/constants';
+import { BlockHeader, EventQueue } from '../../../../../../src/node/state_machine';
+import { SidechainInteroperabilityStore } from '../../../../../../src/modules/interoperability/sidechain/store';
+
+jest.mock('@liskhq/lisk-cryptography', () => ({
+	...jest.requireActual('@liskhq/lisk-cryptography'),
+}));
+
+describe('CrossChainUpdateCommand', () => {
+	const getAPIContextMock = jest.fn();
+	const getStoreMock = jest.fn();
+	const moduleID = 1;
+	const networkIdentifier = cryptography.getRandomBytes(32);
+	const defaultCertificateValues: Certificate = {
+		blockID: cryptography.getRandomBytes(20),
+		height: 21,
+		timestamp: Math.floor(Date.now() / 1000),
+		stateRoot: cryptography.getRandomBytes(38),
+		validatorsHash: cryptography.getRandomBytes(48),
+		aggregationBits: cryptography.getRandomBytes(38),
+		signature: cryptography.getRandomBytes(32),
+	};
+
+	const defaultNewCertificateThreshold = BigInt(20);
+	const defaultSendingChainID = 20;
+	const defaultSendingChainIDBuffer = interopUtils.getIDAsKeyForStore(defaultSendingChainID);
+	const defaultCCMs: CCMsg[] = [
+		{
+			crossChainCommandID: 1,
+			fee: BigInt(0),
+			moduleID: 1,
+			nonce: BigInt(1),
+			params: Buffer.alloc(2),
+			receivingChainID: 2,
+			sendingChainID: defaultSendingChainID,
+			status: CCM_STATUS_OK,
+		},
+		{
+			crossChainCommandID: 2,
+			fee: BigInt(0),
+			moduleID: 1,
+			nonce: BigInt(1),
+			params: Buffer.alloc(2),
+			receivingChainID: 3,
+			sendingChainID: defaultSendingChainID,
+			status: CCM_STATUS_OK,
+		},
+		{
+			crossChainCommandID: 3,
+			fee: BigInt(0),
+			moduleID: 1,
+			nonce: BigInt(1),
+			params: Buffer.alloc(2),
+			receivingChainID: 4,
+			sendingChainID: defaultSendingChainID,
+			status: CCM_STATUS_OK,
+		},
+	];
+	const defaultCCMsEncoded = defaultCCMs.map(ccm => codec.encode(ccmSchema, ccm));
+	const defaultInboxUpdateValue = {
+		crossChainMessages: defaultCCMsEncoded,
+		messageWitness: {
+			partnerChainOutboxSize: BigInt(2),
+			siblingHashes: [Buffer.alloc(1)],
+		},
+		outboxRootWitness: {
+			bitmap: Buffer.alloc(1),
+			siblingHashes: [Buffer.alloc(1)],
+		},
+	};
+	const defaultTransaction = { moduleID: 1 };
+	const encodedDefaultCertificate = codec.encode(certificateSchema, defaultCertificateValues);
+
+	const partnerChainStore = {
+		getWithSchema: jest.fn(),
+	};
+
+	const partnerChannelStore = {
+		getWithSchema: jest.fn(),
+	};
+
+	const partnerValidatorStore = {
+		getWithSchema: jest.fn(),
+		setWithSchema: jest.fn(),
+	};
+
+	let partnerChainAccount: ChainAccount;
+	let partnerChannelAccount: ChannelData;
+	let verifyContext: CommandVerifyContext<CrossChainUpdateTransactionParams>;
+	let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
+	let sidechainCCUUpdateCommand: SidechainCCUpdateCommand;
+	let params: CrossChainUpdateTransactionParams;
+	let activeValidatorsUpdate: ActiveValidator[];
+	let sortedActiveValidatorsUpdate: ActiveValidator[];
+
+	beforeEach(async () => {
+		activeValidatorsUpdate = [
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(1) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+		];
+		sortedActiveValidatorsUpdate = [...activeValidatorsUpdate].sort((v1, v2) =>
+			v1.blsKey.compare(v2.blsKey),
+		);
+		partnerChainAccount = {
+			lastCertificate: {
+				height: 10,
+				stateRoot: cryptography.getRandomBytes(38),
+				timestamp: Math.floor(Date.now() / 1000),
+				validatorsHash: cryptography.getRandomBytes(48),
+			},
+			name: 'sidechain1',
+			networkID: cryptography.getRandomBytes(32),
+			status: CHAIN_ACTIVE,
+		};
+		partnerChannelAccount = {
+			inbox: {
+				appendPath: [Buffer.alloc(1), Buffer.alloc(1)],
+				root: cryptography.getRandomBytes(38),
+				size: 18,
+			},
+			messageFeeTokenID: { chainID: 1, localID: 0 },
+			outbox: {
+				appendPath: [Buffer.alloc(1), Buffer.alloc(1)],
+				root: cryptography.getRandomBytes(38),
+				size: 18,
+			},
+			partnerChainOutboxRoot: cryptography.getRandomBytes(38),
+		};
+
+		params = {
+			activeValidatorsUpdate: sortedActiveValidatorsUpdate,
+			certificate: encodedDefaultCertificate,
+			inboxUpdate: { ...defaultInboxUpdateValue },
+			newCertificateThreshold: defaultNewCertificateThreshold,
+			sendingChainID: defaultSendingChainID,
+		};
+
+		when(partnerChainStore.getWithSchema)
+			.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
+			.mockResolvedValue(partnerChainAccount);
+
+		when(partnerChannelStore.getWithSchema)
+			.calledWith(defaultSendingChainIDBuffer, channelSchema)
+			.mockResolvedValue(partnerChannelAccount);
+
+		when(getStoreMock)
+			.calledWith(defaultTransaction.moduleID, STORE_PREFIX_CHAIN_DATA)
+			.mockReturnValueOnce(partnerChainStore);
+
+		when(getStoreMock)
+			.calledWith(defaultTransaction.moduleID, STORE_PREFIX_CHANNEL_DATA)
+			.mockReturnValueOnce(partnerChannelStore);
+
+		jest
+			.spyOn(interopUtils, 'checkInboxUpdateValidity')
+			.mockReturnValue({ status: VerifyStatus.OK });
+
+		jest.spyOn(SidechainInteroperabilityStore.prototype, 'isLive').mockResolvedValue(true);
+	});
+
+	describe('verify', () => {
+		beforeEach(() => {
+			verifyContext = {
+				getAPIContext: getAPIContextMock,
+				getStore: getStoreMock,
+				logger: testing.mocks.loggerMock,
+				networkIdentifier,
+				params,
+				transaction: defaultTransaction as any,
+			};
+			jest.spyOn(SidechainInteroperabilityStore.prototype, 'isLive').mockResolvedValue(true);
+			sidechainCCUUpdateCommand = new SidechainCCUpdateCommand(moduleID, new Map(), new Map());
+		});
+
+		it('should return error when ccu params validation fails', async () => {
+			const { status, error } = await sidechainCCUUpdateCommand.verify({
+				...verifyContext,
+				params: { ...params, sendingChainID: Buffer.alloc(2) } as any,
+			});
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('.sendingChainID');
+		});
+
+		it('should return error when chain has terminated status', async () => {
+			when(partnerChainStore.getWithSchema)
+				.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
+				.mockResolvedValue({ ...partnerChainAccount, status: CHAIN_TERMINATED });
+
+			const { status, error } = await sidechainCCUUpdateCommand.verify(verifyContext);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('Sending partner chain 20 is terminated.');
+		});
+
+		it('should return error when chain is active but not live', async () => {
+			jest.spyOn(SidechainInteroperabilityStore.prototype, 'isLive').mockResolvedValue(false);
+			const { status, error } = await sidechainCCUUpdateCommand.verify(verifyContext);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain('Sending partner chain 20 is not live');
+		});
+
+		it('should return error checkLivenessRequirementFirstCCU fails', async () => {
+			when(partnerChainStore.getWithSchema)
+				.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
+				.mockResolvedValue({ ...partnerChainAccount, status: CHAIN_REGISTERED });
+
+			const { status, error } = await sidechainCCUUpdateCommand.verify({
+				...verifyContext,
+				params: { ...params, certificate: EMPTY_BYTES },
+			});
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				`Sending partner chain ${defaultSendingChainID} is in registered status so certificate cannot be empty.`,
+			);
+		});
+
+		it('should return error checkCertificateValidity fails when certificate height is less than lastCertificateHeight', async () => {
+			const encodedDefaultCertificateWithLowerheight = codec.encode(certificateSchema, {
+				...defaultCertificateValues,
+				height: 9,
+			});
+
+			const { status, error } = await sidechainCCUUpdateCommand.verify({
+				...verifyContext,
+				params: { ...params, certificate: encodedDefaultCertificateWithLowerheight },
+			});
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				'Certificate height should be greater than last certificate height.',
+			);
+		});
+
+		it('should return error checkActiveValidatorsUpdate fails when Validators blsKeys are not unique and lexicographically ordered', async () => {
+			const { status, error } = await sidechainCCUUpdateCommand.verify({
+				...verifyContext,
+				params: { ...params, activeValidatorsUpdate },
+			});
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				'Validators blsKeys must be unique and lexicographically ordered.',
+			);
+		});
+
+		it('should return error checkInboxUpdateValidity fails', async () => {
+			jest.spyOn(interopUtils, 'checkInboxUpdateValidity').mockReturnValue({
+				status: VerifyStatus.FAIL,
+				error: new Error(
+					'Failed at verifying state root when messageWitness is non-empty and certificate is empty.',
+				),
+			});
+
+			const { status, error } = await sidechainCCUUpdateCommand.verify(verifyContext);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toContain(
+				'Failed at verifying state root when messageWitness is non-empty and certificate is empty.',
+			);
+		});
+
+		it('should return Verify.OK when all the checks pass', async () => {
+			const { status, error } = await sidechainCCUUpdateCommand.verify(verifyContext);
+
+			expect(status).toEqual(VerifyStatus.OK);
+			expect(error).toBeUndefined();
+		});
+	});
+
+	describe('execute', () => {
+		let blockHeader: any;
+		let partnerValidatorsData: ChainValidators;
+		let activeValidators: ActiveValidator[];
+
+		beforeEach(async () => {
+			activeValidators = [...activeValidatorsUpdate];
+			blockHeader = {
+				height: 25,
+				timestamp: Math.floor(Date.now() / 1000) + 100000,
+			};
+
+			partnerValidatorsData = {
+				activeValidators,
+				certificateThreshold: BigInt(10),
+			};
+
+			executeContext = {
+				getAPIContext: getAPIContextMock,
+				getStore: getStoreMock,
+				logger: testing.mocks.loggerMock,
+				networkIdentifier,
+				params,
+				transaction: defaultTransaction as any,
+				assets: new BlockAssets(),
+				eventQueue: new EventQueue(),
+				header: blockHeader as BlockHeader,
+			};
+
+			when(partnerValidatorStore.getWithSchema)
+				.calledWith(defaultSendingChainIDBuffer, chainValidatorsSchema)
+				.mockResolvedValue(partnerValidatorsData);
+
+			when(getStoreMock)
+				.calledWith(defaultTransaction.moduleID, STORE_PREFIX_CHAIN_VALIDATORS)
+				.mockReturnValueOnce(partnerValidatorStore);
+
+			sidechainCCUUpdateCommand = new SidechainCCUpdateCommand(moduleID, new Map(), new Map());
+		});
+
+		it('should throw error when checkValidCertificateLiveness() throws error', async () => {
+			const blockHeaderWithInvalidTimestamp = {
+				height: 25,
+				timestamp: Math.floor(Date.now() / 1000) + LIVENESS_LIMIT,
+			};
+			await expect(
+				sidechainCCUUpdateCommand.execute({
+					...executeContext,
+					header: { ...blockHeader, timestamp: blockHeaderWithInvalidTimestamp.timestamp },
+				}),
+			).rejects.toThrow('Certificate is not valid as it passed Liveness limit of 2592000 seconds.');
+		});
+
+		it('should throw error when checkCertificateTimestampAndSignature() throws error', async () => {
+			const blockHeaderWithInvalidTimestamp = {
+				height: 25,
+				timestamp: Math.floor(Date.now() / 1000) - LIVENESS_LIMIT,
+			};
+			await expect(
+				sidechainCCUUpdateCommand.execute({
+					...executeContext,
+					header: { ...blockHeader, timestamp: blockHeaderWithInvalidTimestamp.timestamp },
+				}),
+			).rejects.toThrow(
+				'Certificate is invalid due to invalid last certified height or timestamp or signature.',
+			);
+		});
+
+		it('should throw error when checkValidatorsHashWithCertificate() throws error', async () => {
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
+			await expect(sidechainCCUUpdateCommand.execute(executeContext)).rejects.toThrow(
+				'Validators hash is incorrect given in the certificate.',
+			);
+		});
+
+		it('should throw error and calls terminateChainInternal() if CCM decoding fails', async () => {
+			const invalidCCM = Buffer.from([1]);
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
+			jest
+				.spyOn(interopUtils, 'computeValidatorsHash')
+				.mockReturnValue(defaultCertificateValues.validatorsHash);
+			const terminateChainInternalMock = jest
+				.spyOn(SidechainInteroperabilityStore.prototype, 'terminateChainInternal')
+				.mockResolvedValue({} as never);
+			const invalidCCMContext = {
+				...executeContext,
+				params: {
+					...executeContext.params,
+					inboxUpdate: { ...executeContext.params.inboxUpdate, crossChainMessages: [invalidCCM] },
+				},
+			};
+			await expect(sidechainCCUUpdateCommand.execute(invalidCCMContext)).rejects.toThrow(
+				'Value yields unsupported wireType',
+			);
+			expect(terminateChainInternalMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('should throw error when chain.status === CHAIN_REGISTERED and inboxUpdate is non-empty and the first CCM is not a registration CCM', async () => {
+			when(partnerChainStore.getWithSchema)
+				.calledWith(defaultSendingChainIDBuffer, chainAccountSchema)
+				.mockResolvedValue({ ...partnerChainAccount, status: CHAIN_REGISTERED });
+
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
+			jest
+				.spyOn(interopUtils, 'computeValidatorsHash')
+				.mockReturnValue(defaultCertificateValues.validatorsHash);
+			const terminateChainInternalMock = jest
+				.spyOn(SidechainInteroperabilityStore.prototype, 'terminateChainInternal')
+				.mockResolvedValue({} as never);
+
+			await expect(sidechainCCUUpdateCommand.execute(executeContext)).resolves.toBeUndefined();
+			expect(terminateChainInternalMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call terminateChainInternal() for a ccm when txParams.sendingChainID !== ccm.deserilized.sendingChainID', async () => {
+			const invalidCCM = codec.encode(ccmSchema, {
+				crossChainCommandID: 1,
+				fee: BigInt(0),
+				moduleID: 1,
+				nonce: BigInt(1),
+				params: Buffer.alloc(2),
+				receivingChainID: 2,
+				sendingChainID: 50,
+				status: CCM_STATUS_OK,
+			});
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
+			jest
+				.spyOn(interopUtils, 'computeValidatorsHash')
+				.mockReturnValue(defaultCertificateValues.validatorsHash);
+			jest.spyOn(interopUtils, 'commonCCUExecutelogic').mockReturnValue({} as never);
+			const terminateChainInternalMock = jest
+				.spyOn(SidechainInteroperabilityStore.prototype, 'terminateChainInternal')
+				.mockResolvedValue({} as never);
+
+			const invalidCCMContext = {
+				...executeContext,
+				params: {
+					...executeContext.params,
+					inboxUpdate: { ...executeContext.params.inboxUpdate, crossChainMessages: [invalidCCM] },
+				},
+			};
+			await expect(sidechainCCUUpdateCommand.execute(invalidCCMContext)).resolves.toBeUndefined();
+			expect(terminateChainInternalMock).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call terminateChainInternal() for a ccm when it fails on validateFormat', async () => {
+			const invalidCCM = {
+				crossChainCommandID: 1,
+				fee: BigInt(0),
+				moduleID: 1,
+				nonce: BigInt(1),
+				params: Buffer.alloc(MAX_CCM_SIZE + 10),
+				receivingChainID: 2,
+				sendingChainID: defaultSendingChainID,
+				status: CCM_STATUS_OK,
+			};
+			const invalidCCMSerialized = codec.encode(ccmSchema, invalidCCM);
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
+			jest
+				.spyOn(interopUtils, 'computeValidatorsHash')
+				.mockReturnValue(defaultCertificateValues.validatorsHash);
+			jest.spyOn(interopUtils, 'commonCCUExecutelogic').mockReturnValue({} as never);
+
+			const terminateChainInternalMock = jest
+				.spyOn(SidechainInteroperabilityStore.prototype, 'terminateChainInternal')
+				.mockResolvedValue({} as never);
+
+			const invalidCCMContext = {
+				...executeContext,
+				params: {
+					...executeContext.params,
+					inboxUpdate: {
+						...executeContext.params.inboxUpdate,
+						crossChainMessages: [invalidCCMSerialized],
+					},
+				},
+			};
+			await expect(sidechainCCUUpdateCommand.execute(invalidCCMContext)).resolves.toBeUndefined();
+			expect(terminateChainInternalMock).toHaveBeenCalledTimes(1);
+			expect(terminateChainInternalMock).toHaveBeenCalledWith(
+				invalidCCM.sendingChainID,
+				expect.any(Object),
+			);
+		});
+
+		it('should call apply() for all the valid CCMs', async () => {
+			const sidechainCCM = {
+				crossChainCommandID: 1,
+				fee: BigInt(0),
+				moduleID: 1,
+				nonce: BigInt(1),
+				params: Buffer.alloc(10),
+				receivingChainID: 80,
+				sendingChainID: defaultSendingChainID,
+				status: CCM_STATUS_OK,
+			};
+			const sidechainCCMSerialized = codec.encode(ccmSchema, sidechainCCM);
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
+			jest
+				.spyOn(interopUtils, 'computeValidatorsHash')
+				.mockReturnValue(defaultCertificateValues.validatorsHash);
+			const commonCCUExecutelogicMock = jest
+				.spyOn(interopUtils, 'commonCCUExecutelogic')
+				.mockReturnValue({} as never);
+
+			const appendToInboxTreeMock = jest
+				.spyOn(SidechainInteroperabilityStore.prototype, 'appendToInboxTree')
+				.mockResolvedValue({} as never);
+			const applyMock = jest
+				.spyOn(SidechainInteroperabilityStore.prototype, 'apply')
+				.mockResolvedValue({} as never);
+
+			const invalidCCMContext = {
+				...executeContext,
+				params: {
+					...executeContext.params,
+					inboxUpdate: {
+						...executeContext.params.inboxUpdate,
+						crossChainMessages: [sidechainCCMSerialized],
+					},
+				},
+			};
+			await expect(sidechainCCUUpdateCommand.execute(invalidCCMContext)).resolves.toBeUndefined();
+			expect(appendToInboxTreeMock).toHaveBeenCalledTimes(1);
+			expect(applyMock).toHaveBeenCalledTimes(1);
+			expect(applyMock).toHaveBeenCalledTimes(1);
+			expect(commonCCUExecutelogicMock).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/framework/test/unit/modules/interoperability/sidechain/commands/mainchain_registration.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/mainchain_registration.spec.ts
@@ -245,6 +245,7 @@ describe('Mainchain registration command', () => {
 		];
 		const mockBFTAPI = {
 			getBFTParameters: jest.fn(),
+			setBFTParameters: jest.fn(),
 		};
 		const mockValidatorsAPI = {
 			getValidatorAccount: jest.fn(),

--- a/framework/test/unit/modules/interoperability/utils.spec.ts
+++ b/framework/test/unit/modules/interoperability/utils.spec.ts
@@ -381,9 +381,7 @@ describe('Utils', () => {
 					certificate,
 					header,
 				),
-			).toThrow(
-				'Certificate is invalid due to invalid last certified height or timestamp or signature.',
-			);
+			).toThrow('Certificate is invalid due to invalid certificate timestamp or signature');
 			expect(cryptography.verifyWeightedAggSig).toHaveBeenCalledTimes(1);
 		});
 
@@ -398,9 +396,7 @@ describe('Utils', () => {
 					certificateWithHigherTimestamp,
 					header,
 				),
-			).toThrow(
-				'Certificate is invalid due to invalid last certified height or timestamp or signature.',
-			);
+			).toThrow('Certificate is invalid due to invalid certificate timestamp or signature');
 			expect(cryptography.verifyWeightedAggSig).toHaveBeenCalledTimes(1);
 		});
 	});
@@ -439,7 +435,7 @@ describe('Utils', () => {
 					{ ...certificate, validatorsHash: cryptography.getRandomBytes(32) },
 					partnerValidators,
 				),
-			).toThrow('Validators hash is incorrect given in the certificate.');
+			).toThrow('Validators hash given in the certificate is incorrect.');
 		});
 
 		it('should return undefined when validators hash is correct', () => {

--- a/framework/test/unit/modules/interoperability/utils.spec.ts
+++ b/framework/test/unit/modules/interoperability/utils.spec.ts
@@ -22,7 +22,6 @@ import {
 	EMPTY_BYTES,
 	LIVENESS_LIMIT,
 	STORE_PREFIX_CHANNEL_DATA,
-	VALID_BLS_KEY_LENGTH,
 } from '../../../../src/modules/interoperability/constants';
 import { channelSchema } from '../../../../src/modules/interoperability/schema';
 import {
@@ -214,12 +213,6 @@ describe('Utils', () => {
 		const sortedValidatorsList = [...activeValidatorsUpdate].sort((v1, v2) =>
 			v1.blsKey.compare(v2.blsKey),
 		);
-		const activeValidatorsUpdateWithInvalidKeyLength = [
-			{ blsKey: cryptography.getRandomBytes(16), bftWeight: BigInt(1) },
-			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
-			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
-			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
-		];
 
 		const txParams = {
 			activeValidatorsUpdate,
@@ -245,14 +238,6 @@ describe('Utils', () => {
 			inboxUpdate: {},
 		};
 
-		const txParamsWithInvalidActiveValidatorsKeyLength = {
-			activeValidatorsUpdate: activeValidatorsUpdateWithInvalidKeyLength,
-			newCertificateThreshold: BigInt(10),
-			certificate: Buffer.alloc(2),
-			sendingChainID: 2,
-			inboxUpdate: {},
-		};
-
 		it('should return VerifyStatus.FAIL when certificate is empty', () => {
 			const { status, error } = checkActiveValidatorsUpdate(
 				txParamsWithEmptyCertificate as CrossChainUpdateTransactionParams,
@@ -260,17 +245,8 @@ describe('Utils', () => {
 
 			expect(status).toEqual(VerifyStatus.FAIL);
 			expect(error?.message).toEqual(
-				'Certificate cannot be empty when activeValidatorsUpdate is non-empty or newCertificateThreshold >0.',
+				'Certificate cannot be empty when activeValidatorsUpdate is non-empty or newCertificateThreshold > 0.',
 			);
-		});
-
-		it('should return VerifyStatus.FAIL for invalid key validator blsKey', () => {
-			const { status, error } = checkActiveValidatorsUpdate(
-				txParamsWithInvalidActiveValidatorsKeyLength as CrossChainUpdateTransactionParams,
-			);
-
-			expect(status).toEqual(VerifyStatus.FAIL);
-			expect(error?.message).toEqual(`BlsKey length should be equal to ${VALID_BLS_KEY_LENGTH}.`);
 		});
 
 		it('should return VerifyStatus.FAIL when validators blsKeys are not unique and lexicographically ordered', () => {

--- a/framework/test/unit/modules/interoperability/utils.spec.ts
+++ b/framework/test/unit/modules/interoperability/utils.spec.ts
@@ -12,17 +12,54 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { getRandomBytes } from '@liskhq/lisk-cryptography';
-import { updateActiveValidators } from '../../../../src/modules/interoperability/utils';
+import { codec } from '@liskhq/lisk-codec';
+import * as cryptography from '@liskhq/lisk-cryptography';
+import * as merkleTree from '@liskhq/lisk-tree';
+import { when } from 'jest-when';
+import { VerifyStatus } from '../../../../src';
+import {
+	CHAIN_REGISTERED,
+	EMPTY_BYTES,
+	LIVENESS_LIMIT,
+	STORE_PREFIX_CHANNEL_DATA,
+	VALID_BLS_KEY_LENGTH,
+} from '../../../../src/modules/interoperability/constants';
+import { channelSchema } from '../../../../src/modules/interoperability/schema';
+import {
+	ChainAccount,
+	CrossChainUpdateTransactionParams,
+	InboxUpdate,
+} from '../../../../src/modules/interoperability/types';
+import {
+	checkActiveValidatorsUpdate,
+	checkCertificateTimestampAndSignature,
+	checkCertificateValidity,
+	checkLivenessRequirementFirstCCU,
+	checkValidatorsHashWithCertificate,
+	checkValidCertificateLiveness,
+	commonCCUExecutelogic,
+	computeValidatorsHash,
+	getIDAsKeyForStore,
+	updateActiveValidators,
+} from '../../../../src/modules/interoperability/utils';
+import { certificateSchema } from '../../../../src/node/consensus/certificate_generation/schema';
+
+jest.mock('@liskhq/lisk-cryptography', () => ({
+	...jest.requireActual('@liskhq/lisk-cryptography'),
+}));
+
+jest.mock('@liskhq/lisk-tree', () => ({
+	...jest.requireActual('@liskhq/lisk-tree'),
+}));
 
 describe('Utils', () => {
 	describe('updateActiveValidators', () => {
 		const validator1 = {
-			blsKey: getRandomBytes(48),
+			blsKey: cryptography.getRandomBytes(48),
 			bftWeight: BigInt(1),
 		};
 		const validator2 = {
-			blsKey: getRandomBytes(48),
+			blsKey: cryptography.getRandomBytes(48),
 			bftWeight: BigInt(2),
 		};
 		const activeValidators = [validator1, validator2];
@@ -39,7 +76,7 @@ describe('Utils', () => {
 			const activeValidatorsUpdate = [
 				validator1,
 				validator2,
-				{ blsKey: getRandomBytes(48), bftWeight: BigInt(1) },
+				{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(1) },
 			];
 
 			// Should be in lexicographical order
@@ -52,7 +89,7 @@ describe('Utils', () => {
 
 		it('should remove a validator when its bftWeight=0', () => {
 			const activeValidatorsLocal = [...activeValidators];
-			const validator3 = { blsKey: getRandomBytes(48), bftWeight: BigInt(3) };
+			const validator3 = { blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) };
 			activeValidatorsLocal.push(validator3);
 			const activeValidatorsUpdate = [
 				validator1,
@@ -66,6 +103,623 @@ describe('Utils', () => {
 
 			const validator3Exists = updatedValidators.some(v => v.blsKey.equals(validator3.blsKey));
 			expect(validator3Exists).toEqual(false);
+		});
+	});
+
+	describe('checkLivenessRequirementFirstCCU', () => {
+		const partnerChainAccount = {
+			status: CHAIN_REGISTERED,
+		};
+
+		const txParamsEmptyCertificate = {
+			certificate: EMPTY_BYTES,
+		};
+
+		const txParamsNonEmptyCertificate = {
+			certificate: cryptography.getRandomBytes(32),
+		};
+
+		it(`should return VerifyStatus.FAIL status when chain status ${CHAIN_REGISTERED} && certificate is empty`, () => {
+			const result = checkLivenessRequirementFirstCCU(
+				partnerChainAccount as ChainAccount,
+				txParamsEmptyCertificate as CrossChainUpdateTransactionParams,
+			);
+			expect(result.status).toEqual(VerifyStatus.FAIL);
+		});
+
+		it(`should return status VerifyStatus.OK status when chain status ${CHAIN_REGISTERED} && certificate is non-empty`, () => {
+			const result = checkLivenessRequirementFirstCCU(
+				partnerChainAccount as ChainAccount,
+				txParamsNonEmptyCertificate as CrossChainUpdateTransactionParams,
+			);
+			expect(result.status).toEqual(VerifyStatus.OK);
+		});
+	});
+
+	describe('checkCertificateValidity', () => {
+		const partnerChainAccount = {
+			lastCertificate: {
+				height: 20,
+			},
+		};
+
+		const partnerChainAccountWithHigherHeight = {
+			lastCertificate: {
+				height: 40,
+			},
+		};
+
+		const certificate = {
+			blockID: cryptography.getRandomBytes(20),
+			height: 23,
+			stateRoot: Buffer.alloc(2),
+			timestamp: Date.now(),
+			validatorsHash: cryptography.getRandomBytes(20),
+		};
+
+		const certificateWithEmptyValues = {
+			blockID: cryptography.getRandomBytes(20),
+			height: 23,
+			stateRoot: EMPTY_BYTES,
+			timestamp: Date.now(),
+			validatorsHash: EMPTY_BYTES,
+		};
+
+		const encodedCertificate = codec.encode(certificateSchema, certificate);
+		const encodedWithEmptyValuesCertificate = codec.encode(
+			certificateSchema,
+			certificateWithEmptyValues,
+		);
+
+		it('should return VerifyStatus.FAIL when certificate required properties are missing', () => {
+			const { status, error } = checkCertificateValidity(
+				partnerChainAccount as ChainAccount,
+				encodedWithEmptyValuesCertificate,
+			);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toEqual('Certificate is missing required values.');
+		});
+
+		it('should return VerifyStatus.FAIL when certificate height is less than or equal to last certificate height', () => {
+			const { status, error } = checkCertificateValidity(
+				partnerChainAccountWithHigherHeight as ChainAccount,
+				encodedCertificate,
+			);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toEqual(
+				'Certificate height should be greater than last certificate height.',
+			);
+		});
+
+		it('should return VerifyStatus.OK when certificate has all values and height greater than last certificate height', () => {
+			const { status, error } = checkCertificateValidity(
+				partnerChainAccount as ChainAccount,
+				encodedCertificate,
+			);
+
+			expect(status).toEqual(VerifyStatus.OK);
+			expect(error).toBeUndefined();
+		});
+	});
+
+	describe('checkActiveValidatorsUpdate', () => {
+		const activeValidatorsUpdate = [
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(1) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+		];
+		const sortedValidatorsList = [...activeValidatorsUpdate].sort((v1, v2) =>
+			v1.blsKey.compare(v2.blsKey),
+		);
+		const activeValidatorsUpdateWithInvalidKeyLength = [
+			{ blsKey: cryptography.getRandomBytes(16), bftWeight: BigInt(1) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+		];
+
+		const txParams = {
+			activeValidatorsUpdate,
+			newCertificateThreshold: BigInt(10),
+			certificate: Buffer.alloc(2),
+			sendingChainID: 2,
+			inboxUpdate: {},
+		};
+
+		const txParamsWithEmptyCertificate = {
+			activeValidatorsUpdate,
+			newCertificateThreshold: BigInt(10),
+			certificate: EMPTY_BYTES,
+			sendingChainID: 2,
+			inboxUpdate: {},
+		};
+
+		const txParamsSortedValidators = {
+			activeValidatorsUpdate: sortedValidatorsList,
+			newCertificateThreshold: BigInt(10),
+			certificate: Buffer.alloc(2),
+			sendingChainID: 2,
+			inboxUpdate: {},
+		};
+
+		const txParamsWithInvalidActiveValidatorsKeyLength = {
+			activeValidatorsUpdate: activeValidatorsUpdateWithInvalidKeyLength,
+			newCertificateThreshold: BigInt(10),
+			certificate: Buffer.alloc(2),
+			sendingChainID: 2,
+			inboxUpdate: {},
+		};
+
+		it('should return VerifyStatus.FAIL when certificate is empty', () => {
+			const { status, error } = checkActiveValidatorsUpdate(
+				txParamsWithEmptyCertificate as CrossChainUpdateTransactionParams,
+			);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toEqual(
+				'Certificate cannot be empty when activeValidatorsUpdate is non-empty or newCertificateThreshold >0.',
+			);
+		});
+
+		it('should return VerifyStatus.FAIL for invalid key validator blsKey', () => {
+			const { status, error } = checkActiveValidatorsUpdate(
+				txParamsWithInvalidActiveValidatorsKeyLength as CrossChainUpdateTransactionParams,
+			);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toEqual(`BlsKey length should be equal to ${VALID_BLS_KEY_LENGTH}.`);
+		});
+
+		it('should return VerifyStatus.FAIL when validators blsKeys are not unique and lexicographically ordered', () => {
+			const { status, error } = checkActiveValidatorsUpdate(
+				txParams as CrossChainUpdateTransactionParams,
+			);
+
+			expect(status).toEqual(VerifyStatus.FAIL);
+			expect(error?.message).toEqual(
+				'Validators blsKeys must be unique and lexicographically ordered.',
+			);
+		});
+
+		it('should return VerifyStatus.OK', () => {
+			const { status, error } = checkActiveValidatorsUpdate(
+				txParamsSortedValidators as CrossChainUpdateTransactionParams,
+			);
+
+			expect(status).toEqual(VerifyStatus.OK);
+			expect(error).toBeUndefined();
+		});
+	});
+
+	describe('checkValidCertificateLiveness', () => {
+		const inboxUpdate = {
+			crossChainMessages: [Buffer.alloc(1)],
+			messageWitness: {
+				partnerChainOutboxSize: BigInt(2),
+				siblingHashes: [Buffer.alloc(1)],
+			},
+			outboxRootWitness: {
+				bitmap: Buffer.alloc(1),
+				siblingHashes: [Buffer.alloc(1)],
+			},
+		} as InboxUpdate;
+		const inboxUpdateEmpty = {
+			crossChainMessages: [],
+			messageWitness: {
+				partnerChainOutboxSize: BigInt(0),
+				siblingHashes: [],
+			},
+			outboxRootWitness: {
+				bitmap: Buffer.alloc(1),
+				siblingHashes: [],
+			},
+		} as InboxUpdate;
+		const txParams: any = {
+			inboxUpdate,
+		};
+		const timestamp = Date.now();
+		const header: any = {
+			timestamp,
+		};
+		const invalidCertificate: any = {
+			timestamp: timestamp - LIVENESS_LIMIT / 2,
+		};
+		const certificate: any = {
+			timestamp: timestamp + 100,
+		};
+
+		it('should throw error when certificate has passed liveness condition', () => {
+			expect(() => checkValidCertificateLiveness(txParams, header, invalidCertificate)).toThrow(
+				`Certificate is not valid as it passed Liveness limit of ${LIVENESS_LIMIT} seconds.`,
+			);
+		});
+
+		it('should pass when inboxUpdate is undefined', () => {
+			expect(
+				checkValidCertificateLiveness(
+					{ inboxUpdate: inboxUpdateEmpty } as any,
+					header,
+					certificate,
+				),
+			).toBeUndefined();
+		});
+
+		it('should pass successfully', () => {
+			expect(checkValidCertificateLiveness(txParams, header, certificate)).toBeUndefined();
+		});
+	});
+
+	describe('checkCertificateTimestampAndSignature', () => {
+		const timestamp = Date.now();
+		const activeValidatorsUpdate: any = [
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(1) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+		];
+		const txParams: any = {
+			certificate: Buffer.alloc(2),
+		};
+		const txParamsWithEmptyCertificate: any = {
+			certificate: Buffer.alloc(0),
+		};
+		const partnerValidators: any = {
+			activeValidators: activeValidatorsUpdate,
+			certificateThreshold: 10,
+		};
+		const partnerChainAccount: any = { networkID: cryptography.getRandomBytes(32) };
+		const certificate: any = {
+			aggregationBits: Buffer.alloc(2),
+			signature: Buffer.alloc(2),
+			timestamp,
+		};
+		const certificateWithHigherTimestamp: any = {
+			aggregationBits: Buffer.alloc(2),
+			signature: Buffer.alloc(2),
+			timestamp: timestamp + 200,
+		};
+		const header: any = { timestamp: timestamp + 100 };
+
+		it('should return if certificate is empty', () => {
+			expect(
+				checkCertificateTimestampAndSignature(
+					txParamsWithEmptyCertificate,
+					partnerValidators,
+					partnerChainAccount,
+					certificate,
+					header,
+				),
+			).toBeUndefined();
+		});
+
+		it('should throw error when certificate signature verification fails', () => {
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(false);
+
+			expect(() =>
+				checkCertificateTimestampAndSignature(
+					txParams,
+					partnerValidators,
+					partnerChainAccount,
+					certificate,
+					header,
+				),
+			).toThrow(
+				'Certificate is invalid due to invalid last certified height or timestamp or signature.',
+			);
+			expect(cryptography.verifyWeightedAggSig).toHaveBeenCalledTimes(1);
+		});
+
+		it('should throw error when certificate.timestamp is greater than header.timestamp', () => {
+			jest.spyOn(cryptography, 'verifyWeightedAggSig').mockReturnValue(true);
+
+			expect(() =>
+				checkCertificateTimestampAndSignature(
+					txParams,
+					partnerValidators,
+					partnerChainAccount,
+					certificateWithHigherTimestamp,
+					header,
+				),
+			).toThrow(
+				'Certificate is invalid due to invalid last certified height or timestamp or signature.',
+			);
+			expect(cryptography.verifyWeightedAggSig).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('checkValidatorsHashWithCertificate', () => {
+		const activeValidatorsUpdate = [
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(1) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
+			{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+		];
+
+		const txParams: any = {
+			certificate: Buffer.alloc(2),
+			activeValidatorsUpdate,
+			newCertificateThreshold: BigInt(10),
+		};
+
+		const partnerValidators: any = {
+			certificateThreshold: BigInt(10),
+			activeValidators: activeValidatorsUpdate.map(v => ({
+				blsKey: v.blsKey,
+				bftWeight: v.bftWeight + BigInt(1),
+			})),
+		};
+		const validatorsHash = computeValidatorsHash(
+			activeValidatorsUpdate,
+			partnerValidators.certificateThreshold,
+		);
+
+		const certificate: any = {
+			aggregationBits: Buffer.alloc(2),
+			signature: Buffer.alloc(2),
+			validatorsHash,
+		};
+
+		it('should throw error when validators hash is incorrect', () => {
+			expect(() =>
+				checkValidatorsHashWithCertificate(
+					txParams,
+					{ ...certificate, validatorsHash: cryptography.getRandomBytes(32) },
+					partnerValidators,
+				),
+			).toThrow('Validators hash is incorrect given in the certificate.');
+		});
+
+		it('should return undefined when validators hash is correct', () => {
+			expect(
+				checkValidatorsHashWithCertificate(
+					{ ...txParams, newCertificateThreshold: BigInt(0) },
+					certificate,
+					partnerValidators,
+				),
+			).toBeUndefined();
+		});
+
+		it('should return undefined when activeValidatorsUpdate is of zero length', () => {
+			expect(
+				checkValidatorsHashWithCertificate(
+					{ ...txParams, activeValidatorsUpdate: [] },
+					certificate,
+					partnerValidators,
+				),
+			).toBeUndefined();
+		});
+
+		it('should return undefined when newCertificateThreshold is zero', () => {
+			expect(
+				checkValidatorsHashWithCertificate(
+					{ ...txParams, newCertificateThreshold: BigInt(0) },
+					certificate,
+					partnerValidators,
+				),
+			).toBeUndefined();
+		});
+	});
+
+	describe('commonCCUExecutelogic', () => {
+		const chainIDBuffer = getIDAsKeyForStore(1);
+		const defaultCalculatedRootFromRightWitness = cryptography.getRandomBytes(20);
+		let activeValidatorsUpdate: any;
+		let inboxUpdate: InboxUpdate;
+		let certificate: any;
+		let partnerChainAccount: any;
+		let partnerValidatorStore: any;
+		let partnerChainStore: any;
+		let partnerValidators: any;
+		let params: any;
+		let partnerChannelStoreMock: any;
+		let partnerChannelData: any;
+		let context: any;
+
+		beforeEach(async () => {
+			activeValidatorsUpdate = [
+				{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(1) },
+				{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+				{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(4) },
+				{ blsKey: cryptography.getRandomBytes(48), bftWeight: BigInt(3) },
+			];
+			inboxUpdate = {
+				crossChainMessages: [Buffer.alloc(1)],
+				messageWitness: {
+					partnerChainOutboxSize: BigInt(2),
+					siblingHashes: [Buffer.alloc(1)],
+				},
+				outboxRootWitness: {
+					bitmap: Buffer.alloc(1),
+					siblingHashes: [Buffer.alloc(1)],
+				},
+			} as InboxUpdate;
+
+			certificate = {
+				stateRoot: Buffer.alloc(2),
+				validatorsHash: Buffer.alloc(2),
+				height: 10,
+				timestamp: Date.now(),
+			};
+			partnerChainAccount = {
+				lastCertificate: { ...certificate, height: 5 },
+				height: 8,
+			};
+			partnerValidatorStore = {
+				setWithSchema: jest.fn(),
+			};
+			partnerChainStore = {
+				setWithSchema: jest.fn(),
+			};
+			partnerValidators = {
+				activeValidators: activeValidatorsUpdate,
+				certificateThreshold: BigInt(12),
+			};
+			params = {
+				activeValidatorsUpdate,
+				newCertificateThreshold: BigInt(10),
+				certificate: Buffer.alloc(2),
+				inboxUpdate,
+			};
+			partnerChannelStoreMock = {
+				getWithSchema: jest.fn(),
+				setWithSchema: jest.fn(),
+			};
+			partnerChannelData = {
+				partnerChainOutboxRoot: Buffer.alloc(1),
+				inbox: {
+					size: BigInt(2),
+					appendPath: [Buffer.alloc(1)],
+					root: cryptography.getRandomBytes(20),
+				},
+			};
+			context = {
+				getStore: jest.fn(),
+				params,
+				transaction: {
+					moduleID: 1,
+				},
+			};
+
+			when(context.getStore)
+				.calledWith(context.transaction.moduleID, STORE_PREFIX_CHANNEL_DATA)
+				.mockReturnValueOnce(partnerChannelStoreMock);
+
+			when(partnerChannelStoreMock.getWithSchema)
+				.calledWith(chainIDBuffer, channelSchema)
+				.mockResolvedValueOnce(partnerChannelData as never);
+
+			when(partnerChannelStoreMock.setWithSchema)
+				.calledWith(chainIDBuffer, partnerChannelData, channelSchema)
+				.mockResolvedValueOnce({} as never);
+			jest
+				.spyOn(merkleTree.regularMerkleTree, 'calculateRootFromRightWitness')
+				.mockReturnValue(defaultCalculatedRootFromRightWitness);
+		});
+
+		it('should run successfully and return undefined when newCertificateThreshold is non-zero', async () => {
+			await expect(
+				commonCCUExecutelogic({
+					certificate,
+					partnerChainAccount,
+					partnerValidatorStore,
+					partnerChainStore,
+					partnerValidators,
+					chainIDBuffer,
+					context,
+				}),
+			).resolves.toBeUndefined();
+			expect(partnerValidatorStore.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChainStore.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChannelStoreMock.getWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChannelStoreMock.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(context.getStore).toHaveBeenCalledTimes(1);
+			expect(partnerValidators.certificateThreshold).toEqual(params.newCertificateThreshold);
+			expect(partnerChannelData.partnerChainOutboxRoot).toEqual(
+				defaultCalculatedRootFromRightWitness,
+			);
+		});
+
+		it('should run successfully and return undefined when newCertificateThreshold is zero', async () => {
+			const paramsWithThresholdZero = {
+				activeValidatorsUpdate,
+				newCertificateThreshold: BigInt(0),
+				certificate: Buffer.alloc(2),
+				inboxUpdate,
+			};
+			const contextWithThresholdZero: any = { ...context, params: paramsWithThresholdZero };
+
+			await expect(
+				commonCCUExecutelogic({
+					certificate,
+					partnerChainAccount,
+					partnerValidatorStore,
+					partnerChainStore,
+					partnerValidators,
+					chainIDBuffer,
+					context: contextWithThresholdZero,
+				}),
+			).resolves.toBeUndefined();
+			expect(partnerValidatorStore.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChainStore.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChannelStoreMock.getWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChannelStoreMock.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(context.getStore).toHaveBeenCalledTimes(1);
+			expect(partnerValidators.certificateThreshold).toEqual(BigInt(12)); // original partnerValidator value unchanged
+			expect(partnerChannelData.partnerChainOutboxRoot).toEqual(
+				defaultCalculatedRootFromRightWitness,
+			);
+		});
+
+		it('should run successfully and return undefined when certificate is empty', async () => {
+			const paramsWithEmptyCertificate = {
+				activeValidatorsUpdate,
+				newCertificateThreshold: params.newCertificateThreshold,
+				certificate: EMPTY_BYTES,
+				inboxUpdate,
+			};
+			const contextWithEmptyCertificate: any = { ...context, params: paramsWithEmptyCertificate };
+
+			await expect(
+				commonCCUExecutelogic({
+					certificate: {} as any,
+					partnerChainAccount,
+					partnerValidatorStore,
+					partnerChainStore,
+					partnerValidators,
+					chainIDBuffer,
+					context: contextWithEmptyCertificate,
+				}),
+			).resolves.toBeUndefined();
+			expect(partnerValidatorStore.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChainStore.setWithSchema).not.toHaveBeenCalled();
+			expect(partnerChannelStoreMock.getWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChannelStoreMock.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(context.getStore).toHaveBeenCalledTimes(1);
+			expect(partnerChainAccount.lastCertificate.height).toEqual(5); // original partnerValidator value unchange
+			expect(partnerChannelData.partnerChainOutboxRoot).toEqual(
+				defaultCalculatedRootFromRightWitness,
+			);
+		});
+
+		it('should run successfully and return undefined when messageWitness is empty', async () => {
+			const paramsWithEmptyMessageWitness = {
+				activeValidatorsUpdate,
+				newCertificateThreshold: params.newCertificateThreshold,
+				certificate: params.certificate,
+				inboxUpdate: {
+					...inboxUpdate,
+					messageWitness: {
+						partnerChainOutboxSize: BigInt(0),
+						siblingHashes: [],
+					},
+				},
+			};
+			const contextWithEmptyMessageWitness: any = {
+				...context,
+				params: paramsWithEmptyMessageWitness,
+			};
+
+			await expect(
+				commonCCUExecutelogic({
+					certificate,
+					partnerChainAccount,
+					partnerValidatorStore,
+					partnerChainStore,
+					partnerValidators,
+					chainIDBuffer,
+					context: contextWithEmptyMessageWitness,
+				}),
+			).resolves.toBeUndefined();
+			expect(partnerValidatorStore.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChainStore.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChannelStoreMock.getWithSchema).toHaveBeenCalledTimes(1);
+			expect(partnerChannelStoreMock.setWithSchema).toHaveBeenCalledTimes(1);
+			expect(context.getStore).toHaveBeenCalledTimes(1);
+			expect(partnerChainAccount.lastCertificate.height).toEqual(certificate.height);
+			expect(partnerChannelData.partnerChainOutboxRoot).toEqual(partnerChannelData.inbox.root);
 		});
 	});
 });

--- a/framework/test/unit/modules/interoperability/utils.spec.ts
+++ b/framework/test/unit/modules/interoperability/utils.spec.ts
@@ -211,8 +211,10 @@ describe('Utils', () => {
 	});
 
 	describe('checkActiveValidatorsUpdate', () => {
-		const activeValidatorsUpdate = [...defaultActiveValidatorsUpdate];
-		const sortedValidatorsList = [...activeValidatorsUpdate].sort((v1, v2) =>
+		const activeValidatorsUpdate = [...defaultActiveValidatorsUpdate].sort((v1, v2) =>
+			v2.blsKey.compare(v1.blsKey),
+		);
+		const sortedValidatorsList = [...defaultActiveValidatorsUpdate].sort((v1, v2) =>
 			v1.blsKey.compare(v2.blsKey),
 		);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #7038 & #7039

### How was it solved?

[♻️ Export calculateRootFromRightWitness from lisk-tree](https://github.com/LiskHQ/lisk-sdk/commit/8060c5de246e3bbad8faf3b8c3449afa014bd40c)

[🌱 Implement ccu on mainchain](https://github.com/LiskHQ/lisk-sdk/commit/9bc38478467c67949b51d7fc04b6e5997b57e80a)

[🌱 Implement CCU command on sidechain](https://github.com/LiskHQ/lisk-sdk/commit/c8e152a78e735d76fcee2c7288a91f2ed34c8b28)

### How was it tested?

`npm run test:unit interoperability`
