### PR TITLE
Remove interoperability_getInteroperabilityStore endpoint

### DIFF
--- a/framework/src/modules/interoperability/base_interoperability_endpoint.ts
+++ b/framework/src/modules/interoperability/base_interoperability_endpoint.ts
@@ -36,6 +36,7 @@ export abstract class BaseInteroperabilityEndpoint<
 	T extends BaseInteroperabilityStore
 > extends BaseEndpoint {
 	protected readonly interoperableCCMethods = new Map<string, BaseInteroperableMethod>();
+	protected abstract getInteroperabilityStore: (context: StoreGetter | ImmutableStoreGetter) => T;
 
 	public constructor(
 		protected stores: NamedRegistry,
@@ -153,6 +154,4 @@ export abstract class BaseInteroperabilityEndpoint<
 			size: box.size,
 		};
 	}
-
-	protected abstract getInteroperabilityStore(context: StoreGetter | ImmutableStoreGetter): T;
 }

--- a/framework/src/modules/interoperability/mainchain/endpoint.ts
+++ b/framework/src/modules/interoperability/mainchain/endpoint.ts
@@ -17,9 +17,8 @@ import { BaseInteroperabilityEndpoint } from '../base_interoperability_endpoint'
 import { ImmutableStoreGetter, StoreGetter } from '../../base_store';
 
 export class MainchainInteroperabilityEndpoint extends BaseInteroperabilityEndpoint<MainchainInteroperabilityStore> {
-	protected getInteroperabilityStore(
+	protected getInteroperabilityStore = (
 		context: StoreGetter | ImmutableStoreGetter,
-	): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
-	}
+	): MainchainInteroperabilityStore =>
+		new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
 }

--- a/framework/src/modules/interoperability/sidechain/endpoint.ts
+++ b/framework/src/modules/interoperability/sidechain/endpoint.ts
@@ -12,14 +12,13 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { SidechainInteroperabilityStore } from './store';
 import { BaseInteroperabilityEndpoint } from '../base_interoperability_endpoint';
-import { ImmutableStoreGetter, StoreGetter } from '../../base_store';
+import { StoreGetter, ImmutableStoreGetter } from '../../base_store';
+import { SidechainInteroperabilityStore } from './store';
 
 export class SidechainInteroperabilityEndpoint extends BaseInteroperabilityEndpoint<SidechainInteroperabilityStore> {
-	protected getInteroperabilityStore(
+	protected getInteroperabilityStore = (
 		context: StoreGetter | ImmutableStoreGetter,
-	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
-	}
+	): SidechainInteroperabilityStore =>
+		new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves #7466

### How was it solved?
`getInteroperabilityStore` method from concrete & abstract class is replaced with a private method in `abstract` class

### How was it tested?
- `cd /lisk-sdk/examples/dpos-mainchain/`
-  `./bin/run start --api-ipc` (it shouldn't show registered endpoints in logs like this)

```bash
18:00:20 INFO lisk-framework: Starting controller (module=lisk:app)
18:00:20 INFO lisk-framework: [
  'app_getRegisteredActions',
  'app_getRegisteredEvents',
  'auth_getAuthAccount',
  'auth_isValidSignature',
  'auth_isValidNonce',
  'validators_validateBLSKey',
  'validators_getValidator',
  'token_getBalances',
  'token_getBalance',
  'token_getTotalSupply',
  'token_getSupportedTokens',
  'token_getEscrowedAmounts',
  'reward_getDefaultRewardAtHeight',
  'random_isSeedRevealValid',
  'dpos_getVoter',
  'dpos_getDelegate',
  'dpos_getAllDelegates',
  'dpos_getConstants'
] Application ready for endpoints (module=lisk:app)
```