### PR TITLE
:bug: Fix invalid init response - Closes #7260

### DIFF
--- a/examples/dpos-mainchain/config/default/config.json
+++ b/examples/dpos-mainchain/config/default/config.json
@@ -13,6 +13,7 @@
 	},
 	"genesis": {
 		"blockTime": 10,
+		"bftBatchSize": 103,
 		"communityIdentifier": "sdk",
 		"maxTransactionsSize": 15360,
 		"minFeePerByte": 1000,

--- a/framework/src/abi_handler/abi_handler.ts
+++ b/framework/src/abi_handler/abi_handler.ts
@@ -177,7 +177,7 @@ export class ABIHandler implements ABI {
 					networkVersion: this._config.networkVersion,
 				},
 				genesis: {
-					bftBatchSize: this._config.genesis.blockTime,
+					bftBatchSize: this._config.genesis.bftBatchSize,
 					blockTime: this._config.genesis.blockTime,
 					communityIdentifier: this._config.genesis.communityIdentifier,
 					minFeePerByte: this._config.genesis.minFeePerByte,
@@ -229,8 +229,8 @@ export class ABIHandler implements ABI {
 						port: this._config.rpc.http?.port ?? DEFAULT_PORT_RPC,
 					},
 					ws: {
-						host: this._config.rpc.http?.host ?? DEFAULT_HOST,
-						port: this._config.rpc.http?.port ?? DEFAULT_PORT_RPC,
+						host: this._config.rpc.ws?.host ?? DEFAULT_HOST,
+						port: this._config.rpc.ws?.port ?? DEFAULT_PORT_RPC,
 					},
 				},
 			},

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -296,6 +296,7 @@ export const applicationConfigSchema = {
 			type: 'object',
 			required: [
 				'blockTime',
+				'bftBatchSize',
 				'communityIdentifier',
 				'maxTransactionsSize',
 				'minFeePerByte',
@@ -307,6 +308,11 @@ export const applicationConfigSchema = {
 					type: 'number',
 					minimum: 2,
 					description: 'Slot time interval in seconds',
+				},
+				bftBatchSize: {
+					type: 'number',
+					minimum: 1,
+					description: 'The length of a round',
 				},
 				communityIdentifier: {
 					type: 'string',
@@ -415,6 +421,7 @@ export const applicationConfigSchema = {
 		plugins: {},
 		genesis: {
 			blockTime: 10,
+			bftBatchSize: 103,
 			communityIdentifier: 'sdk',
 			// eslint-disable-next-line @typescript-eslint/no-magic-numbers
 			maxTransactionsSize: 15 * 1024, // Kilo Bytes

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -67,6 +67,7 @@ export interface GenesisConfig {
 	maxTransactionsSize: number;
 	minFeePerByte: number;
 	blockTime: number;
+	bftBatchSize: number;
 	baseFees: {
 		moduleID: number;
 		commandID: number;

--- a/framework/test/unit/__snapshots__/application.spec.ts.snap
+++ b/framework/test/unit/__snapshots__/application.spec.ts.snap
@@ -2182,6 +2182,7 @@ Object {
         "moduleID": 5,
       },
     ],
+    "bftBatchSize": 103,
     "blockTime": 10,
     "communityIdentifier": "Lisk",
     "maxTransactionsSize": 15360,

--- a/framework/test/unit/abi_handler/__snapshots__/abi_handler.spec.ts.snap
+++ b/framework/test/unit/abi_handler/__snapshots__/abi_handler.spec.ts.snap
@@ -8,7 +8,7 @@ Object {
     "password": "",
   },
   "genesis": Object {
-    "bftBatchSize": 10,
+    "bftBatchSize": 103,
     "blockTime": 10,
     "communityIdentifier": "sdk",
     "maxTransactionsSize": 15360,
@@ -43,7 +43,7 @@ Object {
     ],
     "ws": Object {
       "host": "127.0.0.1",
-      "port": 8000,
+      "port": 8080,
     },
   },
   "system": Object {

--- a/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
+++ b/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
@@ -13,6 +13,7 @@ Object {
     },
     "genesis": Object {
       "baseFees": Array [],
+      "bftBatchSize": 103,
       "blockTime": 10,
       "communityIdentifier": "sdk",
       "maxTransactionsSize": 15360,
@@ -160,6 +161,11 @@ Object {
           },
           "type": "array",
         },
+        "bftBatchSize": Object {
+          "description": "The length of a round",
+          "minimum": 1,
+          "type": "number",
+        },
         "blockTime": Object {
           "description": "Slot time interval in seconds",
           "minimum": 2,
@@ -192,6 +198,7 @@ Object {
       },
       "required": Array [
         "blockTime",
+        "bftBatchSize",
         "communityIdentifier",
         "maxTransactionsSize",
         "minFeePerByte",

--- a/framework/test/unit/schema/application_config_schema.spec.ts
+++ b/framework/test/unit/schema/application_config_schema.spec.ts
@@ -21,6 +21,12 @@ describe('schema/application_config_schema.js', () => {
 		expect(applicationConfigSchema).toMatchSnapshot();
 	});
 
+	it('should validate the defined schema', () => {
+		const errors = validator.validateSchema(applicationConfigSchema);
+
+		expect(errors).toHaveLength(0);
+	});
+
 	it('should validate if module properties are objects', () => {
 		const config = objects.cloneDeep(applicationConfigSchema.default);
 		config.genesis.modules = { myModule: { myProp: 1 } };

--- a/framework/test/utils/configs/config_constants.ts
+++ b/framework/test/utils/configs/config_constants.ts
@@ -28,6 +28,7 @@ export const constantsConfig = (overriddenConfigProperties = {}) => ({
 		distance: 3000000, // Distance between each milestone
 	},
 	bftThreshold: 68,
+	bftBatchSize: 103,
 	minRemainingBalance: '5000000',
 	minFeePerByte: 1000,
 	baseFees: [

--- a/sdk/src/samples/config_devnet.json
+++ b/sdk/src/samples/config_devnet.json
@@ -7,6 +7,7 @@
 	},
 	"genesisConfig": {
 		"blockTime": 10,
+		"bftBatchSize": 103,
 		"communityIdentifier": "Lisk",
 		"maxTransactionsSize": 15360,
 		"bftThreshold": 68,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7260 

### How was it solved?

Updated `ABIHandler.init` to:
- Configure `bftBatchSize` from injected `genesis` configuration.
- Configure `rpc.ws` from injected  `rpc.ws` configuration.

Updated `applicationConfigSchema` to allow for a numeric `bftBatchSize` value with minimum value of 1 and default set to 103.
Updated `GenesisConfig` interface to allow for a numeric `bftBatchSize`.

Update configuration for `dev_net` and and `dpos-mainchain`, to contain `bftBatchSize` property set to 103.

Modified unit tests.

### How was it tested?
Passing unit tests.