### PR TITLE
Fixed `getMetadata` function to be invoked from `system` namespace - Closes #7512

### DIFF
--- a/commander/src/bootstrapping/commands/node/metadata.ts
+++ b/commander/src/bootstrapping/commands/node/metadata.ts
@@ -28,7 +28,7 @@ export abstract class MetadataCommand extends BaseIPCClientCommand {
 			this.error('APIClient is not initialized.');
 		}
 		try {
-			const metadataInfo = await this._client.invoke('node_getMetadata');
+			const metadataInfo = await this._client.invoke('system_getMetadata');
 			this.printJSON((metadataInfo as unknown) as Record<string, unknown>);
 		} catch (errors) {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/commander/test/bootstrapping/commands/node/metadata.spec.ts
+++ b/commander/test/bootstrapping/commands/node/metadata.spec.ts
@@ -96,7 +96,7 @@ describe('node:metadata command', () => {
 		it('should get node metadata and display as an object', async () => {
 			await MetadataCommand.run([], config);
 			expect(getMock).toHaveBeenCalledTimes(1);
-			expect(getMock).toHaveBeenCalledWith('node_getMetadata');
+			expect(getMock).toHaveBeenCalledWith('system_getMetadata');
 			expect(BaseIPCClientCommand.prototype.printJSON).toHaveBeenCalledTimes(1);
 			expect(BaseIPCClientCommand.prototype.printJSON).toHaveBeenCalledWith(queryResult);
 		});


### PR DESCRIPTION
### What was the problem?

Someone forgot to change `node_getMetadata` into `system_getMetadata`. See #7512 for details.

### How was it tested?

Updated the test suite, too. All `commander` test are OK.

@shuse2 should I also change both Commander `.bin/run node:*` commands to be invoked as `.bin/run system:*` commands instead?