### PR TITLE
Update preid of canary version - Closes #7661

### DIFF
--- a/.jenkins/Jenkinsfile.publish
+++ b/.jenkins/Jenkinsfile.publish
@@ -48,7 +48,7 @@ pipeline {
 				}
 				nvm(getNodejsVersion()) {
 					sh '''
-					npx lerna publish --canary --registry https://npm.lisk.com --yes
+					npx lerna publish --canary --preid canary --registry https://npm.lisk.com --yes
 					'''
 				}
 			}


### PR DESCRIPTION
### What was the problem?

This PR resolves #7661 

### How was it solved?

- Update jenkins job to use `--preid` flag

### How was it tested?

- Once this is merged, we need to check the npm.lisk.com
