### PR TITLE
Update Auth module according update of LIP0041 - Closes #7345

### DIFF
--- a/framework/src/modules/auth/commands/register_multisignature.ts
+++ b/framework/src/modules/auth/commands/register_multisignature.ts
@@ -22,8 +22,8 @@ import {
 	VerifyStatus,
 } from '../../../state_machine';
 import {
-	COMMAND_ID_MULTISIGNATURE_REGISTRATION,
-	MAX_KEYS_COUNT,
+	COMMAND_ID_REGISTER_MULTISIGNATURE_GROUP,
+	MAX_NUMBER_OF_SIGNATURES,
 	MODULE_ID_AUTH,
 	STORE_PREFIX_AUTH,
 } from '../constants';
@@ -32,7 +32,7 @@ import { AuthAccount, RegisterMultisignatureParams } from '../types';
 import { getIDAsKeyForStore } from '../utils';
 
 export class RegisterMultisignatureCommand extends BaseCommand {
-	public id = getIDAsKeyForStore(COMMAND_ID_MULTISIGNATURE_REGISTRATION);
+	public id = getIDAsKeyForStore(COMMAND_ID_REGISTER_MULTISIGNATURE_GROUP);
 	public name = 'registerMultisignatureGroup';
 	public schema = registerMultisignatureParamsSchema;
 
@@ -78,7 +78,7 @@ export class RegisterMultisignatureCommand extends BaseCommand {
 
 		// Check if key count is out of bounds
 		if (
-			mandatoryKeys.length + optionalKeys.length > MAX_KEYS_COUNT ||
+			mandatoryKeys.length + optionalKeys.length > MAX_NUMBER_OF_SIGNATURES ||
 			mandatoryKeys.length + optionalKeys.length <= 0
 		) {
 			return {

--- a/framework/src/modules/auth/constants.ts
+++ b/framework/src/modules/auth/constants.ts
@@ -17,7 +17,16 @@ import { utils } from '@liskhq/lisk-cryptography';
 export const MODULE_ID_AUTH = 12; // TBD
 export const MODULE_ID_AUTH_BUFFER = utils.intToBuffer(MODULE_ID_AUTH, 4);
 export const STORE_PREFIX_AUTH = 0x0000;
-export const MAX_KEYS_COUNT = 64;
+export const MAX_NUMBER_OF_SIGNATURES = 64;
 
 // Commands
-export const COMMAND_ID_MULTISIGNATURE_REGISTRATION = 0;
+export const COMMAND_ID_REGISTER_MULTISIGNATURE_GROUP = 0x0000;
+// Events
+export const TYPE_ID_MULTISIGNATURE_GROUP_REGISTERED = 0x0001;
+export const TYPE_ID_INVALID_SIGNATURE_ERROR = 0x0002;
+export const MESSAGE_TAG_MULTISIG_REG = Buffer.from('LSK_RMSG_', 'utf8');
+export const MESSAGE_TAG_TRANSACTION = Buffer.from('LSK_TX_', 'utf8');
+// Constants
+export const ADDRESS_LENGTH = 20;
+export const ED25519_PUBLIC_KEY_LENGTH = 32;
+export const ED25519_SIGNATURE_LENGTH = 64;

--- a/framework/src/modules/auth/module.ts
+++ b/framework/src/modules/auth/module.ts
@@ -26,8 +26,8 @@ import {
 import { AuthAPI } from './api';
 import { RegisterMultisignatureCommand } from './commands/register_multisignature';
 import {
-	COMMAND_ID_MULTISIGNATURE_REGISTRATION,
-	MAX_KEYS_COUNT,
+	COMMAND_ID_REGISTER_MULTISIGNATURE_GROUP,
+	MAX_NUMBER_OF_SIGNATURES,
 	MODULE_ID_AUTH,
 	STORE_PREFIX_AUTH,
 } from './constants';
@@ -113,9 +113,9 @@ export class AuthModule extends BaseModule {
 					throw new Error('Invalid store value for auth module. OptionalKeys are not unique.');
 				}
 			}
-			if (mandatoryKeys.length + optionalKeys.length > MAX_KEYS_COUNT) {
+			if (mandatoryKeys.length + optionalKeys.length > MAX_NUMBER_OF_SIGNATURES) {
 				throw new Error(
-					`The count of Mandatory and Optional keys should be maximum ${MAX_KEYS_COUNT}.`,
+					`The count of Mandatory and Optional keys should be maximum ${MAX_NUMBER_OF_SIGNATURES}.`,
 				);
 			}
 
@@ -179,7 +179,7 @@ export class AuthModule extends BaseModule {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
 			transaction.moduleID.equals(this.id) &&
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			transaction.commandID.equals(getIDAsKeyForStore(COMMAND_ID_MULTISIGNATURE_REGISTRATION))
+			transaction.commandID.equals(getIDAsKeyForStore(COMMAND_ID_REGISTER_MULTISIGNATURE_GROUP))
 		) {
 			verifyRegisterMultiSignatureTransaction(
 				TAG_TRANSACTION,

--- a/framework/src/modules/auth/schemas.ts
+++ b/framework/src/modules/auth/schemas.ts
@@ -12,6 +12,12 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import {
+	ED25519_PUBLIC_KEY_LENGTH,
+	ED25519_SIGNATURE_LENGTH,
+	MAX_NUMBER_OF_SIGNATURES,
+} from './constants';
+
 export const authAccountSchema = {
 	$id: '/auth/account',
 	type: 'object',
@@ -24,28 +30,28 @@ export const authAccountSchema = {
 			dataType: 'uint32',
 			fieldNumber: 2,
 			minimum: 0,
-			maximum: 64,
+			maximum: MAX_NUMBER_OF_SIGNATURES,
 		},
 		mandatoryKeys: {
 			type: 'array',
 			items: {
 				dataType: 'bytes',
-				minLength: 32,
-				maxLength: 32,
+				minLength: ED25519_PUBLIC_KEY_LENGTH,
+				maxLength: ED25519_PUBLIC_KEY_LENGTH,
 			},
 			minItems: 0,
-			maxItems: 64,
+			maxItems: MAX_NUMBER_OF_SIGNATURES,
 			fieldNumber: 3,
 		},
 		optionalKeys: {
 			type: 'array',
 			items: {
 				dataType: 'bytes',
-				minLength: 32,
-				maxLength: 32,
+				minLength: ED25519_PUBLIC_KEY_LENGTH,
+				maxLength: ED25519_PUBLIC_KEY_LENGTH,
 			},
 			minItems: 0,
-			maxItems: 64,
+			maxItems: MAX_NUMBER_OF_SIGNATURES,
 			fieldNumber: 4,
 		},
 	},
@@ -141,6 +147,85 @@ export const genesisAuthStoreSchema = {
 					},
 				},
 			},
+		},
+	},
+};
+
+// Events schema
+export const multisigRegDataSchema = {
+	$id: '/auth/events/multisigRegData',
+	type: 'object',
+	required: ['numberOfSignatures', 'mandatoryKeys', 'optionalKeys'],
+	properties: {
+		numberOfSignatures: {
+			dataType: 'uint32',
+			fieldNumber: 1,
+		},
+		mandatoryKeys: {
+			type: 'array',
+			items: {
+				dataType: 'bytes',
+				minLength: ED25519_PUBLIC_KEY_LENGTH,
+				maxLength: ED25519_PUBLIC_KEY_LENGTH,
+			},
+			fieldNumber: 2,
+		},
+		optionalKeys: {
+			type: 'array',
+			items: {
+				dataType: 'bytes',
+				minLength: ED25519_PUBLIC_KEY_LENGTH,
+				maxLength: ED25519_PUBLIC_KEY_LENGTH,
+			},
+			fieldNumber: 3,
+		},
+	},
+};
+
+export const invalidSigDataSchema = {
+	$id: '/auth/events/invalidSigData',
+	type: 'object',
+	required: [
+		'numberOfSignatures',
+		'mandatoryKeys',
+		'optionalKeys',
+		'failingPublicKey',
+		'failingSignature',
+	],
+	properties: {
+		numberOfSignatures: {
+			dataType: 'uint32',
+			fieldNumber: 1,
+		},
+		mandatoryKeys: {
+			type: 'array',
+			items: {
+				dataType: 'bytes',
+				minLength: ED25519_PUBLIC_KEY_LENGTH,
+				maxLength: ED25519_PUBLIC_KEY_LENGTH,
+			},
+			fieldNumber: 2,
+		},
+		optionalKeys: {
+			type: 'array',
+			items: {
+				dataType: 'bytes',
+				minLength: ED25519_PUBLIC_KEY_LENGTH,
+				maxLength: ED25519_PUBLIC_KEY_LENGTH,
+			},
+			fieldNumber: 3,
+		},
+		failingPublicKey: {
+			dataType: 'bytes',
+			minLength: ED25519_PUBLIC_KEY_LENGTH,
+			maxLength: ED25519_PUBLIC_KEY_LENGTH,
+			fieldNumber: 4,
+		},
+		failingSignature: {
+			dataType: 'bytes',
+			minLength: ED25519_SIGNATURE_LENGTH,
+			maxLength: ED25519_SIGNATURE_LENGTH,
+			fieldNumber: 5,
 		},
 	},
 };


### PR DESCRIPTION
### What was the problem?

This PR resolves #7345

### How was it solved?

[♻️ Update Auth module according update of LIP0041](https://github.com/LiskHQ/lisk-sdk/commit/c6ce7e2158c080a6a165db865b4194207abec184)

### How was it tested?

Run `npm run test:unit auth` under `framework`
