### PR TITLE
Register interoperability module - Closes #7362

### DIFF
--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -196,6 +196,7 @@ export class Application {
 		application._registerModule(rewardModule);
 		application._registerModule(randomModule);
 		application._registerModule(dposModule);
+		application._registerModule(interoperabilityModule);
 
 		return {
 			app: application,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7362

### How was it solved?

[♻️ Register interoperability module](https://github.com/LiskHQ/lisk-sdk/commit/418dd619064c0a9954c8b1edc59822bd46d53e81)

### How was it tested?

Run `examples/dpos-mainchain` and call interoperability endpoints to check if it is registered
