### PR TITLE
Accept transaction params input from file - Closes #7276

### DIFF
--- a/commander/src/bootstrapping/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/commands/transaction/create.ts
@@ -79,9 +79,7 @@ const getParamsObject = async (metadata: ModuleMetadataJSON[], flags: CreateFlag
 	) as Schema;
 
 	if (flags.file) {
-		params = flags.file
-			? JSON.parse(getFileParams(flags.file))
-			: await getParamsFromPrompt(paramsSchema);
+		params = JSON.parse(getFileParams(flags.file));
 	} else {
 		params = flags.params ? JSON.parse(flags.params) : await getParamsFromPrompt(paramsSchema);
 	}
@@ -239,6 +237,8 @@ export abstract class CreateCommand extends Command {
 		'transaction:create 2 0 100000000 --params=\'{"amount":100000000,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}\'',
 		'transaction:create 2 0 100000000 --params=\'{"amount":100000000,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}\' --json',
 		'transaction:create 2 0 100000000 --offline --network mainnet --network-identifier 873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3 --nonce 1 --params=\'{"amount":100000000,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}\'',
+		'transaction:create 2 0 100000000 --file=/txn_params.json',
+		'transaction:create 2 0 100000000 --file=/txn_params.json --json',
 	];
 
 	static flags = {

--- a/commander/src/utils/flags.ts
+++ b/commander/src/utils/flags.ts
@@ -53,6 +53,11 @@ const prettyDescription = 'Prints JSON in pretty format rather than condensed.';
 
 const outputDescription = 'The output directory. Default will set to current working directory.';
 
+const transactionParametersInputFile = `Transaction parameters input file.
+	Example:
+	- ./transaction-parameters.json
+`;
+
 export type AlphabetLowercase =
 	| 'a'
 	| 'b'
@@ -138,6 +143,10 @@ export const flags: FlagMap = {
 		description:
 			'Sign the transaction with provided sender public key, when passphrase is not provided',
 	},
+	file: {
+		char: 'f',
+		description: transactionParametersInputFile,
+	},
 };
 
 export const flagsWithParser = {
@@ -164,4 +173,5 @@ export const flagsWithParser = {
 	json: flagParser.boolean(flags.json),
 	senderPublicKey: flagParser.string(flags.senderPublicKey),
 	networkIdentifier: flagParser.string(flags.networkIdentifier),
+	file: flagParser.string(flags.file),
 };

--- a/commander/src/utils/flags.ts
+++ b/commander/src/utils/flags.ts
@@ -55,7 +55,7 @@ const outputDescription = 'The output directory. Default will set to current wor
 
 const transactionParametersInputFile = `Transaction parameters input file.
 	Example:
-	- ./transaction-parameters.json
+		--file=./transaction-parameters.json
 `;
 
 export type AlphabetLowercase =

--- a/commander/src/utils/flags.ts
+++ b/commander/src/utils/flags.ts
@@ -53,9 +53,9 @@ const prettyDescription = 'Prints JSON in pretty format rather than condensed.';
 
 const outputDescription = 'The output directory. Default will set to current working directory.';
 
-const transactionParametersInputFile = `Transaction parameters input file.
+const fileDescription = `The file to upload.
 	Example:
-		--file=./transaction-parameters.json
+		--file=./myfile.json
 `;
 
 export type AlphabetLowercase =
@@ -145,7 +145,7 @@ export const flags: FlagMap = {
 	},
 	file: {
 		char: 'f',
-		description: transactionParametersInputFile,
+		description: fileDescription,
 	},
 };
 

--- a/commander/src/utils/reader.ts
+++ b/commander/src/utils/reader.ts
@@ -358,14 +358,12 @@ export const getParamsFromPrompt = async (
 		: transformAsset(assetSchema, result as Record<string, string>);
 };
 
-export const getFileExtension = (filePath: string): string => {
+export const checkFileExtension = (filePath: string): void => {
 	const ext = path.extname(filePath);
 
 	if (!ext || ext !== '.json') {
 		throw new ValidationError(INVALID_JSON_FILE);
 	}
-
-	return ext;
 };
 
 export const readParamsFile = (filePath: string): string => {
@@ -378,6 +376,6 @@ export const readParamsFile = (filePath: string): string => {
 };
 
 export const getFileParams = (filePath: string): string => {
-	getFileExtension(filePath);
+	checkFileExtension(filePath);
 	return readParamsFile(filePath);
 };

--- a/commander/src/utils/reader.ts
+++ b/commander/src/utils/reader.ts
@@ -156,6 +156,7 @@ const getDataFromFile = (filePath: string) => fs.readFileSync(filePath, 'utf8');
 const ERROR_DATA_MISSING = 'No data was provided.';
 const ERROR_DATA_SOURCE = 'Unknown data source type.';
 const INVALID_JSON_FILE = 'Not a JSON file.';
+const FILE_NOT_FOUND = 'no such file or directory.';
 
 export const isFileSource = (source?: string): boolean => {
 	if (!source) {
@@ -360,7 +361,7 @@ export const getParamsFromPrompt = async (
 export const getFileExtension = (filePath: string): string => {
 	const ext = path.extname(filePath);
 
-	if (!ext) {
+	if (!ext || ext !== '.json') {
 		throw new ValidationError(INVALID_JSON_FILE);
 	}
 
@@ -372,7 +373,7 @@ export const readParamsFile = (filePath: string): string => {
 		const params = fs.readFileSync(filePath, 'utf8');
 		return params;
 	} catch (err) {
-		throw new ValidationError(INVALID_JSON_FILE);
+		throw new ValidationError(FILE_NOT_FOUND);
 	}
 };
 
@@ -383,7 +384,7 @@ export const getFileParams = (filePath: string): string => {
 	if (ext === '.json') {
 		data = readParamsFile(filePath);
 	} else {
-		throw new Error('Not a JSON file');
+		throw new ValidationError(INVALID_JSON_FILE);
 	}
 
 	return data;

--- a/commander/src/utils/reader.ts
+++ b/commander/src/utils/reader.ts
@@ -156,7 +156,7 @@ const getDataFromFile = (filePath: string) => fs.readFileSync(filePath, 'utf8');
 const ERROR_DATA_MISSING = 'No data was provided.';
 const ERROR_DATA_SOURCE = 'Unknown data source type.';
 const INVALID_JSON_FILE = 'Not a JSON file.';
-const FILE_NOT_FOUND = 'no such file or directory.';
+const FILE_NOT_FOUND = 'No such file or directory.';
 
 export const isFileSource = (source?: string): boolean => {
 	if (!source) {
@@ -378,14 +378,6 @@ export const readParamsFile = (filePath: string): string => {
 };
 
 export const getFileParams = (filePath: string): string => {
-	let data = '';
-	const ext = getFileExtension(filePath);
-
-	if (ext === '.json') {
-		data = readParamsFile(filePath);
-	} else {
-		throw new ValidationError(INVALID_JSON_FILE);
-	}
-
-	return data;
+	getFileExtension(filePath);
+	return readParamsFile(filePath);
 };

--- a/commander/test/utils/reader.spec.ts
+++ b/commander/test/utils/reader.spec.ts
@@ -22,7 +22,7 @@ import {
 	getPassphraseFromPrompt,
 	isFileSource,
 	readFileSource,
-	getFileExtension,
+	checkFileExtension,
 	readParamsFile,
 } from '../../src/utils/reader';
 
@@ -165,17 +165,15 @@ describe('reader', () => {
 			});
 		});
 
-		describe('getFileExtension', () => {
-			it('should return a json file extension', () => {
-				const filePath = './some/path.json';
-				const fileExtension = getFileExtension(filePath);
-
-				return expect(fileExtension).toEqual('.json');
-			});
-
+		describe('checkFileExtension', () => {
 			it('should throw an error if no file extension is passed', () => {
 				const filePath = './some/path';
-				expect(() => getFileExtension(filePath)).toThrow('Not a JSON file.');
+				expect(() => checkFileExtension(filePath)).toThrow('Not a JSON file.');
+			});
+
+			it('should throw an error if file extension is not .json', () => {
+				const filePath = './some/path.txt';
+				expect(() => checkFileExtension(filePath)).toThrow('Not a JSON file.');
 			});
 		});
 

--- a/commander/test/utils/reader.spec.ts
+++ b/commander/test/utils/reader.spec.ts
@@ -192,21 +192,22 @@ describe('reader', () => {
 				jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(fileData));
 			});
 
-			it('should read a json file', () => {
+			it('should read a json file and check that an amount value and a recipient address are contained in the file', () => {
 				const result = readParamsFile(filePath);
-				return expect(JSON.parse(result)).toEqual(fileData);
-			});
 
-			it('should have an amount', () => {
-				const result = readParamsFile(filePath);
-				return expect(JSON.parse(result).amount).toEqual(100000000);
-			});
-
-			it('should have a recipient address', () => {
-				const result = readParamsFile(filePath);
-				return expect(JSON.parse(result).recipientAddress).toEqual(
+				expect(JSON.parse(result)).toEqual(fileData);
+				expect(JSON.parse(result).amount).toEqual(100000000);
+				expect(JSON.parse(result).recipientAddress).toEqual(
 					'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
 				);
+			});
+
+			it('should throw an error if the file is not found', () => {
+				jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+					throw new Error('ENOENT');
+				});
+
+				expect(() => readParamsFile(filePath)).toThrow(`No such file or directory.`);
 			});
 		});
 	});

--- a/commander/test/utils/reader.spec.ts
+++ b/commander/test/utils/reader.spec.ts
@@ -22,6 +22,8 @@ import {
 	getPassphraseFromPrompt,
 	isFileSource,
 	readFileSource,
+	getFileExtension,
+	readParamsFile,
 } from '../../src/utils/reader';
 
 describe('reader', () => {
@@ -160,6 +162,51 @@ describe('reader', () => {
 					.mockReturnValue(createFakeInterface(multilineStdContents) as any);
 				const result = await readStdIn();
 				return expect(result).toEqual(['passphrase', 'password', 'data']);
+			});
+		});
+
+		describe('getFileExtension', () => {
+			it('should return a json file extension', () => {
+				const filePath = './some/path.json';
+				const fileExtension = getFileExtension(filePath);
+
+				return expect(fileExtension).toEqual('.json');
+			});
+
+			it('should throw an error if no file extension is passed', () => {
+				const filePath = './some/path';
+				expect(() => getFileExtension(filePath)).toThrow('Not a JSON file.');
+			});
+		});
+
+		describe('readParamsFile', () => {
+			const filePath = './some/path.json';
+			const fileData = {
+				tokenID: '0000000000000000',
+				amount: 100000000,
+				recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+				data: 'send token',
+			};
+
+			beforeEach(() => {
+				jest.spyOn(fs, 'readFileSync').mockReturnValue(JSON.stringify(fileData));
+			});
+
+			it('should read a json file', () => {
+				const result = readParamsFile(filePath);
+				return expect(JSON.parse(result)).toEqual(fileData);
+			});
+
+			it('should have an amount', () => {
+				const result = readParamsFile(filePath);
+				return expect(JSON.parse(result).amount).toEqual(100000000);
+			});
+
+			it('should have a recipient address', () => {
+				const result = readParamsFile(filePath);
+				return expect(JSON.parse(result).recipientAddress).toEqual(
+					'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+				);
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves [#7276](https://github.com/LiskHQ/lisk-sdk/issues/7276)

### How was it solved?

Added functions to parse the transaction parameters input file

### How was it tested?

Added unit tests.
Run `npm t` at the root of the `commander` directory
