### PR TITLE
Update encrypt/decrpt name and accept buffer - Closes #7333

### DIFF
--- a/commander/src/bootstrapping/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/commands/genesis-block/create.ts
@@ -233,14 +233,14 @@ export abstract class BaseGenesisBlockCommand extends Command {
 		const password = createMnemonicPassphrase();
 		const passwordList = { defaultPassword: password };
 		const generatorInfo = validatorList.map(async (val, index) => {
-			const encryptedPassphrase = await cryptography.encrypt.encryptPassphraseWithPassword(
+			const encryptedPassphrase = await cryptography.encrypt.encryptMessageWithPassword(
 				val.passphrase,
 				password,
 				{ kdfparams: { iterations: validatorsPassphraseEncryptionIterations } },
 			);
 			const info = {
 				// TODO: use a better password, user sourced using flag
-				encryptedPassphrase: cryptography.encrypt.stringifyEncryptedPassphrase(encryptedPassphrase),
+				encryptedPassphrase: cryptography.encrypt.stringifyEncryptedMessage(encryptedPassphrase),
 				hashOnion: {
 					count: validatorsHashOnionCount,
 					distance: validatorsHashOnionDistance,

--- a/commander/src/bootstrapping/commands/passphrase/decrypt.ts
+++ b/commander/src/bootstrapping/commands/passphrase/decrypt.ts
@@ -25,12 +25,11 @@ const processInputs = async (
 	password: string,
 	encryptedPassphrase: string,
 ): Promise<Record<string, string>> => {
-	const encryptedPassphraseObject = cryptography.encrypt.parseEncryptedPassphrase(
-		encryptedPassphrase,
-	);
-	const passphrase = await cryptography.encrypt.decryptPassphraseWithPassword(
+	const encryptedPassphraseObject = cryptography.encrypt.parseEncryptedMessage(encryptedPassphrase);
+	const passphrase = await cryptography.encrypt.decryptMessageWithPassword(
 		encryptedPassphraseObject as never,
 		password,
+		'utf-8',
 	);
 
 	return { passphrase };

--- a/commander/src/utils/commons.ts
+++ b/commander/src/utils/commons.ts
@@ -31,11 +31,11 @@ export const encryptPassphrase = async (
 	password: string,
 	outputPublicKey: boolean,
 ): Promise<Record<string, unknown>> => {
-	const encryptedPassphraseObject = await cryptography.encrypt.encryptPassphraseWithPassword(
+	const encryptedPassphraseObject = await cryptography.encrypt.encryptMessageWithPassword(
 		passphrase,
 		password,
 	);
-	const encryptedPassphrase = cryptography.encrypt.stringifyEncryptedPassphrase(
+	const encryptedPassphrase = cryptography.encrypt.stringifyEncryptedMessage(
 		encryptedPassphraseObject,
 	);
 

--- a/commander/test/bootstrapping/commands/forging/config.spec.ts
+++ b/commander/test/bootstrapping/commands/forging/config.spec.ts
@@ -73,10 +73,10 @@ describe('forging:config command', () => {
 		jest.spyOn(fs, 'ensureDirSync').mockReturnValue();
 		jest.spyOn(fs, 'writeJSONSync').mockReturnValue();
 		jest
-			.spyOn(cryptography.encrypt, 'encryptPassphraseWithPassword')
+			.spyOn(cryptography.encrypt, 'encryptMessageWithPassword')
 			.mockReturnValue(encryptedPassphraseObject as any);
 		jest
-			.spyOn(cryptography.encrypt, 'stringifyEncryptedPassphrase')
+			.spyOn(cryptography.encrypt, 'stringifyEncryptedMessage')
 			.mockReturnValue(encryptedPassphraseString);
 		jest.spyOn(readerUtils, 'getPassphraseFromPrompt').mockImplementation(async (name?: string) => {
 			if (name === 'passphrase') {
@@ -96,11 +96,11 @@ describe('forging:config command', () => {
 		describe('generate forging config and print', () => {
 			it('should encrypt passphrase and with default hash-onions', async () => {
 				await ConfigCommand.run(['--count=2', '--distance=1', '--pretty'], config);
-				expect(cryptography.encrypt.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+				expect(cryptography.encrypt.encryptMessageWithPassword).toHaveBeenCalledWith(
 					defaultInputs.passphrase,
 					defaultInputs.password,
 				);
-				expect(cryptography.encrypt.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+				expect(cryptography.encrypt.stringifyEncryptedMessage).toHaveBeenCalledWith(
 					encryptedPassphraseObject,
 				);
 				expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
@@ -132,11 +132,11 @@ describe('forging:config command', () => {
 					],
 					config,
 				);
-				expect(cryptography.encrypt.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+				expect(cryptography.encrypt.encryptMessageWithPassword).toHaveBeenCalledWith(
 					defaultInputs.passphrase,
 					defaultInputs.password,
 				);
-				expect(cryptography.encrypt.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+				expect(cryptography.encrypt.stringifyEncryptedMessage).toHaveBeenCalledWith(
 					encryptedPassphraseObject,
 				);
 				expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);

--- a/commander/test/bootstrapping/commands/passphrase/decrypt.spec.ts
+++ b/commander/test/bootstrapping/commands/passphrase/decrypt.spec.ts
@@ -48,10 +48,10 @@ describe('passphrase:decrypt', () => {
 		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
 		jest.spyOn(DecryptCommand.prototype, 'printJSON').mockReturnValue();
 		jest
-			.spyOn(cryptography.encrypt, 'parseEncryptedPassphrase')
+			.spyOn(cryptography.encrypt, 'parseEncryptedMessage')
 			.mockReturnValue(encryptedPassphraseObject as never);
 		jest
-			.spyOn(cryptography.encrypt, 'decryptPassphraseWithPassword')
+			.spyOn(cryptography.encrypt, 'decryptMessageWithPassword')
 			.mockResolvedValue(passphrase as never);
 		jest.spyOn(readerUtils, 'getPasswordFromPrompt').mockResolvedValue(defaultInputs);
 	});
@@ -66,12 +66,13 @@ describe('passphrase:decrypt', () => {
 		it('should decrypt passphrase with arg', async () => {
 			await DecryptCommand.run([defaultEncryptedPassphrase], config);
 			expect(readerUtils.getPasswordFromPrompt).toHaveBeenCalledWith('password', true);
-			expect(cryptography.encrypt.parseEncryptedPassphrase).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.parseEncryptedMessage).toHaveBeenCalledWith(
 				defaultEncryptedPassphrase,
 			);
-			expect(cryptography.encrypt.decryptPassphraseWithPassword).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.decryptMessageWithPassword).toHaveBeenCalledWith(
 				encryptedPassphraseObject,
 				defaultInputs,
+				'utf-8',
 			);
 			expect(DecryptCommand.prototype.printJSON).toHaveBeenCalledWith({ passphrase }, undefined);
 		});
@@ -81,12 +82,13 @@ describe('passphrase:decrypt', () => {
 		it('should decrypt passphrase with passphrase flag and password flag', async () => {
 			await DecryptCommand.run([defaultEncryptedPassphrase, '--password=LbYpLpV9Wpec6ux8'], config);
 			expect(readerUtils.getPasswordFromPrompt).not.toHaveBeenCalled();
-			expect(cryptography.encrypt.parseEncryptedPassphrase).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.parseEncryptedMessage).toHaveBeenCalledWith(
 				defaultEncryptedPassphrase,
 			);
-			expect(cryptography.encrypt.decryptPassphraseWithPassword).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.decryptMessageWithPassword).toHaveBeenCalledWith(
 				encryptedPassphraseObject,
 				defaultInputs,
+				'utf-8',
 			);
 			expect(DecryptCommand.prototype.printJSON).toHaveBeenCalledWith(
 				{

--- a/commander/test/bootstrapping/commands/passphrase/encrypt.spec.ts
+++ b/commander/test/bootstrapping/commands/passphrase/encrypt.spec.ts
@@ -58,10 +58,10 @@ describe('passphrase:encrypt', () => {
 		jest.spyOn(EncryptCommand.prototype, 'printJSON').mockReturnValue();
 		jest.spyOn(cryptography.ed, 'getKeys').mockReturnValue(defaultKeys as never);
 		jest
-			.spyOn(cryptography.encrypt, 'encryptPassphraseWithPassword')
+			.spyOn(cryptography.encrypt, 'encryptMessageWithPassword')
 			.mockResolvedValue(encryptedPassphraseObject as never);
 		jest
-			.spyOn(cryptography.encrypt, 'stringifyEncryptedPassphrase')
+			.spyOn(cryptography.encrypt, 'stringifyEncryptedMessage')
 			.mockReturnValue(encryptedPassphraseString);
 		jest.spyOn(readerUtils, 'getPassphraseFromPrompt').mockImplementation(async (name?: string) => {
 			if (name === 'passphrase') {
@@ -80,11 +80,11 @@ describe('passphrase:encrypt', () => {
 	describe('passphrase:encrypt', () => {
 		it('should encrypt passphrase', async () => {
 			await EncryptCommand.run([], config);
-			expect(cryptography.encrypt.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.encryptMessageWithPassword).toHaveBeenCalledWith(
 				defaultInputs.passphrase,
 				defaultInputs.password,
 			);
-			expect(cryptography.encrypt.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.stringifyEncryptedMessage).toHaveBeenCalledWith(
 				encryptedPassphraseObject,
 			);
 			expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
@@ -103,11 +103,11 @@ describe('passphrase:encrypt', () => {
 	describe('passphrase:encrypt --output-public-key', () => {
 		it('should encrypt passphrase and output public key', async () => {
 			await EncryptCommand.run(['--output-public-key'], config);
-			expect(cryptography.encrypt.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.encryptMessageWithPassword).toHaveBeenCalledWith(
 				defaultInputs.passphrase,
 				defaultInputs.password,
 			);
-			expect(cryptography.encrypt.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.stringifyEncryptedMessage).toHaveBeenCalledWith(
 				encryptedPassphraseObject,
 			);
 			expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
@@ -128,11 +128,11 @@ describe('passphrase:encrypt', () => {
 				['--passphrase=enemy pill squeeze gold spoil aisle awake thumb congress false box wagon'],
 				config,
 			);
-			expect(cryptography.encrypt.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.encryptMessageWithPassword).toHaveBeenCalledWith(
 				defaultInputs.passphrase,
 				defaultInputs.password,
 			);
-			expect(cryptography.encrypt.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.stringifyEncryptedMessage).toHaveBeenCalledWith(
 				encryptedPassphraseObject,
 			);
 			expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);
@@ -155,11 +155,11 @@ describe('passphrase:encrypt', () => {
 				],
 				config,
 			);
-			expect(cryptography.encrypt.encryptPassphraseWithPassword).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.encryptMessageWithPassword).toHaveBeenCalledWith(
 				defaultInputs.passphrase,
 				defaultInputs.password,
 			);
-			expect(cryptography.encrypt.stringifyEncryptedPassphrase).toHaveBeenCalledWith(
+			expect(cryptography.encrypt.stringifyEncryptedMessage).toHaveBeenCalledWith(
 				encryptedPassphraseObject,
 			);
 			expect(readerUtils.getPassphraseFromPrompt).not.toHaveBeenCalledWith('passphrase', true);

--- a/elements/lisk-client/test/lisk-cryptography/encrypt.spec.ts
+++ b/elements/lisk-client/test/lisk-cryptography/encrypt.spec.ts
@@ -19,10 +19,10 @@ jest.mock('@liskhq/lisk-cryptography', () => ({
 
 const {
 	encrypt: {
-		encryptPassphraseWithPassword,
-		decryptPassphraseWithPassword,
-		stringifyEncryptedPassphrase,
-		parseEncryptedPassphrase,
+		encryptMessageWithPassword,
+		decryptMessageWithPassword,
+		stringifyEncryptedMessage,
+		parseEncryptedMessage,
 		KDF,
 		Cipher,
 	},
@@ -71,63 +71,60 @@ describe('encrypt', () => {
 			);
 		});
 
-		describe('#encryptPassphraseWithPassword', () => {
-			let encryptedPassphrase: cryptography.encrypt.EncryptedPassphraseObject;
+		describe('#encryptMessageWithPassword', () => {
+			let encryptedMessage: cryptography.encrypt.EncryptedMessageObject;
 
 			beforeEach(async () => {
-				encryptedPassphrase = await encryptPassphraseWithPassword(
-					defaultPassphrase,
-					defaultPassword,
-					{ kdf: KDF.PBKDF2 },
-				);
+				encryptedMessage = await encryptMessageWithPassword(defaultPassphrase, defaultPassword, {
+					kdf: KDF.PBKDF2,
+				});
 				return Promise.resolve();
 			});
 
 			it('should encrypt a passphrase', () => {
-				expect(encryptedPassphrase).toHaveProperty('ciphertext');
-				expect(regHexadecimal.test(encryptedPassphrase.cipherparams.iv)).toBe(true);
-				expect(encryptedPassphrase.cipherparams.iv).toHaveLength(24);
+				expect(encryptedMessage).toHaveProperty('ciphertext');
+				expect(regHexadecimal.test(encryptedMessage.cipherparams.iv)).toBe(true);
+				expect(encryptedMessage.cipherparams.iv).toHaveLength(24);
 			});
 
 			it('should output the IV', () => {
-				expect(encryptedPassphrase.cipherparams).toHaveProperty('iv');
-				expect(encryptedPassphrase.cipherparams.iv).toHaveLength(24);
+				expect(encryptedMessage.cipherparams).toHaveProperty('iv');
+				expect(encryptedMessage.cipherparams.iv).toHaveLength(24);
 			});
 
 			it('should output the salt', () => {
-				expect(encryptedPassphrase.kdfparams).toHaveProperty('salt');
-				expect(encryptedPassphrase.kdfparams.salt).toHaveLength(32);
+				expect(encryptedMessage.kdfparams).toHaveProperty('salt');
+				expect(encryptedMessage.kdfparams.salt).toHaveLength(32);
 			});
 
 			it('should output the tag', () => {
-				expect(encryptedPassphrase.cipherparams).toHaveProperty('tag');
-				expect(encryptedPassphrase.cipherparams.tag).toHaveLength(32);
+				expect(encryptedMessage.cipherparams).toHaveProperty('tag');
+				expect(encryptedMessage.cipherparams.tag).toHaveLength(32);
 			});
 
 			it('should output the current version of Lisk Elements', () => {
-				expect(encryptedPassphrase).toHaveProperty('version', ENCRYPTION_VERSION);
+				expect(encryptedMessage).toHaveProperty('version', ENCRYPTION_VERSION);
 			});
 
 			it('should output the default number of iterations', () => {
-				expect(encryptedPassphrase.kdfparams).toHaveProperty('iterations', PBKDF2_ITERATIONS);
+				expect(encryptedMessage.kdfparams).toHaveProperty('iterations', PBKDF2_ITERATIONS);
 			});
 
 			it('should accept and output a custom number of iterations', async () => {
-				encryptedPassphrase = await encryptPassphraseWithPassword(
-					defaultPassphrase,
-					defaultPassword,
-					{ kdf: KDF.PBKDF2, kdfparams: { iterations: customIterations } },
-				);
+				encryptedMessage = await encryptMessageWithPassword(defaultPassphrase, defaultPassword, {
+					kdf: KDF.PBKDF2,
+					kdfparams: { iterations: customIterations },
+				});
 
-				expect(encryptedPassphrase.kdfparams.iterations).toBe(customIterations);
+				expect(encryptedMessage.kdfparams.iterations).toBe(customIterations);
 			});
 		});
 
-		describe('#decryptPassphraseWithPassword', () => {
-			let encryptedPassphrase: cryptography.encrypt.EncryptedPassphraseObject;
+		describe('#decryptMessageWithPassword', () => {
+			let encryptedMessage: cryptography.encrypt.EncryptedMessageObject;
 
 			beforeEach(() => {
-				encryptedPassphrase = {
+				encryptedMessage = {
 					ciphertext:
 						'35e25c6278eaf16891e8bd436615eb5fcd7d94a5bbd553535287a4175c0f8b27a67ee3767c4a7d07d0eaa515679f6c9267c34a3c55c2e921b1ede893e7f6f570de6bbf3bea',
 					mac: '0ad2a34f25fe791dcb72f5e0f9b1689566f834efcddcf7f490f4e0962756b5f2',
@@ -148,79 +145,81 @@ describe('encrypt', () => {
 			});
 
 			it('should decrypt a passphrase with a password', async () => {
-				const decrypted = await decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword);
+				const decrypted = await decryptMessageWithPassword(
+					encryptedMessage,
+					defaultPassword,
+					'utf-8',
+				);
 				expect(decrypted).toBe(defaultPassphrase);
 			});
 
 			it('should inform the user if cipherText is missing', async () => {
-				const { ciphertext, ...encryptedPassphraseWithoutCipherText } = encryptedPassphrase;
+				const { ciphertext, ...encryptedMessageWithoutCipherText } = encryptedMessage;
 
 				await expect(
-					decryptPassphraseWithPassword(
-						encryptedPassphraseWithoutCipherText as any,
+					decryptMessageWithPassword(
+						encryptedMessageWithoutCipherText as any,
 						defaultPassword,
+						'utf-8',
 					),
 				).rejects.toThrow('Cipher text must be a string.');
 			});
 
 			it('should inform the user if iv is missing', async () => {
-				encryptedPassphrase.cipherparams.iv = undefined as any;
+				encryptedMessage.cipherparams.iv = undefined as any;
 
 				await expect(
-					decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword),
+					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('IV must be a string.');
 			});
 
 			it('should inform the user if salt is missing', async () => {
-				encryptedPassphrase.kdfparams.salt = undefined as any;
+				encryptedMessage.kdfparams.salt = undefined as any;
 				await expect(
-					decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword),
+					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('Salt must be a string.');
 			});
 
 			it('should inform the user if tag is missing', async () => {
-				encryptedPassphrase.cipherparams.tag = undefined as any;
+				encryptedMessage.cipherparams.tag = undefined as any;
 				await expect(
-					decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword),
+					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('Tag must be a string.');
 			});
 
 			it('should inform the user if the salt has been altered', async () => {
-				encryptedPassphrase.kdfparams.salt = `00${encryptedPassphrase.kdfparams.salt.slice(2)}`;
+				encryptedMessage.kdfparams.salt = `00${encryptedMessage.kdfparams.salt.slice(2)}`;
 				await expect(
-					decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword),
+					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('Unsupported state or unable to authenticate data');
 			});
 
 			it('should inform the user if the tag has been shortened', async () => {
-				encryptedPassphrase.cipherparams.tag = encryptedPassphrase.cipherparams.tag.slice(0, 30);
+				encryptedMessage.cipherparams.tag = encryptedMessage.cipherparams.tag.slice(0, 30);
 				await expect(
-					decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword),
+					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('Tag must be 16 bytes.');
 			});
 
 			it('should inform the user if the tag is not a hex string', async () => {
-				encryptedPassphrase.cipherparams.tag = `${encryptedPassphrase.cipherparams.tag.slice(
-					0,
-					30,
-				)}gg`;
+				encryptedMessage.cipherparams.tag = `${encryptedMessage.cipherparams.tag.slice(0, 30)}gg`;
 				await expect(
-					decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword),
+					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('Tag must be a valid hex string.');
 			});
 
 			it('should inform the user if the tag has been altered', async () => {
-				encryptedPassphrase.cipherparams.tag = `00${encryptedPassphrase.cipherparams.tag.slice(2)}`;
+				encryptedMessage.cipherparams.tag = `00${encryptedMessage.cipherparams.tag.slice(2)}`;
 				await expect(
-					decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword),
+					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('Unsupported state or unable to authenticate data');
 			});
 
 			it('should decrypt a passphrase with a password and a custom number of iterations', async () => {
-				encryptedPassphrase = {
-					...encryptedPassphrase,
+				encryptedMessage = {
+					...encryptedMessage,
 					kdfparams: {
-						...encryptedPassphrase.kdfparams,
+						...encryptedMessage.kdfparams,
 						iterations: 12,
 						salt: '245c6859a96339a7735a6cac78ccf625',
 					},
@@ -228,79 +227,87 @@ describe('encrypt', () => {
 						'1f06671e13c0329aee057fee995e08a516bdacd287c7ff2714a74be6099713c87bbc3e005c63d4d3d02f8ba89b42810a5854444ad2b76855007a0925fafa7d870875beb010',
 					cipherparams: { iv: '3a583b21bbac609c7df3e7e0', tag: '63653f1d4e8d422a42d98b25d3844792' },
 				};
-				const decrypted = await decryptPassphraseWithPassword(encryptedPassphrase, defaultPassword);
+				const decrypted = await decryptMessageWithPassword(
+					encryptedMessage,
+					defaultPassword,
+					'utf-8',
+				);
 				expect(decrypted).toBe(defaultPassphrase);
 			});
 		});
 
 		describe('integration test', () => {
 			it('should encrypt a given passphrase with a password and decrypt it back to the original passphrase with PBKDF2 @node-only', async () => {
-				const encryptedPassphrase = await encryptPassphraseWithPassword(
+				const encryptedMessage = await encryptMessageWithPassword(
 					defaultPassphrase,
 					defaultPassword,
 					{ kdf: KDF.PBKDF2 },
 				);
 
-				const decryptedString = await decryptPassphraseWithPassword(
-					encryptedPassphrase,
+				const decryptedString = await decryptMessageWithPassword(
+					encryptedMessage,
 					defaultPassword,
+					'utf-8',
 				);
 				expect(decryptedString).toBe(defaultPassphrase);
 			});
 
 			it('should encrypt a given passphrase with a password and custom number of iterations and decrypt it back to the original passphrase with PBKDF2 @node-only', async () => {
-				const encryptedPassphrase = await encryptPassphraseWithPassword(
+				const encryptedMessage = await encryptMessageWithPassword(
 					defaultPassphrase,
 					defaultPassword,
 					{ kdf: KDF.PBKDF2, kdfparams: { iterations: customIterations } },
 				);
-				const decryptedString = await decryptPassphraseWithPassword(
-					encryptedPassphrase,
+				const decryptedString = await decryptMessageWithPassword(
+					encryptedMessage,
 					defaultPassword,
+					'utf-8',
 				);
 				expect(decryptedString).toBe(defaultPassphrase);
 			});
 
 			it('should encrypt a given passphrase with a password and decrypt it back to the original passphrase with ARGON2 @node-only', async () => {
-				const encryptedPassphrase = await encryptPassphraseWithPassword(
+				const encryptedMessage = await encryptMessageWithPassword(
 					defaultPassphrase,
 					defaultPassword,
 					{ kdf: KDF.ARGON2 },
 				);
 
-				const decryptedString = await decryptPassphraseWithPassword(
-					encryptedPassphrase,
+				const decryptedString = await decryptMessageWithPassword(
+					encryptedMessage,
 					defaultPassword,
+					'utf-8',
 				);
 				expect(decryptedString).toBe(defaultPassphrase);
 			});
 
 			it('should encrypt a given passphrase with a password and custom number of iterations and decrypt it back to the original passphrase with ARGON2 @node-only', async () => {
-				const encryptedPassphrase = await encryptPassphraseWithPassword(
+				const encryptedMessage = await encryptMessageWithPassword(
 					defaultPassphrase,
 					defaultPassword,
 					{ kdf: KDF.ARGON2, kdfparams: { iterations: customIterations } },
 				);
-				const decryptedString = await decryptPassphraseWithPassword(
-					encryptedPassphrase,
+				const decryptedString = await decryptMessageWithPassword(
+					encryptedMessage,
 					defaultPassword,
+					'utf-8',
 				);
 				expect(decryptedString).toBe(defaultPassphrase);
 			});
 		});
 	});
 
-	describe('#stringifyEncryptedPassphrase', () => {
+	describe('#stringifyEncryptedMessage', () => {
 		it('should throw an error if encrypted passphrase is not an object', () => {
-			const encryptedPassphrase =
+			const encryptedMessage =
 				'salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
-			expect(stringifyEncryptedPassphrase.bind(null, encryptedPassphrase as any)).toThrow(
-				'Encrypted passphrase to stringify must be an object.',
+			expect(stringifyEncryptedMessage.bind(null, encryptedMessage as any)).toThrow(
+				'Encrypted message to stringify must be an object.',
 			);
 		});
 
 		it('should format an encrypted passphrase as a string', () => {
-			const encryptedPassphrase = {
+			const encryptedMessage = {
 				ciphertext:
 					'fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4',
 				mac: '997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d',
@@ -320,13 +327,13 @@ describe('encrypt', () => {
 			};
 			const stringifiedEncryptedPassphrase =
 				'kdf=argon2id&cipher=aes-256-gcm&version=1&ciphertext=fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4&mac=997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d&salt=d3228c53c27a44cbd9d88ea0919bdade&iv=b5c86483366f4698708e6985&tag=5d6c0f628ba12930111c33ef678b2319&iterations=1&parallelism=4&memorySize=2024';
-			expect(stringifyEncryptedPassphrase(encryptedPassphrase as any)).toBe(
+			expect(stringifyEncryptedMessage(encryptedMessage as any)).toBe(
 				stringifiedEncryptedPassphrase,
 			);
 		});
 
 		it('should format an encrypted passphrase with custom iterations as a string', () => {
-			const encryptedPassphrase = {
+			const encryptedMessage = {
 				ciphertext:
 					'fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4',
 				mac: '997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d',
@@ -346,40 +353,40 @@ describe('encrypt', () => {
 			};
 			const stringifiedEncryptedPassphrase =
 				'kdf=argon2id&cipher=aes-256-gcm&version=1&ciphertext=fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4&mac=997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d&salt=d3228c53c27a44cbd9d88ea0919bdade&iv=b5c86483366f4698708e6985&tag=5d6c0f628ba12930111c33ef678b2319&iterations=10000&parallelism=4&memorySize=2024';
-			expect(stringifyEncryptedPassphrase(encryptedPassphrase as any)).toBe(
+			expect(stringifyEncryptedMessage(encryptedMessage as any)).toBe(
 				stringifiedEncryptedPassphrase,
 			);
 		});
 	});
 
-	describe('#parseEncryptedPassphrase', () => {
+	describe('#parseEncryptedMessage', () => {
 		it('should throw an error if encrypted passphrase is not a string', () => {
 			const stringifiedEncryptedPassphrase = { abc: 'def' };
-			expect(parseEncryptedPassphrase.bind(null, stringifiedEncryptedPassphrase as any)).toThrow(
-				'Encrypted passphrase to parse must be a string.',
+			expect(parseEncryptedMessage.bind(null, stringifiedEncryptedPassphrase as any)).toThrow(
+				'Encrypted message to parse must be a string.',
 			);
 		});
 
 		it('should throw an error if iterations is present but not a valid number', () => {
 			const stringifiedEncryptedPassphrase =
 				'iterations=null&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
-			expect(parseEncryptedPassphrase.bind(null, stringifiedEncryptedPassphrase)).toThrow(
-				'Encrypted passphrase to parse must have only one value per key.',
+			expect(parseEncryptedMessage.bind(null, stringifiedEncryptedPassphrase)).toThrow(
+				'Encrypted message to parse must have only one value per key.',
 			);
 		});
 
 		it('should throw an error if multiple values are in a key', () => {
 			const stringifiedEncryptedPassphrase =
 				'salt=xxx&salt=e8c7dae4c893e458e0ebb8bff9a36d84&cipherText=c0fab123d83c386ffacef9a171b6e0e0e9d913e58b7972df8e5ef358afbc65f99c9a2b6fe7716f708166ed72f59f007d2f96a91f48f0428dd51d7c9962e0c6a5fc27ca0722038f1f2cf16333&iv=1a2206e426c714091b7e48f6&tag=3a9d9f9f9a92c9a58296b8df64820c15&version=1';
-			expect(parseEncryptedPassphrase.bind(null, stringifiedEncryptedPassphrase)).toThrow(
-				'Encrypted passphrase to parse must have only one value per key.',
+			expect(parseEncryptedMessage.bind(null, stringifiedEncryptedPassphrase)).toThrow(
+				'Encrypted message to parse must have only one value per key.',
 			);
 		});
 
 		it('should parse an encrypted passphrase string', () => {
 			const stringifiedEncryptedPassphrase =
 				'kdf=argon2id&cipher=aes-256-gcm&version=1&ciphertext=fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4&mac=997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d&salt=d3228c53c27a44cbd9d88ea0919bdade&iv=b5c86483366f4698708e6985&tag=5d6c0f628ba12930111c33ef678b2319&iterations=1&parallelism=4&memorySize=2024';
-			const encryptedPassphrase = {
+			const encryptedMessage = {
 				ciphertext:
 					'fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4',
 				mac: '997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d',
@@ -397,13 +404,13 @@ describe('encrypt', () => {
 				},
 				version: '1',
 			};
-			expect(parseEncryptedPassphrase(stringifiedEncryptedPassphrase)).toEqual(encryptedPassphrase);
+			expect(parseEncryptedMessage(stringifiedEncryptedPassphrase)).toEqual(encryptedMessage);
 		});
 
 		it('should parse an encrypted passphrase string with custom iterations', () => {
 			const stringifiedEncryptedPassphrase =
 				'kdf=argon2id&cipher=aes-256-gcm&version=1&ciphertext=fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4&mac=997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d&salt=d3228c53c27a44cbd9d88ea0919bdade&iv=b5c86483366f4698708e6985&tag=5d6c0f628ba12930111c33ef678b2319&iterations=10000&parallelism=4&memorySize=2024';
-			const encryptedPassphrase = {
+			const encryptedMessage = {
 				ciphertext:
 					'fc8cdb068314590fa7e3156c60bf4a6b1f908f91bb81c79319e858cead7fba581101167c12a4f63acf86908b5c2d7dad96246cd9cd25bc8adca61d7301925869e8bf5cf2a573ae9e5a84e4',
 				mac: '997afad0b38f2d47f347648994a65e8d7ec46feec92720ab629a77cc11875c4d',
@@ -421,7 +428,7 @@ describe('encrypt', () => {
 				},
 				version: '1',
 			};
-			expect(parseEncryptedPassphrase(stringifiedEncryptedPassphrase)).toEqual(encryptedPassphrase);
+			expect(parseEncryptedMessage(stringifiedEncryptedPassphrase)).toEqual(encryptedMessage);
 		});
 	});
 });

--- a/elements/lisk-cryptography/src/ed.ts
+++ b/elements/lisk-cryptography/src/ed.ts
@@ -36,7 +36,7 @@ const signatureFooter = createHeader('END LISK SIGNED MESSAGE');
 const SIGNED_MESSAGE_PREFIX_BYTES = Buffer.from(SIGNED_MESSAGE_PREFIX, 'utf8');
 const SIGNED_MESSAGE_PREFIX_LENGTH = encodeVarInt(SIGNED_MESSAGE_PREFIX.length);
 
-const digestMessage = (message: string): Buffer => {
+export const digestMessage = (message: string): Buffer => {
 	const msgBytes = Buffer.from(message, 'utf8');
 	const msgLenBytes = encodeVarInt(message.length);
 	const dataBytes = Buffer.concat([

--- a/framework-plugins/lisk-framework-faucet-plugin/src/plugin/endpoint.ts
+++ b/framework-plugins/lisk-framework-faucet-plugin/src/plugin/endpoint.ts
@@ -47,13 +47,14 @@ export class Endpoint extends BasePluginEndpoint {
 		const { enable, password } = context.params;
 
 		try {
-			const parsedEncryptedPassphrase = cryptography.encrypt.parseEncryptedPassphrase(
+			const parsedEncryptedPassphrase = cryptography.encrypt.parseEncryptedMessage(
 				this._config.encryptedPassphrase,
 			);
 
-			const passphrase = await cryptography.encrypt.decryptPassphraseWithPassword(
-				parsedEncryptedPassphrase as cryptography.encrypt.EncryptedPassphraseObject,
+			const passphrase = await cryptography.encrypt.decryptMessageWithPassword(
+				parsedEncryptedPassphrase,
 				password as string,
+				'utf-8',
 			);
 
 			const { publicKey } = cryptography.address.getAddressAndPublicKeyFromPassphrase(passphrase);

--- a/framework-plugins/lisk-framework-report-misbehavior-plugin/src/endpoint.ts
+++ b/framework-plugins/lisk-framework-report-misbehavior-plugin/src/endpoint.ts
@@ -43,13 +43,14 @@ export class Endpoint extends BasePluginEndpoint {
 		const { enable, password } = context.params;
 
 		try {
-			const parsedEncryptedPassphrase = encrypt.parseEncryptedPassphrase(
+			const parsedEncryptedPassphrase = encrypt.parseEncryptedMessage(
 				this._config.encryptedPassphrase,
 			);
 
-			const passphrase = await encrypt.decryptPassphraseWithPassword(
+			const passphrase = await encrypt.decryptMessageWithPassword(
 				parsedEncryptedPassphrase as any,
 				password as string,
+				'utf-8',
 			);
 
 			const { publicKey } = address.getAddressAndPublicKeyFromPassphrase(passphrase);

--- a/framework/src/engine/generator/endpoint.ts
+++ b/framework/src/engine/generator/endpoint.ts
@@ -93,11 +93,10 @@ export class Endpoint {
 		}
 
 		try {
-			passphrase = await encrypt.decryptPassphraseWithPassword(
-				encrypt.parseEncryptedPassphrase(
-					encryptedGenerator.encryptedPassphrase,
-				) as encrypt.EncryptedPassphraseObject,
+			passphrase = await encrypt.decryptMessageWithPassword(
+				encrypt.parseEncryptedMessage(encryptedGenerator.encryptedPassphrase),
 				req.password,
+				'utf-8',
 			);
 		} catch (e) {
 			throw new Error('Invalid password and public key combination.');

--- a/framework/src/engine/generator/generator.ts
+++ b/framework/src/engine/generator/generator.ts
@@ -328,11 +328,10 @@ export class Generator {
 		for (const encryptedItem of encryptedList) {
 			let passphrase;
 			try {
-				passphrase = await encrypt.decryptPassphraseWithPassword(
-					encrypt.parseEncryptedPassphrase(
-						encryptedItem.encryptedPassphrase,
-					) as encrypt.EncryptedPassphraseObject,
+				passphrase = await encrypt.decryptMessageWithPassword(
+					encrypt.parseEncryptedMessage(encryptedItem.encryptedPassphrase),
 					this._config.password,
+					'utf-8',
 				);
 			} catch (error) {
 				const decryptionError = `Invalid encryptedPassphrase for address: ${encryptedItem.address.toString(

--- a/framework/src/testing/fixtures/config.ts
+++ b/framework/src/testing/fixtures/config.ts
@@ -2622,12 +2622,13 @@ const getDelegateFromDefaultConfig = (address: Buffer) => {
 
 export const getPassphraseFromDefaultConfig = async (address: Buffer): Promise<string> => {
 	const delegateConfig = getDelegateFromDefaultConfig(address);
-	const encryptedPassphraseObject = encrypt.parseEncryptedPassphrase(
+	const encryptedPassphraseObject = encrypt.parseEncryptedMessage(
 		delegateConfig.encryptedPassphrase,
-	) as encrypt.EncryptedPassphraseObject;
-	const passphrase = await encrypt.decryptPassphraseWithPassword(
+	);
+	const passphrase = await encrypt.decryptMessageWithPassword(
 		encryptedPassphraseObject,
 		defaultPassword,
+		'utf-8',
 	);
 
 	return passphrase;


### PR DESCRIPTION
### What was the problem?

This PR resolves #7333 and resolves #7331

### How was it solved?

- Updated function names to remove `passphrase`
- Removed unnecessary type

### How was it tested?

- Add tests for invalid decryption
- Updated the usage
