### PR TITLE
Implements `getMessageFeeTokenID` - Closes #7566

### DIFF
--- a/framework/src/modules/interoperability/base_interoperability_method.ts
+++ b/framework/src/modules/interoperability/base_interoperability_method.ts
@@ -62,12 +62,12 @@ export abstract class BaseInteroperabilityMethod<
 
 	public async getMessageFeeTokenID(
 		context: ImmutableMethodContext,
-		_chainID: Buffer,
+		chainID: Buffer,
 	): Promise<Buffer> {
-		const chainID = !(await this.getChainAccount(context, _chainID))
+		const updatedChainID = !(await this.getInteroperabilityStore(context).hasChainAccount(chainID))
 			? MAINCHAIN_ID_BUFFER
-			: _chainID;
-		return (await this.getChannel(context, chainID)).messageFeeTokenID.localID;
+			: chainID;
+		return (await this.getChannel(context, updatedChainID)).messageFeeTokenID.localID;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await

--- a/framework/src/modules/interoperability/base_interoperability_method.ts
+++ b/framework/src/modules/interoperability/base_interoperability_method.ts
@@ -20,6 +20,7 @@ import { ChainAccount } from './stores/chain_account';
 import { CCMsg } from './types';
 import { StoreGetter, ImmutableStoreGetter } from '../base_store';
 import { BaseInteroperabilityStore } from './base_interoperability_store';
+import { MAINCHAIN_ID_BUFFER } from './constants';
 
 export abstract class BaseInteroperabilityMethod<
 	T extends BaseInteroperabilityStore
@@ -57,6 +58,16 @@ export abstract class BaseInteroperabilityMethod<
 
 	public async getTerminatedOutboxAccount(context: ImmutableMethodContext, chainID: Buffer) {
 		return this.getInteroperabilityStore(context).getTerminatedOutboxAccount(chainID);
+	}
+
+	public async getMessageFeeTokenID(
+		context: ImmutableMethodContext,
+		_chainID: Buffer,
+	): Promise<Buffer> {
+		const chainID = !(await this.getChainAccount(context, _chainID))
+			? MAINCHAIN_ID_BUFFER
+			: _chainID;
+		return (await this.getChannel(context, chainID)).messageFeeTokenID.localID;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await

--- a/framework/src/modules/interoperability/base_interoperability_store.ts
+++ b/framework/src/modules/interoperability/base_interoperability_store.ts
@@ -148,8 +148,8 @@ export abstract class BaseInteroperabilityStore {
 	}
 
 	public async hasChainAccount(chainID: Buffer): Promise<boolean> {
-		const chainSubstore = this.stores.get(ChainAccountStore);
-		return chainSubstore.has(this.context, chainID);
+		const chainAccountStore = this.stores.get(ChainAccountStore);
+		return chainAccountStore.has(this.context, chainID);
 	}
 
 	public async getAllChainAccounts(startChainID: Buffer): Promise<ChainAccount[]> {

--- a/framework/src/modules/interoperability/base_interoperability_store.ts
+++ b/framework/src/modules/interoperability/base_interoperability_store.ts
@@ -147,6 +147,11 @@ export abstract class BaseInteroperabilityStore {
 		return chainSubstore.get(this.context, chainID);
 	}
 
+	public async hasChainAccount(chainID: Buffer): Promise<boolean> {
+		const chainSubstore = this.stores.get(ChainAccountStore);
+		return chainSubstore.has(this.context, chainID);
+	}
+
 	public async getAllChainAccounts(startChainID: Buffer): Promise<ChainAccount[]> {
 		const chainSubstore = this.stores.get(ChainAccountStore);
 		const endBuf = utils.intToBuffer(MAX_UINT32, 4);

--- a/framework/test/unit/modules/interoperability/mainchain/method.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/method.spec.ts
@@ -19,6 +19,7 @@ import { MainchainInteroperabilityStore } from '../../../../../src/modules/inter
 import { NamedRegistry } from '../../../../../src/modules/named_registry';
 import { MethodContext } from '../../../../../src/state_machine';
 import { createTransientMethodContext } from '../../../../../src/testing';
+import { MAINCHAIN_ID_BUFFER } from '../../../../../dist-node/modules/interoperability/constants';
 
 describe('Mainchain Method', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -135,6 +136,33 @@ describe('Mainchain Method', () => {
 			expect(mainchainInteroperabilityStore.getTerminatedOutboxAccount).toHaveBeenCalledWith(
 				chainID,
 			);
+		});
+	});
+
+	describe('getMessageFeeTokenID', () => {
+		beforeEach(() => {
+			jest.spyOn(mainchainInteroperabilityStore, 'getChannel').mockResolvedValue({
+				messageFeeTokenID: {
+					localID: Buffer.from('10000000', 'hex'),
+				},
+			} as never);
+		});
+
+		it('should assign chainID as MAINCHAIN_ID_BUFFER if chainAccount not found', async () => {
+			jest
+				.spyOn(mainchainInteroperabilityStore, 'getChainAccount')
+				.mockResolvedValue(null as never);
+			const newChainID = Buffer.from('1234', 'hex');
+
+			await mainchainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
+			expect(mainchainInteroperabilityStore.getChannel).toHaveBeenCalledWith(MAINCHAIN_ID_BUFFER);
+		});
+
+		it('should process with input chainID', async () => {
+			const newChainID = Buffer.from('1234', 'hex');
+
+			await mainchainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
+			expect(mainchainInteroperabilityStore.getChannel).toHaveBeenCalledWith(newChainID);
 		});
 	});
 });

--- a/framework/test/unit/modules/interoperability/mainchain/method.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/method.spec.ts
@@ -19,7 +19,7 @@ import { MainchainInteroperabilityStore } from '../../../../../src/modules/inter
 import { NamedRegistry } from '../../../../../src/modules/named_registry';
 import { MethodContext } from '../../../../../src/state_machine';
 import { createTransientMethodContext } from '../../../../../src/testing';
-import { MAINCHAIN_ID_BUFFER } from '../../../../../dist-node/modules/interoperability/constants';
+import { MAINCHAIN_ID_BUFFER } from '../../../../../src/modules/interoperability/constants';
 
 describe('Mainchain Method', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -55,6 +55,7 @@ describe('Mainchain Method', () => {
 		jest
 			.spyOn(mainchainInteroperabilityStore, 'getTerminatedOutboxAccount')
 			.mockResolvedValue({} as never);
+		jest.spyOn(mainchainInteroperabilityStore, 'hasChainAccount').mockResolvedValue(false);
 	});
 
 	describe('getChainAccount', () => {
@@ -140,6 +141,7 @@ describe('Mainchain Method', () => {
 	});
 
 	describe('getMessageFeeTokenID', () => {
+		const newChainID = Buffer.from('1234', 'hex');
 		beforeEach(() => {
 			jest.spyOn(mainchainInteroperabilityStore, 'getChannel').mockResolvedValue({
 				messageFeeTokenID: {
@@ -149,17 +151,12 @@ describe('Mainchain Method', () => {
 		});
 
 		it('should assign chainID as MAINCHAIN_ID_BUFFER if chainAccount not found', async () => {
-			jest
-				.spyOn(mainchainInteroperabilityStore, 'getChainAccount')
-				.mockResolvedValue(null as never);
-			const newChainID = Buffer.from('1234', 'hex');
-
 			await mainchainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
 			expect(mainchainInteroperabilityStore.getChannel).toHaveBeenCalledWith(MAINCHAIN_ID_BUFFER);
 		});
 
 		it('should process with input chainID', async () => {
-			const newChainID = Buffer.from('1234', 'hex');
+			jest.spyOn(mainchainInteroperabilityStore, 'hasChainAccount').mockResolvedValue(true);
 
 			await mainchainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
 			expect(mainchainInteroperabilityStore.getChannel).toHaveBeenCalledWith(newChainID);

--- a/framework/test/unit/modules/interoperability/sidechain/method.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/method.spec.ts
@@ -18,6 +18,7 @@ import { SidechainInteroperabilityMethod } from '../../../../../src/modules/inte
 import { SidechainInteroperabilityStore } from '../../../../../src/modules/interoperability/sidechain/store';
 import { NamedRegistry } from '../../../../../src/modules/named_registry';
 import { MethodContext } from '../../../../../src/state_machine';
+import { MAINCHAIN_ID_BUFFER } from '../../../../../dist-node/modules/interoperability/constants';
 
 describe('Sidechain Method', () => {
 	const interopMod = new SidechainInteroperabilityModule();
@@ -134,6 +135,33 @@ describe('Sidechain Method', () => {
 			expect(sidechainInteroperabilityStore.getTerminatedOutboxAccount).toHaveBeenCalledWith(
 				chainID,
 			);
+		});
+	});
+
+	describe('getMessageFeeTokenID', () => {
+		beforeEach(() => {
+			jest.spyOn(sidechainInteroperabilityStore, 'getChannel').mockResolvedValue({
+				messageFeeTokenID: {
+					localID: Buffer.from('10000000', 'hex'),
+				},
+			} as never);
+		});
+
+		it('should assign chainID as MAINCHAIN_ID_BUFFER if chainAccount not found', async () => {
+			jest
+				.spyOn(sidechainInteroperabilityStore, 'getChainAccount')
+				.mockResolvedValue(null as never);
+			const newChainID = Buffer.from('1234', 'hex');
+
+			await sidechainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
+			expect(sidechainInteroperabilityStore.getChannel).toHaveBeenCalledWith(MAINCHAIN_ID_BUFFER);
+		});
+
+		it('should process with input chainID', async () => {
+			const newChainID = Buffer.from('1234', 'hex');
+
+			await sidechainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
+			expect(sidechainInteroperabilityStore.getChannel).toHaveBeenCalledWith(newChainID);
 		});
 	});
 });

--- a/framework/test/unit/modules/interoperability/sidechain/method.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/method.spec.ts
@@ -18,7 +18,7 @@ import { SidechainInteroperabilityMethod } from '../../../../../src/modules/inte
 import { SidechainInteroperabilityStore } from '../../../../../src/modules/interoperability/sidechain/store';
 import { NamedRegistry } from '../../../../../src/modules/named_registry';
 import { MethodContext } from '../../../../../src/state_machine';
-import { MAINCHAIN_ID_BUFFER } from '../../../../../dist-node/modules/interoperability/constants';
+import { MAINCHAIN_ID_BUFFER } from '../../../../../src/modules/interoperability/constants';
 
 describe('Sidechain Method', () => {
 	const interopMod = new SidechainInteroperabilityModule();
@@ -54,6 +54,7 @@ describe('Sidechain Method', () => {
 		jest
 			.spyOn(sidechainInteroperabilityStore, 'getTerminatedOutboxAccount')
 			.mockResolvedValue({} as never);
+		jest.spyOn(sidechainInteroperabilityStore, 'hasChainAccount').mockResolvedValue(false);
 	});
 
 	describe('getChainAccount', () => {
@@ -139,6 +140,7 @@ describe('Sidechain Method', () => {
 	});
 
 	describe('getMessageFeeTokenID', () => {
+		const newChainID = Buffer.from('1234', 'hex');
 		beforeEach(() => {
 			jest.spyOn(sidechainInteroperabilityStore, 'getChannel').mockResolvedValue({
 				messageFeeTokenID: {
@@ -148,17 +150,12 @@ describe('Sidechain Method', () => {
 		});
 
 		it('should assign chainID as MAINCHAIN_ID_BUFFER if chainAccount not found', async () => {
-			jest
-				.spyOn(sidechainInteroperabilityStore, 'getChainAccount')
-				.mockResolvedValue(null as never);
-			const newChainID = Buffer.from('1234', 'hex');
-
 			await sidechainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
 			expect(sidechainInteroperabilityStore.getChannel).toHaveBeenCalledWith(MAINCHAIN_ID_BUFFER);
 		});
 
 		it('should process with input chainID', async () => {
-			const newChainID = Buffer.from('1234', 'hex');
+			jest.spyOn(sidechainInteroperabilityStore, 'hasChainAccount').mockResolvedValue(true);
 
 			await sidechainInteroperabilityMethod.getMessageFeeTokenID(methodContext, newChainID);
 			expect(sidechainInteroperabilityStore.getChannel).toHaveBeenCalledWith(newChainID);


### PR DESCRIPTION
### What was the problem?

This PR resolves #7566

### How was it solved?

A new function `getMessageFeeTokenID` is implemented

### How was it tested?

Updated unit-test