### PR TITLE
Fix transaction create command - Closes #7516

### DIFF
--- a/commander/src/utils/config.ts
+++ b/commander/src/utils/config.ts
@@ -39,4 +39,4 @@ export const defaultConfig = {
 	plugins: {},
 };
 
-export const DEFAULT_KEY_DERIVATION_PATH = "m/25519'/134'/0'/0'";
+export const DEFAULT_KEY_DERIVATION_PATH = "m/44'/134'/0'";

--- a/commander/src/utils/transaction.ts
+++ b/commander/src/utils/transaction.ts
@@ -77,6 +77,28 @@ export const encodeTransaction = (
 	return txBytes;
 };
 
+export const encodeTransactionJSON = (
+	schema: RegisteredSchema,
+	metadata: ModuleMetadataJSON[],
+	transaction: Record<string, unknown>,
+	apiClient?: liskApiClient.APIClient,
+): Buffer => {
+	if (apiClient) {
+		return apiClient.transaction.encode(apiClient.transaction.fromJSON(transaction as never));
+	}
+	const paramsSchema = getParamsSchema(
+		metadata,
+		transaction.module as string,
+		transaction.command as string,
+	);
+	const paramsBytes = codec.encodeJSON(paramsSchema as Schema, transaction.params as object);
+	const txBytes = codec.encodeJSON(schema.transaction, {
+		...transaction,
+		params: paramsBytes.toString('hex'),
+	});
+	return txBytes;
+};
+
 export const transactionToJSON = (
 	schema: RegisteredSchema,
 	metadata: ModuleMetadataJSON[],

--- a/commander/test/bootstrapping/commands/transaction/create.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/create.spec.ts
@@ -30,11 +30,11 @@ import { PromiseResolvedType } from '../../../../src/types';
 describe('transaction:create command', () => {
 	const passphrase = 'peanut hundred pen hawk invite exclude brain chunk gadget wait wrong ready';
 	const transferParams =
-		'{"tokenID": "0000000000000000","amount":100,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","data":"send token"}';
+		'{"tokenID": "0000000000000000","amount":100,"recipientAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","data":"send token"}';
 	const voteParams =
-		'{"votes":[{"delegateAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","amount":100},{"delegateAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","amount":-50}]}';
+		'{"votes":[{"delegateAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","amount":100},{"delegateAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","amount":-50}]}';
 	const unVoteParams =
-		'{"votes":[{"delegateAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815","amount":-50}]}';
+		'{"votes":[{"delegateAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","amount":-50}]}';
 	const { publicKey } = cryptography.legacy.getPrivateAndPublicKeyFromPassphrase(passphrase);
 	const senderPublicKey = publicKey.toString('hex');
 	const mockEncodedTransaction = Buffer.from('encoded transaction');
@@ -43,13 +43,13 @@ describe('transaction:create command', () => {
 			tokenID: '0000000000000000',
 			amount: '100',
 			data: 'send token',
-			recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+			recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 		},
 		command: 'transfer',
 		fee: '100000000',
 		module: 'token',
 		nonce: 'transfer',
-		senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+		senderPublicKey: '31048f87ca35a00a553633dd03c788d4b82ea9caf6ccc36315cf8e595f3e7a83',
 		signatures: [
 			'3cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',
 		],
@@ -123,7 +123,7 @@ describe('transaction:create command', () => {
 		jest.spyOn(inquirer, 'prompt').mockResolvedValue({
 			tokenID: '0000000000000000',
 			amount: 100,
-			recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+			recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 			data: 'send token',
 		});
 		jest.spyOn(readerUtils, 'getPassphraseFromPrompt').mockResolvedValue(passphrase);
@@ -251,7 +251,7 @@ describe('transaction:create command', () => {
 								'token',
 								'transfer',
 								'100000000',
-								'--params={"tokenID":"0000000000000000","amount":100,"recipientAddress":"ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815"}',
+								'--params={"tokenID":"0000000000000000","amount":100,"recipientAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9"}',
 								`--passphrase=${passphrase}`,
 								'--offline',
 								'--chain-id=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
@@ -448,12 +448,12 @@ describe('transaction:create command', () => {
 							command: 'transfer',
 							nonce: '1',
 							fee: '100000000',
-							senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+							senderPublicKey,
 							params: {
 								tokenID: '0000000000000000',
 								amount: '100',
 								data: 'send token',
-								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 							},
 							signatures: [],
 						},
@@ -488,12 +488,12 @@ describe('transaction:create command', () => {
 							nonce: '1',
 							fee: '100000000',
 							id: expect.any(String),
-							senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+							senderPublicKey: '31048f87ca35a00a553633dd03c788d4b82ea9caf6ccc36315cf8e595f3e7a83',
 							params: {
 								tokenID: '0000000000000000',
 								amount: '100',
 								data: 'send token',
-								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 							},
 							signatures: [expect.any(String)],
 						},
@@ -715,12 +715,12 @@ describe('transaction:create command', () => {
 							command: 'transfer',
 							nonce: 'transfer',
 							fee: '100000000',
-							senderPublicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+							senderPublicKey: '31048f87ca35a00a553633dd03c788d4b82ea9caf6ccc36315cf8e595f3e7a83',
 							params: {
 								tokenID: '0000000000000000',
 								amount: '100',
 								data: 'send token',
-								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 							},
 							signatures: [
 								'3cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',

--- a/commander/test/bootstrapping/commands/transaction/get.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/get.spec.ts
@@ -40,7 +40,7 @@ describe('transaction:get command', () => {
 		amount: '1',
 		fee: '0.2',
 		nonce: 1,
-		recipientAddress: '0903f4c5cb599a7928aef27e314e98291d1e3888',
+		recipientAddress: 'lskxpxg4y755b9nr6m7f4gcvtk2mp7yj7p364mzem',
 	});
 	const encodedTransaction = encodeTransactionFromJSON(
 		transferTransaction as any,

--- a/commander/test/bootstrapping/commands/transaction/send.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/send.spec.ts
@@ -40,7 +40,7 @@ describe('transaction:send command', () => {
 		amount: '1',
 		fee: '0.2',
 		nonce: 1,
-		recipientAddress: '0903f4c5cb599a7928aef27e314e98291d1e3888',
+		recipientAddress: 'lskxpxg4y755b9nr6m7f4gcvtk2mp7yj7p364mzem',
 	});
 	const encodedTransaction = encodeTransactionFromJSON(
 		transferTransaction as any,

--- a/commander/test/bootstrapping/commands/transaction/sign.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/sign.spec.ts
@@ -56,7 +56,7 @@ describe('transaction:sign command', () => {
 			tokenID: '0000000000000000',
 			amount: '100',
 			data: 'send token',
-			recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+			recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 		},
 		command: 'transfer',
 		fee: '100000000',
@@ -66,6 +66,13 @@ describe('transaction:sign command', () => {
 		signatures: [
 			'3cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',
 		],
+	};
+	const mockTransaction = {
+		...codec.fromJSON(transactionSchema, {
+			...mockJSONTransaction,
+			params: '',
+		}),
+		params: codec.fromJSON(tokenTransferParamsSchema, mockJSONTransaction.params),
 	};
 
 	const senderPassphrase =
@@ -192,6 +199,7 @@ describe('transaction:sign command', () => {
 				sign: jest.fn().mockReturnValue(mockJSONTransaction),
 				encode: jest.fn().mockReturnValue(mockEncodedTransaction),
 				toJSON: jest.fn().mockReturnValue(mockJSONTransaction),
+				fromJSON: jest.fn().mockReturnValue(mockTransaction),
 				decode: jest.fn().mockImplementation(val => {
 					const root = codec.decode<Record<string, unknown>>(transactionSchema, val);
 					const params = codec.decode(commands[0].schema, root.asset as Buffer);
@@ -295,7 +303,7 @@ describe('transaction:sign command', () => {
 							tokenID: '0000000000000000',
 							amount: '100',
 							data: 'send token',
-							recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+							recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 						},
 						command: 'transfer',
 						fee: '100000000',
@@ -584,7 +592,7 @@ describe('transaction:sign command', () => {
 								tokenID: '0000000000000000',
 								amount: '100',
 								data: 'send token',
-								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 							},
 							command: 'transfer',
 							fee: '100000000',
@@ -910,7 +918,7 @@ describe('transaction:sign command', () => {
 								tokenID: '0000000000000000',
 								amount: '100',
 								data: 'send token',
-								recipientAddress: 'ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815',
+								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 							},
 							command: 'transfer',
 							fee: '100000000',

--- a/commander/test/helpers/transactions.ts
+++ b/commander/test/helpers/transactions.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import * as cryptography from '@liskhq/lisk-cryptography';
 import * as transactions from '@liskhq/lisk-transactions';
 import { codec, Schema } from '@liskhq/lisk-codec';
 
@@ -39,8 +40,7 @@ export const tokenTransferParamsSchema = {
 		recipientAddress: {
 			dataType: 'bytes',
 			fieldNumber: 3,
-			minLength: 20,
-			maxLength: 20,
+			format: 'lisk32',
 		},
 		data: {
 			dataType: 'string',
@@ -103,8 +103,7 @@ export const dposVoteParamsSchema = {
 					delegateAddress: {
 						dataType: 'bytes',
 						fieldNumber: 1,
-						minLength: 20,
-						maxLength: 20,
+						format: 'lisk32',
 					},
 					amount: {
 						dataType: 'sint64',
@@ -147,7 +146,7 @@ export const createTransferTransaction = ({
 			params: {
 				tokenID: Buffer.from([0, 0, 0, 0, 0, 0]),
 				amount: BigInt(transactions.convertLSKToBeddows(amount)),
-				recipientAddress: Buffer.from(recipientAddress, 'hex'),
+				recipientAddress: cryptography.address.getAddressFromLisk32Address(recipientAddress),
 				data: '',
 			},
 		},
@@ -165,7 +164,9 @@ export const createTransferTransaction = ({
 			...transaction.params,
 			tokenID: transaction.params.tokenID.toString('hex'),
 			amount: transaction.params.amount.toString(),
-			recipientAddress: transaction.params.recipientAddress.toString('hex'),
+			recipientAddress: cryptography.address.getLisk32AddressFromAddress(
+				transaction.params.recipientAddress,
+			),
 		},
 		nonce: transaction.nonce.toString(),
 		fee: transaction.fee.toString(),

--- a/framework/src/modules/dpos_v2/schemas.ts
+++ b/framework/src/modules/dpos_v2/schemas.ts
@@ -77,8 +77,7 @@ export const voteCommandParamsSchema = {
 					delegateAddress: {
 						dataType: 'bytes',
 						fieldNumber: 1,
-						minLength: 20,
-						maxLength: 20,
+						format: 'lisk32',
 					},
 					amount: {
 						dataType: 'sint64',
@@ -440,7 +439,7 @@ export const getVoterResponseSchema = {
 				properties: {
 					delegateAddress: {
 						type: 'string',
-						format: 'hex',
+						format: 'lisk32',
 					},
 					amount: {
 						type: 'string',
@@ -458,7 +457,7 @@ export const getVoterResponseSchema = {
 				properties: {
 					delegateAddress: {
 						type: 'string',
-						format: 'hex',
+						format: 'lisk32',
 					},
 					amount: {
 						type: 'string',

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -12,13 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import {
-	CHAIN_ID_LENGTH,
-	LOCAL_ID_LENGTH,
-	TOKEN_ID_LENGTH,
-	ADDRESS_LENGTH,
-	MAX_DATA_LENGTH,
-} from './constants';
+import { CHAIN_ID_LENGTH, LOCAL_ID_LENGTH, TOKEN_ID_LENGTH, MAX_DATA_LENGTH } from './constants';
 
 export const configSchema = {
 	$id: '/token/config',
@@ -161,8 +155,7 @@ export const transferParamsSchema = {
 		recipientAddress: {
 			dataType: 'bytes',
 			fieldNumber: 3,
-			minLength: ADDRESS_LENGTH,
-			maxLength: ADDRESS_LENGTH,
+			format: 'lisk32',
 		},
 		data: {
 			dataType: 'string',
@@ -197,8 +190,7 @@ export const crossChainTransferParams = {
 		recipientAddress: {
 			dataType: 'bytes',
 			fieldNumber: 4,
-			minLength: ADDRESS_LENGTH,
-			maxLength: ADDRESS_LENGTH,
+			format: 'lisk32',
 		},
 		data: {
 			dataType: 'string',
@@ -239,14 +231,12 @@ export const crossChainTransferMessageParams = {
 		senderAddress: {
 			dataType: 'bytes',
 			fieldNumber: 3,
-			minLength: ADDRESS_LENGTH,
-			maxLength: ADDRESS_LENGTH,
+			format: 'lisk32',
 		},
 		recipientAddress: {
 			dataType: 'bytes',
 			fieldNumber: 4,
-			minLength: ADDRESS_LENGTH,
-			maxLength: ADDRESS_LENGTH,
+			format: 'lisk32',
 		},
 		data: {
 			dataType: 'string',
@@ -293,8 +283,7 @@ export const crossChainForwardMessageParams = {
 		senderAddress: {
 			dataType: 'bytes',
 			fieldNumber: 3,
-			minLength: ADDRESS_LENGTH,
-			maxLength: ADDRESS_LENGTH,
+			format: 'lisk32',
 		},
 		forwardToChainID: {
 			dataType: 'bytes',
@@ -305,8 +294,7 @@ export const crossChainForwardMessageParams = {
 		recipientAddress: {
 			dataType: 'bytes',
 			fieldNumber: 5,
-			minLength: ADDRESS_LENGTH,
-			maxLength: ADDRESS_LENGTH,
+			format: 'lisk32',
 		},
 		data: {
 			dataType: 'string',

--- a/framework/test/unit/modules/dpos_v2/commands/__snapshots__/vote.spec.ts.snap
+++ b/framework/test/unit/modules/dpos_v2/commands/__snapshots__/vote.spec.ts.snap
@@ -15,8 +15,7 @@ Object {
           "delegateAddress": Object {
             "dataType": "bytes",
             "fieldNumber": 1,
-            "maxLength": 20,
-            "minLength": 20,
+            "format": "lisk32",
           },
         },
         "required": Array [

--- a/framework/test/unit/modules/token/cc_commands/cc_forward.spec.ts
+++ b/framework/test/unit/modules/token/cc_commands/cc_forward.spec.ts
@@ -209,7 +209,7 @@ describe('CrossChain Forward command', () => {
 				}),
 			).resolves.toBeUndefined();
 			expect((fakeLogger.debug as jest.Mock).mock.calls[0][0].err.message).toInclude(
-				"senderAddress' maxLength exceeded",
+				"senderAddress' address length invalid",
 			);
 			expect(interopMethod.terminateChain).toHaveBeenCalledWith(
 				expect.any(MethodContext),
@@ -248,7 +248,7 @@ describe('CrossChain Forward command', () => {
 				}),
 			).resolves.toBeUndefined();
 			expect((fakeLogger.debug as jest.Mock).mock.calls[0][0].err.message).toInclude(
-				"recipientAddress' minLength not satisfied",
+				"recipientAddress' address length invalid",
 			);
 			expect(interopMethod.terminateChain).toHaveBeenCalledWith(
 				expect.any(MethodContext),

--- a/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
@@ -239,7 +239,7 @@ describe('CrossChain Transfer command', () => {
 				}),
 			).resolves.toBeUndefined();
 			expect((fakeLogger.debug as jest.Mock).mock.calls[0][0].err.message).toInclude(
-				"senderAddress' maxLength exceeded",
+				"senderAddress' address length invalid",
 			);
 			expect(interopMethod.terminateChain).toHaveBeenCalledWith(
 				expect.any(MethodContext),
@@ -276,7 +276,7 @@ describe('CrossChain Transfer command', () => {
 				}),
 			).resolves.toBeUndefined();
 			expect((fakeLogger.debug as jest.Mock).mock.calls[0][0].err.message).toInclude(
-				"recipientAddress' minLength not satisfied",
+				"recipientAddress' address length invalid",
 			);
 			expect(interopMethod.terminateChain).toHaveBeenCalledWith(
 				expect.any(MethodContext),

--- a/framework/test/unit/modules/token/commands/transfer.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer.spec.ts
@@ -106,7 +106,7 @@ describe('Transfer command', () => {
 			const result = await command.verify(context.createCommandVerifyContext(transferParamsSchema));
 
 			expect(result.status).toEqual(VerifyStatus.FAIL);
-			expect(result.error?.message).toInclude(".recipientAddress' maxLength exceeded");
+			expect(result.error?.message).toInclude(".recipientAddress' address length invalid");
 		});
 
 		it('should fail when data is more than 64 characters', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #7516 

- Related problem is token transfer / cc token transfer and cc token forward had some address not in `lisk32` format
- Vote command had delegate address not in `lisk32` format

### How was it solved?

- Fix transaction create command not to use legacy key derivation and matching key pairs
- Update token transfer cross chain token transfer commands schema to use lisk32 format
- Update vote command to use lisk32 format

### How was it tested?
Using DPoS mainchain example
- Create transaction with below command
```
./bin/run transaction:create token transfer 100000000 --json --passphrase="economy cliff diamond van multiply general visa picture actor teach cruel tree adjust quit maid hurry fence peace glare library curve soap cube must" -f ./tx.json
```
where tx.json is
```
{
	"amount": "100000000",
	"recipientAddress": "lsk7tyskeefnd6p6bfksd7ytp5jyaw8f2r9foa6ch",
	"data": "",
	"tokenID": "0000000000000000"
}
```
Observe json format shows lsk address
send the transaction hex using
```
./bin/run transaction:send xxx
```
- Check transaction:sign both online and offline
```
./bin/run transaction:sign  0a05746f6b656e12087472616e7366657218022080c2d72f2a20a3f96c50d0446220ef2f98240898515cbba8155730679ca35326d98dcfb680f032290a0800000000000000001080c2d72f1a14e98757149b5f7b6cadc85573ffc604d6cbfd71f0220227273a40a396480a6495c187da5880840cce93c303bfc3357a6f5780adc0be9ba4472ee7d8a486eba1399b427a55c9ed1e8d563e5d37f7f6b84425dd5e40066ce6009e0a
```

and
```
./bin/run transaction:sign  --offline --network-identifier="873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3" 0a05746f6b656e12087472616e7366657218022080c2d72f2a20a3f96c50d0446220ef2f98240898515cbba8155730679ca35326d98dcfb680f032290a0800000000000000001080c2d72f1a14e98757149b5f7b6cadc85573ffc604d6cbfd71f0220227273a40a396480a6495c187da5880840cce93c303bfc3357a6f5780adc0be9ba4472ee7d8a486eba1399b427a55c9ed1e8d563e5d37f7f6b84425dd5e40066ce6009e0a
```
