### PR TITLE
Export testing components - Closes #7632

### DIFF
--- a/framework/src/testing/index.ts
+++ b/framework/src/testing/index.ts
@@ -20,5 +20,6 @@ export * from './create_block';
 export * from './app_env';
 export * from './create_contexts';
 export * from './block_processing_env';
+export * from './in_memory_prefixed_state';
 
 export { fixtures, mocks };


### PR DESCRIPTION
### What was the problem?

This PR resolves #7632 

### How was it solved?

Exported `InMemoryPrefixedStateDB` in `framework/src/testing/index.ts` 

### How was it tested?

Successful build.

Verifying that all the components listed below are exported in `lisk-sdk` in an example app.

- InMemoryPrefixedStateDB
- createGenesisBlockContext
- createBlockHeaderWithDefaults
- createBlockContext