### PR TITLE
Align BLST version in `framework` to the one in `lisk-cryptography` - Closes #7620

### DIFF
--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -58,9 +58,13 @@ export const blsAggregate = (signatures: Buffer[]): Buffer | false => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.6
 export const blsSign = (sk: Buffer, message: Buffer): Buffer => {
-	const signature = Buffer.from(SecretKey.fromBytes(sk).sign(message).toBytes());
+	// In case of zero private key, it should return particular output regardless of message.
+	// elements/lisk-cryptography/test/protocol_specs/bls_specs/sign/zero_private_key.yml
+	if (sk.equals(Buffer.alloc(32))) {
+		return Buffer.concat([Buffer.from([192]), Buffer.alloc(95)]);
+	}
 
-	return signature;
+	return Buffer.from(SecretKey.fromBytes(sk).sign(message).toBytes());
 };
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.7

--- a/framework/package.json
+++ b/framework/package.json
@@ -40,7 +40,7 @@
 		"test:functional": "jest --config=./test/functional/jest.config.js --runInBand"
 	},
 	"dependencies": {
-		"@chainsafe/blst": "0.2.0",
+		"@chainsafe/blst": "0.2.4",
 		"@liskhq/lisk-api-client": "^6.0.0-alpha.4",
 		"@liskhq/lisk-chain": "^0.4.0-alpha.4",
 		"@liskhq/lisk-codec": "^0.3.0-alpha.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,13 +296,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chainsafe/blst@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.0.tgz#5e2d2707c2c0d56ff077a00179a5255eaca14099"
-  integrity sha512-eyyLm4C+Zhl18YwFa93J+xRSHj0NrBZodBO+z+aaREf71RnA7/EvOcAPVLpEW2CI7PsInhVne/ufb+A7gfHQrg==
+"@chainsafe/blst@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.4.tgz#ed0737dcf52a8775bd163c9a892424fa365d2c8b"
+  integrity sha512-jjhB4dALUvLdTc2flHE6BEI7KCvXVGevIP8si4OdtERu+Ed+cc6zBsrpLvOySX9pgAMAmAuTnB349AlmRfmR2Q==
   dependencies:
     node-fetch "^2.6.1"
-    node-gyp "^7.1.2"
+    node-gyp "^8.4.0"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -11336,7 +11336,7 @@ node-gyp@^5.0.2:
     tar "^4.4.12"
     which "^1.3.1"
 
-node-gyp@^7.1.0, node-gyp@^7.1.2:
+node-gyp@^7.1.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
   integrity sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
@@ -11352,7 +11352,7 @@ node-gyp@^7.1.0, node-gyp@^7.1.2:
     tar "^6.0.2"
     which "^2.0.2"
 
-node-gyp@^8.2.0:
+node-gyp@^8.2.0, node-gyp@^8.4.0:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
   integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==


### PR DESCRIPTION
### What was the problem?

This PR resolves https://github.com/LiskHQ/lisk-sdk/issues/7620

I could not complete SDK bootstrap using yarn. I was getting error:

```
Retrieving BLST native bindings...
Error: Error importing BLST native bindings: 404 Not Found
```

### How was it solved?

Bumped the BLST version in `framework` to 0.2.4, to make it the same as what is listed as peer dependency in `lisk-cryptography` package.

### How was it tested?

I am finally able to complete the `yarn` process on my environment.

But one of the test cases actually fails:

```
bls_lib › blsSign › bls_specs/sign/zero_private_key.yml › should generate valid signature
```

I need someone to help me with this one. Could it be that the new version of BLS no longer accepts 0 values for a private key?