### PR TITLE
Fix getMetadata response and socket ipc data path- Closes #7172

### DIFF
--- a/elements/lisk-api-client/src/api_client.ts
+++ b/elements/lisk-api-client/src/api_client.ts
@@ -31,7 +31,10 @@ export class APIClient {
 	}
 
 	public async init(): Promise<void> {
-		this._metadata = await this._channel.invoke<ModuleMetadata[]>('system_getMetadata');
+		const { modules } = await this._channel.invoke<{ modules: ModuleMetadata[] }>(
+			'system_getMetadata',
+		);
+		this._metadata = modules;
 		this._schema = await this._channel.invoke<RegisteredSchemas>('system_getSchema');
 		this._node = new Node(this._channel);
 		this._block = new Block(this._channel, this._schema, this._metadata);

--- a/elements/lisk-api-client/src/ipc_channel.ts
+++ b/elements/lisk-api-client/src/ipc_channel.ts
@@ -24,7 +24,7 @@ const CONNECTION_TIME_OUT = 2000;
 const RESPONSE_TIMEOUT = 3000;
 
 const getSocketsPath = (dataPath: string) => {
-	const socketDir = path.join(path.resolve(dataPath.replace('~', homedir())));
+	const socketDir = path.join(path.resolve(dataPath.replace('~', homedir())), 'socket', 'ipc');
 	return {
 		pub: `ipc://${socketDir}/external.pub.ipc`,
 		sub: `ipc://${socketDir}/external.sub.ipc`,

--- a/elements/lisk-api-client/test/api_client.spec.ts
+++ b/elements/lisk-api-client/test/api_client.spec.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { when } from 'jest-when';
 import { APIClient } from '../src/api_client';
 import { Channel } from '../src/types';
 
@@ -31,6 +32,10 @@ describe('APIClient module', () => {
 
 	describe('when init is called', () => {
 		beforeEach(async () => {
+			when(channel.invoke as any)
+				.calledWith('system_getMetadata')
+				.mockResolvedValue({ modules: [] } as never);
+
 			await client.init();
 		});
 

--- a/examples/dpos-mainchain/config/default/config.json
+++ b/examples/dpos-mainchain/config/default/config.json
@@ -9,10 +9,7 @@
 		"logFileName": "lisk.log"
 	},
 	"rpc": {
-		"modes": ["ipc"],
-		"ipc": {
-			"path": "~/.lisk/dpos-mainchain/socket/ipc"
-		}
+		"modes": ["ipc"]
 	},
 	"genesis": {
 		"blockTime": 10,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7172 

### How was it solved?

- [🐛 Fix getMetaData response](https://github.com/LiskHQ/lisk-sdk/commit/b1e5f4858033626338b67d09f195f2c82122acda)
- [🐛 Fix socketPath for IPC api](https://github.com/LiskHQ/lisk-sdk/commit/89c1c27160543a7ba744127de8dc0b47b744c658)

### How was it tested?

- Run `npm t` under `elements/lisk-api-client`
- Create an API client using createIPCClient and run a node with with `--api-ipc` enabled. check if it gets connected successfully and is able to call `system_getMetadata` endpoint.
