### PR TITLE
Update commander blockchain:reset command - Closes #7349

### DIFF
--- a/commander/src/bootstrapping/commands/blockchain/reset.ts
+++ b/commander/src/bootstrapping/commands/blockchain/reset.ts
@@ -12,12 +12,17 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import * as fs from 'fs-extra';
 import { Command, flags as flagParser } from '@oclif/command';
 import * as inquirer from 'inquirer';
-import { getDefaultPath } from '../../../utils/path';
+import {
+	getDefaultPath,
+	getBlockchainDBPath,
+	getStateDBPath,
+	getModuleDBPath,
+} from '../../../utils/path';
 import { flagsWithParser } from '../../../utils/flags';
 import { getPid, isApplicationRunning } from '../../../utils/application';
-import { getBlockchainDB } from '../../../utils/db';
 
 export class ResetCommand extends Command {
 	static description = 'Reset the blockchain data.';
@@ -67,8 +72,13 @@ export class ResetCommand extends Command {
 			}
 		}
 
-		const db = getBlockchainDB(dataPath);
-		await db.clear();
+		// Remove blockchain, state and module dbs
+		// Generator and node dbs will not be cleared
+		// We manually remove the dbs vs. using db.clear as clear is not implemented yet in state and module dbs (blockchain db for consistency)
+		fs.removeSync(getBlockchainDBPath(dataPath));
+		fs.removeSync(getStateDBPath(dataPath));
+		fs.removeSync(getModuleDBPath(dataPath));
+
 		this.log('Blockchain data has been reset.');
 	}
 }

--- a/commander/src/utils/path.ts
+++ b/commander/src/utils/path.ts
@@ -63,6 +63,11 @@ export const ensureConfigDir = (dataPath: string, network: string): void =>
 export const getBlockchainDBPath = (dataPath: string): string =>
 	path.join(dataPath, 'data', 'blockchain.db');
 
+export const getStateDBPath = (dataPath: string): string => path.join(dataPath, 'data', 'state.db');
+
+export const getModuleDBPath = (dataPath: string): string =>
+	path.join(dataPath, 'data', 'module.db');
+
 export const getForgerDBPath = (dataPath: string): string =>
 	path.join(dataPath, 'data', 'forger.db');
 

--- a/commander/test/bootstrapping/commands/blockchain/reset.spec.ts
+++ b/commander/test/bootstrapping/commands/blockchain/reset.spec.ts
@@ -13,13 +13,14 @@
  *
  */
 
+import * as fs from 'fs-extra';
 import * as inquirer from 'inquirer';
 import { homedir } from 'os';
 import { join } from 'path';
 import * as Config from '@oclif/config';
 
 import * as appUtils from '../../../../src/utils/application';
-import * as dbUtils from '../../../../src/utils/db';
+import * as pathUtils from '../../../../src/utils/path';
 import { ResetCommand } from '../../../../src/bootstrapping/commands/blockchain/reset';
 import { getConfig } from '../../../helpers/config';
 
@@ -31,20 +32,17 @@ describe('blockchain:reset', () => {
 	let stdout: string[];
 	let stderr: string[];
 	let config: Config.IConfig;
-	let kvStoreStubInstance: any;
 
 	beforeEach(async () => {
 		stdout = [];
 		stderr = [];
-		kvStoreStubInstance = {
-			clear: jest.fn(),
-		};
 		config = await getConfig();
 		jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
 		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
-		jest.spyOn(dbUtils, 'getBlockchainDB').mockReturnValue(kvStoreStubInstance);
+		jest.spyOn(pathUtils, 'getBlockchainDBPath').mockReturnValue('path');
 		jest.spyOn(appUtils, 'getPid').mockReturnValue(pid);
 		jest.spyOn(inquirer, 'prompt').mockResolvedValue({ answer: false });
+		jest.spyOn(fs, 'removeSync').mockReturnValue();
 	});
 
 	describe('when application is running', () => {
@@ -85,8 +83,8 @@ describe('blockchain:reset', () => {
 		describe('when reset without flag', () => {
 			it('should create db object for "blockchain.db" for default data path', async () => {
 				await ResetCommand.run([], config);
-				expect(dbUtils.getBlockchainDB).toHaveBeenCalledTimes(1);
-				expect(dbUtils.getBlockchainDB).toHaveBeenCalledWith(defaultDataPath);
+				expect(pathUtils.getBlockchainDBPath).toHaveBeenCalledTimes(1);
+				expect(pathUtils.getBlockchainDBPath).toHaveBeenCalledWith(defaultDataPath);
 			});
 
 			it('should prompt user for confirmation', async () => {
@@ -104,7 +102,7 @@ describe('blockchain:reset', () => {
 
 			it('should reset the blockchain db', async () => {
 				await ResetCommand.run([], config);
-				expect(kvStoreStubInstance.clear).toHaveBeenCalledTimes(1);
+				expect(fs.removeSync).toHaveBeenCalledTimes(3);
 			});
 		});
 
@@ -115,8 +113,8 @@ describe('blockchain:reset', () => {
 
 			it('should create db object for "blockchain.db" for given data path', async () => {
 				await ResetCommand.run(['--data-path=/my/app/'], config);
-				expect(dbUtils.getBlockchainDB).toHaveBeenCalledTimes(1);
-				expect(dbUtils.getBlockchainDB).toHaveBeenCalledWith('/my/app/');
+				expect(pathUtils.getBlockchainDBPath).toHaveBeenCalledTimes(1);
+				expect(pathUtils.getBlockchainDBPath).toHaveBeenCalledWith('/my/app/');
 			});
 
 			it('should prompt user for confirmation', async () => {
@@ -134,7 +132,7 @@ describe('blockchain:reset', () => {
 
 			it('should reset the blockchain db', async () => {
 				await ResetCommand.run(['--data-path=/my/app/'], config);
-				expect(kvStoreStubInstance.clear).toHaveBeenCalledTimes(1);
+				expect(fs.removeSync).toHaveBeenCalledTimes(3);
 			});
 		});
 
@@ -145,12 +143,12 @@ describe('blockchain:reset', () => {
 
 			it('should create db object for "blockchain.db"', async () => {
 				await ResetCommand.run(['--yes'], config);
-				expect(dbUtils.getBlockchainDB).toHaveBeenCalledTimes(1);
+				expect(pathUtils.getBlockchainDBPath).toHaveBeenCalledTimes(1);
 			});
 
 			it('should reset the blockchain db', async () => {
 				await ResetCommand.run(['--yes'], config);
-				expect(kvStoreStubInstance.clear).toHaveBeenCalledTimes(1);
+				expect(fs.removeSync).toHaveBeenCalledTimes(3);
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #7349

### How was it solved?

- Remove state, module and blockchain dbs using fs remove
- Leave generator and node dbs for security reasons

### How was it tested?

- Update unit tests

