### PR TITLE
Expose endpoints for legacy under endpoints in engine

### DIFF
--- a/framework/src/engine/engine.ts
+++ b/framework/src/engine/engine.ts
@@ -208,7 +208,6 @@ export class Engine {
 		const legacyEndpoint = new LegacyEndpoint({
 			db: this._legacyDB,
 		});
-		legacyEndpoint.init(this._blockchainDB);
 
 		const chainEndpoint = new ChainEndpoint({
 			chain: this._chain,

--- a/framework/src/engine/engine.ts
+++ b/framework/src/engine/engine.ts
@@ -46,6 +46,7 @@ import { ConsensusEndpoint } from './endpoint/consensus';
 import { EngineConfig } from '../types';
 import { readGenesisBlock } from '../utils/genesis_block';
 import { LegacyChainHandler } from './legacy/legacy_chain_handler';
+import { LegacyEndpoint } from './legacy/endpoint';
 
 const isEmpty = (value: unknown): boolean => {
 	switch (typeof value) {
@@ -203,6 +204,12 @@ export class Engine {
 			logger: this._logger,
 			chainID: this._chain.chainID,
 		});
+
+		const legacyEndpoint = new LegacyEndpoint({
+			db: this._legacyDB,
+		});
+		legacyEndpoint.init(this._blockchainDB);
+
 		const chainEndpoint = new ChainEndpoint({
 			chain: this._chain,
 			genesisBlockTimestamp: genesis.header.timestamp,
@@ -229,6 +236,9 @@ export class Engine {
 			blockchainDB: this._blockchainDB,
 		});
 
+		for (const [name, handler] of Object.entries(getEndpointHandlers(legacyEndpoint))) {
+			this._rpcServer.registerEndpoint('legacy', name, handler);
+		}
 		for (const [name, handler] of Object.entries(getEndpointHandlers(chainEndpoint))) {
 			this._rpcServer.registerEndpoint('chain', name, handler);
 		}

--- a/framework/src/engine/legacy/endpoint.ts
+++ b/framework/src/engine/legacy/endpoint.ts
@@ -25,28 +25,27 @@ interface EndpointArgs {
 
 export class LegacyEndpoint {
 	[key: string]: unknown;
-	private readonly _storage: Storage;
+	public readonly storage: Storage;
 
 	public constructor(args: EndpointArgs) {
-		this._storage = new Storage(args.db);
+		this.storage = new Storage(args.db);
 	}
 
 	public async getBlockByID(context: RequestContext): Promise<LegacyBlockJSON> {
 		const { id } = context.params;
 		if (!isHexString(id)) {
-			throw new Error('Invalid parameters. id must be a valid hex string.');
+			throw new Error('Invalid parameters. `id` must be a valid hex string.');
 		}
 
-		return decodeBlockJSON(await this._storage.getBlockByID(Buffer.from(id as string, 'hex')))
-			.block;
+		return decodeBlockJSON(await this.storage.getBlockByID(Buffer.from(id as string, 'hex'))).block;
 	}
 
 	public async getBlockByHeight(context: RequestContext): Promise<LegacyBlockJSON> {
 		const { height } = context.params;
 		if (typeof height !== 'number' || height < 0) {
-			throw new Error('Invalid parameters. height must be zero or a positive number.');
+			throw new Error('Invalid parameters. `height` must be zero or a positive number.');
 		}
 
-		return decodeBlockJSON(await this._storage.getBlockByHeight(height)).block;
+		return decodeBlockJSON(await this.storage.getBlockByHeight(height)).block;
 	}
 }

--- a/framework/test/unit/engine/legacy/endpoint.spec.ts
+++ b/framework/test/unit/engine/legacy/endpoint.spec.ts
@@ -13,12 +13,62 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { InMemoryDatabase } from '@liskhq/lisk-db';
+import { codec } from '@liskhq/lisk-codec';
+import { LegacyEndpoint } from '../../../../src/engine/legacy/endpoint';
+import { blockFixtures } from './fixtures';
+import { blockSchemaV2, blockHeaderSchemaV2 } from '../../../../src/engine/legacy/schemas';
+import { LegacyBlockJSON } from '../../../../src/engine/legacy/types';
+
+const bufferToHex = (b: Buffer) => Buffer.from(b).toString('hex');
+
 describe('Legacy endpoint', () => {
-	describe('getBlockByID', () => {
-		it.todo('test behaviors');
+	const legacyEndpoint = new LegacyEndpoint({ db: new InMemoryDatabase() as any });
+	const encodedBlock = codec.encode(blockSchemaV2, {
+		header: codec.encode(blockHeaderSchemaV2, blockFixtures[0].header),
+		transactions: blockFixtures[0].transactions,
 	});
 
-	describe('getBlockByHeight', () => {
-		it.todo('test behaviors');
+	legacyEndpoint.storage.getBlockByID = jest.fn().mockResolvedValue(encodedBlock);
+	legacyEndpoint.storage.getBlockByHeight = jest.fn().mockResolvedValue(encodedBlock);
+
+	describe('LegacyEndpoint', () => {
+		const matchExpectations = (block: LegacyBlockJSON) => {
+			expect(block.header.id).toEqual(bufferToHex(blockFixtures[0].header.id));
+			expect(block.header.version).toEqual(blockFixtures[0].header.version);
+			expect(block.header.timestamp).toEqual(blockFixtures[0].header.timestamp);
+			expect(block.header.height).toEqual(blockFixtures[0].header.height);
+			expect(block.header.previousBlockID).toEqual(
+				bufferToHex(blockFixtures[0].header.previousBlockID),
+			);
+			expect(block.header.transactionRoot).toEqual(
+				bufferToHex(blockFixtures[0].header.transactionRoot),
+			);
+			expect(block.header.generatorPublicKey).toEqual(
+				bufferToHex(blockFixtures[0].header.generatorPublicKey),
+			);
+			expect(BigInt(block.header.reward)).toEqual(blockFixtures[0].header.reward);
+			expect(block.header.asset).toEqual(bufferToHex(blockFixtures[0].header.asset));
+			expect(block.header.signature).toEqual(bufferToHex(blockFixtures[0].header.signature));
+
+			expect(block.transactions).toHaveLength(blockFixtures[0].transactions.length);
+			expect(block.transactions[0]).toEqual(bufferToHex(blockFixtures[0].transactions[0]));
+		};
+
+		it('getBlockByID', async () => {
+			const block = await legacyEndpoint.getBlockByID({
+				params: { id: bufferToHex(blockFixtures[0].header.id) },
+			} as any);
+
+			matchExpectations(block);
+		});
+
+		it('getBlockByHeight', async () => {
+			const block = await legacyEndpoint.getBlockByHeight({
+				params: { height: blockFixtures[0].header.height },
+			} as any);
+
+			matchExpectations(block);
+		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #7488

### How was it solved?
Legacy endpoints are now exposed through engine & can be seen on server startup.

### How was it tested?

1. test cases added in framework/test/unit/engine/legacy/endpoint.spec.ts

2. Logs output
<img width="939" alt="Screenshot 2022-09-16 at 02 01 49 PM" src="https://user-images.githubusercontent.com/1403133/190627170-eb7004de-4d89-4670-b476-3e1f7e8e1515.png">
