### PR TITLE
Fix to return empty array when calling getEvents - Closes #7598

### DIFF
--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -244,10 +244,17 @@ export class Storage {
 	}
 
 	public async getEvents(height: number): Promise<Event[]> {
-		const eventsByte = await this._db.get(concatDBKeys(DB_KEY_BLOCK_EVENTS, uint32BE(height)));
-		const events = decodeByteArray(eventsByte);
+		try {
+			const eventsByte = await this._db.get(concatDBKeys(DB_KEY_BLOCK_EVENTS, uint32BE(height)));
+			const events = decodeByteArray(eventsByte);
 
-		return events.map(e => Event.fromBytes(e));
+			return events.map(e => Event.fromBytes(e));
+		} catch (error) {
+			if (!(error instanceof NotFoundError)) {
+				throw error;
+			}
+			return [];
+		}
 	}
 
 	public async getTempBlocks(): Promise<Buffer[]> {

--- a/elements/lisk-chain/src/event.ts
+++ b/elements/lisk-chain/src/event.ts
@@ -34,7 +34,8 @@ export interface EventAttr {
 type EventJSON = JSONObject<EventAttr>;
 
 export class Event {
-	private readonly _index: number;
+	private _index: number;
+
 	private readonly _module: string;
 	private readonly _name: string;
 	private readonly _topics: Buffer[];
@@ -57,6 +58,10 @@ export class Event {
 
 	public id(): Buffer {
 		return utils.hash(codec.encode(eventSchema, this.toObject()));
+	}
+
+	public setIndex(index: number): void {
+		this._index = index;
 	}
 
 	public getBytes(): Buffer {

--- a/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
+++ b/elements/lisk-chain/test/unit/data_access/data_access.spec.ts
@@ -365,6 +365,14 @@ describe('data_access', () => {
 	});
 
 	describe('#getEvents', () => {
+		it('should get empty array if the event does not exist', async () => {
+			db.get.mockRejectedValue(new NotFoundError());
+
+			const resp = await dataAccess.getEvents(30);
+			expect(db.get).toHaveBeenCalledWith(concatDBKeys(DB_KEY_BLOCK_EVENTS, uint32BE(30)));
+			expect(resp).toEqual([]);
+		});
+
 		it('should get the events related to heights', async () => {
 			const original = [
 				new Event({

--- a/framework/src/engine/generator/generator.ts
+++ b/framework/src/engine/generator/generator.ts
@@ -565,6 +565,7 @@ export class Generator {
 			consensus,
 			transactions: transactions.map(tx => tx.toObject()),
 		});
+		blockEvents.push(...afterResult.events.map(e => new Event(e)));
 		if (
 			!isEmptyConsensusUpdate(
 				afterResult.preCommitThreshold,
@@ -593,7 +594,9 @@ export class Generator {
 
 		// Add event root calculation
 		const keypairs = [];
-		for (const e of blockEvents) {
+		for (let index = 0; index < blockEvents.length; index += 1) {
+			const e = blockEvents[index];
+			e.setIndex(index);
 			const pairs = e.keyPair();
 			for (const pair of pairs) {
 				keypairs.push(pair);

--- a/framework/test/integration/node/processor/block_process/process_block.spec.ts
+++ b/framework/test/integration/node/processor/block_process/process_block.spec.ts
@@ -111,10 +111,8 @@ describe('Process block', () => {
 				expect(processedBlock.header.id).toEqual(newBlock.header.id);
 			});
 
-			it('should not save the events to the database', async () => {
-				await expect(dataAccess.getEvents(newBlock.header.height)).rejects.toThrow(
-					'does not exist',
-				);
+			it('should save the events to the database', async () => {
+				await expect(dataAccess.getEvents(newBlock.header.height)).resolves.not.toBeEmpty();
 			});
 		});
 	});

--- a/framework/test/integration/node/processor/delete_block.spec.ts
+++ b/framework/test/integration/node/processor/delete_block.spec.ts
@@ -120,9 +120,9 @@ describe('Delete block', () => {
 			});
 
 			it('should delete the events from the database', async () => {
-				await expect(processEnv.getDataAccess().getEvents(newBlock.header.height)).rejects.toThrow(
-					'does not exist',
-				);
+				await expect(
+					processEnv.getDataAccess().getEvents(newBlock.header.height),
+				).resolves.toBeEmpty();
 			});
 
 			it('should match the sender account to the original state', async () => {

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { Block, BlockAssets, Chain, StateStore, Event } from '@liskhq/lisk-chain';
+import { Block, BlockAssets, Chain, StateStore, Event, Transaction } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { when } from 'jest-when';
 import { Mnemonic } from '@liskhq/lisk-passphrase';
@@ -39,7 +39,7 @@ import * as forkchoice from '../../../../src/engine/consensus/fork_choice/fork_c
 import { postBlockEventSchema } from '../../../../src/engine/consensus/schema';
 import { fakeLogger } from '../../../utils/mocks';
 import { BFTModule } from '../../../../src/engine/bft';
-import { ABI } from '../../../../src/abi';
+import { ABI, TransactionExecutionResult, TransactionVerifyResult } from '../../../../src/abi';
 import {
 	CONSENSUS_EVENT_BLOCK_BROADCAST,
 	NETWORK_EVENT_POST_BLOCK,
@@ -618,6 +618,9 @@ describe('consensus', () => {
 				db: dbMock,
 				genesisBlock: genesis,
 			});
+			jest.spyOn(abi, 'verifyTransaction').mockResolvedValue({
+				result: TransactionVerifyResult.OK,
+			});
 		});
 
 		describe('when skipBroadcast option is not specified', () => {
@@ -628,6 +631,17 @@ describe('consensus', () => {
 						previousBlockID: chain.lastBlock.header.id,
 						timestamp: consensus['_chain'].lastBlock.header.timestamp + 10,
 					},
+					transactions: [
+						new Transaction({
+							command: 'exec',
+							module: 'sample',
+							fee: BigInt(200),
+							nonce: BigInt(2),
+							params: utils.getRandomBytes(100),
+							senderPublicKey: utils.getRandomBytes(32),
+							signatures: [utils.getRandomBytes(64)],
+						}),
+					],
 				});
 				stateStore = new StateStore(new InMemoryDatabase());
 				jest.spyOn(bft.method, 'getBFTParameters').mockResolvedValue({
@@ -656,6 +670,57 @@ describe('consensus', () => {
 				expect(consensus.events.emit).toHaveBeenCalledWith(CONSENSUS_EVENT_BLOCK_BROADCAST, {
 					block: expect.any(Block),
 				});
+			});
+
+			it('should include events from hooks', async () => {
+				jest.spyOn(abi, 'beforeTransactionsExecute').mockResolvedValue({
+					events: [
+						{
+							module: 'sample',
+							name: 'init',
+							data: Buffer.from([0, 0, 2]),
+							topics: [Buffer.from([2])],
+							height: 2,
+							index: 0,
+						},
+					],
+				});
+				jest.spyOn(abi, 'afterTransactionsExecute').mockResolvedValue({
+					events: [
+						{
+							module: 'sample',
+							name: 'init',
+							data: Buffer.from([0, 0, 1]),
+							topics: [Buffer.from([3])],
+							height: 2,
+							index: 0,
+						},
+					],
+					nextValidators: [],
+					preCommitThreshold: BigInt(0),
+					certificateThreshold: BigInt(0),
+				});
+				jest.spyOn(abi, 'executeTransaction').mockResolvedValue({
+					result: TransactionExecutionResult.OK,
+					events: [
+						{
+							module: 'sample',
+							name: 'exec',
+							data: Buffer.from([0, 0, 2]),
+							topics: [utils.getRandomBytes(32)],
+							height: 2,
+							index: 0,
+						},
+					],
+				});
+
+				jest.spyOn(chain, 'saveBlock');
+
+				await consensus['_executeValidated'](block);
+
+				const savingEvents = (chain.saveBlock as jest.Mock).mock.calls[0][1];
+				expect(savingEvents).toHaveLength(3);
+				savingEvents.forEach((e: Event, i: number) => expect(e.toObject().index).toEqual(i));
 			});
 		});
 

--- a/framework/test/unit/engine/generator/generator.spec.ts
+++ b/framework/test/unit/engine/generator/generator.spec.ts
@@ -114,7 +114,9 @@ describe('generator', () => {
 			}),
 		} as never;
 		abi = {
-			beforeTransactionsExecute: jest.fn().mockResolvedValue({ events: [] }),
+			beforeTransactionsExecute: jest.fn().mockResolvedValue({
+				events: [],
+			}),
 			afterTransactionsExecute: jest.fn().mockResolvedValue({
 				events: [],
 				nextValidators: [],
@@ -537,14 +539,29 @@ describe('generator', () => {
 			jest.spyOn(abi, 'beforeTransactionsExecute').mockResolvedValue({
 				events: [
 					{
-						data: utils.getRandomBytes(32),
+						module: 'sample',
+						name: 'init',
+						data: Buffer.from([0, 0, 2]),
+						topics: [Buffer.from([2])],
+						height: 2,
 						index: 0,
-						module: 'token',
-						topics: [Buffer.from([0])],
-						name: 'Transfer Name',
-						height: 12,
 					},
 				],
+			});
+			jest.spyOn(abi, 'afterTransactionsExecute').mockResolvedValue({
+				events: [
+					{
+						module: 'sample',
+						name: 'init',
+						data: Buffer.from([0, 0, 1]),
+						topics: [Buffer.from([3])],
+						height: 2,
+						index: 0,
+					},
+				],
+				nextValidators: [],
+				preCommitThreshold: BigInt(0),
+				certificateThreshold: BigInt(0),
 			});
 			const block = await generator.generateBlock({
 				generatorAddress,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7598

### How was it solved?

Update to return empty array when the event does not exist for the height

### How was it tested?
send transaction to dpos-mainchain example
```
./bin/run transaction:send 0a05746f6b656e12087472616e7366657218002080c2d72f2a20a3f96c50d0446220ef2f98240898515cbba8155730679ca35326d98dcfb680f032290a0810000000000000001080c2d72f1a143152da8f438d4591068553438c1a62edc2a161d4220227273a40cbefbdbeda4aa4d41e0a5f2887378ddec84ecf41f1227f029e442a82b3c29b56423c087354378368f719e55b1d8cc5e5ccc6aade8517d854c72799f2ca7cbd01
```
- call ` ./bin/run endpoint:invoke chain_getEvents --pretty '{"height": X }' ` for both height with event and height without event

