### PR TITLE
Adds skipVerify flag to dryRunTransaction endpoint - Closes #7568

### DIFF
--- a/framework/src/engine/endpoint/txpool.ts
+++ b/framework/src/engine/endpoint/txpool.ts
@@ -115,16 +115,18 @@ export class TxpoolEndpoint {
 		const transaction = Transaction.fromBytes(Buffer.from(req.transaction, 'hex'));
 		const header = this._chain.lastBlock.header.toObject();
 
-		const { result } = await this._abi.verifyTransaction({
-			contextID: Buffer.alloc(0),
-			transaction: transaction.toObject(),
-			header,
-		});
-		if (result === TransactionVerifyResult.INVALID) {
-			return {
-				success: false,
-				events: [],
-			};
+		if (!req.skipVerify) {
+			const { result } = await this._abi.verifyTransaction({
+				contextID: Buffer.alloc(0),
+				transaction: transaction.toObject(),
+				header,
+			});
+			if (result === TransactionVerifyResult.INVALID) {
+				return {
+					success: false,
+					events: [],
+				};
+			}
 		}
 
 		const stateStore = new StateStore(this._blockchainDB);

--- a/framework/src/engine/generator/schemas.ts
+++ b/framework/src/engine/generator/schemas.ts
@@ -252,6 +252,7 @@ export const previouslyGeneratedInfoSchema = {
 
 export interface DryRunTransactionRequest {
 	transaction: string;
+	skipVerify: boolean;
 }
 
 export interface DryRunTransactionResponse {
@@ -268,6 +269,10 @@ export const dryRunTransactionRequestSchema = {
 		transaction: {
 			type: 'string',
 			format: 'hex',
+		},
+		skipVerify: {
+			type: 'boolean',
+			default: false,
 		},
 	},
 };


### PR DESCRIPTION
### What was the problem?

This PR resolves #7568 

### How was it solved?

Added `skipVerify` flag to `DryRunTransactionRequest` and `dryRunTransactionRequestSchema`, with default value set to false.
 
### How was it tested?
Added unit tests.

<!--- Please describe how you tested your changes -->
