### PR TITLE
Add legacy property to nodeInfo - Closes #7498

### DIFF
--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -549,11 +549,13 @@ export class Consensus {
 			});
 			await this._executeValidated(block);
 
+			// Since legacy property is optional we don't need to send it here
 			this._network.applyNodeInfo({
 				height: block.header.height,
 				lastBlockID: block.header.id,
 				maxHeightPrevoted: block.header.maxHeightPrevoted,
 				blockVersion: block.header.version,
+				legacy: [], // TODO: call legacyChainHandler to get the updated value https://github.com/LiskHQ/lisk-sdk/issues/7503
 			});
 		});
 	}

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -555,7 +555,6 @@ export class Consensus {
 				lastBlockID: block.header.id,
 				maxHeightPrevoted: block.header.maxHeightPrevoted,
 				blockVersion: block.header.version,
-				legacy: [], // TODO: call legacyChainHandler to get the updated value https://github.com/LiskHQ/lisk-sdk/issues/7503
 			});
 		});
 	}

--- a/framework/src/engine/network/network.ts
+++ b/framework/src/engine/network/network.ts
@@ -56,6 +56,7 @@ interface NodeInfoOptions {
 	readonly height: number;
 	readonly maxHeightPrevoted: number;
 	readonly blockVersion: number;
+	readonly legacy?: Buffer[];
 }
 
 interface NetworkConstructor {
@@ -164,6 +165,11 @@ export class Network {
 				blockVersion: 0,
 				height: 0,
 				maxHeightPrevoted: 0,
+				/* As soon as network will start, the node will sync
+				   with the network or check if all the legacy blocks are already present
+				   and update "legacy" field with corresponding snapshotBlockID
+				*/
+				legacy: [],
 			},
 		};
 

--- a/framework/src/engine/network/schema.ts
+++ b/framework/src/engine/network/schema.ts
@@ -15,6 +15,7 @@
 export const customNodeInfoSchema = {
 	$id: '/nodeInfo/custom',
 	type: 'object',
+	required: ['height', 'blockVersion', 'lastBlockID', 'maxHeightPrevoted'],
 	properties: {
 		height: {
 			dataType: 'uint32',
@@ -31,6 +32,13 @@ export const customNodeInfoSchema = {
 		lastBlockID: {
 			dataType: 'bytes',
 			fieldNumber: 4,
+		},
+		legacy: {
+			type: 'array',
+			fieldNumber: 5,
+			items: {
+				dataType: 'bytes',
+			},
 		},
 	},
 };

--- a/framework/src/engine/network/schema.ts
+++ b/framework/src/engine/network/schema.ts
@@ -15,7 +15,7 @@
 export const customNodeInfoSchema = {
 	$id: '/nodeInfo/custom',
 	type: 'object',
-	required: ['height', 'blockVersion', 'lastBlockID', 'maxHeightPrevoted'],
+	required: ['height', 'blockVersion', 'lastBlockID', 'maxHeightPrevoted', 'legacy'],
 	properties: {
 		height: {
 			dataType: 'uint32',


### PR DESCRIPTION
### What was the problem?

This PR resolves #7498

### How was it solved?

[🌱 Add legacy property to nodeInfo](https://github.com/LiskHQ/lisk-sdk/commit/30cf910e9a0ca21e92ea70ca8f246e181560d7fb)

### How was it tested?

- Run two nodes with configuration that connects them and observe that there is `legacy` property is being shared
