### PR TITLE
Update stateStore to use DB iterateOptions - Closes #7229

### DIFF
--- a/elements/lisk-chain/src/state_store/state_store.ts
+++ b/elements/lisk-chain/src/state_store/state_store.ts
@@ -13,7 +13,7 @@
  */
 
 import { codec, Schema } from '@liskhq/lisk-codec';
-import { NotFoundError as DBNotFoundError } from '@liskhq/lisk-db';
+import { IterateOptions, NotFoundError as DBNotFoundError } from '@liskhq/lisk-db';
 import { DB_KEY_STATE_STORE } from '../db_keys';
 import { StateDiff } from '../types';
 import { CacheDB } from './cache_db';
@@ -21,12 +21,7 @@ import { NotFoundError } from './errors';
 import { DatabaseReader, DatabaseWriter } from './types';
 import { copyBuffer } from './utils';
 
-export interface IterateOptions {
-	start: Buffer;
-	end: Buffer;
-	limit?: number;
-	reverse?: boolean;
-}
+export { IterateOptions };
 
 export interface KeyValue {
 	key: Buffer;
@@ -140,8 +135,8 @@ export class StateStore {
 	}
 
 	public async iterate(options: IterateOptions): Promise<KeyValue[]> {
-		const start = this._getKey(options.start);
-		const end = this._getKey(options.end);
+		const start = this._getKey(options.gte as Buffer);
+		const end = this._getKey(options.lte as Buffer);
 		const stream = this._db.createReadStream({
 			gte: start,
 			lte: end,

--- a/elements/lisk-chain/test/unit/state_store/state_store.spec.ts
+++ b/elements/lisk-chain/test/unit/state_store/state_store.spec.ts
@@ -206,8 +206,8 @@ describe('state store', () => {
 			await subStore.set(Buffer.from([2]), getRandomBytes(40));
 
 			const result = await subStore.iterate({
-				start: Buffer.from([0]),
-				end: Buffer.from([255]),
+				gte: Buffer.from([0]),
+				lte: Buffer.from([255]),
 			});
 
 			expect(result).toHaveLength(3);
@@ -224,8 +224,8 @@ describe('state store', () => {
 			await subStore.set(Buffer.from([2]), getRandomBytes(40));
 
 			const result = await subStore.iterate({
-				start: Buffer.from([0]),
-				end: Buffer.from([255]),
+				gte: Buffer.from([0]),
+				lte: Buffer.from([255]),
 				reverse: true,
 				limit: 2,
 			});
@@ -243,8 +243,8 @@ describe('state store', () => {
 			await subStore.del(Buffer.from([1]));
 
 			const result = await subStore.iterate({
-				start: Buffer.from([0]),
-				end: Buffer.from([255]),
+				gte: Buffer.from([0]),
+				lte: Buffer.from([255]),
 			});
 
 			expect(result).toHaveLength(2);
@@ -262,8 +262,8 @@ describe('state store', () => {
 			await subStore.set(existingKey, expectedValue);
 
 			const result = await subStore.iterate({
-				start: Buffer.from([0]),
-				end: Buffer.from([255]),
+				gte: Buffer.from([0]),
+				lte: Buffer.from([255]),
 			});
 
 			expect(result).toHaveLength(5);
@@ -282,8 +282,8 @@ describe('state store', () => {
 
 			const result = await subStore.iterateWithSchema(
 				{
-					start: Buffer.from([0]),
-					end: Buffer.from([255]),
+					gte: Buffer.from([0]),
+					lte: Buffer.from([255]),
 				},
 				sampleSchema,
 			);

--- a/framework/src/engine/bft/api.ts
+++ b/framework/src/engine/bft/api.ts
@@ -130,8 +130,8 @@ export class BFTAPI extends BaseAPI {
 		const end = intToBuffer(MAX_UINT32, 4, BIG_ENDIAN);
 		const results = await paramsStore.iterate({
 			limit: 1,
-			start,
-			end,
+			gte: start,
+			lte: end,
 		});
 		if (results.length !== 1) {
 			throw new BFTParameterNotFoundError();

--- a/framework/src/engine/bft/bft_params.ts
+++ b/framework/src/engine/bft/bft_params.ts
@@ -26,8 +26,8 @@ export const getBFTParameters = async (
 	const end = intToBuffer(height, 4, BIG_ENDIAN);
 	const results = await paramsStore.iterate({
 		limit: 1,
-		start,
-		end,
+		gte: start,
+		lte: end,
 		reverse: true,
 	});
 	if (results.length !== 1) {
@@ -44,8 +44,8 @@ export const deleteBFTParameters = async (
 	const start = intToBuffer(0, 4, BIG_ENDIAN);
 	const end = intToBuffer(height, 4, BIG_ENDIAN);
 	const results = await paramsStore.iterate({
-		start,
-		end,
+		gte: start,
+		lte: end,
 	});
 	if (results.length <= 1) {
 		return;
@@ -70,8 +70,8 @@ export class BFTParametersCache {
 		const end = intToBuffer(to, 4, BIG_ENDIAN);
 		const results = await this._paramsStore.iterateWithSchema<BFTParameters>(
 			{
-				start,
-				end,
+				gte: start,
+				lte: end,
 				reverse: true,
 			},
 			bftParametersSchema,

--- a/framework/src/engine/bft/utils.ts
+++ b/framework/src/engine/bft/utils.ts
@@ -106,8 +106,8 @@ export const getGeneratorKeys = async (
 	const end = intToBuffer(height, 4);
 	const results = await keysStore.iterate({
 		limit: 1,
-		start,
-		end,
+		gte: start,
+		lte: end,
 		reverse: true,
 	});
 	if (results.length !== 1) {
@@ -122,8 +122,8 @@ export const deleteGeneratorKeys = async (keysStore: StateStore, height: number)
 	const start = intToBuffer(0, 4);
 	const end = intToBuffer(height, 4);
 	const results = await keysStore.iterate({
-		start,
-		end,
+		gte: start,
+		lte: end,
 	});
 	if (results.length <= 1) {
 		return;


### PR DESCRIPTION
### What was the problem?

This PR resolves #7229

### How was it solved?

- Update stateStore to use DB iterateOptions in the iterate method - e39c215f7aa3d92dfa73ae4b5c1a88b2154302f7

### How was it tested?

`npm t`
