### PR TITLE
Add events to interoperability module - Closes #7558 

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -23,8 +23,13 @@ import { AuthAccountStore } from './stores/auth_account';
 import { NamedRegistry } from '../named_registry';
 
 export class AuthEndpoint extends BaseEndpoint {
-	public constructor(_moduleName: string, stores: NamedRegistry, offchainStores: NamedRegistry) {
-		super(stores, offchainStores);
+	public constructor(
+		_moduleName: string,
+		stores: NamedRegistry,
+		offchainStores: NamedRegistry,
+		events: NamedRegistry,
+	) {
+		super(stores, offchainStores, events);
 	}
 
 	public async getAuthAccount(context: ModuleEndpointContext): Promise<AuthAccountJSON> {

--- a/framework/src/modules/auth/module.ts
+++ b/framework/src/modules/auth/module.ts
@@ -34,7 +34,7 @@ import { RegisterMultisignatureCommand } from './commands/register_multisignatur
 
 export class AuthModule extends BaseModule {
 	public method = new AuthMethod(this.stores, this.events);
-	public endpoint = new AuthEndpoint(this.name, this.stores, this.offchainStores);
+	public endpoint = new AuthEndpoint(this.name, this.stores, this.offchainStores, this.events);
 	public configSchema = configSchema;
 	public commands = [new RegisterMultisignatureCommand(this.stores, this.events)];
 

--- a/framework/src/modules/base_endpoint.ts
+++ b/framework/src/modules/base_endpoint.ts
@@ -17,5 +17,9 @@ export abstract class BaseEndpoint {
 	[key: string]: unknown;
 
 	// eslint-disable-next-line no-useless-constructor
-	public constructor(protected stores: NamedRegistry, protected offchainStores: NamedRegistry) {}
+	public constructor(
+		protected stores: NamedRegistry,
+		protected offchainStores: NamedRegistry,
+		protected events: NamedRegistry,
+	) {}
 }

--- a/framework/src/modules/dpos_v2/module.ts
+++ b/framework/src/modules/dpos_v2/module.ts
@@ -71,7 +71,7 @@ import { VoterStore } from './stores/voter';
 export class DPoSModule extends BaseModule {
 	public method = new DPoSMethod(this.stores, this.events);
 	public configSchema = configSchema;
-	public endpoint = new DPoSEndpoint(this.stores, this.offchainStores);
+	public endpoint = new DPoSEndpoint(this.stores, this.offchainStores, this.events);
 
 	private readonly _delegateRegistrationCommand = new DelegateRegistrationCommand(
 		this.stores,

--- a/framework/src/modules/fee/module.ts
+++ b/framework/src/modules/fee/module.ts
@@ -30,7 +30,7 @@ import { configSchema } from './schemas';
 export class FeeModule extends BaseModule {
 	public method = new FeeMethod(this.stores, this.events);
 	public configSchema = configSchema;
-	public endpoint = new FeeEndpoint(this.stores, this.offchainStores);
+	public endpoint = new FeeEndpoint(this.stores, this.offchainStores, this.events);
 	private _tokenMethod!: TokenMethod;
 	private _minFeePerByte!: number;
 	private _tokenID!: Buffer;

--- a/framework/src/modules/interoperability/base_interoperability_endpoint.ts
+++ b/framework/src/modules/interoperability/base_interoperability_endpoint.ts
@@ -42,8 +42,9 @@ export abstract class BaseInteroperabilityEndpoint<
 		protected stores: NamedRegistry,
 		protected offchainStores: NamedRegistry,
 		interoperableCCMethods: Map<string, BaseInteroperableMethod>,
+		protected events: NamedRegistry,
 	) {
-		super(stores, offchainStores);
+		super(stores, offchainStores, events);
 		this.interoperableCCMethods = interoperableCCMethods;
 	}
 

--- a/framework/src/modules/interoperability/base_interoperability_store.ts
+++ b/framework/src/modules/interoperability/base_interoperability_store.ts
@@ -57,6 +57,7 @@ import { ChainAccountStore } from './stores/chain_account';
 import { TerminatedOutboxAccount, TerminatedOutboxStore } from './stores/terminated_outbox';
 
 export abstract class BaseInteroperabilityStore {
+	public readonly events: NamedRegistry;
 	public readonly context: StoreGetter | ImmutableStoreGetter;
 	protected readonly stores: NamedRegistry;
 	protected readonly interoperableModuleMethods = new Map<string, BaseInteroperableMethod>();
@@ -65,10 +66,12 @@ export abstract class BaseInteroperabilityStore {
 		stores: NamedRegistry,
 		context: StoreGetter | ImmutableStoreGetter,
 		interoperableModuleMethods: Map<string, BaseInteroperableMethod>,
+		events: NamedRegistry,
 	) {
 		this.context = context;
 		this.stores = stores;
 		this.interoperableModuleMethods = interoperableModuleMethods;
+		this.events = events;
 	}
 
 	public async getOwnChainAccount(): Promise<OwnChainAccount> {

--- a/framework/src/modules/interoperability/constants.ts
+++ b/framework/src/modules/interoperability/constants.ts
@@ -64,10 +64,15 @@ export const CCM_STATUS_OK = 0;
 export const CCM_STATUS_MODULE_NOT_SUPPORTED = 1;
 export const CCM_STATUS_CROSS_CHAIN_COMMAND_NOT_SUPPORTED = 2;
 export const CCM_STATUS_CHANNEL_UNAVAILABLE = 3;
-export const CCM_STATUS_RECOVERED = 4;
+export const CCM_STATUS_CODE_FAILED_CCM = 4;
+export const CCM_STATUS_CODE_CHANNEL_UNAVAILABLE = 1;
+export const CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE = 1;
 export const MIN_RETURN_FEE = BigInt(1000);
 export const CROSS_CHAIN_COMMAND_REGISTRATION = 'crossChainCommandRegistration';
 export const CCM_SENT_STATUS_SUCCESS = 0;
+export const CCM_PROCESSED_RESULT_BOUNCED = 2;
+export const CCM_PROCESSED_RESULT_DISCARDED = 3;
+export const CCM_STATUS_CODE_RECOVERED = 5;
 
 // Commands
 export const COMMAND_NAME_SIDECHAIN_REG = 'sidechainRegistration';
@@ -79,3 +84,4 @@ export const COMMAND_NAME_STATE_RECOVERY_INIT = 'stateRecoveryInitialization';
 // Events
 export const EVENT_NAME_CHAIN_ACCOUNT_UPDATED = 'chainAccountUpdated';
 export const EVENT_NAME_CCM_PROCESSED = 'ccmProcessed';
+export const EVENT_NAME_CCM_SEND_SUCCESS = 'ccmSendSucess';

--- a/framework/src/modules/interoperability/events/ccm_processed.ts
+++ b/framework/src/modules/interoperability/events/ccm_processed.ts
@@ -16,13 +16,14 @@ import { BaseEvent, EventQueuer } from '../../base_event';
 
 export interface CcmProcessedEventData {
 	ccmID: Buffer;
-	status: number;
+	result: number;
+	code: number;
 }
 
 export const ccmProcessedEventSchema = {
 	$id: '/interoperability/events/ccmProcessed',
 	type: 'object',
-	required: ['ccmID', 'status'],
+	required: ['ccmID', 'result', 'code'],
 	properties: {
 		ccmID: {
 			dataType: 'bytes',
@@ -32,7 +33,7 @@ export const ccmProcessedEventSchema = {
 			dataType: 'uint32',
 			fieldNumber: 2,
 		},
-		status: {
+		code: {
 			dataType: 'uint32',
 			fieldNumber: 3,
 		},

--- a/framework/src/modules/interoperability/mainchain/cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/channel_terminated.ts
@@ -35,6 +35,11 @@ export class MainchainCCChannelTerminatedCommand extends BaseInteroperabilityCCC
 	}
 
 	protected getInteroperabilityStore(context: StoreGetter): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/registration.ts
@@ -75,6 +75,11 @@ export class MainchainCCRegistrationCommand extends BaseInteroperabilityCCComman
 	}
 
 	protected getInteroperabilityStore(context: StoreGetter): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/cc_commands/sidechain_terminated.ts
+++ b/framework/src/modules/interoperability/mainchain/cc_commands/sidechain_terminated.ts
@@ -73,6 +73,11 @@ export class MainchainCCSidechainTerminatedCommand extends BaseInteroperabilityC
 	}
 
 	protected getInteroperabilityStore(context: StoreGetter): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/cc_update.ts
@@ -273,6 +273,11 @@ export class MainchainCCUpdateCommand extends BaseInteroperabilityCommand {
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/commands/message_recovery.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/message_recovery.ts
@@ -25,7 +25,7 @@ import { CCMsg, MessageRecoveryParams } from '../../types';
 import { BaseInteroperabilityCommand } from '../../base_interoperability_command';
 import { MainchainInteroperabilityStore } from '../store';
 import { verifyMessageRecovery, swapReceivingAndSendingChainIDs, getCCMSize } from '../../utils';
-import { CCM_STATUS_RECOVERED, CHAIN_ACTIVE, EMPTY_FEE_ADDRESS } from '../../constants';
+import { CCM_STATUS_CODE_RECOVERED, CHAIN_ACTIVE, EMPTY_FEE_ADDRESS } from '../../constants';
 import { ccmSchema, messageRecoveryParamsSchema } from '../../schemas';
 import { BaseInteroperableMethod } from '../../base_interoperable_method';
 import { createCCCommandExecuteContext } from '../../context';
@@ -94,7 +94,7 @@ export class MainchainMessageRecoveryCommand extends BaseInteroperabilityCommand
 			const recoveryCCM: CCMsg = {
 				...ccm,
 				fee: BigInt(0),
-				status: CCM_STATUS_RECOVERED,
+				status: CCM_STATUS_CODE_RECOVERED,
 			};
 			const encodedUpdatedCCM = codec.encode(ccmSchema, recoveryCCM);
 			updatedCCMs.push(encodedUpdatedCCM);
@@ -182,6 +182,11 @@ export class MainchainMessageRecoveryCommand extends BaseInteroperabilityCommand
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/commands/state_recovery.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/state_recovery.ts
@@ -150,6 +150,11 @@ export class StateRecoveryCommand extends BaseInteroperabilityCommand {
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/commands/state_recovery_init.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/state_recovery_init.ts
@@ -168,6 +168,11 @@ export class StateRecoveryInitializationCommand extends BaseInteroperabilityComm
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/endpoint.ts
+++ b/framework/src/modules/interoperability/mainchain/endpoint.ts
@@ -20,5 +20,10 @@ export class MainchainInteroperabilityEndpoint extends BaseInteroperabilityEndpo
 	protected getInteroperabilityStore = (
 		context: StoreGetter | ImmutableStoreGetter,
 	): MainchainInteroperabilityStore =>
-		new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 }

--- a/framework/src/modules/interoperability/mainchain/method.ts
+++ b/framework/src/modules/interoperability/mainchain/method.ts
@@ -87,6 +87,11 @@ export class MainchainInteroperabilityMethod extends BaseMethod {
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): MainchainInteroperabilityStore {
-		return new MainchainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new MainchainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/mainchain/module.ts
+++ b/framework/src/modules/interoperability/mainchain/module.ts
@@ -42,6 +42,7 @@ import { ChainAccountUpdatedEvent } from '../events/chain_account_updated';
 import { RegisteredNamesStore } from '../stores/registered_names';
 import { OutboxRootStore } from '../stores/outbox_root';
 import { ChainValidatorsStore } from '../stores/chain_validators';
+import { CcmSendSuccessEvent } from '../events/ccm_send_success';
 
 export class MainchainInteroperabilityModule extends BaseInteroperabilityModule {
 	public crossChainMethod = new MainchainCCMethod(this.stores, this.events);
@@ -54,6 +55,7 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 		this.stores,
 		this.offchainStores,
 		this.interoperableCCMethods,
+		this.events,
 	);
 
 	private readonly _sidechainRegistrationCommand = new SidechainRegistrationCommand(
@@ -76,6 +78,7 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 		this.stores.register(ChainValidatorsStore, new ChainValidatorsStore(this.name));
 		this.events.register(ChainAccountUpdatedEvent, new ChainAccountUpdatedEvent(this.name));
 		this.events.register(CcmProcessedEvent, new CcmProcessedEvent(this.name));
+		this.events.register(CcmSendSuccessEvent, new CcmSendSuccessEvent(this.name));
 	}
 
 	public addDependencies(tokenMethod: TokenMethod) {

--- a/framework/src/modules/interoperability/mainchain/store.ts
+++ b/framework/src/modules/interoperability/mainchain/store.ts
@@ -13,9 +13,15 @@
  */
 
 import { NotFoundError } from '@liskhq/lisk-chain';
+import { codec } from '@liskhq/lisk-codec';
+import { utils } from '@liskhq/lisk-cryptography';
 import { BaseInteroperabilityStore } from '../base_interoperability_store';
 import {
-	CCM_STATUS_CHANNEL_UNAVAILABLE,
+	CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE,
+	CCM_PROCESSED_RESULT_BOUNCED,
+	CCM_PROCESSED_RESULT_DISCARDED,
+	CCM_STATUS_CODE_CHANNEL_UNAVAILABLE,
+	CCM_STATUS_CODE_FAILED_CCM,
 	CCM_STATUS_OK,
 	CHAIN_ACTIVE,
 	CHAIN_REGISTERED,
@@ -24,10 +30,11 @@ import {
 	EMPTY_FEE_ADDRESS,
 	LIVENESS_LIMIT,
 	MAINCHAIN_ID_BUFFER,
+	MIN_RETURN_FEE,
 	MODULE_NAME_INTEROPERABILITY,
 } from '../constants';
 import { createCCMsgBeforeSendContext } from '../context';
-import { CCMForwardContext, CCMsg, SendInternalContext } from '../types';
+import { CCMBounceContext, CCMForwardContext, CCMsg, SendInternalContext } from '../types';
 import {
 	getEncodedSidechainTerminatedCCMParam,
 	handlePromiseErrorWithNull,
@@ -35,6 +42,9 @@ import {
 } from '../utils';
 import { MODULE_NAME_TOKEN, TokenCCMethod } from '../cc_methods';
 import { ForwardCCMsgResult } from './types';
+import { ccmSchema } from '../schemas';
+import { CcmProcessedEvent } from '../events/ccm_processed';
+import { CcmSendSuccessEvent } from '../events/ccm_send_success';
 
 export class MainchainInteroperabilityStore extends BaseInteroperabilityStore {
 	public async isLive(chainID: Buffer, timestamp: number): Promise<boolean> {
@@ -106,8 +116,12 @@ export class MainchainInteroperabilityStore extends BaseInteroperabilityStore {
 		if (ccm.status !== CCM_STATUS_OK) {
 			return ForwardCCMsgResult.INVALID_CCM;
 		}
-
-		await this.bounce(ccm);
+		await this.bounce({
+			ccm,
+			newCCMStatus: CCM_STATUS_CODE_CHANNEL_UNAVAILABLE,
+			ccmProcessedEventCode: CCM_PROCESSED_CODE_CHANNEL_UNAVAILABLE,
+			eventQueue,
+		});
 
 		if (!receivingChainAccount || receivingChainAccount.status === CHAIN_REGISTERED) {
 			return ForwardCCMsgResult.INACTIVE_RECEIVING_CHAIN;
@@ -136,22 +150,47 @@ export class MainchainInteroperabilityStore extends BaseInteroperabilityStore {
 		return ForwardCCMsgResult.INFORM_SIDECHAIN_TERMINATION;
 	}
 
-	public async bounce(ccm: CCMsg): Promise<void> {
-		const terminatedStateAccountExists = await this.hasTerminatedStateAccount(ccm.sendingChainID);
+	public async bounce(context: CCMBounceContext): Promise<void> {
+		const { ccm, eventQueue, newCCMStatus, ccmProcessedEventCode } = context;
+		const ccmID = utils.hash(codec.encode(ccmSchema, ccm));
+		const minimumFee = MIN_RETURN_FEE * BigInt(ccmID.length);
+		if (ccm.status === CCM_STATUS_OK && ccm.fee >= minimumFee) {
+			this.events
+				.get(CcmProcessedEvent)
+				.log({ eventQueue }, ccm.sendingChainID, ccm.receivingChainID, {
+					ccmID,
+					result: CCM_PROCESSED_RESULT_BOUNCED,
+					code: ccmProcessedEventCode,
+				});
+			const newCCM = {
+				...ccm,
+				sendingChainID: ccm.receivingChainID,
+				receivingChainID: ccm.sendingChainID,
+				status: newCCMStatus,
+			};
 
-		// Messages from terminated chains are discarded, and never returned
-		if (terminatedStateAccountExists) {
+			// If the function is called during the cross-chain command execution, the fee is set to 0
+			if (newCCMStatus === CCM_STATUS_CODE_FAILED_CCM) {
+				newCCM.fee = BigInt(0);
+			} else {
+				newCCM.fee -= minimumFee;
+			}
+			await this.addToOutbox(newCCM.receivingChainID, newCCM);
+			const newCCMID = utils.hash(codec.encode(ccmSchema, newCCM));
+			this.events
+				.get(CcmSendSuccessEvent)
+				.log({ eventQueue }, newCCM.sendingChainID, newCCM.receivingChainID, newCCMID, { ccmID });
+
 			return;
 		}
 
-		const newCCM = {
-			...ccm,
-			sendingChainID: ccm.receivingChainID,
-			receivingChainID: ccm.sendingChainID,
-			status: CCM_STATUS_CHANNEL_UNAVAILABLE,
-		};
-
-		await this.addToOutbox(newCCM.receivingChainID, newCCM);
+		this.events
+			.get(CcmProcessedEvent)
+			.log({ eventQueue }, ccm.sendingChainID, ccm.receivingChainID, {
+				ccmID,
+				result: CCM_PROCESSED_RESULT_DISCARDED,
+				code: ccmProcessedEventCode,
+			});
 	}
 
 	public async sendInternal(sendContext: SendInternalContext): Promise<boolean> {

--- a/framework/src/modules/interoperability/sidechain/cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/channel_terminated.ts
@@ -37,6 +37,11 @@ export class SidechainCCChannelTerminatedCommand extends BaseInteroperabilityCCC
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new SidechainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/sidechain/cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/registration.ts
@@ -75,6 +75,11 @@ export class SidechainCCRegistrationCommand extends BaseInteroperabilityCCComman
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new SidechainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
@@ -73,6 +73,11 @@ export class SidechainCCSidechainTerminatedCommand extends BaseInteroperabilityC
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new SidechainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/cc_update.ts
@@ -265,6 +265,11 @@ export class SidechainCCUpdateCommand extends BaseInteroperabilityCommand {
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new SidechainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/sidechain/commands/message_recovery.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/message_recovery.ts
@@ -26,7 +26,7 @@ import { BaseInteroperabilityCommand } from '../../base_interoperability_command
 import { SidechainInteroperabilityStore } from '../store';
 import { verifyMessageRecovery, swapReceivingAndSendingChainIDs, getCCMSize } from '../../utils';
 import {
-	CCM_STATUS_RECOVERED,
+	CCM_STATUS_CODE_RECOVERED,
 	COMMAND_NAME_MESSAGE_RECOVERY,
 	EMPTY_FEE_ADDRESS,
 } from '../../constants';
@@ -99,7 +99,7 @@ export class SidechainMessageRecoveryCommand extends BaseInteroperabilityCommand
 			const recoveryCCM: CCMsg = {
 				...ccm,
 				fee: BigInt(0),
-				status: CCM_STATUS_RECOVERED,
+				status: CCM_STATUS_CODE_RECOVERED,
 			};
 			const encodedUpdatedCCM = codec.encode(ccmSchema, recoveryCCM);
 			updatedCCMs.push(encodedUpdatedCCM);
@@ -172,6 +172,11 @@ export class SidechainMessageRecoveryCommand extends BaseInteroperabilityCommand
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new SidechainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/sidechain/endpoint.ts
+++ b/framework/src/modules/interoperability/sidechain/endpoint.ts
@@ -20,5 +20,10 @@ export class SidechainInteroperabilityEndpoint extends BaseInteroperabilityEndpo
 	protected getInteroperabilityStore = (
 		context: StoreGetter | ImmutableStoreGetter,
 	): SidechainInteroperabilityStore =>
-		new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		new SidechainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 }

--- a/framework/src/modules/interoperability/sidechain/method.ts
+++ b/framework/src/modules/interoperability/sidechain/method.ts
@@ -87,6 +87,11 @@ export class SidechainInteroperabilityMethod extends BaseMethod {
 	protected getInteroperabilityStore(
 		context: StoreGetter | ImmutableStoreGetter,
 	): SidechainInteroperabilityStore {
-		return new SidechainInteroperabilityStore(this.stores, context, this.interoperableCCMethods);
+		return new SidechainInteroperabilityStore(
+			this.stores,
+			context,
+			this.interoperableCCMethods,
+			this.events,
+		);
 	}
 }

--- a/framework/src/modules/interoperability/sidechain/module.ts
+++ b/framework/src/modules/interoperability/sidechain/module.ts
@@ -42,6 +42,7 @@ import { ChainValidatorsStore } from '../stores/chain_validators';
 import { ChainAccountUpdatedEvent } from '../events/chain_account_updated';
 import { CcmProcessedEvent } from '../events/ccm_processed';
 import { InvalidRegistrationSignatureEvent } from '../events/invalid_registration_signature';
+import { CcmSendSuccessEvent } from '../events/ccm_send_success';
 
 export class SidechainInteroperabilityModule extends BaseInteroperabilityModule {
 	public crossChainMethod: BaseInteroperableMethod = new SidechainCCMethod(
@@ -57,6 +58,7 @@ export class SidechainInteroperabilityModule extends BaseInteroperabilityModule 
 		this.stores,
 		this.offchainStores,
 		this.interoperableCCMethods,
+		this.events,
 	);
 
 	private readonly _mainchainRegistrationCommand = new MainchainRegistrationCommand(
@@ -78,6 +80,7 @@ export class SidechainInteroperabilityModule extends BaseInteroperabilityModule 
 		this.stores.register(ChainValidatorsStore, new ChainValidatorsStore(this.name));
 		this.events.register(ChainAccountUpdatedEvent, new ChainAccountUpdatedEvent(this.name));
 		this.events.register(CcmProcessedEvent, new CcmProcessedEvent(this.name));
+		this.events.register(CcmSendSuccessEvent, new CcmSendSuccessEvent(this.name));
 		this.events.register(
 			InvalidRegistrationSignatureEvent,
 			new InvalidRegistrationSignatureEvent(this.name),

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -140,6 +140,13 @@ export interface CCMForwardContext {
 	ccu: CCUpdateParams;
 }
 
+export interface CCMBounceContext {
+	eventQueue: EventQueue;
+	ccm: CCMsg;
+	newCCMStatus: number;
+	ccmProcessedEventCode: number;
+}
+
 export interface LastCertificate {
 	height: number;
 	timestamp: number;

--- a/framework/src/modules/random/module.ts
+++ b/framework/src/modules/random/module.ts
@@ -42,7 +42,7 @@ import { HashOnion, HashOnionStore } from './stores/hash_onion';
 
 export class RandomModule extends BaseModule {
 	public method = new RandomMethod(this.stores, this.events, this.name);
-	public endpoint = new RandomEndpoint(this.stores, this.offchainStores);
+	public endpoint = new RandomEndpoint(this.stores, this.offchainStores, this.events);
 
 	private _maxLengthReveals!: number;
 

--- a/framework/src/modules/reward/module.ts
+++ b/framework/src/modules/reward/module.ts
@@ -32,7 +32,7 @@ import { EVENT_REWARD_MINTED_DATA_NAME } from '../../state_machine/constants';
 export class RewardModule extends BaseModule {
 	public method = new RewardMethod(this.stores, this.events);
 	public configSchema = configSchema;
-	public endpoint = new RewardEndpoint(this.stores, this.offchainStores);
+	public endpoint = new RewardEndpoint(this.stores, this.offchainStores, this.events);
 	private _tokenMethod!: TokenMethod;
 	private _randomMethod!: RandomMethod;
 	private _tokenID!: Buffer;

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -57,7 +57,7 @@ import { TransferEvent } from './events/transfer';
 
 export class TokenModule extends BaseInteroperableModule {
 	public method = new TokenMethod(this.stores, this.events, this.name);
-	public endpoint = new TokenEndpoint(this.stores, this.offchainStores);
+	public endpoint = new TokenEndpoint(this.stores, this.offchainStores, this.events);
 	public crossChainMethod = new TokenInteroperableMethod(this.stores, this.events, this.method);
 
 	private _minBalances!: MinBalance[];

--- a/framework/src/modules/validators/module.ts
+++ b/framework/src/modules/validators/module.ts
@@ -28,7 +28,7 @@ import { BLSKeyRegistrationEvent } from './events/bls_key_registration';
 
 export class ValidatorsModule extends BaseModule {
 	public method = new ValidatorsMethod(this.stores, this.events);
-	public endpoint = new ValidatorsEndpoint(this.stores, this.offchainStores);
+	public endpoint = new ValidatorsEndpoint(this.stores, this.offchainStores, this.events);
 	private _blockTime!: number;
 
 	public constructor() {

--- a/framework/src/testing/create_contexts.ts
+++ b/framework/src/testing/create_contexts.ts
@@ -226,7 +226,7 @@ export const createTransientModuleEndpointContext = (params: {
 	return ctx;
 };
 
-const createCCMethodContext = (params: {
+export const createCCMethodContext = (params: {
 	stateStore?: PrefixedStateReadWriter;
 	logger?: Logger;
 	chainID?: Buffer;

--- a/framework/test/unit/modules/dpos_v2/endpoint.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/endpoint.spec.ts
@@ -73,7 +73,7 @@ describe('DposModuleEndpoint', () => {
 	};
 
 	beforeEach(() => {
-		dposEndpoint = new DPoSEndpoint(dpos.stores, dpos.offchainStores);
+		dposEndpoint = new DPoSEndpoint(dpos.stores, dpos.offchainStores, dpos.events);
 		dposEndpoint.init(config);
 		stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 		voterSubStore = dpos.stores.get(VoterStore);

--- a/framework/test/unit/modules/interoperability/mainchain/cc_commands/channel_terminated.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/cc_commands/channel_terminated.spec.ts
@@ -21,6 +21,7 @@ import {
 import { MainchainCCChannelTerminatedCommand } from '../../../../../../src/modules/interoperability/mainchain/cc_commands/channel_terminated';
 import { MainchainInteroperabilityStore } from '../../../../../../src/modules/interoperability/mainchain/store';
 import { CCCommandExecuteContext } from '../../../../../../src/modules/interoperability/types';
+import { NamedRegistry } from '../../../../../../src/modules/named_registry';
 import { createExecuteCCMsgMethodContext } from '../../../../../../src/testing';
 
 describe('MainchainCCChannelTerminatedCommand', () => {
@@ -62,6 +63,7 @@ describe('MainchainCCChannelTerminatedCommand', () => {
 		interopMod.stores,
 		sampleExecuteContext,
 		ccMethodsMap,
+		new NamedRegistry(),
 	);
 	mainchainInteroperabilityStore.createTerminatedStateAccount = createTerminatedStateAccountMock;
 	(ccChannelTerminatedCommand as any)['getInteroperabilityStore'] = jest

--- a/framework/test/unit/modules/interoperability/mainchain/cc_commands/registration.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/cc_commands/registration.spec.ts
@@ -24,6 +24,7 @@ import { MainchainCCRegistrationCommand } from '../../../../../../src/modules/in
 import { MainchainInteroperabilityStore } from '../../../../../../src/modules/interoperability/mainchain/store';
 import { registrationCCMParamsSchema } from '../../../../../../src/modules/interoperability/schemas';
 import { CCCommandExecuteContext } from '../../../../../../src/modules/interoperability/types';
+import { NamedRegistry } from '../../../../../../src/modules/named_registry';
 import { createExecuteCCMsgMethodContext } from '../../../../../../src/testing';
 
 describe('MainchainCCRegistrationCommand', () => {
@@ -109,6 +110,7 @@ describe('MainchainCCRegistrationCommand', () => {
 			interopMod.stores,
 			sampleExecuteContext,
 			ccMethodsMap,
+			new NamedRegistry(),
 		);
 		mainchainInteroperabilityStore.terminateChainInternal = terminateChainInternalMock;
 		mainchainInteroperabilityStore.getChannel = getChannelMock;

--- a/framework/test/unit/modules/interoperability/mainchain/cc_commands/sidechain_terminated.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/cc_commands/sidechain_terminated.spec.ts
@@ -24,6 +24,7 @@ import { MainchainCCSidechainTerminatedCommand } from '../../../../../../src/mod
 import { MainchainInteroperabilityStore } from '../../../../../../src/modules/interoperability/mainchain/store';
 import { sidechainTerminatedCCMParamsSchema } from '../../../../../../src/modules/interoperability/schemas';
 import { CCCommandExecuteContext } from '../../../../../../src/modules/interoperability/types';
+import { NamedRegistry } from '../../../../../../src/modules/named_registry';
 import { createExecuteCCMsgMethodContext } from '../../../../../../src/testing';
 
 describe('MainchainCCSidechainTerminatedCommand', () => {
@@ -90,6 +91,7 @@ describe('MainchainCCSidechainTerminatedCommand', () => {
 			interopMod.stores,
 			sampleExecuteContext,
 			ccMethodsMap,
+			new NamedRegistry(),
 		);
 		mainchainInteroperabilityStore.terminateChainInternal = terminateChainInternalMock;
 		mainchainInteroperabilityStore.hasTerminatedStateAccount = hasTerminatedStateAccountMock;

--- a/framework/test/unit/modules/interoperability/mainchain/commands/message_recovery.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/message_recovery.spec.ts
@@ -42,6 +42,7 @@ import { PrefixedStateReadWriter } from '../../../../../../src/state_machine/pre
 import { InMemoryPrefixedStateDB } from '../../../../../../src/testing/in_memory_prefixed_state';
 import { TerminatedOutboxStore } from '../../../../../../src/modules/interoperability/stores/terminated_outbox';
 import { createStoreGetter } from '../../../../../../src/testing/utils';
+import { NamedRegistry } from '../../../../../../src/modules/named_registry';
 
 describe('Mainchain MessageRecoveryCommand', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -80,6 +81,7 @@ describe('Mainchain MessageRecoveryCommand', () => {
 				interopMod.stores,
 				createStoreGetter(stateStore),
 				new Map(),
+				new NamedRegistry(),
 			);
 			messageRecoveryCommand = new MainchainMessageRecoveryCommand(
 				interopMod.stores,

--- a/framework/test/unit/modules/interoperability/mainchain/endpoint.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/endpoint.spec.ts
@@ -36,6 +36,7 @@ import {
 import { chainAccountToJSON } from '../../../../../src/modules/interoperability/utils';
 import { PrefixedStateReadWriter } from '../../../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../../../src/testing/in_memory_prefixed_state';
+import { NamedRegistry } from '../../../../../src/modules/named_registry';
 
 describe('Mainchain endpoint', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -160,11 +161,13 @@ describe('Mainchain endpoint', () => {
 			interopMod.stores,
 			moduleContext,
 			interoperableCCMethods,
+			new NamedRegistry(),
 		);
 		mainchainInteroperabilityEndpoint = new MainchainInteroperabilityEndpoint(
 			interopMod.stores,
 			interopMod.offchainStores,
 			interoperableCCMethods,
+			new NamedRegistry(),
 		);
 
 		jest

--- a/framework/test/unit/modules/interoperability/mainchain/method.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/method.spec.ts
@@ -16,6 +16,7 @@ import { utils } from '@liskhq/lisk-cryptography';
 import { MainchainInteroperabilityModule } from '../../../../../src';
 import { MainchainInteroperabilityMethod } from '../../../../../src/modules/interoperability/mainchain/method';
 import { MainchainInteroperabilityStore } from '../../../../../src/modules/interoperability/mainchain/store';
+import { NamedRegistry } from '../../../../../src/modules/named_registry';
 import { MethodContext } from '../../../../../src/state_machine';
 import { createTransientMethodContext } from '../../../../../src/testing';
 
@@ -39,6 +40,7 @@ describe('Mainchain Method', () => {
 			interopMod.stores,
 			methodContext,
 			interoperableCCMethods,
+			new NamedRegistry(),
 		);
 		jest
 			.spyOn(mainchainInteroperabilityMethod as any, 'getInteroperabilityStore')

--- a/framework/test/unit/modules/interoperability/sidechain/cc_commands/channel_terminated.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/cc_commands/channel_terminated.spec.ts
@@ -21,6 +21,7 @@ import {
 import { SidechainCCChannelTerminatedCommand } from '../../../../../../src/modules/interoperability/sidechain/cc_commands/channel_terminated';
 import { SidechainInteroperabilityStore } from '../../../../../../src/modules/interoperability/sidechain/store';
 import { CCCommandExecuteContext } from '../../../../../../src/modules/interoperability/types';
+import { NamedRegistry } from '../../../../../../src/modules/named_registry';
 import { createExecuteCCMsgMethodContext } from '../../../../../../src/testing';
 
 describe('SidechainCCChannelTerminatedCommand', () => {
@@ -63,6 +64,7 @@ describe('SidechainCCChannelTerminatedCommand', () => {
 		interopMod.stores,
 		sampleExecuteContext,
 		ccMethodsMap,
+		new NamedRegistry(),
 	);
 	mainchainInteroperabilityStore.createTerminatedStateAccount = createTerminatedStateAccountMock;
 	(ccChannelTerminatedCommand as any)['getInteroperabilityStore'] = jest

--- a/framework/test/unit/modules/interoperability/sidechain/cc_commands/registration.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/cc_commands/registration.spec.ts
@@ -24,6 +24,7 @@ import {
 	CROSS_CHAIN_COMMAND_NAME_REGISTRATION,
 	MODULE_NAME_INTEROPERABILITY,
 } from '../../../../../../src/modules/interoperability/constants';
+import { NamedRegistry } from '../../../../../../src/modules/named_registry';
 
 describe('SidechainCCRegistrationCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
@@ -108,6 +109,7 @@ describe('SidechainCCRegistrationCommand', () => {
 			interopMod.stores,
 			sampleExecuteContext,
 			ccMethodsMap,
+			new NamedRegistry(),
 		);
 		sidechainInteroperabilityStore.terminateChainInternal = terminateChainInternalMock;
 		sidechainInteroperabilityStore.getChannel = getChannelMock;

--- a/framework/test/unit/modules/interoperability/sidechain/cc_commands/sidechain_terminated.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/cc_commands/sidechain_terminated.spec.ts
@@ -25,6 +25,7 @@ import { sidechainTerminatedCCMParamsSchema } from '../../../../../../src/module
 import { CCCommandExecuteContext } from '../../../../../../src/modules/interoperability/types';
 import { createExecuteCCMsgMethodContext } from '../../../../../../src/testing';
 import { SidechainInteroperabilityModule } from '../../../../../../src';
+import { NamedRegistry } from '../../../../../../src/modules/named_registry';
 
 describe('SidechainCCSidechainTerminatedCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
@@ -90,6 +91,7 @@ describe('SidechainCCSidechainTerminatedCommand', () => {
 			interopMod.stores,
 			sampleExecuteContext,
 			ccMethodsMap,
+			new NamedRegistry(),
 		);
 		mainchainInteroperabilityStore.terminateChainInternal = terminateChainInternalMock;
 		mainchainInteroperabilityStore.hasTerminatedStateAccount = hasTerminatedStateAccountMock;

--- a/framework/test/unit/modules/interoperability/sidechain/endpoint.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/endpoint.spec.ts
@@ -34,6 +34,7 @@ import {
 	OwnChainAccountJSON,
 } from '../../../../../src/modules/interoperability/types';
 import { chainAccountToJSON } from '../../../../../src/modules/interoperability/utils';
+import { NamedRegistry } from '../../../../../src/modules/named_registry';
 import { PrefixedStateReadWriter } from '../../../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../../../src/testing/in_memory_prefixed_state';
 
@@ -158,11 +159,13 @@ describe('Sidechain endpoint', () => {
 			interopMod.stores,
 			interopMod.offchainStores,
 			interoperableCCMethods,
+			new NamedRegistry(),
 		);
 		sidechainInteroperabilityStore = new SidechainInteroperabilityStore(
 			interopMod.stores,
 			moduleContext,
 			interoperableCCMethods,
+			new NamedRegistry(),
 		);
 		jest
 			.spyOn(sidechainInteroperabilityEndpoint as any, 'getInteroperabilityStore')

--- a/framework/test/unit/modules/interoperability/sidechain/method.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/method.spec.ts
@@ -16,6 +16,7 @@ import { utils } from '@liskhq/lisk-cryptography';
 import { SidechainInteroperabilityModule } from '../../../../../src';
 import { SidechainInteroperabilityMethod } from '../../../../../src/modules/interoperability/sidechain/method';
 import { SidechainInteroperabilityStore } from '../../../../../src/modules/interoperability/sidechain/store';
+import { NamedRegistry } from '../../../../../src/modules/named_registry';
 import { MethodContext } from '../../../../../src/state_machine';
 
 describe('Sidechain Method', () => {
@@ -38,6 +39,7 @@ describe('Sidechain Method', () => {
 			interopMod.stores,
 			methodContext,
 			interoperableCCMethods,
+			new NamedRegistry(),
 		);
 		jest
 			.spyOn(sidechainInteroperabilityMethod as any, 'getInteroperabilityStore')

--- a/framework/test/unit/modules/interoperability/sidechain/store.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/store.spec.ts
@@ -35,6 +35,7 @@ import { ChainAccountStore } from '../../../../../src/modules/interoperability/s
 import { TerminatedStateStore } from '../../../../../src/modules/interoperability/stores/terminated_state';
 import { StoreGetter } from '../../../../../src/modules/base_store';
 import { createStoreGetter } from '../../../../../src/testing/utils';
+import { NamedRegistry } from '../../../../../src/modules/named_registry';
 
 describe('Sidechain interoperability store', () => {
 	const sidechainInterops = new SidechainInteroperabilityModule();
@@ -79,6 +80,7 @@ describe('Sidechain interoperability store', () => {
 			sidechainInterops.stores,
 			context,
 			new Map(),
+			new NamedRegistry(),
 		);
 	});
 
@@ -173,6 +175,7 @@ describe('Sidechain interoperability store', () => {
 				sidechainInterops.stores,
 				context,
 				modsMap,
+				new NamedRegistry(),
 			);
 
 			jest.spyOn(sidechainInteropStoreLocal, 'isLive').mockResolvedValue(true);
@@ -196,6 +199,7 @@ describe('Sidechain interoperability store', () => {
 				sidechainInterops.stores,
 				context,
 				modsMap,
+				new NamedRegistry(),
 			);
 
 			jest.spyOn(sidechainInteropStoreLocal, 'isLive').mockResolvedValue(true);
@@ -300,6 +304,7 @@ describe('Sidechain interoperability store', () => {
 				sidechainInterops.stores,
 				context,
 				modsMap,
+				new NamedRegistry(),
 			);
 
 			jest.spyOn(sidechainInteropStoreLocal, 'isLive');

--- a/framework/test/unit/modules/interoperability/store.spec.ts
+++ b/framework/test/unit/modules/interoperability/store.spec.ts
@@ -41,6 +41,7 @@ import { ChainAccountStore } from '../../../../src/modules/interoperability/stor
 import { TerminatedStateStore } from '../../../../src/modules/interoperability/stores/terminated_state';
 import { createStoreGetter } from '../../../../src/testing/utils';
 import { StoreGetter } from '../../../../src/modules/base_store';
+import { NamedRegistry } from '../../../../src/modules/named_registry';
 
 describe('Base interoperability store', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -143,6 +144,7 @@ describe('Base interoperability store', () => {
 			interopMod.stores,
 			context,
 			new Map(),
+			new NamedRegistry(),
 		);
 	});
 
@@ -418,6 +420,7 @@ describe('Base interoperability store', () => {
 				interopMod.stores,
 				context,
 				ccMethodModsMap,
+				new NamedRegistry(),
 			);
 		});
 
@@ -442,6 +445,7 @@ describe('Base interoperability store', () => {
 				interopMod.stores,
 				context,
 				new Map().set('mod1', ccMethodSampleMod),
+				new NamedRegistry(),
 			);
 			mainchainStoreLocal.hasTerminatedStateAccount = jest.fn().mockResolvedValue(false);
 			jest.spyOn(mainchainStoreLocal, 'sendInternal');
@@ -468,6 +472,7 @@ describe('Base interoperability store', () => {
 				interopMod.stores,
 				context,
 				new Map().set('newMod', ccMethodMod1),
+				new NamedRegistry(),
 			);
 			mainchainStoreLocal.hasTerminatedStateAccount = jest.fn().mockResolvedValue(false);
 			jest.spyOn(mainchainStoreLocal, 'sendInternal');
@@ -502,6 +507,7 @@ describe('Base interoperability store', () => {
 				interopMod.stores,
 				context,
 				new Map().set('mod1', ccMethodSampleMod),
+				new NamedRegistry(),
 			);
 
 			mainchainStoreLocal.hasTerminatedStateAccount = jest.fn().mockResolvedValue(false);
@@ -531,6 +537,7 @@ describe('Base interoperability store', () => {
 				interopMod.stores,
 				context,
 				new Map().set(MODULE_NAME_INTEROPERABILITY, ccMethodSampleMod),
+				new NamedRegistry(),
 			);
 			mainchainStoreLocal.hasTerminatedStateAccount = jest.fn().mockResolvedValue(false);
 			jest.spyOn(mainchainStoreLocal, 'sendInternal');

--- a/framework/test/unit/modules/random/endpoint.spec.ts
+++ b/framework/test/unit/modules/random/endpoint.spec.ts
@@ -58,7 +58,11 @@ describe('RandomModuleEndpoint', () => {
 
 	beforeEach(async () => {
 		const randomModule = new RandomModule();
-		randomEndpoint = new RandomEndpoint(randomModule.stores, randomModule.offchainStores);
+		randomEndpoint = new RandomEndpoint(
+			randomModule.stores,
+			randomModule.offchainStores,
+			randomModule.events,
+		);
 		const stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 		context = createTransientModuleEndpointContext({
 			stateStore,

--- a/framework/test/unit/modules/token/endpoint.spec.ts
+++ b/framework/test/unit/modules/token/endpoint.spec.ts
@@ -57,7 +57,11 @@ describe('token endpoint', () => {
 
 	beforeEach(async () => {
 		const method = new TokenMethod(tokenModule.stores, tokenModule.events, tokenModule.name);
-		endpoint = new TokenEndpoint(tokenModule.stores, tokenModule.offchainStores);
+		endpoint = new TokenEndpoint(
+			tokenModule.stores,
+			tokenModule.offchainStores,
+			tokenModule.events,
+		);
 		method.init({
 			minBalances: [
 				{


### PR DESCRIPTION
### What was the problem?

This PR resolves #7558

### How was it solved?

- Added events to all modules stores and endpoints
- Updated bounce logic

**Note**: Events to be removed from Endpoint class and dependency uncoupled after `BaseInteroperabilityStore` class redesign issue

### How was it tested?

Added unit tests
