### PR TITLE
Align Commander argument name `maxHeightGenerated` - Closes #7526

### DIFF
--- a/commander/src/bootstrapping/commands/base_forging.ts
+++ b/commander/src/bootstrapping/commands/base_forging.ts
@@ -20,7 +20,7 @@ import { BaseIPCClientCommand } from './base_ipc_client';
 interface Args {
 	readonly address: string;
 	readonly height?: number;
-	readonly maxHeightPreviouslyForged?: number;
+	readonly maxHeightGenerated?: number;
 	readonly maxHeightPrevoted?: number;
 }
 
@@ -45,17 +45,17 @@ export abstract class BaseForgingCommand extends BaseIPCClientCommand {
 
 	async run(): Promise<void> {
 		const { args, flags } = await this.parse(this.constructor as typeof BaseForgingCommand);
-		const { address, height, maxHeightPreviouslyForged, maxHeightPrevoted } = args as Args;
+		const { address, height, maxHeightGenerated, maxHeightPrevoted } = args as Args;
 		let password;
 
 		if (
 			this.forging &&
 			(isLessThanZero(height) ||
-				isLessThanZero(maxHeightPreviouslyForged) ||
+				isLessThanZero(maxHeightGenerated) ||
 				isLessThanZero(maxHeightPrevoted))
 		) {
 			throw new Error(
-				'The maxHeightPreviouslyForged and maxHeightPrevoted parameter value must be greater than or equal to 0',
+				'The maxHeightGenerated and maxHeightPrevoted parameter value must be greater than or equal to 0',
 			);
 		}
 
@@ -81,7 +81,7 @@ export abstract class BaseForgingCommand extends BaseIPCClientCommand {
 				password,
 				enabled: this.forging,
 				height: Number(height ?? 0),
-				maxHeightPreviouslyForged: Number(maxHeightPreviouslyForged ?? 0),
+				maxHeightGenerated: Number(maxHeightGenerated ?? 0),
 				maxHeightPrevoted: Number(maxHeightPrevoted ?? 0),
 			});
 			this.log('Status updated.');

--- a/commander/src/bootstrapping/commands/generator/enable.ts
+++ b/commander/src/bootstrapping/commands/generator/enable.ts
@@ -37,7 +37,7 @@ export abstract class EnableCommand extends BaseForgingCommand {
 			description: 'Last forged block height.',
 		},
 		{
-			name: 'maxHeightPreviouslyForged',
+			name: 'maxHeightGenerated',
 			required: true,
 			description: 'Delegates largest previously forged height.',
 		},

--- a/commander/test/bootstrapping/commands/block/get.spec.ts
+++ b/commander/test/bootstrapping/commands/block/get.spec.ts
@@ -101,7 +101,7 @@ describe('block:get command', () => {
 				'5aa36d00cbcd135b55484c17ba89da8ecbac4df2ccc2c0c12b9db0cf4e48c74122c6c8d5100cf83fa83f79d5684eccf2ef9e6c55408bac9dea45c2b5aa590a0c',
 			timestamp: 1592924699,
 			transactionRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-			maxHeightPreviouslyForged: 0,
+			maxHeightGenerated: 0,
 			maxHeightPrevoted: 0,
 			version: 2,
 		},

--- a/commander/test/bootstrapping/commands/forging.spec.ts
+++ b/commander/test/bootstrapping/commands/forging.spec.ts
@@ -49,13 +49,13 @@ describe('forging', () => {
 			await expect(EnableCommand.run([], config)).rejects.toThrow('Missing 4 required arg');
 		});
 
-		it('should throw an error when height, maxHeightPreviouslyForged and maxHeightPrevoted arg is not provided', async () => {
+		it('should throw an error when height, maxHeightGenerated and maxHeightPrevoted arg is not provided', async () => {
 			await expect(
 				EnableCommand.run(['myAddress', '--password=my-password'], config),
 			).rejects.toThrow('Missing 3 required arg');
 		});
 
-		it('should throw an error when arg maxHeightPreviouslyForged and maxHeightPrevoted  is not provided', async () => {
+		it('should throw an error when arg maxHeightGenerated and maxHeightPrevoted  is not provided', async () => {
 			await expect(
 				EnableCommand.run(['myAddress', '10', '--password=my-password'], config),
 			).rejects.toThrow('Missing 2 required arg');
@@ -75,7 +75,7 @@ describe('forging', () => {
 					enabled: true,
 					password: 'my-password',
 					height: 10,
-					maxHeightPreviouslyForged: 10,
+					maxHeightGenerated: 10,
 					maxHeightPrevoted: 1,
 				});
 			});
@@ -102,7 +102,7 @@ describe('forging', () => {
 					enabled: true,
 					password: 'promptPassword',
 					height: 10,
-					maxHeightPreviouslyForged: 10,
+					maxHeightGenerated: 10,
 					maxHeightPrevoted: 1,
 				});
 			});
@@ -123,7 +123,7 @@ describe('forging', () => {
 						enabled: true,
 						password: 'my-password',
 						height: 10,
-						maxHeightPreviouslyForged: 10,
+						maxHeightGenerated: 10,
 						maxHeightPrevoted: 1,
 					})
 					.mockRejectedValue(new Error('Custom Error'));
@@ -150,7 +150,7 @@ describe('forging', () => {
 					enabled: false,
 					password: 'my-password',
 					height: 0,
-					maxHeightPreviouslyForged: 0,
+					maxHeightGenerated: 0,
 					maxHeightPrevoted: 0,
 				});
 			});
@@ -177,7 +177,7 @@ describe('forging', () => {
 					enabled: false,
 					password: 'promptPassword',
 					height: 0,
-					maxHeightPreviouslyForged: 0,
+					maxHeightGenerated: 0,
 					maxHeightPrevoted: 0,
 				});
 			});
@@ -198,7 +198,7 @@ describe('forging', () => {
 						enabled: false,
 						password: 'my-password',
 						height: 0,
-						maxHeightPreviouslyForged: 0,
+						maxHeightGenerated: 0,
 						maxHeightPrevoted: 0,
 					})
 					.mockRejectedValue(new Error('Custom Error'));


### PR DESCRIPTION
### What was the problem?

Commander was still using the old argument name `maxHeightPreviouslyForged`.

This PR resolves #7526

### How was it solved?

Renamed the argument to `maxHeightGenerated`.

### How was it tested?

Updated the tests too. All passing ✅
