### PR TITLE
Implement `getLegacyBlocksFromId` Handler - Closes #7487

### DIFF
--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -174,7 +174,7 @@ export class Consensus {
 		});
 
 		this._network.registerEndpoint(NETWORK_LEGACY_GET_BLOCKS_FROM_ID, async ({ data, peerId }) =>
-			this._legacyEndpoint.handleRPCGetLegacyBlocksFromId(data, peerId),
+			this._legacyEndpoint.handleRPCGetLegacyBlocksFromID(data, peerId),
 		);
 		this._network.registerEndpoint(NETWORK_RPC_GET_LAST_BLOCK, ({ peerId }) =>
 			this._endpoint.handleRPCGetLastBlock(peerId),

--- a/framework/src/engine/legacy/codec.ts
+++ b/framework/src/engine/legacy/codec.ts
@@ -15,7 +15,13 @@
 import { codec, Schema } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
 import { blockHeaderSchemaV2, blockSchemaV2 } from './schemas';
-import { LegacyBlock, LegacyBlockJSON, RawLegacyBlock } from './types';
+import {
+	LegacyBlock,
+	LegacyBlockHeaderWithID,
+	LegacyBlockJSON,
+	LegacyBlockWithID,
+	RawLegacyBlock,
+} from './types';
 
 interface LegacyBlockSchema {
 	header: Schema;
@@ -32,7 +38,9 @@ export const blockSchemaMap: Record<number, LegacyBlockSchema> = {
 // Implement read version logic when adding more versions
 const readVersion = (): number => 2;
 
-export const decodeBlock = (data: Buffer): { block: LegacyBlock; schema: LegacyBlockSchema } => {
+export const decodeBlock = (
+	data: Buffer,
+): { block: LegacyBlockWithID; schema: LegacyBlockSchema } => {
 	const version = readVersion();
 	const blockSchema = blockSchemaMap[version];
 	if (!blockSchema) {
@@ -44,7 +52,7 @@ export const decodeBlock = (data: Buffer): { block: LegacyBlock; schema: LegacyB
 		block: {
 			...rawBlock,
 			header: {
-				...codec.decode(blockSchema.header, rawBlock.header),
+				...codec.decode<LegacyBlockHeaderWithID>(blockSchema.header, rawBlock.header),
 				id,
 			},
 		},

--- a/framework/src/engine/legacy/network_endpoint.ts
+++ b/framework/src/engine/legacy/network_endpoint.ts
@@ -49,50 +49,53 @@ export class LegacyNetworkEndpoint extends BaseNetworkEndpoint {
 
 	// return 100 blocks desc starting from the id
 	// eslint-disable-next-line @typescript-eslint/require-await
-	public async handleRPCGetLegacyBlocksFromId(data: unknown, peerId: string): Promise<Buffer> {
+	public async handleRPCGetLegacyBlocksFromID(data: unknown, peerID: string): Promise<Buffer> {
 		this.addRateLimit(
 			NETWORK_LEGACY_GET_BLOCKS_FROM_ID,
-			peerId,
+			peerID,
 			LEGACY_BLOCKS_FROM_IDS_RATE_LIMIT_FREQUENCY,
 		);
 
-		let decodedData: RPCBlocksByIdData;
+		let rpcBlocksByIdData: RPCBlocksByIdData;
 		try {
-			decodedData = codec.decode<RPCBlocksByIdData>(getBlocksFromIdRequestSchema, data as never);
+			rpcBlocksByIdData = codec.decode<RPCBlocksByIdData>(
+				getBlocksFromIdRequestSchema,
+				data as never,
+			);
 		} catch (error) {
 			this._logger.warn(
 				{
 					err: error as Error,
 					req: data,
-					peerID: peerId,
+					peerID,
 				},
 				`${NETWORK_LEGACY_GET_BLOCKS_FROM_ID} response failed on decoding`,
 			);
 			this._network.applyPenaltyOnPeer({
-				peerId,
+				peerId: peerID,
 				penalty: 100,
 			});
 			throw error;
 		}
 
 		try {
-			validator.validate(getBlocksFromIdRequestSchema, decodedData);
+			validator.validate(getBlocksFromIdRequestSchema, rpcBlocksByIdData);
 		} catch (error) {
 			this._logger.warn(
 				{
 					err: error as Error,
 					req: data,
-					peerID: peerId,
+					peerID,
 				},
 				`${NETWORK_LEGACY_GET_BLOCKS_FROM_ID} response failed on validation`,
 			);
 			this._network.applyPenaltyOnPeer({
-				peerId,
+				peerId: peerID,
 				penalty: 100,
 			});
 			throw error;
 		}
-		const { blockId } = decodedData;
+		const { blockId } = rpcBlocksByIdData;
 
 		let lastBlockHeader;
 		try {

--- a/framework/src/engine/legacy/types.ts
+++ b/framework/src/engine/legacy/types.ts
@@ -16,7 +16,6 @@ import { JSONObject } from '../../types';
 
 export interface LegacyBlockHeader {
 	[key: string]: unknown;
-	id: Buffer;
 	version: number;
 	height: number;
 	previousBlockID: Buffer;
@@ -32,6 +31,15 @@ export interface RawLegacyBlock {
 
 export interface LegacyBlock {
 	header: LegacyBlockHeader;
+	transactions: Buffer[];
+}
+
+export interface LegacyBlockHeaderWithID extends LegacyBlockHeader {
+	id: Buffer;
+}
+
+export interface LegacyBlockWithID extends LegacyBlock {
+	header: LegacyBlockHeaderWithID;
 	transactions: Buffer[];
 }
 

--- a/framework/src/engine/legacy/validate.ts
+++ b/framework/src/engine/legacy/validate.ts
@@ -16,9 +16,12 @@ import { utils } from '@liskhq/lisk-cryptography';
 import { regularMerkleTree } from '@liskhq/lisk-tree';
 import { validator } from '@liskhq/lisk-validator';
 import { decodeBlock } from './codec';
-import { LegacyBlock } from './types';
+import { LegacyBlockWithID } from './types';
 
-export const validateLegacyBlock = (receivedBlock: Buffer, decodedNextBlock: LegacyBlock): void => {
+export const validateLegacyBlock = (
+	receivedBlock: Buffer,
+	decodedNextBlock: LegacyBlockWithID,
+): void => {
 	const { block: decodedBlock, schema: blockSchema } = decodeBlock(receivedBlock);
 	validator.validate(blockSchema.header, decodedBlock.header);
 

--- a/framework/test/unit/engine/legacy/fixtures.ts
+++ b/framework/test/unit/engine/legacy/fixtures.ts
@@ -115,15 +115,16 @@ export const createFakeLegacyBlockHeaderV2 = (
 /**
  * @params start: Start height of the block range going backwards
  * @params numberOfBlocks: Number of blocks to be generated with decreasing height
- * */
-export const getLegacyBlocksRangeV2 = (start: number, numberOfBlocks: number): Buffer[] => {
+ */
+export const getLegacyBlocksRangeV2 = (startHeight: number, numberOfBlocks: number): Buffer[] => {
 	const blocks: LegacyBlockWithID[] = [];
 
-	for (let i = start; i >= start - numberOfBlocks; i -= 1) {
+	for (let i = startHeight; i >= startHeight - numberOfBlocks; i -= 1) {
 		// After the startHeight, all the blocks are generated with previousBlockID as previous height block ID
 		const block = createFakeLegacyBlockHeaderV2({
 			height: i,
-			previousBlockID: i === start ? utils.getRandomBytes(32) : blocks[start - i - 1].header.id,
+			previousBlockID:
+				i === startHeight ? utils.getRandomBytes(32) : blocks[startHeight - i - 1].header.id,
 		});
 		blocks.push(block);
 	}

--- a/framework/test/unit/engine/legacy/network_endpoint.spec.ts
+++ b/framework/test/unit/engine/legacy/network_endpoint.spec.ts
@@ -12,9 +12,80 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import { utils } from '@liskhq/lisk-cryptography';
+import { Block, BlockAssets } from '@liskhq/lisk-chain';
+import { Database, InMemoryDatabase } from '@liskhq/lisk-db';
+import { codec } from '@liskhq/lisk-codec';
+import { LegacyNetworkEndpoint } from '../../../../src/engine/legacy/network_endpoint';
+import { loggerMock } from '../../../../src/testing/mocks';
+import { Network } from '../../../../src/engine/network';
+import {
+	getBlocksFromIdRequestSchema,
+	getBlocksFromIdResponseSchema,
+} from '../../../../src/engine/consensus/schema';
 
-describe('Legacy network endpoint', () => {
+import { createFakeBlockHeader } from '../../../fixtures';
+
+describe('Legacy P2P network endpoint', () => {
+	const defaultPeerId = 'peer-id';
+
+	let network: Network;
+	let db: Database;
+	let endpoint: LegacyNetworkEndpoint;
+
+	beforeEach(() => {
+		network = ({
+			applyPenaltyOnPeer: jest.fn(),
+		} as unknown) as Network;
+		db = (new InMemoryDatabase() as unknown) as Database;
+
+		endpoint = new LegacyNetworkEndpoint({
+			logger: loggerMock,
+			network,
+			db,
+		});
+	});
 	describe('handleRPCGetLegacyBlocksFromId', () => {
-		it.todo('test behaviors');
+		it('should apply penalty on the peer when data format is invalid', async () => {
+			const invalidBytes = Buffer.from([244, 21, 21]);
+			await expect(
+				endpoint.handleRPCGetLegacyBlocksFromId(invalidBytes, defaultPeerId),
+			).rejects.toThrow();
+			expect(network.applyPenaltyOnPeer).toHaveBeenCalledTimes(1);
+		});
+		it("should return empty list if id doesn't exist", async () => {
+			const blockId = utils.getRandomBytes(32);
+			const blockIds = codec.encode(getBlocksFromIdRequestSchema, {
+				blockId,
+			});
+			const blocks = await endpoint.handleRPCGetLegacyBlocksFromId(blockIds, defaultPeerId);
+			expect(blocks).toEqual(codec.encode(getBlocksFromIdResponseSchema, { blocks: [] }));
+		});
+		it('should return blocks from Id', async () => {
+			jest.spyOn(endpoint._dataAccess, 'getBlockHeaderByID').mockResolvedValue(
+				createFakeBlockHeader({
+					height: 10,
+				}) as never,
+			);
+			jest.spyOn(endpoint._dataAccess, 'getBlocksByHeightBetween').mockImplementation(
+				async (fromHeight: number, toHeight: number): Promise<Block[]> => {
+					const blocks = [];
+					for (let i = fromHeight; i < toHeight; i += 1) {
+						blocks.push(new Block(createFakeBlockHeader(), [], new BlockAssets()));
+					}
+					return Promise.resolve(blocks);
+				},
+			);
+			const blockId = utils.getRandomBytes(32);
+
+			const blockIds = codec.encode(getBlocksFromIdRequestSchema, {
+				blockId,
+			});
+
+			const blocks = await endpoint.handleRPCGetLegacyBlocksFromId(blockIds, defaultPeerId);
+			expect(
+				codec.decode<{ blocks: Block[] }>(getBlocksFromIdResponseSchema, blocks).blocks,
+			).toHaveLength(100);
+		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #7487 

### How was it solved?

- [Implement function and test cases](https://github.com/LiskHQ/lisk-sdk/pull/7553/commits/dae920444c0cc99c8d947104ca61f96619425648)
- [✅ Create utils for generating legacy fixtures](https://github.com/LiskHQ/lisk-sdk/pull/7553/commits/d525bdc47924c2eb82e6dd8ad253ea6fc3ff7290)
- [♻️ Add handler for getLegacyBlocksFromId RPC](https://github.com/LiskHQ/lisk-sdk/pull/7553/commits/8101d3088be5c902fb24845729c32013af00b040)
  - Define interface for block with ID
  - Add unit tests for handler

### How was it tested?

`npm t`
