### PR TITLE
Rename `ed` function `getKeyPairFromPhraseAndPath` to `getPrivateKeyFromPhraseAndPath` - Closes #7563

### DIFF
--- a/commander/src/bootstrapping/commands/keys/create.ts
+++ b/commander/src/bootstrapping/commands/keys/create.ts
@@ -113,10 +113,10 @@ export class CreateCommand extends Command {
 			const generatorKeyPath = `m/25519'/134'/${chainid}'/${offset + i}'`;
 			const blsKeyPath = `m/12381/134/${chainid}/${offset + i}`;
 
-			const accountPrivateKey = await ed.getKeyPairFromPhraseAndPath(passphrase, accountKeyPath);
+			const accountPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(passphrase, accountKeyPath);
 			const accountPublicKey = ed.getPublicKeyFromPrivateKey(accountPrivateKey);
 			const address = addressUtil.getAddressFromPublicKey(accountPublicKey);
-			const generatorPrivateKey = await ed.getKeyPairFromPhraseAndPath(
+			const generatorPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(
 				passphrase,
 				generatorKeyPath,
 			);

--- a/commander/src/utils/commons.ts
+++ b/commander/src/utils/commons.ts
@@ -48,7 +48,7 @@ export const deriveKeypair = async (passphrase: string, keyDerivationPath: strin
 	if (keyDerivationPath === 'legacy') {
 		return cryptography.legacy.getPrivateAndPublicKeyFromPassphrase(passphrase);
 	}
-	const privateKey = await cryptography.ed.getKeyPairFromPhraseAndPath(
+	const privateKey = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 		passphrase,
 		keyDerivationPath,
 	);

--- a/commander/test/bootstrapping/commands/generator/export.spec.ts
+++ b/commander/test/bootstrapping/commands/generator/export.spec.ts
@@ -69,7 +69,7 @@ describe('generator:export', () => {
 			invoke: invokeMock,
 		} as never);
 
-		const generatorPrivateKey = await ed.getKeyPairFromPhraseAndPath(
+		const generatorPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(
 			'passphrase',
 			"m/25519'/134'/0'/0'",
 		);

--- a/commander/test/bootstrapping/commands/generator/import.spec.ts
+++ b/commander/test/bootstrapping/commands/generator/import.spec.ts
@@ -83,7 +83,7 @@ describe('keys:import', () => {
 
 	describe('when importing with existing file', () => {
 		beforeEach(async () => {
-			const generatorPrivateKey = await ed.getKeyPairFromPhraseAndPath(
+			const generatorPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(
 				'passphrase',
 				"m/25519'/134'/0'/0'",
 			);

--- a/commander/test/bootstrapping/commands/keys/create.spec.ts
+++ b/commander/test/bootstrapping/commands/keys/create.spec.ts
@@ -51,13 +51,13 @@ describe('keys:create command', () => {
 		stderr = [];
 		config = await getConfig();
 
-		defaultAccountPrivateKey = await cryptography.ed.getKeyPairFromPhraseAndPath(
+		defaultAccountPrivateKey = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 			defaultPassphrase,
 			defaultAccountKeyPath,
 		);
 		defaultAccountPublicKey = cryptography.ed.getPublicKeyFromPrivateKey(defaultAccountPrivateKey);
 		defaultAddress = cryptography.address.getAddressFromPublicKey(defaultAccountPublicKey);
-		defaultGeneratorPrivateKey = await cryptography.ed.getKeyPairFromPhraseAndPath(
+		defaultGeneratorPrivateKey = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 			defaultPassphrase,
 			defaultGeneratorKeyPath,
 		);
@@ -89,7 +89,7 @@ describe('keys:create command', () => {
 
 		jest.spyOn(process.stdout, 'write').mockImplementation(val => stdout.push(val as string) > -1);
 		jest.spyOn(process.stderr, 'write').mockImplementation(val => stderr.push(val as string) > -1);
-		jest.spyOn(cryptography.ed, 'getKeyPairFromPhraseAndPath');
+		jest.spyOn(cryptography.ed, 'getPrivateKeyFromPhraseAndPath');
 		jest.spyOn(cryptography.ed, 'getPublicKeyFromPrivateKey');
 		jest.spyOn(cryptography.address, 'getAddressFromPublicKey');
 		jest.spyOn(cryptography.bls, 'getPrivateKeyFromPhraseAndPath');
@@ -115,7 +115,7 @@ describe('keys:create command', () => {
 			await CreateCommand.run([], config);
 			const loggedData = JSON.parse(stdout[0]);
 
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				defaultAccountKeyPath,
 			);
@@ -125,7 +125,7 @@ describe('keys:create command', () => {
 			expect(cryptography.address.getAddressFromPublicKey).toHaveBeenCalledWith(
 				defaultAccountPublicKey,
 			);
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				defaultGeneratorKeyPath,
 			);
@@ -163,7 +163,7 @@ describe('keys:create command', () => {
 			const loggedData = JSON.parse(stdout[0]);
 			const expectedData = [{ ...defaultKeys[0], encrypted: {} }];
 
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				defaultAccountKeyPath,
 			);
@@ -173,7 +173,7 @@ describe('keys:create command', () => {
 			expect(cryptography.address.getAddressFromPublicKey).toHaveBeenCalledWith(
 				defaultAccountPublicKey,
 			);
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				defaultGeneratorKeyPath,
 			);
@@ -205,12 +205,12 @@ describe('keys:create command', () => {
 			const generatorKeyPath2 = `m/25519'/134'/1'/2'`;
 			const blsKeyPath2 = `m/12381/134/1/2`;
 
-			const accountPrivateKey1 = await cryptography.ed.getKeyPairFromPhraseAndPath(
+			const accountPrivateKey1 = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 				defaultPassphrase,
 				accountKeyPath1,
 			);
 			const accountPublicKey1 = cryptography.ed.getPublicKeyFromPrivateKey(accountPrivateKey1);
-			const generatorPrivateKey1 = await cryptography.ed.getKeyPairFromPhraseAndPath(
+			const generatorPrivateKey1 = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 				defaultPassphrase,
 				generatorKeyPath1,
 			);
@@ -220,13 +220,13 @@ describe('keys:create command', () => {
 				blsKeyPath1,
 			);
 
-			const accountPrivateKey2 = await cryptography.ed.getKeyPairFromPhraseAndPath(
+			const accountPrivateKey2 = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 				defaultPassphrase,
 				accountKeyPath2,
 			);
 			const accountPublicKey2 = cryptography.ed.getPublicKeyFromPrivateKey(accountPrivateKey2);
 
-			const generatorPrivateKey2 = await cryptography.ed.getKeyPairFromPhraseAndPath(
+			const generatorPrivateKey2 = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 				defaultPassphrase,
 				generatorKeyPath2,
 			);
@@ -248,13 +248,13 @@ describe('keys:create command', () => {
 				config,
 			);
 
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				accountKeyPath1,
 			);
 			expect(cryptography.ed.getPublicKeyFromPrivateKey).toHaveBeenCalledWith(accountPrivateKey1);
 			expect(cryptography.address.getAddressFromPublicKey).toHaveBeenCalledWith(accountPublicKey1);
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				generatorKeyPath1,
 			);
@@ -265,13 +265,13 @@ describe('keys:create command', () => {
 			);
 			expect(cryptography.bls.getPublicKeyFromPrivateKey).toHaveBeenCalledWith(blsPrivateKey1);
 
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				accountKeyPath2,
 			);
 			expect(cryptography.ed.getPublicKeyFromPrivateKey).toHaveBeenCalledWith(accountPrivateKey2);
 			expect(cryptography.address.getAddressFromPublicKey).toHaveBeenCalledWith(accountPublicKey2);
-			expect(cryptography.ed.getKeyPairFromPhraseAndPath).toHaveBeenCalledWith(
+			expect(cryptography.ed.getPrivateKeyFromPhraseAndPath).toHaveBeenCalledWith(
 				defaultPassphrase,
 				generatorKeyPath2,
 			);

--- a/commander/test/bootstrapping/commands/keys/encrypt.spec.ts
+++ b/commander/test/bootstrapping/commands/keys/encrypt.spec.ts
@@ -71,7 +71,7 @@ describe('keys:encrypt', () => {
 
 	describe('when encrypting with a file path flag', () => {
 		beforeEach(async () => {
-			const generatorPrivateKey = await ed.getKeyPairFromPhraseAndPath(
+			const generatorPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(
 				'passphrase',
 				"m/25519'/134'/0'/0'",
 			);

--- a/commander/test/bootstrapping/commands/keys/export.spec.ts
+++ b/commander/test/bootstrapping/commands/keys/export.spec.ts
@@ -76,7 +76,7 @@ describe('keys:export', () => {
 
 	describe('when exporting with a file path flag', () => {
 		beforeEach(async () => {
-			const generatorPrivateKey = await ed.getKeyPairFromPhraseAndPath(
+			const generatorPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(
 				'passphrase',
 				"m/25519'/134'/0'/0'",
 			);

--- a/commander/test/bootstrapping/commands/keys/import.spec.ts
+++ b/commander/test/bootstrapping/commands/keys/import.spec.ts
@@ -84,7 +84,7 @@ describe('keys:import', () => {
 
 	describe('when importing with existing file', () => {
 		beforeEach(async () => {
-			const generatorPrivateKey = await ed.getKeyPairFromPhraseAndPath(
+			const generatorPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(
 				'passphrase',
 				"m/25519'/134'/0'/0'",
 			);

--- a/elements/lisk-client/test/lisk-cryptography/ed.spec.ts
+++ b/elements/lisk-client/test/lisk-cryptography/ed.spec.ts
@@ -24,7 +24,7 @@ const {
 		signData,
 		signDataWithPrivateKey,
 		verifyData,
-		getKeyPairFromPhraseAndPath,
+		getPrivateKeyFromPhraseAndPath,
 		getPublicKeyFromPrivateKey,
 	},
 	utils: { createMessageTag },
@@ -196,11 +196,11 @@ ${defaultSignature}
 		});
 	});
 
-	describe('getKeyPairFromPhraseAndPath', () => {
+	describe('getPrivateKeyFromPhraseAndPath', () => {
 		const passphrase =
 			'target cancel solution recipe vague faint bomb convince pink vendor fresh patrol';
 		it('should get keypair from valid phrase and path', async () => {
-			const privateKey = await getKeyPairFromPhraseAndPath(passphrase, `m/44'/134'/0'`);
+			const privateKey = await getPrivateKeyFromPhraseAndPath(passphrase, `m/44'/134'/0'`);
 			const publicKey = getPublicKeyFromPrivateKey(privateKey);
 			expect(publicKey.toString('hex')).toBe(
 				'c6bae83af23540096ac58d5121b00f33be6f02f05df785766725acdd5d48be9d',
@@ -211,26 +211,26 @@ ${defaultSignature}
 		});
 
 		it('should fail for empty string path', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, '')).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, '')).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail if path does not start with "m"', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, `/44'/134'/0'`)).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, `/44'/134'/0'`)).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail if path does not include at least one "/"', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, 'm441340')).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, 'm441340')).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail for path with invalid segment', async () => {
 			await expect(
-				getKeyPairFromPhraseAndPath(
+				getPrivateKeyFromPhraseAndPath(
 					passphrase,
 					`m//134'/0'`, // should be number with or without ' between every back slash
 				),
@@ -238,20 +238,20 @@ ${defaultSignature}
 		});
 
 		it('should fail for path with invalid characters', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, `m/a'/134b'/0'`)).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, `m/a'/134b'/0'`)).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail for path with non-sanctioned special characters', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, `m/4a'/#134b'/0'`)).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, `m/4a'/#134b'/0'`)).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it(`should fail for path with segment greater than ${MAX_UINT32} / 2`, async () => {
 			await expect(
-				getKeyPairFromPhraseAndPath(passphrase, `m/44'/134'/${MAX_UINT32}'`),
+				getPrivateKeyFromPhraseAndPath(passphrase, `m/44'/134'/${MAX_UINT32}'`),
 			).rejects.toThrow('Invalid path format');
 		});
 	});

--- a/elements/lisk-cryptography/src/ed.ts
+++ b/elements/lisk-cryptography/src/ed.ts
@@ -76,7 +76,7 @@ const getChildKey = (node: { key: Buffer; chainCode: Buffer }, index: number) =>
 	};
 };
 
-export const getKeyPairFromPhraseAndPath = async (
+export const getPrivateKeyFromPhraseAndPath = async (
 	phrase: string,
 	path: string,
 ): Promise<Buffer> => {

--- a/elements/lisk-cryptography/test/ed.spec.ts
+++ b/elements/lisk-cryptography/test/ed.spec.ts
@@ -22,7 +22,7 @@ import {
 	signData,
 	signDataWithPrivateKey,
 	verifyData,
-	getKeyPairFromPhraseAndPath,
+	getPrivateKeyFromPhraseAndPath,
 	getPublicKeyFromPrivateKey,
 } from '../src/ed';
 import { createMessageTag } from '../src/utils';
@@ -186,11 +186,11 @@ ${defaultSignature}
 		});
 	});
 
-	describe('getKeyPairFromPhraseAndPath', () => {
+	describe('getPrivateKeyFromPhraseAndPath', () => {
 		const passphrase =
 			'target cancel solution recipe vague faint bomb convince pink vendor fresh patrol';
 		it('should get keypair from valid phrase and path', async () => {
-			const privateKey = await getKeyPairFromPhraseAndPath(passphrase, `m/44'/134'/0'`);
+			const privateKey = await getPrivateKeyFromPhraseAndPath(passphrase, `m/44'/134'/0'`);
 			const publicKey = getPublicKeyFromPrivateKey(privateKey);
 			expect(publicKey.toString('hex')).toBe(
 				'c6bae83af23540096ac58d5121b00f33be6f02f05df785766725acdd5d48be9d',
@@ -201,26 +201,26 @@ ${defaultSignature}
 		});
 
 		it('should fail for empty string path', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, '')).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, '')).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail if path does not start with "m"', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, `/44'/134'/0'`)).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, `/44'/134'/0'`)).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail if path does not include at least one "/"', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, 'm441340')).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, 'm441340')).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail for path with invalid segment', async () => {
 			await expect(
-				getKeyPairFromPhraseAndPath(
+				getPrivateKeyFromPhraseAndPath(
 					passphrase,
 					`m//134'/0'`, // should be number with or without ' between every back slash
 				),
@@ -228,20 +228,20 @@ ${defaultSignature}
 		});
 
 		it('should fail for path with invalid characters', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, `m/a'/134b'/0'`)).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, `m/a'/134b'/0'`)).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it('should fail for path with non-sanctioned special characters', async () => {
-			await expect(getKeyPairFromPhraseAndPath(passphrase, `m/4a'/#134b'/0'`)).rejects.toThrow(
+			await expect(getPrivateKeyFromPhraseAndPath(passphrase, `m/4a'/#134b'/0'`)).rejects.toThrow(
 				'Invalid path format',
 			);
 		});
 
 		it(`should fail for path with segment greater than ${MAX_UINT32} / 2`, async () => {
 			await expect(
-				getKeyPairFromPhraseAndPath(passphrase, `m/44'/134'/${MAX_UINT32}'`),
+				getPrivateKeyFromPhraseAndPath(passphrase, `m/44'/134'/${MAX_UINT32}'`),
 			).rejects.toThrow('Invalid path format');
 		});
 	});

--- a/framework/test/unit/engine/generator/endpoint.spec.ts
+++ b/framework/test/unit/engine/generator/endpoint.spec.ts
@@ -55,7 +55,7 @@ describe('generator endpoint', () => {
 	let db: Database;
 
 	beforeEach(async () => {
-		const generatorPrivateKey = await ed.getKeyPairFromPhraseAndPath(
+		const generatorPrivateKey = await ed.getPrivateKeyFromPhraseAndPath(
 			'passphrase',
 			"m/25519'/134'/0'/0'",
 		);

--- a/test/src/utils/account.ts
+++ b/test/src/utils/account.ts
@@ -20,7 +20,7 @@ export const createAccount = async () => {
 	const generatorKeyPath = "m/25519'/134'/0'/0'";
 	const blsKeyPath = 'm/12381/134/0/0';
 	const mnemonicPassphrase = passphrase.Mnemonic.generateMnemonic(256);
-	const privateKey = await cryptography.ed.getKeyPairFromPhraseAndPath(
+	const privateKey = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 		mnemonicPassphrase,
 		accountKeyPath,
 	);
@@ -28,7 +28,7 @@ export const createAccount = async () => {
 
 	const address = cryptography.address.getLisk32AddressFromPublicKey(publicKey);
 
-	const generatorPrivateKey = await cryptography.ed.getKeyPairFromPhraseAndPath(
+	const generatorPrivateKey = await cryptography.ed.getPrivateKeyFromPhraseAndPath(
 		mnemonicPassphrase,
 		generatorKeyPath,
 	);


### PR DESCRIPTION
### What was the problem?

This PR resolves #7563

### How was it solved?

Using a very sophisticated search and replace function in the IDE 😉

### How was it tested?

Ran all the tests. All OK.
