### PR TITLE
Fix - Legacy blocks v2 has incorrect block schema - Closes #7648

### DIFF
--- a/framework/src/engine/legacy/codec.ts
+++ b/framework/src/engine/legacy/codec.ts
@@ -71,7 +71,7 @@ export const decodeBlockJSON = (
 				...codec.toJSON(schema.header, block.header),
 				id: block.header.id.toString('hex'),
 			},
-			transactions: block.transactions.map(tx => tx.toString('hex')),
+			payload: block.payload.map(tx => tx.toString('hex')),
 		},
 		schema,
 	};
@@ -86,7 +86,7 @@ export const encodeBlock = (data: LegacyBlock): Buffer => {
 
 	return codec.encode(blockSchema.block, {
 		header: headerBytes,
-		transactions: data.transactions,
+		payload: data.payload,
 	});
 };
 

--- a/framework/src/engine/legacy/schemas.ts
+++ b/framework/src/engine/legacy/schemas.ts
@@ -20,7 +20,7 @@ export const blockSchemaV2 = {
 			dataType: 'bytes',
 			fieldNumber: 1,
 		},
-		transactions: {
+		payload: {
 			type: 'array',
 			items: {
 				dataType: 'bytes',
@@ -28,7 +28,7 @@ export const blockSchemaV2 = {
 			fieldNumber: 2,
 		},
 	},
-	required: ['header', 'transactions'],
+	required: ['header', 'payload'],
 };
 
 const HASH_LENGTH = 32;

--- a/framework/src/engine/legacy/types.ts
+++ b/framework/src/engine/legacy/types.ts
@@ -26,12 +26,12 @@ export type LegacyBlockHeaderJSON = JSONObject<LegacyBlockHeader>;
 
 export interface RawLegacyBlock {
 	header: Buffer;
-	transactions: Buffer[];
+	payload: Buffer[];
 }
 
 export interface LegacyBlock {
 	header: LegacyBlockHeader;
-	transactions: Buffer[];
+	payload: Buffer[];
 }
 
 export interface LegacyBlockHeaderWithID extends LegacyBlockHeader {
@@ -40,7 +40,7 @@ export interface LegacyBlockHeaderWithID extends LegacyBlockHeader {
 
 export interface LegacyBlockWithID extends LegacyBlock {
 	header: LegacyBlockHeaderWithID;
-	transactions: Buffer[];
+	payload: Buffer[];
 }
 
 export type LegacyBlockJSON = JSONObject<LegacyBlock>;

--- a/framework/src/engine/legacy/validate.ts
+++ b/framework/src/engine/legacy/validate.ts
@@ -40,7 +40,7 @@ export const validateLegacyBlock = (
 	}
 
 	const transactionRoot = regularMerkleTree.calculateMerkleRootWithLeaves(
-		decodedBlock.transactions.map(tx => utils.hash(tx)),
+		decodedBlock.payload.map(tx => utils.hash(tx)),
 	);
 
 	if (!decodedBlock.header.transactionRoot.equals(transactionRoot)) {

--- a/framework/test/unit/engine/legacy/codec.spec.ts
+++ b/framework/test/unit/engine/legacy/codec.spec.ts
@@ -24,7 +24,7 @@ describe('Legacy codec', () => {
 		beforeEach(() => {
 			encodedBlock = codec.encode(blockSchemaV2, {
 				header: codec.encode(blockHeaderSchemaV2, blockFixtures[0].header),
-				transactions: blockFixtures[0].transactions,
+				payload: blockFixtures[0].payload,
 			});
 		});
 

--- a/framework/test/unit/engine/legacy/endpoint.spec.ts
+++ b/framework/test/unit/engine/legacy/endpoint.spec.ts
@@ -30,7 +30,7 @@ describe('Legacy endpoint', () => {
 		legacyEndpoint = new LegacyEndpoint({ db: new InMemoryDatabase() as any });
 		encodedBlock = codec.encode(blockSchemaV2, {
 			header: codec.encode(blockHeaderSchemaV2, blockFixtures[0].header),
-			transactions: blockFixtures[0].transactions,
+			payload: blockFixtures[0].payload,
 		});
 
 		jest.spyOn(legacyEndpoint.storage, 'getBlockByID').mockResolvedValue(encodedBlock);
@@ -56,8 +56,8 @@ describe('Legacy endpoint', () => {
 			expect(block.header.asset).toEqual(bufferToHex(blockFixtures[0].header.asset));
 			expect(block.header.signature).toEqual(bufferToHex(blockFixtures[0].header.signature));
 
-			expect(block.transactions).toHaveLength(blockFixtures[0].transactions.length);
-			expect(block.transactions[0]).toEqual(bufferToHex(blockFixtures[0].transactions[0]));
+			expect(block.payload).toHaveLength(blockFixtures[0].payload.length);
+			expect(block.payload[0]).toEqual(bufferToHex(blockFixtures[0].payload[0]));
 		};
 
 		it('getBlockByID', async () => {

--- a/framework/test/unit/engine/legacy/fixtures.ts
+++ b/framework/test/unit/engine/legacy/fixtures.ts
@@ -44,7 +44,7 @@ export const blockFixtures = [
 				'hex',
 			),
 		},
-		transactions: [
+		payload: [
 			Buffer.from(
 				'0802100018950b2090a10f2a20fdb1de14521b437e61a89d1a2c54f20eef3a897819269ddfed7c2c6f6372ec85322e08e7f6e35e12142d84df54c6465a06069e3e5b566086f827acf4261a11726f62696e686f6f64207061796f7574733a40ce3761c3bd3c7e1e39cf370dc82d11e84f3b1ec85175aad5f004d41de4ec04a6cf0ae4e0f2ed8ad98ce4b93eaafab48f11aeb0dd6b4942d8e0ed0fdf88648e04',
 				'hex',
@@ -76,7 +76,7 @@ export const blockFixtures = [
 			),
 			id: Buffer.from('31636e108a3ee5d22672631c582dbd8e06576b932f3cd303144abf165a3bc84d', 'hex'),
 		},
-		transactions: [
+		payload: [
 			Buffer.from(
 				'0802100018960b2090a10f2a20fdb1de14521b437e61a89d1a2c54f20eef3a897819269ddfed7c2c6f6372ec85322e08e7f6e35e1214ef93860e2196de35f10cdf1b8b17adff7129dae41a11726f62696e686f6f64207061796f7574733a403f2c770abe2f6ad25bce6d83f8b51e8713554bc314042cbce86ff7f5033fdff6f041ad41af0ccb42d946c8c42b95d5f4aab90db6f5b3cef067385fe2c39c5309',
 				'hex',
@@ -87,10 +87,10 @@ export const blockFixtures = [
 
 export const createFakeLegacyBlockHeaderV2 = (
 	header?: Partial<LegacyBlockHeader>,
-	transactions?: Buffer[],
+	payload?: Buffer[],
 ): LegacyBlockWithID => {
-	const transactionRoot = transactions
-		? regularMerkleTree.calculateMerkleRootWithLeaves(transactions.map(tx => utils.hash(tx)))
+	const transactionRoot = payload
+		? regularMerkleTree.calculateMerkleRootWithLeaves(payload.map(tx => utils.hash(tx)))
 		: utils.hash(utils.getRandomBytes(32));
 
 	const blockHeader = {
@@ -104,11 +104,11 @@ export const createFakeLegacyBlockHeaderV2 = (
 		asset: header?.asset ?? utils.getRandomBytes(20),
 		signature: header?.signature ?? utils.getRandomBytes(64),
 	};
-	const id = utils.hash(encodeBlock({ header: blockHeader, transactions: transactions ?? [] }));
+	const id = utils.hash(encodeBlock({ header: blockHeader, payload: payload ?? [] }));
 
 	return {
 		header: { ...blockHeader, id },
-		transactions: transactions ?? [],
+		payload: payload ?? [],
 	};
 };
 

--- a/framework/test/unit/engine/legacy/network_endpoint.spec.ts
+++ b/framework/test/unit/engine/legacy/network_endpoint.spec.ts
@@ -82,10 +82,10 @@ describe('Legacy P2P network endpoint', () => {
 
 			const {
 				header: { id, ...blockHeader },
-				transactions,
+				payload,
 			} = requestedBlock;
 
-			const requestedBlockWithoutID = { header: { ...blockHeader }, transactions };
+			const requestedBlockWithoutID = { header: { ...blockHeader }, payload };
 
 			const encodedBlockWithoutID = encodeBlock(requestedBlockWithoutID);
 			const requestedBlockID = utils.hash(encodedBlockWithoutID);

--- a/framework/test/unit/engine/legacy/storage.spec.ts
+++ b/framework/test/unit/engine/legacy/storage.spec.ts
@@ -34,9 +34,9 @@ describe('Legacy storage', () => {
 	beforeEach(async () => {
 		batch = new Batch();
 		for (const block of blocks) {
-			const { header, transactions } = block;
+			const { header, payload } = block;
 
-			batch.set(Buffer.concat([DB_KEY_BLOCK_ID, header.id]), encodeBlock({ header, transactions }));
+			batch.set(Buffer.concat([DB_KEY_BLOCK_ID, header.id]), encodeBlock({ header, payload }));
 			batch.set(Buffer.concat([DB_KEY_BLOCK_HEIGHT, intToBuffer(header.height, 4)]), header.id);
 		}
 
@@ -53,10 +53,10 @@ describe('Legacy storage', () => {
 
 	describe('getBlockByID', () => {
 		it('should return block with given id', async () => {
-			const { header, transactions } = blockFixtures[0];
+			const { header, payload } = blockFixtures[0];
 			const result = await storage.getBlockByID(header.id);
 
-			expect(result).toEqual(encodeBlock({ header, transactions }));
+			expect(result).toEqual(encodeBlock({ header, payload }));
 		});
 
 		it('should throw error if block with given id does not exist', async () => {
@@ -68,10 +68,10 @@ describe('Legacy storage', () => {
 
 	describe('getBlockByHeight', () => {
 		it('should return block with given height', async () => {
-			const { header, transactions } = blockFixtures[0];
+			const { header, payload } = blockFixtures[0];
 			const result = await storage.getBlockByHeight(header.height);
 
-			expect(result).toEqual(encodeBlock({ header, transactions }));
+			expect(result).toEqual(encodeBlock({ header, payload }));
 		});
 
 		it('should throw an error if the block is not found', async () => {
@@ -83,11 +83,11 @@ describe('Legacy storage', () => {
 
 	describe('getBlocksByHeightBetween', () => {
 		it('should return blocks with given height range', async () => {
-			const { header, transactions } = blockFixtures[0];
+			const { header, payload } = blockFixtures[0];
 			const result = await storage.getBlocksByHeightBetween(header.height, header.height + 1);
 
 			expect(result).toHaveLength(2);
-			expect(result[1]).toEqual(encodeBlock({ header, transactions }));
+			expect(result[1]).toEqual(encodeBlock({ header, payload }));
 		});
 	});
 
@@ -123,12 +123,12 @@ describe('Legacy storage', () => {
 
 	describe('saveBlock', () => {
 		it('should save the block', async () => {
-			const { header, transactions } = blockFixtures[0];
-			await storage.saveBlock(header.id, header.height, encodeBlock({ header, transactions }));
+			const { header, payload } = blockFixtures[0];
+			await storage.saveBlock(header.id, header.height, encodeBlock({ header, payload }));
 
 			const result = await storage.getBlockByID(header.id);
 
-			expect(result).toEqual(encodeBlock({ header, transactions }));
+			expect(result).toEqual(encodeBlock({ header, payload }));
 		});
 	});
 

--- a/framework/test/unit/engine/legacy/validate.spec.ts
+++ b/framework/test/unit/engine/legacy/validate.spec.ts
@@ -31,7 +31,7 @@ describe('Legacy valdate', () => {
 					...blockFixtures[0].header,
 					generatorPublicKey: Buffer.from([0, 0, 1]),
 				},
-				transactions: [...blockFixtures[0].transactions],
+				payload: [...blockFixtures[0].payload],
 			});
 			expect(() => validateLegacyBlock(invalidEncodedBlock, blockFixtures[1])).toThrow(
 				"Property '.generatorPublicKey' minLength not satisfied",
@@ -44,7 +44,7 @@ describe('Legacy valdate', () => {
 					...blockFixtures[0].header,
 					transactionRoot: Buffer.from([0, 0, 1]),
 				},
-				transactions: [...blockFixtures[0].transactions],
+				payload: [...blockFixtures[0].payload],
 			});
 			expect(() => validateLegacyBlock(invalidEncodedBlock, blockFixtures[1])).toThrow(
 				"Property '.transactionRoot' minLength not satisfied",
@@ -57,7 +57,7 @@ describe('Legacy valdate', () => {
 					...blockFixtures[0].header,
 					previousBlockID: Buffer.from([0, 0, 1]),
 				},
-				transactions: [...blockFixtures[0].transactions],
+				payload: [...blockFixtures[0].payload],
 			});
 			expect(() => validateLegacyBlock(invalidEncodedBlock, blockFixtures[1])).toThrow(
 				"Property '.previousBlockID' minLength not satisfied",
@@ -70,7 +70,7 @@ describe('Legacy valdate', () => {
 					...blockFixtures[0].header,
 					signature: Buffer.from([0, 0, 1]),
 				},
-				transactions: [...blockFixtures[0].transactions],
+				payload: [...blockFixtures[0].payload],
 			});
 			expect(() => validateLegacyBlock(invalidEncodedBlock, blockFixtures[1])).toThrow(
 				"Property '.signature' minLength not satisfied",
@@ -84,7 +84,7 @@ describe('Legacy valdate', () => {
 						...blockFixtures[1].header,
 						height: 3333,
 					},
-					transactions: blockFixtures[1].transactions,
+					payload: blockFixtures[1].payload,
 				}),
 			).toThrow('Received block at height 19583714 is not consecutive to next block 3333');
 		});
@@ -99,7 +99,7 @@ describe('Legacy valdate', () => {
 							'hex',
 						),
 					},
-					transactions: blockFixtures[1].transactions,
+					payload: blockFixtures[1].payload,
 				}),
 			).toThrow('is not previous block of');
 		});
@@ -109,7 +109,7 @@ describe('Legacy valdate', () => {
 				header: {
 					...blockFixtures[0].header,
 				},
-				transactions: [],
+				payload: [],
 			});
 			expect(() => validateLegacyBlock(invalidEncodedBlock, blockFixtures[1])).toThrow(
 				'Received block has invalid transaction root',


### PR DESCRIPTION
### What was the problem?

This PR resolves #7648

### How was it solved?
`transactions` updated with `payload` in Schema

### How was it tested?
- cd lisk-sdk/framework/test/unit/engine/legacy 
- yarn test framework/test/unit/engine/legacy

