### PR TITLE
No call to token.mint when reward is zero - Closes #7388

### DIFF
--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -99,12 +99,14 @@ export class RewardModule extends BaseModule {
 			throw new Error("Block reward can't be negative.");
 		}
 
-		await this._tokenAPI.mint(
-			context.getAPIContext(),
-			context.header.generatorAddress,
-			this._tokenID,
-			blockReward,
-		);
+		if (blockReward !== BigInt(0)) {
+			await this._tokenAPI.mint(
+				context.getAPIContext(),
+				context.header.generatorAddress,
+				this._tokenID,
+				blockReward,
+			);
+		}
 
 		const rewardMintedData: RewardMintedData = {
 			amount: blockReward,

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -101,8 +101,9 @@ describe('RewardModule', () => {
 		});
 
 		it('should emit rewardMinted event for event type REWARD_NO_REDUCTION', async () => {
-			rewardModule.api.getBlockReward = jest.fn().mockReturnValue([BigInt(0), REWARD_NO_REDUCTION]);
+			rewardModule.api.getBlockReward = jest.fn().mockReturnValue([BigInt(1), REWARD_NO_REDUCTION]);
 			await rewardModule.afterTransactionsExecute(blockAfterExecuteContext);
+			expect(mint).toHaveBeenCalledTimes(1);
 			expect(blockAfterExecuteContext.eventQueue.getEvents()[0].toObject().typeID).toBe(
 				TYPE_ID_REWARD_MINTED,
 			);
@@ -113,6 +114,7 @@ describe('RewardModule', () => {
 				.fn()
 				.mockReturnValue([BigInt(0), REWARD_REDUCTION_SEED_REVEAL]);
 			await rewardModule.afterTransactionsExecute(blockAfterExecuteContext);
+			expect(mint).toHaveBeenCalledTimes(0);
 			expect(blockAfterExecuteContext.eventQueue.getEvents()[0].toObject().typeID).toBe(
 				TYPE_ID_REWARD_MINTED,
 			);
@@ -125,6 +127,7 @@ describe('RewardModule', () => {
 					BigInt(1) / BigInt(REWARD_REDUCTION_FACTOR_BFT),
 					REWARD_REDUCTION_MAX_PREVOTES,
 				]);
+			expect(mint).toHaveBeenCalledTimes(0);
 			await rewardModule.afterTransactionsExecute(blockAfterExecuteContext);
 			expect(blockAfterExecuteContext.eventQueue.getEvents()[0].toObject().typeID).toBe(
 				TYPE_ID_REWARD_MINTED,


### PR DESCRIPTION
- When reward is zero we should not call token.mint API, we only call it when reward is > 0

### What was the problem?

This PR resolves #7388

### How was it solved?

[🐛 No call to token.mint when reward is zero](https://github.com/LiskHQ/lisk-sdk/commit/18efd13f447252315acdd071b5a7cb9a5eac7ef5)

### How was it tested?

- Run `examples/dpos-mainchain/bin/run start --api-ipc --port 5002`
- Test should pass under `framework/test/unit/modules/reward/reward_module.spec.ts`
