### PR TITLE
Define storage for saving info about legacy chain brackets - Closes #7545

### DIFF
--- a/framework/src/engine/legacy/codec.ts
+++ b/framework/src/engine/legacy/codec.ts
@@ -14,8 +14,8 @@
 
 import { codec, Schema } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
-import { blockHeaderSchemaV2, blockSchemaV2 } from './schemas';
-import { LegacyBlock, LegacyBlockJSON, RawLegacyBlock } from './types';
+import { blockHeaderSchemaV2, blockSchemaV2, legacyChainBracketInfoSchema } from './schemas';
+import { LegacyBlock, LegacyBlockJSON, LegacyChainBracketInfo, RawLegacyBlock } from './types';
 
 interface LegacyBlockSchema {
 	header: Schema;
@@ -80,3 +80,6 @@ export const encodeBlock = (data: LegacyBlock): Buffer => {
 		transactions: data.transactions,
 	});
 };
+
+export const encodeLegacyChainBracketInfo = (data: LegacyChainBracketInfo): Buffer =>
+	codec.encode(legacyChainBracketInfoSchema, data);

--- a/framework/src/engine/legacy/constants.ts
+++ b/framework/src/engine/legacy/constants.ts
@@ -14,3 +14,4 @@
 
 export const DB_KEY_BLOCK_ID = Buffer.from([0]);
 export const DB_KEY_BLOCK_HEIGHT = Buffer.from([1]);
+export const DB_KEY_LEGACY_BRACKET = Buffer.from([2]);

--- a/framework/src/engine/legacy/legacy_chain_handler.ts
+++ b/framework/src/engine/legacy/legacy_chain_handler.ts
@@ -14,6 +14,7 @@
 
 import { Database, InMemoryDatabase } from '@liskhq/lisk-db';
 import { LegacyConfig } from '../../types';
+import { Storage } from './storage';
 
 interface LegacyChainHandlerArgs {
 	legacyConfig: LegacyConfig;
@@ -31,9 +32,19 @@ export class LegacyChainHandler {
 		this._legacyConfig = args.legacyConfig;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/require-await
 	public async init(args: LegacyHandlerInitArgs): Promise<void> {
+		const storage = new Storage(this._db as Database);
 		this._db = args.db;
+
+		for (const bracket of this._legacyConfig.brackets) {
+			if (!bracket.snapshotBlockID) {
+				await storage.setLegacyChainBracketInfo(Buffer.from(bracket.snapshotBlockID), {
+					startHeight: bracket.startHeight,
+					snapshotBlockHeight: bracket.snapshotHeight,
+					lastBlockHeight: bracket.startHeight,
+				});
+			}
+		}
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await

--- a/framework/src/engine/legacy/legacy_chain_handler.ts
+++ b/framework/src/engine/legacy/legacy_chain_handler.ts
@@ -33,8 +33,8 @@ export class LegacyChainHandler {
 	}
 
 	public async init(args: LegacyHandlerInitArgs): Promise<void> {
-		const storage = new Storage(this._db as Database);
 		this._db = args.db;
+		const storage = new Storage(this._db as Database);
 
 		for (const bracket of this._legacyConfig.brackets) {
 			const bracketInfo = await storage.getLegacyChainBracketInfo(

--- a/framework/src/engine/legacy/legacy_chain_handler.ts
+++ b/framework/src/engine/legacy/legacy_chain_handler.ts
@@ -37,7 +37,11 @@ export class LegacyChainHandler {
 		this._db = args.db;
 
 		for (const bracket of this._legacyConfig.brackets) {
-			if (!bracket.snapshotBlockID) {
+			const bracketInfo = await storage.getLegacyChainBracketInfo(
+				Buffer.from(bracket.snapshotBlockID, 'hex'),
+			);
+
+			if (!bracketInfo) {
 				await storage.setLegacyChainBracketInfo(Buffer.from(bracket.snapshotBlockID), {
 					startHeight: bracket.startHeight,
 					snapshotBlockHeight: bracket.snapshotHeight,

--- a/framework/src/engine/legacy/schemas.ts
+++ b/framework/src/engine/legacy/schemas.ts
@@ -80,3 +80,14 @@ export const blockHeaderSchemaV2 = {
 		'asset',
 	],
 };
+
+export const legacyChainBracketInfoSchema = {
+	$id: '/lisk/legacyChainBracketInfo',
+	type: 'object',
+	properties: {
+		startHeight: { dataType: 'uint32', fieldNumber: 1 },
+		snapshotBlockHeight: { dataType: 'uint32', fieldNumber: 2 },
+		lastBlockHeight: { dataType: 'uint32', fieldNumber: 3 },
+	},
+	required: ['startHeight', 'snapshotBlockHeight', 'lastBlockHeight'],
+};

--- a/framework/src/engine/legacy/schemas.ts
+++ b/framework/src/engine/legacy/schemas.ts
@@ -82,7 +82,7 @@ export const blockHeaderSchemaV2 = {
 };
 
 export const legacyChainBracketInfoSchema = {
-	$id: '/lisk/legacyChainBracketInfo',
+	$id: '/legacy/legacyChainBracketInfo',
 	type: 'object',
 	properties: {
 		startHeight: { dataType: 'uint32', fieldNumber: 1 },

--- a/framework/src/engine/legacy/storage.ts
+++ b/framework/src/engine/legacy/storage.ts
@@ -14,7 +14,9 @@
 
 import { intToBuffer } from '@liskhq/lisk-cryptography/dist-node/utils';
 import { Batch, Database } from '@liskhq/lisk-db';
-import { DB_KEY_BLOCK_HEIGHT, DB_KEY_BLOCK_ID } from './constants';
+import { encodeLegacyChainBracketInfo } from './codec';
+import { DB_KEY_BLOCK_HEIGHT, DB_KEY_BLOCK_ID, DB_KEY_LEGACY_BRACKET } from './constants';
+import { LegacyChainBracketInfo } from './types';
 
 export class Storage {
 	private readonly _db: Database;
@@ -52,6 +54,20 @@ export class Storage {
 		batch.set(Buffer.concat([DB_KEY_BLOCK_HEIGHT, intToBuffer(height, 4)]), id);
 
 		await this._db.write(batch);
+	}
+
+	public async getLegacyChainBracketInfo(snapshotBlockID: Buffer): Promise<Buffer> {
+		return this._db.get(Buffer.concat([DB_KEY_LEGACY_BRACKET, snapshotBlockID]));
+	}
+
+	public async setLegacyChainBracketInfo(
+		snapshotBlockID: Buffer,
+		bracketInfo: LegacyChainBracketInfo,
+	): Promise<void> {
+		await this._db.set(
+			Buffer.concat([DB_KEY_LEGACY_BRACKET, snapshotBlockID]),
+			encodeLegacyChainBracketInfo(bracketInfo),
+		);
 	}
 
 	private async _getBlockIDsBetweenHeights(

--- a/framework/src/engine/legacy/types.ts
+++ b/framework/src/engine/legacy/types.ts
@@ -36,3 +36,9 @@ export interface LegacyBlock {
 }
 
 export type LegacyBlockJSON = JSONObject<LegacyBlock>;
+
+export interface LegacyChainBracketInfo {
+	startHeight: number;
+	snapshotBlockHeight: number;
+	lastBlockHeight: number;
+}

--- a/framework/test/unit/engine/legacy/storage.spec.ts
+++ b/framework/test/unit/engine/legacy/storage.spec.ts
@@ -132,37 +132,6 @@ describe('Legacy storage', () => {
 		});
 	});
 
-	describe('setLegacyChainBracketInfo', () => {
-		it('should save the chain bracket info', async () => {
-			const { header } = blockFixtures[1];
-			const bracketInfo = {
-				startHeight: header.height,
-				snapshotBlockHeight: header.height,
-				lastBlockHeight: header.height,
-			};
-			await storage.setLegacyChainBracketInfo(header.id, bracketInfo);
-
-			const result = await storage.getLegacyChainBracketInfo(header.id);
-
-			expect(result).toEqual(encodeLegacyChainBracketInfo(bracketInfo));
-		});
-
-		it('should throw error if block with given id does not exist', async () => {
-			const { header } = blockFixtures[1];
-			const bracketInfo = {
-				startHeight: header.height,
-				snapshotBlockHeight: header.height,
-				lastBlockHeight: header.height,
-			};
-
-			await storage.setLegacyChainBracketInfo(header.id, bracketInfo);
-
-			await expect(storage.getLegacyChainBracketInfo(Buffer.alloc(0))).rejects.toThrow(
-				`Specified key 02 does not exist`,
-			);
-		});
-	});
-
 	describe('getLegacyChainBracketInfo', () => {
 		it('should return the chain bracket info', async () => {
 			const { header } = blockFixtures[1];
@@ -171,6 +140,7 @@ describe('Legacy storage', () => {
 				snapshotBlockHeight: header.height,
 				lastBlockHeight: header.height,
 			};
+
 			await storage.setLegacyChainBracketInfo(header.id, bracketInfo);
 
 			const result = await storage.getLegacyChainBracketInfo(header.id);

--- a/framework/test/unit/engine/legacy/storage.spec.ts
+++ b/framework/test/unit/engine/legacy/storage.spec.ts
@@ -15,7 +15,7 @@
 
 import { intToBuffer } from '@liskhq/lisk-cryptography/dist-node/utils';
 import { Batch, Database, InMemoryDatabase } from '@liskhq/lisk-db';
-import { encodeBlock } from '../../../../src/engine/legacy/codec';
+import { encodeBlock, encodeLegacyChainBracketInfo } from '../../../../src/engine/legacy/codec';
 import { DB_KEY_BLOCK_HEIGHT, DB_KEY_BLOCK_ID } from '../../../../src/engine/legacy/constants';
 import { Storage } from '../../../../src/engine/legacy/storage';
 import { blockFixtures } from './fixtures';
@@ -129,6 +129,59 @@ describe('Legacy storage', () => {
 			const result = await storage.getBlockByID(header.id);
 
 			expect(result).toEqual(encodeBlock({ header, transactions }));
+		});
+	});
+
+	describe('setLegacyChainBracketInfo', () => {
+		it('should save the chain bracket info', async () => {
+			const { header } = blockFixtures[1];
+			const bracketInfo = {
+				startHeight: header.height,
+				snapshotBlockHeight: header.height,
+				lastBlockHeight: header.height,
+			};
+			await storage.setLegacyChainBracketInfo(header.id, bracketInfo);
+
+			const result = await storage.getLegacyChainBracketInfo(header.id);
+
+			expect(result).toEqual(encodeLegacyChainBracketInfo(bracketInfo));
+		});
+
+		it('should throw error if block with given id does not exist', async () => {
+			const { header } = blockFixtures[1];
+			const bracketInfo = {
+				startHeight: header.height,
+				snapshotBlockHeight: header.height,
+				lastBlockHeight: header.height,
+			};
+
+			await storage.setLegacyChainBracketInfo(header.id, bracketInfo);
+
+			await expect(storage.getLegacyChainBracketInfo(Buffer.alloc(0))).rejects.toThrow(
+				`Specified key 02 does not exist`,
+			);
+		});
+	});
+
+	describe('getLegacyChainBracketInfo', () => {
+		it('should return the chain bracket info', async () => {
+			const { header } = blockFixtures[1];
+			const bracketInfo = {
+				startHeight: header.height,
+				snapshotBlockHeight: header.height,
+				lastBlockHeight: header.height,
+			};
+			await storage.setLegacyChainBracketInfo(header.id, bracketInfo);
+
+			const result = await storage.getLegacyChainBracketInfo(header.id);
+
+			expect(result).toEqual(encodeLegacyChainBracketInfo(bracketInfo));
+		});
+
+		it('should throw error if block with given id does not exist', async () => {
+			await expect(storage.getLegacyChainBracketInfo(Buffer.alloc(0))).rejects.toThrow(
+				`Specified key 02 does not exist`,
+			);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #7545

### How was it solved?

- Update codecs
- Update the legacy schema
- Add getLegacyChainBracketInfo() method
- Add setLegacyChainBracketInfo() method

### How was it tested?

Added unit tests
