### PR TITLE
Register getLegacyBlocksFromId to P2P - Closes 7485

### DIFF
--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -53,7 +53,7 @@ import {
 	NETWORK_RPC_GET_BLOCKS_FROM_ID,
 	NETWORK_RPC_GET_HIGHEST_COMMON_BLOCK,
 	NETWORK_RPC_GET_LAST_BLOCK,
-	NETWORK_LEGACY_GET_BLOCKS,
+	NETWORK_LEGACY_GET_BLOCKS_FROM_ID,
 } from './constants';
 import { GenesisConfig } from '../../types';
 import { AggregateCommit } from './types';
@@ -173,7 +173,7 @@ export class Consensus {
 			interval: this._genesisConfig.blockTime,
 		});
 
-		this._network.registerEndpoint(NETWORK_LEGACY_GET_BLOCKS, async ({ data, peerId }) =>
+		this._network.registerEndpoint(NETWORK_LEGACY_GET_BLOCKS_FROM_ID, async ({ data, peerId }) =>
 			this._legacyEndpoint.handleRPCGetLegacyBlocksFromId(data, peerId),
 		);
 		this._network.registerEndpoint(NETWORK_RPC_GET_LAST_BLOCK, ({ peerId }) =>

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -37,7 +37,7 @@ import { AbortError, ApplyPenaltyAndRestartError, RestartError } from './synchro
 import { BlockExecutor } from './synchronizer/type';
 import { Network } from '../network';
 import { NetworkEndpoint, EndpointArgs } from './network_endpoint';
-import { NetworkEndpoint as LegacyNetworkEndpoint } from '../legacy/network_endpoint';
+import { LegacyNetworkEndpoint } from '../legacy/network_endpoint';
 import { EventPostBlockData, postBlockEventSchema } from './schema';
 import {
 	CONSENSUS_EVENT_BLOCK_BROADCAST,
@@ -76,6 +76,7 @@ interface InitArgs {
 	logger: Logger;
 	genesisBlock: Block;
 	db: Database;
+	legacyDB: Database;
 }
 
 interface ExecuteOptions {
@@ -146,7 +147,7 @@ export class Consensus {
 		this._legacyEndpoint = new LegacyNetworkEndpoint({
 			logger: this._logger,
 			network: this._network,
-			db: this._db,
+			db: args.legacyDB,
 		});
 		const blockExecutor = this._createBlockExecutor();
 		const blockSyncMechanism = new BlockSynchronizationMechanism({

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -37,6 +37,7 @@ import { AbortError, ApplyPenaltyAndRestartError, RestartError } from './synchro
 import { BlockExecutor } from './synchronizer/type';
 import { Network } from '../network';
 import { NetworkEndpoint, EndpointArgs } from './network_endpoint';
+import { NetworkEndpoint as LegacyNetworkEndpoint } from '../legacy/network_endpoint';
 import { EventPostBlockData, postBlockEventSchema } from './schema';
 import {
 	CONSENSUS_EVENT_BLOCK_BROADCAST,
@@ -52,6 +53,7 @@ import {
 	NETWORK_RPC_GET_BLOCKS_FROM_ID,
 	NETWORK_RPC_GET_HIGHEST_COMMON_BLOCK,
 	NETWORK_RPC_GET_LAST_BLOCK,
+	NETWORK_LEGACY_GET_BLOCKS,
 } from './constants';
 import { GenesisConfig } from '../../types';
 import { AggregateCommit } from './types';
@@ -109,6 +111,7 @@ export class Consensus {
 	private _db!: Database;
 	private _commitPool!: CommitPool;
 	private _endpoint!: NetworkEndpoint;
+	private _legacyEndpoint!: LegacyNetworkEndpoint;
 	private _synchronizer!: Synchronizer;
 	private _blockSlot!: Slots;
 
@@ -140,6 +143,11 @@ export class Consensus {
 			network: this._network,
 			db: this._db,
 		} as EndpointArgs); // TODO: Remove casting in issue where commitPool is added here
+		this._legacyEndpoint = new LegacyNetworkEndpoint({
+			logger: this._logger,
+			network: this._network,
+			db: this._db,
+		});
 		const blockExecutor = this._createBlockExecutor();
 		const blockSyncMechanism = new BlockSynchronizationMechanism({
 			chain: this._chain,
@@ -164,6 +172,9 @@ export class Consensus {
 			interval: this._genesisConfig.blockTime,
 		});
 
+		this._network.registerEndpoint(NETWORK_LEGACY_GET_BLOCKS, async ({ data, peerId }) =>
+			this._legacyEndpoint.handleRPCGetLegacyBlocksFromId(data, peerId),
+		);
 		this._network.registerEndpoint(NETWORK_RPC_GET_LAST_BLOCK, ({ peerId }) =>
 			this._endpoint.handleRPCGetLastBlock(peerId),
 		);

--- a/framework/src/engine/consensus/constants.ts
+++ b/framework/src/engine/consensus/constants.ts
@@ -29,6 +29,6 @@ export const NETWORK_RPC_GET_BLOCKS_FROM_ID = 'getBlocksFromId';
 export const NETWORK_RPC_GET_HIGHEST_COMMON_BLOCK = 'getHighestCommonBlock';
 export const NETWORK_RPC_GET_SINGLE_COMMIT_FROM_ID = 'getSingleCommit';
 
-export const NETWORK_LEGACY_GET_BLOCKS = 'getLegacyBlocksFromId';
+export const NETWORK_LEGACY_GET_BLOCKS_FROM_ID = 'getLegacyBlocksFromId';
 
 export const EMPTY_HASH = utils.hash(Buffer.alloc(0));

--- a/framework/src/engine/consensus/constants.ts
+++ b/framework/src/engine/consensus/constants.ts
@@ -29,4 +29,6 @@ export const NETWORK_RPC_GET_BLOCKS_FROM_ID = 'getBlocksFromId';
 export const NETWORK_RPC_GET_HIGHEST_COMMON_BLOCK = 'getHighestCommonBlock';
 export const NETWORK_RPC_GET_SINGLE_COMMIT_FROM_ID = 'getSingleCommit';
 
+export const NETWORK_LEGACY_GET_BLOCKS = 'getLegacyBlocksFromId';
+
 export const EMPTY_HASH = utils.hash(Buffer.alloc(0));

--- a/framework/src/engine/engine.ts
+++ b/framework/src/engine/engine.ts
@@ -188,6 +188,7 @@ export class Engine {
 			db: this._blockchainDB,
 			genesisBlock: genesis,
 			logger: this._logger,
+			legacyDB: this._legacyDB,
 		});
 		await this._generator.init({
 			blockchainDB: this._blockchainDB,

--- a/framework/src/engine/legacy/network_endpoint.ts
+++ b/framework/src/engine/legacy/network_endpoint.ts
@@ -23,7 +23,7 @@ export interface EndpointArgs {
 	db: Database;
 }
 
-export class NetworkEndpoint extends BaseNetworkEndpoint {
+export class LegacyNetworkEndpoint extends BaseNetworkEndpoint {
 	private readonly _logger: Logger;
 	private readonly _network: Network;
 	private readonly _db: Database | InMemoryDatabase;

--- a/framework/test/integration/node/genesis_block.spec.ts
+++ b/framework/test/integration/node/genesis_block.spec.ts
@@ -151,6 +151,7 @@ describe('genesis block', () => {
 					db: consensus['_db'],
 					genesisBlock: processEnv.getGenesisBlock(),
 					logger: consensus['_logger'],
+					legacyDB: consensus['_db'],
 				});
 
 				const balance = await processEnv.invoke<{ availableBalance: string }>('token_getBalance', {

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -133,48 +133,37 @@ describe('consensus', () => {
 		genesis.validateGenesis = jest.fn();
 	});
 
+	const initConsensus = async () => {
+		return consensus.init({
+			logger: loggerMock,
+			db: dbMock,
+			genesisBlock: genesis,
+			legacyDB: dbMock,
+		});
+	};
+
 	describe('init', () => {
 		it('should instantiate synchronizer', async () => {
 			(chain.genesisBlockExist as jest.Mock).mockResolvedValue(true);
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 			expect(consensus['_synchronizer']).toBeInstanceOf(Synchronizer);
 		});
 
 		it('should instantiate endpoint', async () => {
 			(chain.genesisBlockExist as jest.Mock).mockResolvedValue(true);
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 			expect(consensus['_endpoint']).toBeInstanceOf(NetworkEndpoint);
 		});
 
 		it('should instantiate legacy endpoint', async () => {
 			(chain.genesisBlockExist as jest.Mock).mockResolvedValue(true);
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 			expect(consensus['_legacyEndpoint']).toBeInstanceOf(LegacyNetworkEndpoint);
 		});
 
 		it('should register endpoints', async () => {
 			(chain.genesisBlockExist as jest.Mock).mockResolvedValue(true);
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 			expect(network.registerEndpoint).toHaveBeenCalledTimes(4);
 		});
 
@@ -184,12 +173,7 @@ describe('consensus', () => {
 				validatorsHash: genesis.header.validatorsHash,
 			} as never);
 			(chain.genesisBlockExist as jest.Mock).mockResolvedValue(false);
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 
 			expect(genesis.validateGenesis).toHaveBeenCalledTimes(1);
 			expect(chain.saveBlock).toHaveBeenCalledTimes(1);
@@ -198,12 +182,7 @@ describe('consensus', () => {
 
 		it('should not execute genesis block if it exists in chain', async () => {
 			(chain.genesisBlockExist as jest.Mock).mockResolvedValue(true);
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 			expect(chain.saveBlock).not.toHaveBeenCalled();
 			expect(chain.loadLastBlocks).toHaveBeenCalledTimes(1);
 		});
@@ -218,14 +197,7 @@ describe('consensus', () => {
 				.spyOn(consensus, '_verifyEventRoot' as never)
 				.mockRejectedValue(new Error('Event root is not valid for the block') as never);
 
-			await expect(
-				consensus.init({
-					logger: loggerMock,
-					db: dbMock,
-					genesisBlock: genesis,
-					legacyDB: dbMock,
-				}),
-			).rejects.toThrow('Event root is not valid for the block');
+			await expect(initConsensus()).rejects.toThrow('Event root is not valid for the block');
 		});
 
 		it('should fail initialization if validatorsHash is invalid', async () => {
@@ -234,14 +206,7 @@ describe('consensus', () => {
 			jest.spyOn(consensus['_bft'].method, 'getBFTParameters').mockResolvedValue({
 				validatorsHash: utils.getRandomBytes(32),
 			} as never);
-			await expect(
-				consensus.init({
-					logger: loggerMock,
-					db: dbMock,
-					genesisBlock: genesis,
-					legacyDB: dbMock,
-				}),
-			).rejects.toThrow('Genesis block validators hash is invalid');
+			await expect(initConsensus()).rejects.toThrow('Genesis block validators hash is invalid');
 		});
 	});
 
@@ -254,12 +219,7 @@ describe('consensus', () => {
 		const blockHeader = createFakeBlockHeader({ height: 303 });
 
 		beforeEach(async () => {
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 
 			jest.spyOn(consensus['_commitPool'], 'addCommit');
 		});
@@ -286,12 +246,7 @@ describe('consensus', () => {
 	describe('onBlockReceive', () => {
 		const peerID = 'peer-id';
 		beforeEach(async () => {
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 		});
 
 		it('should not execute when syncing', async () => {
@@ -613,12 +568,7 @@ describe('consensus', () => {
 	});
 	describe('execute', () => {
 		beforeEach(async () => {
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 		});
 
 		it('should not throw error when block execution fail', async () => {
@@ -635,12 +585,7 @@ describe('consensus', () => {
 		let stateStore: StateStore;
 
 		beforeEach(async () => {
-			await consensus.init({
-				logger: loggerMock,
-				db: dbMock,
-				genesisBlock: genesis,
-				legacyDB: dbMock,
-			});
+			await initConsensus();
 		});
 
 		describe('when skipBroadcast option is not specified', () => {

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -21,6 +21,7 @@ import { utils, address as cryptoAddress, bls, legacy } from '@liskhq/lisk-crypt
 import { ApplyPenaltyError } from '../../../../src/errors';
 import { Consensus } from '../../../../src/engine/consensus/consensus';
 import { NetworkEndpoint } from '../../../../src/engine/consensus/network_endpoint';
+import { LegacyNetworkEndpoint } from '../../../../src/engine/legacy/network_endpoint';
 import { Synchronizer } from '../../../../src/engine/consensus/synchronizer';
 import {
 	ApplyPenaltyAndRestartError,
@@ -139,6 +140,7 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 			expect(consensus['_synchronizer']).toBeInstanceOf(Synchronizer);
 		});
@@ -149,8 +151,20 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 			expect(consensus['_endpoint']).toBeInstanceOf(NetworkEndpoint);
+		});
+
+		it('should instantiate legacy endpoint', async () => {
+			(chain.genesisBlockExist as jest.Mock).mockResolvedValue(true);
+			await consensus.init({
+				logger: loggerMock,
+				db: dbMock,
+				genesisBlock: genesis,
+				legacyDB: dbMock,
+			});
+			expect(consensus['_legacyEndpoint']).toBeInstanceOf(LegacyNetworkEndpoint);
 		});
 
 		it('should register endpoints', async () => {
@@ -159,8 +173,9 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
-			expect(network.registerEndpoint).toHaveBeenCalledTimes(3);
+			expect(network.registerEndpoint).toHaveBeenCalledTimes(4);
 		});
 
 		it('should execute genesis block if genesis block does not exist', async () => {
@@ -173,6 +188,7 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 
 			expect(genesis.validateGenesis).toHaveBeenCalledTimes(1);
@@ -186,6 +202,7 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 			expect(chain.saveBlock).not.toHaveBeenCalled();
 			expect(chain.loadLastBlocks).toHaveBeenCalledTimes(1);
@@ -206,6 +223,7 @@ describe('consensus', () => {
 					logger: loggerMock,
 					db: dbMock,
 					genesisBlock: genesis,
+					legacyDB: dbMock,
 				}),
 			).rejects.toThrow('Event root is not valid for the block');
 		});
@@ -221,6 +239,7 @@ describe('consensus', () => {
 					logger: loggerMock,
 					db: dbMock,
 					genesisBlock: genesis,
+					legacyDB: dbMock,
 				}),
 			).rejects.toThrow('Genesis block validators hash is invalid');
 		});
@@ -239,6 +258,7 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 
 			jest.spyOn(consensus['_commitPool'], 'addCommit');
@@ -270,6 +290,7 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 		});
 
@@ -596,6 +617,7 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 		});
 
@@ -617,6 +639,7 @@ describe('consensus', () => {
 				logger: loggerMock,
 				db: dbMock,
 				genesisBlock: genesis,
+				legacyDB: dbMock,
 			});
 		});
 
@@ -678,6 +701,7 @@ describe('consensus', () => {
 					db: dbMock,
 					genesisBlock: genesis,
 					logger: fakeLogger,
+					legacyDB: dbMock,
 				});
 				jest.spyOn(consensus['_commitPool'], 'verifyAggregateCommit');
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #7485

### How was it solved?

Exposed `getLegacyBlocksFromId` at `consensus`. `Consensus` to accept `legacyDB` in constructor

### How was it tested?

Updated test cases accordingly.