### PR TITLE
Expose ImmutableMethodContext from framework - Closes #7625

### DIFF
--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -87,6 +87,7 @@ export {
 	GenesisBlockExecuteContext,
 	InsertAssetContext,
 	MethodContext,
+	ImmutableMethodContext,
 	CommandExecuteContext,
 	CommandVerifyContext,
 	VerificationResult,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7625 

### How was it solved?

- ImmutableMethodContext is exposed from framework

### How was it tested?

N/A
