### PR TITLE
Update token transfer command - Closes #7573

### DIFF
--- a/commander/test/bootstrapping/commands/transaction/create.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/create.spec.ts
@@ -30,7 +30,7 @@ import { Awaited } from '../../../types';
 describe('transaction:create command', () => {
 	const passphrase = 'peanut hundred pen hawk invite exclude brain chunk gadget wait wrong ready';
 	const transferParams =
-		'{"tokenID": "0000000000000000","amount":100,"recipientAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","data":"send token"}';
+		'{"tokenID": "0000000000000000","amount":100,"recipientAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","data":"send token", "accountInitializationFee": "5000000"}';
 	const voteParams =
 		'{"votes":[{"delegateAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","amount":100},{"delegateAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9","amount":-50}]}';
 	const unVoteParams =
@@ -44,6 +44,7 @@ describe('transaction:create command', () => {
 			amount: '100',
 			data: 'send token',
 			recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+			accountInitializationFee: BigInt(5000000),
 		},
 		command: 'transfer',
 		fee: '100000000',
@@ -125,6 +126,7 @@ describe('transaction:create command', () => {
 			amount: 100,
 			recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
 			data: 'send token',
+			accountInitializationFee: BigInt(5000000),
 		});
 		jest.spyOn(readerUtils, 'getPassphraseFromPrompt').mockResolvedValue(passphrase);
 	});
@@ -255,7 +257,7 @@ describe('transaction:create command', () => {
 								'token',
 								'transfer',
 								'100000000',
-								'--params={"tokenID":"0000000000000000","amount":100,"recipientAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9"}',
+								'--params={"tokenID":"0000000000000000","amount":100,"recipientAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9", "accountInitializationFee": "5000000"}',
 								`--passphrase=${passphrase}`,
 								'--offline',
 								'--chain-id=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
@@ -266,6 +268,27 @@ describe('transaction:create command', () => {
 						),
 					).rejects.toThrow(
 						"Lisk validator found 1 error[s]:\nMissing property, must have required property 'data'",
+					);
+				});
+
+				it('should throw error when transfer params accountInitializationFee is empty.', async () => {
+					await expect(
+						CreateCommandExtended.run(
+							[
+								'token',
+								'transfer',
+								'100000000',
+								'--params={"tokenID":"0000000000000000","amount":100,"recipientAddress":"lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9", "data": ""}',
+								`--passphrase=${passphrase}`,
+								'--offline',
+								'--chain-id=873da85a2cee70da631d90b0f17fada8c3ac9b83b2613f4ca5fddd374d1034b3.',
+								'--nonce=1',
+								'--network=devnet',
+							],
+							config,
+						),
+					).rejects.toThrow(
+						"Lisk validator found 1 error[s]:\nMissing property, must have required property 'accountInitializationFee'",
 					);
 				});
 			});
@@ -385,6 +408,11 @@ describe('transaction:create command', () => {
 							type: 'input',
 						},
 						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						{
+							message: 'Please enter: accountInitializationFee: ',
+							name: 'accountInitializationFee',
+							type: 'input',
+						},
 					]);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledTimes(1);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledWith(undefined, {
@@ -416,6 +444,11 @@ describe('transaction:create command', () => {
 							type: 'input',
 						},
 						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						{
+							message: 'Please enter: accountInitializationFee: ',
+							name: 'accountInitializationFee',
+							type: 'input',
+						},
 					]);
 					expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledTimes(1);
@@ -458,6 +491,7 @@ describe('transaction:create command', () => {
 								amount: '100',
 								data: 'send token',
 								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+								accountInitializationFee: '5000000',
 							},
 							signatures: [],
 						},
@@ -498,6 +532,7 @@ describe('transaction:create command', () => {
 								amount: '100',
 								data: 'send token',
 								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+								accountInitializationFee: '5000000',
 							},
 							signatures: [expect.any(String)],
 						},
@@ -621,6 +656,11 @@ describe('transaction:create command', () => {
 							type: 'input',
 						},
 						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						{
+							message: 'Please enter: accountInitializationFee: ',
+							name: 'accountInitializationFee',
+							type: 'input',
+						},
 					]);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledTimes(1);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledWith(undefined, {
@@ -645,6 +685,11 @@ describe('transaction:create command', () => {
 							type: 'input',
 						},
 						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						{
+							message: 'Please enter: accountInitializationFee: ',
+							name: 'accountInitializationFee',
+							type: 'input',
+						},
 					]);
 					expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledTimes(1);
@@ -667,6 +712,11 @@ describe('transaction:create command', () => {
 							type: 'input',
 						},
 						{ message: 'Please enter: data: ', name: 'data', type: 'input' },
+						{
+							message: 'Please enter: accountInitializationFee: ',
+							name: 'accountInitializationFee',
+							type: 'input',
+						},
 					]);
 					expect(readerUtils.getPassphraseFromPrompt).toHaveBeenCalledWith('passphrase', true);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledTimes(1);
@@ -725,6 +775,7 @@ describe('transaction:create command', () => {
 								amount: '100',
 								data: 'send token',
 								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+								accountInitializationFee: BigInt(5000000),
 							},
 							signatures: [
 								'3cc8c8c81097fe59d9df356b3c3f1dd10f619bfabb54f5d187866092c67e0102c64dbe24f357df493cc7ebacdd2e55995db8912245b718d88ebf7f4f4ac01f04',

--- a/commander/test/bootstrapping/commands/transaction/prompt.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/prompt.spec.ts
@@ -37,6 +37,11 @@ describe('prompt', () => {
 					message: 'Please enter: recipientAddress: ',
 				},
 				{ type: 'input', name: 'data', message: 'Please enter: data: ' },
+				{
+					type: 'input',
+					name: 'accountInitializationFee',
+					message: 'Please enter: accountInitializationFee: ',
+				},
 			]);
 		});
 	});

--- a/commander/test/bootstrapping/commands/transaction/sign.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/sign.spec.ts
@@ -196,6 +196,7 @@ describe('transaction:sign command', () => {
 							amount: '100',
 							data: 'send token',
 							recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+							accountInitializationFee: BigInt(5000000).toString(),
 						},
 						command: 'transfer',
 						fee: '100000000',
@@ -232,6 +233,7 @@ describe('transaction:sign command', () => {
 				numberOfSignatures: messageForRegistration.numberOfSignatures,
 				mandatoryKeys: messageForRegistration.mandatoryKeys,
 				optionalKeys: messageForRegistration.optionalKeys,
+				accountInitializationFee: BigInt(5000000),
 				signatures: [] as Buffer[],
 			};
 
@@ -365,8 +367,9 @@ describe('transaction:sign command', () => {
 				nonce: '2',
 				fee: '100000000',
 				senderPublicKey: 'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
-				params:
-					'0a08000000000000000010641a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815220a73656e6420746f6b656e',
+				params: codec
+					.encodeJSON(tokenTransferParamsSchema, (mockJSONTransaction as any).params)
+					.toString('hex'),
 				signatures: [],
 			};
 			const unsignedMultiSigTransaction = codec
@@ -463,6 +466,7 @@ describe('transaction:sign command', () => {
 								amount: '100',
 								data: 'send token',
 								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+								accountInitializationFee: BigInt(5000000).toString(),
 							},
 							command: 'transfer',
 							fee: '100000000',
@@ -705,8 +709,9 @@ describe('transaction:sign command', () => {
 				nonce: '2',
 				fee: '100000000',
 				senderPublicKey: 'f1b9f4ee71b5d5857d3b346d441ca967f27870ebee88569db364fd13e28adba3',
-				params:
-					'0a08000000000000000010641a14ab0041a7d3f7b2c290b5b834d46bdc7b7eb85815220a73656e6420746f6b656e',
+				params: codec
+					.encodeJSON(tokenTransferParamsSchema, (mockJSONTransaction as any).params)
+					.toString('hex'),
 				signatures: [],
 			};
 			const unsignedTransaction = codec.encodeJSON(transactionSchema, baseTX).toString('hex');
@@ -800,6 +805,7 @@ describe('transaction:sign command', () => {
 								amount: '100',
 								data: 'send token',
 								recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+								accountInitializationFee: BigInt(5000000).toString(),
 							},
 							command: 'transfer',
 							fee: '100000000',

--- a/commander/test/helpers/mocks.ts
+++ b/commander/test/helpers/mocks.ts
@@ -53,6 +53,7 @@ export const mockJSONTransaction = {
 		amount: '100',
 		data: 'send token',
 		recipientAddress: 'lskqozpc4ftffaompmqwzd93dfj89g5uezqwhosg9',
+		accountInitializationFee: BigInt(5000000),
 	},
 	command: 'transfer',
 	fee: '100000000',

--- a/commander/test/helpers/transactions.ts
+++ b/commander/test/helpers/transactions.ts
@@ -112,7 +112,7 @@ export const tokenTransferParamsSchema = {
 	$id: '/lisk/transferCommand',
 	title: 'Transfer transaction command',
 	type: 'object',
-	required: ['tokenID', 'amount', 'recipientAddress', 'data'],
+	required: ['tokenID', 'amount', 'recipientAddress', 'data', 'accountInitializationFee'],
 	properties: {
 		tokenID: {
 			dataType: 'bytes',
@@ -132,6 +132,10 @@ export const tokenTransferParamsSchema = {
 			fieldNumber: 4,
 			minLength: 0,
 			maxLength: 64,
+		},
+		accountInitializationFee: {
+			dataType: 'uint64',
+			fieldNumber: 5,
 		},
 	},
 };
@@ -233,6 +237,7 @@ export const createTransferTransaction = ({
 				amount: BigInt(transactions.convertLSKToBeddows(amount)),
 				recipientAddress: cryptography.address.getAddressFromLisk32Address(recipientAddress),
 				data: '',
+				accountInitializationFee: BigInt(5000000),
 			},
 		},
 		chainID,

--- a/framework/src/modules/token/commands/transfer.ts
+++ b/framework/src/modules/token/commands/transfer.ts
@@ -11,38 +11,92 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+
+import * as cryptography from '@liskhq/lisk-cryptography';
 import { validator } from '@liskhq/lisk-validator';
+import { dataStructures } from '@liskhq/lisk-utils';
 import { BaseCommand } from '../../base_command';
 import {
 	CommandExecuteContext,
 	CommandVerifyContext,
+	MethodContext,
 	VerificationResult,
 	VerifyStatus,
 } from '../../../state_machine';
 import { TokenMethod } from '../method';
 import { transferParamsSchema } from '../schemas';
+import { UserStore } from '../stores/user';
+import { InitializeUserAccountEvent } from '../events/initialize_user_account';
+import { TokenID } from '../types';
+import { TransferEvent } from '../events/transfer';
 
 interface Params {
-	tokenID: Buffer;
+	tokenID: TokenID;
 	amount: bigint;
 	recipientAddress: Buffer;
 	data: string;
+	accountInitializationFee: bigint;
 }
 
 export class TransferCommand extends BaseCommand {
 	public schema = transferParamsSchema;
 	private _method!: TokenMethod;
+	private _accountInitializationFee!: bigint;
+	private _feeTokenID!: TokenID;
 
-	public init(args: { method: TokenMethod }) {
+	public init(args: {
+		method: TokenMethod;
+		feeTokenID: TokenID;
+		accountInitializationFee: bigint;
+	}) {
 		this._method = args.method;
+		this._feeTokenID = args.feeTokenID;
+		this._accountInitializationFee = args.accountInitializationFee;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/require-await
 	public async verify(context: CommandVerifyContext<Params>): Promise<VerificationResult> {
 		const { params } = context;
 
 		try {
 			validator.validate(transferParamsSchema, params);
+
+			const userStore = this.stores.get(UserStore);
+
+			const balanceCheck = new dataStructures.BufferMap<bigint>();
+
+			const userAccountExists = await userStore.has(
+				context,
+				userStore.getKey(params.recipientAddress, params.tokenID),
+			);
+
+			if (!userAccountExists) {
+				if (params.accountInitializationFee !== this._accountInitializationFee) {
+					throw new Error('Invalid account initialization fee.');
+				}
+
+				balanceCheck.set(this._feeTokenID, this._accountInitializationFee);
+			}
+
+			balanceCheck.set(
+				params.tokenID,
+				(balanceCheck.get(params.tokenID) ?? BigInt(0)) + params.amount,
+			);
+
+			for (const [tokenID, amount] of balanceCheck.entries()) {
+				const availableBalance = await this._method.getAvailableBalance(
+					context.getMethodContext(),
+					context.transaction.senderAddress,
+					tokenID,
+				);
+
+				if (availableBalance < amount) {
+					throw new Error(
+						`${cryptography.address.getLisk32AddressFromAddress(
+							context.transaction.senderAddress,
+						)} balance ${availableBalance.toString()} is not sufficient for ${amount.toString()}.`,
+					);
+				}
+			}
 		} catch (err) {
 			return {
 				status: VerifyStatus.FAIL,
@@ -56,20 +110,70 @@ export class TransferCommand extends BaseCommand {
 
 	public async execute(context: CommandExecuteContext<Params>): Promise<void> {
 		const { params } = context;
-		// TODO: Fix in https://github.com/LiskHQ/lisk-sdk/issues/7573
-		await this._method.initializeUserAccount(
-			context.getMethodContext(),
-			params.recipientAddress,
-			params.tokenID,
-			context.transaction.senderAddress,
-			BigInt(50000000),
+
+		const userStore = this.stores.get(UserStore);
+
+		const recipientAccountKey = userStore.getKey(params.recipientAddress, params.tokenID);
+
+		const recipientAccountExists = await userStore.has(context, recipientAccountKey);
+
+		if (!recipientAccountExists) {
+			await this._intializeUserStore(
+				context,
+				params.recipientAddress,
+				params.tokenID,
+				context.transaction.senderAddress,
+			);
+		}
+
+		const senderAccountKey = userStore.getKey(context.transaction.senderAddress, params.tokenID);
+		const senderAccount = await userStore.get(context, senderAccountKey);
+		if (senderAccount.availableBalance < params.amount) {
+			throw new Error(
+				`${cryptography.address.getLisk32AddressFromAddress(
+					context.transaction.senderAddress,
+				)} balance ${senderAccount.availableBalance.toString()} is not sufficient for ${params.amount.toString()}.`,
+			);
+		}
+
+		senderAccount.availableBalance -= params.amount;
+		await userStore.save(context, context.transaction.senderAddress, params.tokenID, senderAccount);
+
+		const recipientAccount = await userStore.get(context, recipientAccountKey);
+		recipientAccount.availableBalance += params.amount;
+		await userStore.save(context, params.recipientAddress, params.tokenID, recipientAccount);
+
+		this.events.get(TransferEvent).log(context, {
+			senderAddress: context.transaction.senderAddress,
+			recipientAddress: params.recipientAddress,
+			tokenID: params.tokenID,
+			amount: params.amount,
+		});
+	}
+
+	private async _intializeUserStore(
+		methodContext: MethodContext,
+		address: Buffer,
+		tokenID: TokenID,
+		initPayingAddress: Buffer,
+	) {
+		const userStore = this.stores.get(UserStore);
+
+		await userStore.addAvailableBalanceWithCreate(methodContext, address, tokenID, BigInt(0));
+
+		await this._method.burn(
+			methodContext,
+			initPayingAddress,
+			this._feeTokenID,
+			this._accountInitializationFee,
 		);
-		await this._method.transfer(
-			context.getMethodContext(),
-			context.transaction.senderAddress,
-			params.recipientAddress,
-			params.tokenID,
-			params.amount,
-		);
+
+		const initializeUserAccountEvent = this.events.get(InitializeUserAccountEvent);
+		initializeUserAccountEvent.log(methodContext, {
+			address,
+			tokenID,
+			initPayingAddress,
+			initializationFee: this._accountInitializationFee,
+		});
 	}
 }

--- a/framework/src/modules/token/constants.ts
+++ b/framework/src/modules/token/constants.ts
@@ -37,6 +37,8 @@ export const TOKEN_ID_LENGTH = CHAIN_ID_LENGTH + LOCAL_ID_LENGTH;
 export const LOCAL_ID_LSK = Buffer.alloc(LOCAL_ID_LENGTH, 0);
 export const CHAIN_ID_LSK = Buffer.from([0, 0, 0, 0]);
 export const TOKEN_ID_LSK = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
+export const USER_SUBSTORE_INITIALIZATION_FEE = '5000000';
+export const TOKEN_ID_STORE_INITIALIZATION = TOKEN_ID_LSK;
 
 export const defaultConfig = {
 	minBalances: [
@@ -45,6 +47,7 @@ export const defaultConfig = {
 			amount: DEFAULT_MIN_REMAINING_BALANCE,
 		},
 	],
+	accountInitializationFee: USER_SUBSTORE_INITIALIZATION_FEE,
 };
 
 export const EMPTY_BYTES = Buffer.alloc(0);

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -157,6 +157,7 @@ export class TokenModule extends BaseInteroperableModule {
 	public async init(args: ModuleInitArgs) {
 		const { moduleConfig, genesisConfig } = args;
 		this._ownChainID = Buffer.from(genesisConfig.chainID, 'hex');
+
 		const config = objects.mergeDeep(
 			{},
 			defaultConfig,
@@ -182,6 +183,8 @@ export class TokenModule extends BaseInteroperableModule {
 		this.endpoint.init(this.method);
 		this._transferCommand.init({
 			method: this.method,
+			accountInitializationFee: BigInt(config.accountInitializationFee),
+			feeTokenID: Buffer.from(config.feeTokenID, 'hex'),
 		});
 	}
 

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -46,6 +46,16 @@ export const configSchema = {
 				format: 'hex',
 			},
 		},
+		accountInitializationFee: {
+			type: 'string',
+			format: 'uint64',
+		},
+		feeTokenID: {
+			type: 'string',
+			format: 'hex',
+			minLength: TOKEN_ID_LENGTH * 2,
+			maxLength: TOKEN_ID_LENGTH * 2,
+		},
 	},
 };
 
@@ -146,7 +156,7 @@ export const transferParamsSchema = {
 	$id: '/lisk/transferParams',
 	title: 'Transfer transaction params',
 	type: 'object',
-	required: ['tokenID', 'amount', 'recipientAddress', 'data'],
+	required: ['tokenID', 'amount', 'recipientAddress', 'data', 'accountInitializationFee'],
 	properties: {
 		tokenID: {
 			dataType: 'bytes',
@@ -168,6 +178,10 @@ export const transferParamsSchema = {
 			fieldNumber: 4,
 			minLength: 0,
 			maxLength: MAX_DATA_LENGTH,
+		},
+		accountInitializationFee: {
+			dataType: 'uint64',
+			fieldNumber: 5,
 		},
 	},
 };

--- a/framework/src/modules/token/types.ts
+++ b/framework/src/modules/token/types.ts
@@ -23,6 +23,7 @@ export interface ModuleConfig {
 		amount: string;
 	}[];
 	feeTokenID: string;
+	accountInitializationFee: string;
 }
 
 export interface MinBalance {

--- a/framework/test/integration/node/processor/block_process/process_block.spec.ts
+++ b/framework/test/integration/node/processor/block_process/process_block.spec.ts
@@ -76,7 +76,7 @@ describe('Process block', () => {
 					address: genesis.address,
 					tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
 				});
-				const expected = originalBalance - transaction.fee - amount - BigInt(50000000);
+				const expected = originalBalance - transaction.fee - amount - BigInt(5000000);
 				expect(balance.availableBalance).toEqual(expected.toString());
 			});
 

--- a/framework/test/integration/node/processor/report_misbehavior_transaction.spec.ts
+++ b/framework/test/integration/node/processor/report_misbehavior_transaction.spec.ts
@@ -50,7 +50,7 @@ describe('Transaction order', () => {
 			amount: BigInt('10000000000'),
 			chainID,
 			privateKey: Buffer.from(genesis.privateKey, 'hex'),
-			fee: BigInt(165000), // minFee not to give fee for generator
+			fee: BigInt(170000), // minFee not to give fee for generator
 		});
 		newBlock = await processEnv.createBlock([transaction]);
 

--- a/framework/test/integration/node/processor/transaction_order.spec.ts
+++ b/framework/test/integration/node/processor/transaction_order.spec.ts
@@ -234,7 +234,7 @@ describe('Transaction order', () => {
 					nonce: BigInt(authData.nonce),
 					fee: BigInt('200000'),
 					recipientAddress: accountWithoutBalance.address,
-					amount: BigInt('10000000000'),
+					amount: BigInt('14000000000'),
 					chainID,
 					privateKey: Buffer.from(genesis.privateKey, 'hex'),
 				});

--- a/framework/test/unit/abi_handler/abi_handler.spec.ts
+++ b/framework/test/unit/abi_handler/abi_handler.spec.ts
@@ -28,6 +28,7 @@ import { TransactionExecutionResult, TransactionVerifyResult } from '../../../sr
 import { AuthModule } from '../../../src/modules/auth';
 import { InMemoryPrefixedStateDB } from '../../../src/testing/in_memory_prefixed_state';
 import { PrefixedStateReadWriter } from '../../../src/state_machine/prefixed_state_read_writer';
+import { USER_SUBSTORE_INITIALIZATION_FEE } from '../../../src/modules/token/constants';
 
 describe('abi handler', () => {
 	let abiHandler: ABIHandler;
@@ -473,6 +474,7 @@ describe('abi handler', () => {
 					amount: BigInt(0),
 					recipientAddress: Buffer.alloc(20, 2),
 					data: '',
+					accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 				}),
 				senderPublicKey: utils.getRandomBytes(32),
 				signatures: [utils.getRandomBytes(64)],
@@ -525,6 +527,7 @@ describe('abi handler', () => {
 					amount: BigInt(0),
 					recipientAddress: Buffer.alloc(20, 2),
 					data: '',
+					accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 				}),
 				senderPublicKey: utils.getRandomBytes(32),
 				signatures: [utils.getRandomBytes(64)],

--- a/framework/test/unit/modules/token/commands/transfer.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer.spec.ts
@@ -14,22 +14,39 @@
 
 import { Transaction } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
-import { address, legacy, utils } from '@liskhq/lisk-cryptography';
+import { utils } from '@liskhq/lisk-cryptography';
 import { TokenModule, VerifyStatus } from '../../../../../src';
 import { TokenMethod } from '../../../../../src/modules/token/method';
 import { TransferCommand } from '../../../../../src/modules/token/commands/transfer';
-import { MIN_BALANCE } from '../../../../../src/modules/token/constants';
+import {
+	MIN_BALANCE,
+	TOKEN_ID_STORE_INITIALIZATION,
+	USER_SUBSTORE_INITIALIZATION_FEE,
+} from '../../../../../src/modules/token/constants';
 import { transferParamsSchema } from '../../../../../src/modules/token/schemas';
-import { SupplyStore } from '../../../../../src/modules/token/stores/supply';
 import { UserStore } from '../../../../../src/modules/token/stores/user';
-import { PrefixedStateReadWriter } from '../../../../../src/state_machine/prefixed_state_read_writer';
-import { createTransactionContext, createTransientMethodContext } from '../../../../../src/testing';
-import { InMemoryPrefixedStateDB } from '../../../../../src/testing/in_memory_prefixed_state';
+import { createTransactionContext } from '../../../../../src/testing';
+import { TokenID } from '../../../../../src/modules/token/types';
+import { EventQueue } from '../../../../../src/state_machine';
+import { InitializeUserAccountEvent } from '../../../../../src/modules/token/events/initialize_user_account';
+import { TransferEvent } from '../../../../../src/modules/token/events/transfer';
 
-// TODO: Fix in https://github.com/LiskHQ/lisk-sdk/issues/7573
-describe.skip('Transfer command', () => {
+interface Params {
+	tokenID: TokenID;
+	amount: bigint;
+	recipientAddress: Buffer;
+	data: string;
+	accountInitializationFee: bigint;
+}
+
+describe('Transfer command', () => {
+	const feeTokenID = TOKEN_ID_STORE_INITIALIZATION;
 	const tokenModule = new TokenModule();
+	const ownChainID = Buffer.from([0, 0, 0, 1]);
+	const defaultUserAccountInitFee = BigInt('50000000');
+	const defaultEscrowAccountInitFee = BigInt('50000000');
 
+	const defaultTokenID = Buffer.concat([ownChainID, Buffer.alloc(4)]);
 	const localTokenID = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
 	const secondTokenID = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
 	const method = new TokenMethod(tokenModule.stores, tokenModule.events, tokenModule.name);
@@ -42,6 +59,24 @@ describe.skip('Transfer command', () => {
 		getChannel: jest.Mock;
 	};
 
+	const checkEventResult = (
+		eventQueue: EventQueue,
+		length: number,
+		EventClass: any,
+		index: number,
+		expectedResult: any,
+	) => {
+		expect(eventQueue.getEvents()).toHaveLength(length);
+		expect(eventQueue.getEvents()[index].toObject().name).toEqual(new EventClass('token').name);
+
+		const eventData = codec.decode<Record<string, unknown>>(
+			new EventClass('token').schema,
+			eventQueue.getEvents()[index].toObject().data,
+		);
+
+		expect(eventData).toEqual({ ...expectedResult, result: 0 });
+	};
+
 	beforeEach(() => {
 		command = new TransferCommand(tokenModule.stores, tokenModule.events);
 		interopMethod = {
@@ -52,20 +87,22 @@ describe.skip('Transfer command', () => {
 			getChannel: jest.fn(),
 		};
 		method.addDependencies(interopMethod as never);
+
 		method.init({
 			ownChainID: Buffer.from([0, 0, 0, 1]),
-			escrowAccountInitializationFee: BigInt(50000000),
-			userAccountInitializationFee: BigInt(50000000),
-			feeTokenID: localTokenID,
+			escrowAccountInitializationFee: defaultEscrowAccountInitFee,
+			userAccountInitializationFee: defaultUserAccountInitFee,
+			feeTokenID: defaultTokenID,
 			minBalances: [
-				{
-					tokenID: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]),
-					amount: BigInt(5000000),
-				},
+				{ tokenID: localTokenID, amount: BigInt(MIN_BALANCE) },
+				{ tokenID: secondTokenID, amount: BigInt(MIN_BALANCE) },
 			],
 		});
+
 		command.init({
 			method,
+			accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
+			feeTokenID,
 		});
 	});
 
@@ -83,6 +120,7 @@ describe.skip('Transfer command', () => {
 						amount: BigInt(100000000),
 						recipientAddress: utils.getRandomBytes(20),
 						data: '',
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
@@ -106,6 +144,7 @@ describe.skip('Transfer command', () => {
 						amount: BigInt(100000000),
 						recipientAddress: utils.getRandomBytes(30),
 						data: '',
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
@@ -129,6 +168,7 @@ describe.skip('Transfer command', () => {
 						amount: BigInt(100000000),
 						recipientAddress: utils.getRandomBytes(20),
 						data: '1'.repeat(65),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
@@ -140,6 +180,10 @@ describe.skip('Transfer command', () => {
 		});
 
 		it('should success when all parameters are valid', async () => {
+			jest
+				.spyOn(command['_method'], 'getAvailableBalance')
+				.mockResolvedValue(BigInt(100000000 + 1));
+
 			const context = createTransactionContext({
 				transaction: new Transaction({
 					module: 'token',
@@ -152,6 +196,7 @@ describe.skip('Transfer command', () => {
 						amount: BigInt(100000000),
 						recipientAddress: utils.getRandomBytes(20),
 						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
@@ -160,277 +205,319 @@ describe.skip('Transfer command', () => {
 
 			expect(result.status).toEqual(VerifyStatus.OK);
 		});
-	});
 
-	describe('execute', () => {
-		let stateStore: PrefixedStateReadWriter;
-		const sender = legacy.getPrivateAndPublicKeyFromPassphrase('sender');
-		const recipient = legacy.getPrivateAndPublicKeyFromPassphrase('recipient');
-		const thirdTokenID = Buffer.from([1, 0, 0, 0, 4, 0, 0, 0]);
-		const tokenID = Buffer.from([0, 0, 0, 1, 0, 0, 0, 0]);
-		const senderBalance = BigInt(200000000);
-		const totalSupply = BigInt('1000000000000');
-		const recipientBalance = BigInt(1000);
-
-		beforeEach(async () => {
-			stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
-			const userStore = tokenModule.stores.get(UserStore);
-			const context = createTransientMethodContext({ stateStore });
-			await userStore.save(
-				context,
-				address.getAddressFromPublicKey(sender.publicKey),
-				localTokenID,
-				{ availableBalance: senderBalance, lockedBalances: [] },
-			);
-			await userStore.save(
-				context,
-				address.getAddressFromPublicKey(sender.publicKey),
-				secondTokenID,
-				{ availableBalance: senderBalance, lockedBalances: [] },
-			);
-			await userStore.save(
-				context,
-				address.getAddressFromPublicKey(sender.publicKey),
-				thirdTokenID,
-				{ availableBalance: senderBalance, lockedBalances: [] },
-			);
-			await userStore.save(
-				context,
-				address.getAddressFromPublicKey(recipient.publicKey),
-				localTokenID,
-				{ availableBalance: recipientBalance, lockedBalances: [] },
-			);
-			const supplyStore = tokenModule.stores.get(SupplyStore);
-			await supplyStore.set(context, localTokenID.slice(4), { totalSupply });
-		});
-
-		it.skip('should reject when sender does not have enough balance for amount', async () => {
+		it('should fail for non existent account when initialization fee is not what is configured in init', async () => {
 			const context = createTransactionContext({
-				stateStore,
-				transaction: new Transaction({
-					module: 'token',
-					command: 'transfer',
-					fee: BigInt(0),
-					nonce: BigInt(0),
-					senderPublicKey: sender.publicKey,
-					params: codec.encode(transferParamsSchema, {
-						tokenID,
-						amount: senderBalance + BigInt(1),
-						recipientAddress: utils.getRandomBytes(20),
-						data: '1'.repeat(64),
-					}),
-					signatures: [utils.getRandomBytes(64)],
-				}),
-			});
-			await expect(
-				command.execute(context.createCommandExecuteContext(transferParamsSchema)),
-			).rejects.toThrow('balance 200000000 is not sufficient');
-		});
-
-		it('should resolve when recipient exist for different tokenID but does not have enough balance for minBalance', async () => {
-			const context = createTransactionContext({
-				stateStore,
 				transaction: new Transaction({
 					module: 'token',
 					command: 'transfer',
 					fee: BigInt(5000000),
 					nonce: BigInt(0),
-					senderPublicKey: sender.publicKey,
+					senderPublicKey: utils.getRandomBytes(32),
 					params: codec.encode(transferParamsSchema, {
-						tokenID: thirdTokenID,
-						amount: recipientBalance + BigInt(1),
-						recipientAddress: address.getAddressFromPublicKey(recipient.publicKey),
+						tokenID: Buffer.from('0000000100000000', 'hex'),
+						amount: BigInt(100000000),
+						recipientAddress: utils.getRandomBytes(20),
 						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE) - BigInt(1),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
 			});
-			await expect(
-				command.execute(context.createCommandExecuteContext(transferParamsSchema)),
-			).resolves.toBeUndefined();
-
-			// Recipient should receive full amount
-			const userStore = tokenModule.stores.get(UserStore);
-			const result = await userStore.get(
-				context.createCommandExecuteContext(transferParamsSchema),
-				userStore.getKey(address.getAddressFromPublicKey(recipient.publicKey), thirdTokenID),
-			);
-			expect(result.availableBalance).toEqual(recipientBalance + BigInt(1));
+			const result = await command.verify(context.createCommandVerifyContext(transferParamsSchema));
+			expect(result.status).toEqual(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude('Invalid account initialization fee.');
 		});
 
-		it('should reject when recipient does not exist and the token does not have min balance set', async () => {
-			const recipientAddress = utils.getRandomBytes(20);
+		it('should fail if token balance for feeTokenID is less than the sum of configured initialzation fee and transaction amount', async () => {
 			const amount = BigInt(100000000);
+
+			const availableBalance = amount + BigInt(USER_SUBSTORE_INITIALIZATION_FEE) - BigInt(1);
+
+			jest
+				.spyOn(command['_method'], 'getAvailableBalance')
+				.mockResolvedValue(amount + BigInt(USER_SUBSTORE_INITIALIZATION_FEE) - BigInt(1));
+
 			const context = createTransactionContext({
-				stateStore,
 				transaction: new Transaction({
 					module: 'token',
 					command: 'transfer',
-					fee: BigInt(0),
+					fee: BigInt(5000000),
 					nonce: BigInt(0),
-					senderPublicKey: sender.publicKey,
+					senderPublicKey: utils.getRandomBytes(32),
 					params: codec.encode(transferParamsSchema, {
-						tokenID: thirdTokenID,
+						tokenID: feeTokenID,
 						amount,
-						recipientAddress,
+						recipientAddress: utils.getRandomBytes(20),
 						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
 			});
-			await expect(
-				command.execute(context.createCommandExecuteContext(transferParamsSchema)),
-			).rejects.toThrow('Address cannot be initialized because min balance is not set');
+			const result = await command.verify(context.createCommandVerifyContext(transferParamsSchema));
+			expect(result.status).toEqual(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude(
+				`balance ${availableBalance} is not sufficient for ${
+					amount + BigInt(USER_SUBSTORE_INITIALIZATION_FEE)
+				}`,
+			);
 		});
 
-		// TODO: Fix in https://github.com/LiskHQ/lisk-sdk/issues/7573
-		it.skip('should reject when recipient does not exist and amount is less than minBalance', async () => {
-			const recipientAddress = utils.getRandomBytes(20);
-			const amount = BigInt(100);
+		it('should pass if token balance for token ID TOKEN_ID_STORE_INITIALIZATION is at least the sum of configured initialization fee and transaction amount', async () => {
+			const amount = BigInt(100000000);
+
+			jest
+				.spyOn(command['_method'], 'getAvailableBalance')
+				.mockResolvedValue(amount + BigInt(USER_SUBSTORE_INITIALIZATION_FEE));
+
 			const context = createTransactionContext({
-				stateStore,
 				transaction: new Transaction({
 					module: 'token',
 					command: 'transfer',
-					fee: BigInt(0),
+					fee: BigInt(5000000),
 					nonce: BigInt(0),
-					senderPublicKey: sender.publicKey,
+					senderPublicKey: utils.getRandomBytes(32),
+					params: codec.encode(transferParamsSchema, {
+						tokenID: TOKEN_ID_STORE_INITIALIZATION,
+						amount: BigInt(100000000),
+						recipientAddress: utils.getRandomBytes(20),
+						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
+					}),
+					signatures: [utils.getRandomBytes(64)],
+				}),
+			});
+			const result = await command.verify(context.createCommandVerifyContext(transferParamsSchema));
+			expect(result.status).toEqual(VerifyStatus.OK);
+		});
+
+		it('should fail if balance for the provided tokenID is insufficient', async () => {
+			const amount = BigInt(100000000);
+			const availableBalance = amount - BigInt(1);
+
+			jest.spyOn(command['_method'], 'getAvailableBalance').mockResolvedValue(amount - BigInt(1));
+
+			const context = createTransactionContext({
+				transaction: new Transaction({
+					module: 'token',
+					command: 'transfer',
+					fee: BigInt(5000000),
+					nonce: BigInt(0),
+					senderPublicKey: utils.getRandomBytes(32),
+					params: codec.encode(transferParamsSchema, {
+						tokenID: Buffer.from('0000000100000000', 'hex'),
+						amount: BigInt(100000000),
+						recipientAddress: utils.getRandomBytes(20),
+						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
+					}),
+					signatures: [utils.getRandomBytes(64)],
+				}),
+			});
+			const result = await command.verify(context.createCommandVerifyContext(transferParamsSchema));
+			expect(result.status).toEqual(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude(
+				`balance ${availableBalance} is not sufficient for ${amount}`,
+			);
+		});
+
+		it('should pass if balance for the provided tokenID is sufficient', async () => {
+			const amount = BigInt(100000000);
+
+			jest.spyOn(command['_method'], 'getAvailableBalance').mockResolvedValue(amount);
+			const context = createTransactionContext({
+				transaction: new Transaction({
+					module: 'token',
+					command: 'transfer',
+					fee: BigInt(5000000),
+					nonce: BigInt(0),
+					senderPublicKey: utils.getRandomBytes(32),
+					params: codec.encode(transferParamsSchema, {
+						tokenID: Buffer.from('0000000100000000', 'hex'),
+						amount,
+						recipientAddress: utils.getRandomBytes(20),
+						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
+					}),
+					signatures: [utils.getRandomBytes(64)],
+				}),
+			});
+			const result = await command.verify(context.createCommandVerifyContext(transferParamsSchema));
+			expect(result.status).toEqual(VerifyStatus.OK);
+		});
+	});
+
+	describe('execute', () => {
+		it('should initialize recipient account for tokenID does not exist and transfer the amount from sender to recipient', async () => {
+			const amount = BigInt(5);
+			const recipientAddress = utils.getRandomBytes(20);
+			const tokenID = Buffer.from('0000000100000000', 'hex');
+			const userStore = tokenModule.stores.get(UserStore);
+
+			const context = createTransactionContext({
+				transaction: new Transaction({
+					module: 'token',
+					command: 'transfer',
+					fee: BigInt(5000000),
+					nonce: BigInt(0),
+					senderPublicKey: utils.getRandomBytes(32),
 					params: codec.encode(transferParamsSchema, {
 						tokenID,
 						amount,
 						recipientAddress,
 						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
 			});
-			await expect(
-				command.execute(context.createCommandExecuteContext(transferParamsSchema)),
-			).rejects.toThrow('does not satisfy min balance requirement');
+
+			const commandExecuteContext = context.createCommandExecuteContext<Params>(
+				transferParamsSchema,
+			);
+
+			jest.spyOn(command['_method'], 'burn').mockImplementation(async () => Promise.resolve());
+
+			await userStore.save(commandExecuteContext, context.transaction.senderAddress, tokenID, {
+				availableBalance: BigInt(10),
+				lockedBalances: [],
+			});
+
+			await command.execute(commandExecuteContext);
+
+			const senderAccount = await userStore.get(
+				commandExecuteContext,
+				userStore.getKey(context.transaction.senderAddress, tokenID),
+			);
+			const recipientAccount = await userStore.get(
+				commandExecuteContext,
+				userStore.getKey(recipientAddress, tokenID),
+			);
+
+			expect(senderAccount.availableBalance.toString()).toEqual(BigInt(5).toString());
+			expect(recipientAccount.availableBalance.toString()).toEqual(BigInt(5).toString());
+
+			expect(command['_method'].burn).toHaveBeenCalledTimes(1);
+
+			checkEventResult(commandExecuteContext.eventQueue, 2, InitializeUserAccountEvent, 0, {
+				address: recipientAddress,
+				tokenID,
+				initPayingAddress: context.transaction.senderAddress,
+				initializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
+			});
+
+			checkEventResult(commandExecuteContext.eventQueue, 2, TransferEvent, 1, {
+				senderAddress: context.transaction.senderAddress,
+				recipientAddress,
+				tokenID,
+				amount,
+			});
 		});
 
-		// TODO: Fix in https://github.com/LiskHQ/lisk-sdk/issues/7573
-		it.skip('should resolve when recipient does not exist but amount is greater than minBalance', async () => {
+		it('should not initialize existing recipient account for tokenID and transfer the amount from sender to recipient', async () => {
+			const amount = BigInt(5);
 			const recipientAddress = utils.getRandomBytes(20);
-			const amount = BigInt(100000000);
+			const tokenID = Buffer.from('0000000100000000', 'hex');
+			const userStore = tokenModule.stores.get(UserStore);
+
 			const context = createTransactionContext({
-				stateStore,
 				transaction: new Transaction({
 					module: 'token',
 					command: 'transfer',
-					fee: BigInt(0),
+					fee: BigInt(5000000),
 					nonce: BigInt(0),
-					senderPublicKey: sender.publicKey,
+					senderPublicKey: utils.getRandomBytes(32),
 					params: codec.encode(transferParamsSchema, {
 						tokenID,
 						amount,
 						recipientAddress,
 						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
 			});
-			await expect(
-				command.execute(context.createCommandExecuteContext(transferParamsSchema)),
-			).resolves.toBeUndefined();
 
-			// Recipient should receive amount - min balance if not exist
-			const userStore = tokenModule.stores.get(UserStore);
-			const result = await userStore.get(
-				context.createCommandExecuteContext(transferParamsSchema),
-				userStore.getKey(recipientAddress, localTokenID),
+			const commandExecuteContext = context.createCommandExecuteContext<Params>(
+				transferParamsSchema,
 			);
-			expect(result.availableBalance).toEqual(amount - MIN_BALANCE);
 
-			// Min balance is burnt
-			const supplyStore = tokenModule.stores.get(SupplyStore);
-			const supply = await supplyStore.get(
-				context.createCommandExecuteContext(transferParamsSchema),
-				localTokenID.slice(4),
+			jest.spyOn(command['_method'], 'burn').mockImplementation(async () => Promise.resolve());
+
+			await userStore.save(commandExecuteContext, context.transaction.senderAddress, tokenID, {
+				availableBalance: BigInt(10),
+				lockedBalances: [],
+			});
+
+			await userStore.save(commandExecuteContext, recipientAddress, tokenID, {
+				availableBalance: BigInt(15),
+				lockedBalances: [],
+			});
+
+			await command.execute(commandExecuteContext);
+
+			const senderAccount = await userStore.get(
+				commandExecuteContext,
+				userStore.getKey(context.transaction.senderAddress, tokenID),
 			);
-			expect(supply.totalSupply).toEqual(totalSupply - MIN_BALANCE);
+			const recipientAccount = await userStore.get(
+				commandExecuteContext,
+				userStore.getKey(recipientAddress, tokenID),
+			);
+
+			expect(senderAccount.availableBalance).toEqual(BigInt(5));
+			expect(recipientAccount.availableBalance).toEqual(BigInt(20));
+
+			expect(command['_method'].burn).toHaveBeenCalledTimes(0);
+
+			checkEventResult(commandExecuteContext.eventQueue, 1, TransferEvent, 0, {
+				senderAddress: context.transaction.senderAddress,
+				recipientAddress,
+				tokenID,
+				amount,
+			});
 		});
 
-		it('should resolve and not burn supply when tokenID is not native and recipient does not exist', async () => {
+		it('should fail if balance for tokenID is not sufficient', async () => {
+			const amount = BigInt(17);
 			const recipientAddress = utils.getRandomBytes(20);
-			const amount = BigInt(100000000);
-			const context = createTransactionContext({
-				stateStore,
-				transaction: new Transaction({
-					module: 'token',
-					command: 'transfer',
-					fee: BigInt(0),
-					nonce: BigInt(0),
-					senderPublicKey: sender.publicKey,
-					params: codec.encode(transferParamsSchema, {
-						tokenID: secondTokenID,
-						amount,
-						recipientAddress,
-						data: '1'.repeat(64),
-					}),
-					signatures: [utils.getRandomBytes(64)],
-				}),
-			});
-			await expect(
-				command.execute(context.createCommandExecuteContext(transferParamsSchema)),
-			).resolves.toBeUndefined();
-
-			// Recipient should receive amount - min balance if not exist
+			const tokenID = Buffer.from('0000000100000000', 'hex');
 			const userStore = tokenModule.stores.get(UserStore);
-			const result = await userStore.get(
-				context.createCommandExecuteContext(transferParamsSchema),
-				userStore.getKey(recipientAddress, secondTokenID),
-			);
-			expect(result.availableBalance).toEqual(amount - MIN_BALANCE);
+			const balance = BigInt(10);
 
-			// Total supply should not change
-			// const supplyStore = stateStore.getStore(MODULE_ID_TOKEN_BUFFER, STORE_PREFIX_SUPPLY);
-			// const supply = await supplyStore.getWithSchema<SupplyStoreData>(
-			// 	localTokenID.slice(4),
-			// 	supplyStoreSchema,
-			// );
-			// expect(supply.totalSupply).toEqual(totalSupply);
-		});
-
-		// TODO: Fix in https://github.com/LiskHQ/lisk-sdk/issues/7573
-		it.skip('should resolve when recipient receive enough amount and sender has enough balance', async () => {
-			const amount = BigInt(100000000);
 			const context = createTransactionContext({
-				stateStore,
 				transaction: new Transaction({
 					module: 'token',
 					command: 'transfer',
-					fee: BigInt(0),
+					fee: BigInt(5000000),
 					nonce: BigInt(0),
-					senderPublicKey: sender.publicKey,
+					senderPublicKey: utils.getRandomBytes(32),
 					params: codec.encode(transferParamsSchema, {
 						tokenID,
 						amount,
-						recipientAddress: address.getAddressFromPublicKey(recipient.publicKey),
+						recipientAddress,
 						data: '1'.repeat(64),
+						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
 					}),
 					signatures: [utils.getRandomBytes(64)],
 				}),
 			});
-			await expect(
-				command.execute(context.createCommandExecuteContext(transferParamsSchema)),
-			).toResolve();
 
-			// Recipient should get full amount
-			const userStore = tokenModule.stores.get(UserStore);
-			const result = await userStore.get(
-				context.createCommandExecuteContext(transferParamsSchema),
-				userStore.getKey(address.getAddressFromPublicKey(recipient.publicKey), localTokenID),
+			const commandExecuteContext = context.createCommandExecuteContext<Params>(
+				transferParamsSchema,
 			);
-			expect(result.availableBalance).toEqual(amount + recipientBalance);
 
-			// total supply should not change
-			const supplyStore = tokenModule.stores.get(SupplyStore);
-			const supply = await supplyStore.get(
-				context.createCommandExecuteContext(transferParamsSchema),
-				localTokenID.slice(4),
+			jest.spyOn(command['_method'], 'burn').mockImplementation(async () => Promise.resolve());
+
+			await userStore.save(commandExecuteContext, context.transaction.senderAddress, tokenID, {
+				availableBalance: balance,
+				lockedBalances: [],
+			});
+
+			await expect(command.execute(commandExecuteContext)).rejects.toThrow(
+				`balance ${balance} is not sufficient for ${amount}.`,
 			);
-			expect(supply.totalSupply).toEqual(totalSupply);
 		});
 	});
 });

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -19,6 +19,7 @@ import {
 	CHAIN_ID_LENGTH,
 	CROSS_CHAIN_COMMAND_NAME_TRANSFER,
 	TokenEventResult,
+	USER_SUBSTORE_INITIALIZATION_FEE,
 } from '../../../../src/modules/token/constants';
 import { AllTokensFromChainSupportedEvent } from '../../../../src/modules/token/events/all_tokens_from_chain_supported';
 import { AllTokensFromChainSupportRemovedEvent } from '../../../../src/modules/token/events/all_tokens_from_chain_supported_removed';
@@ -104,7 +105,9 @@ describe('token module', () => {
 				chainID: '00000001',
 			} as never,
 			generatorConfig: {},
-			moduleConfig: {},
+			moduleConfig: {
+				accountInitializationFee: USER_SUBSTORE_INITIALIZATION_FEE,
+			},
 		});
 		method.addDependencies({
 			send: jest.fn().mockResolvedValue(true),

--- a/framework/test/utils/mocks/transaction.ts
+++ b/framework/test/utils/mocks/transaction.ts
@@ -48,6 +48,7 @@ export const createTransferTransaction = (input: {
 		recipientAddress: input.recipientAddress,
 		amount: input.amount ?? BigInt('10000000000'),
 		data: '',
+		accountInitializationFee: BigInt(5000000),
 	});
 
 	const publicKey = ed.getPublicKeyFromPrivateKey(input.privateKey);
@@ -211,6 +212,7 @@ export const createMultisignatureTransferTransaction = (input: {
 		recipientAddress: input.recipientAddress,
 		amount: BigInt('10000000000'),
 		data: '',
+		accountInitializationFee: BigInt(5000000),
 	};
 	const encodedAsset = codec.encode(command.schema, params);
 	const transaction = input.privateKeys.reduce<Record<string, unknown>>(

--- a/test/src/scenarios/modules/token/token.ts
+++ b/test/src/scenarios/modules/token/token.ts
@@ -41,6 +41,7 @@ export const sampleTokenTestScenario = (fixtures: Fixtures) =>
 						recipientAddress: target.address,
 						data: '',
 						tokenID: Buffer.alloc(8, 0).toString('hex'),
+						accountInitializationFee: BigInt(5000000),
 					},
 				},
 				fixtures.validators.keys[0].privateKey,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7573

### How was it solved?

Made changes to `execute` method to `initializeUserAccount` for `tokenID` and `recipientAddress` if not defined and `validate` method to fail if the sender's `availableBalance` is less than `amount` or USER_SUBSTORE_INITIALIZATION_FEE.

### How was it tested?

Implemented unit tests.