### PR TITLE
Remove redundant Token module config interface - Closes #7694

### DIFF
--- a/framework/src/modules/token/constants.ts
+++ b/framework/src/modules/token/constants.ts
@@ -38,8 +38,6 @@ export const TOKEN_ID_LSK = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
 export const USER_SUBSTORE_INITIALIZATION_FEE = BigInt(5000000);
 export const ESCROW_SUBSTORE_INITIALIZATION_FEE = BigInt(5000000);
 
-export const TOKEN_ID_STORE_INITIALIZATION = TOKEN_ID_LSK;
-
 export const defaultConfig = {
 	userAccountInitializationFee: USER_SUBSTORE_INITIALIZATION_FEE.toString(),
 	escrowAccountInitializationFee: ESCROW_SUBSTORE_INITIALIZATION_FEE.toString(),

--- a/framework/src/modules/token/constants.ts
+++ b/framework/src/modules/token/constants.ts
@@ -21,7 +21,7 @@ export const MIN_MODULE_NAME_LENGTH = 1;
 export const MAX_MODULE_NAME_LENGTH = 32;
 
 export const MAX_TRANSACTION_AMOUNT = '9223372036854775807';
-export const DEFAULT_MIN_REMAINING_BALANCE = '5000000';
+export const DEFAULT_MIN_REMAINING_BALANCE = BigInt(5000000);
 
 export const CCM_STATUS_OK = 0;
 export const CCM_STATUS_TOKEN_NOT_SUPPORTED = 64;
@@ -38,19 +38,20 @@ export const TOKEN_ID_LENGTH = CHAIN_ID_LENGTH + LOCAL_ID_LENGTH;
 export const LOCAL_ID_LSK = Buffer.alloc(LOCAL_ID_LENGTH, 0);
 export const CHAIN_ID_LSK = Buffer.from([0, 0, 0, 0]);
 export const TOKEN_ID_LSK = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
-export const USER_SUBSTORE_INITIALIZATION_FEE = '5000000';
-export const TOKEN_ID_STORE_INITIALIZATION = TOKEN_ID_LSK;
-
+export const USER_SUBSTORE_INITIALIZATION_FEE = BigInt(5000000);
 export const ESCROW_SUBSTORE_INITIALIZATION_FEE = BigInt(5000000);
+
+export const TOKEN_ID_STORE_INITIALIZATION = TOKEN_ID_LSK;
 
 export const defaultConfig = {
 	minBalances: [
 		{
 			tokenID: Buffer.alloc(TOKEN_ID_LENGTH, 0).toString('hex'),
-			amount: DEFAULT_MIN_REMAINING_BALANCE,
+			amount: String(DEFAULT_MIN_REMAINING_BALANCE),
 		},
 	],
-	accountInitializationFee: USER_SUBSTORE_INITIALIZATION_FEE,
+	userAccountInitializationFee: String(USER_SUBSTORE_INITIALIZATION_FEE),
+	escrowAccountInitializationFee: String(ESCROW_SUBSTORE_INITIALIZATION_FEE),
 };
 
 export const EMPTY_BYTES = Buffer.alloc(0);

--- a/framework/src/modules/token/constants.ts
+++ b/framework/src/modules/token/constants.ts
@@ -21,14 +21,11 @@ export const MIN_MODULE_NAME_LENGTH = 1;
 export const MAX_MODULE_NAME_LENGTH = 32;
 
 export const MAX_TRANSACTION_AMOUNT = '9223372036854775807';
-export const DEFAULT_MIN_REMAINING_BALANCE = BigInt(5000000);
 
 export const CCM_STATUS_OK = 0;
 export const CCM_STATUS_TOKEN_NOT_SUPPORTED = 64;
 export const CCM_STATUS_PROTOCOL_VIOLATION = 65;
-export const CCM_STATUS_MIN_BALANCE_NOT_REACHED = 66;
 
-export const MIN_BALANCE = BigInt(5000000);
 export const MIN_RETURN_FEE = BigInt(1000);
 export const FEE_CCM_INIT_USER_STORE = BigInt(5000000);
 
@@ -44,14 +41,8 @@ export const ESCROW_SUBSTORE_INITIALIZATION_FEE = BigInt(5000000);
 export const TOKEN_ID_STORE_INITIALIZATION = TOKEN_ID_LSK;
 
 export const defaultConfig = {
-	minBalances: [
-		{
-			tokenID: Buffer.alloc(TOKEN_ID_LENGTH, 0).toString('hex'),
-			amount: String(DEFAULT_MIN_REMAINING_BALANCE),
-		},
-	],
-	userAccountInitializationFee: String(USER_SUBSTORE_INITIALIZATION_FEE),
-	escrowAccountInitializationFee: String(ESCROW_SUBSTORE_INITIALIZATION_FEE),
+	userAccountInitializationFee: USER_SUBSTORE_INITIALIZATION_FEE.toString(),
+	escrowAccountInitializationFee: ESCROW_SUBSTORE_INITIALIZATION_FEE.toString(),
 };
 
 export const EMPTY_BYTES = Buffer.alloc(0);

--- a/framework/src/modules/token/method.ts
+++ b/framework/src/modules/token/method.ts
@@ -49,9 +49,13 @@ import { AllTokensFromChainSupportedEvent } from './events/all_tokens_from_chain
 import { AllTokensFromChainSupportRemovedEvent } from './events/all_tokens_from_chain_supported_removed';
 import { TokenIDSupportRemovedEvent } from './events/token_id_supported_removed';
 
+interface MethodConfig extends ModuleConfig {
+	ownChainID: Buffer;
+}
+
 export class TokenMethod extends BaseMethod {
 	private readonly _moduleName: string;
-	private _config!: ModuleConfig;
+	private _config!: MethodConfig;
 	private _interoperabilityMethod!: InteroperabilityMethod;
 
 	public constructor(stores: NamedRegistry, events: NamedRegistry, moduleName: string) {
@@ -59,7 +63,7 @@ export class TokenMethod extends BaseMethod {
 		this._moduleName = moduleName;
 	}
 
-	public init(config: ModuleConfig): void {
+	public init(config: MethodConfig): void {
 		this._config = config;
 	}
 

--- a/framework/src/modules/token/method.ts
+++ b/framework/src/modules/token/method.ts
@@ -26,7 +26,7 @@ import {
 	CHAIN_ID_LENGTH,
 } from './constants';
 import { crossChainTransferMessageParams, UserStoreData } from './schemas';
-import { InteroperabilityMethod, MinBalance } from './types';
+import { InteroperabilityMethod, ModuleConfig } from './types';
 import { splitTokenID } from './utils';
 import { UserStore } from './stores/user';
 import { EscrowStore } from './stores/escrow';
@@ -49,17 +49,9 @@ import { AllTokensFromChainSupportedEvent } from './events/all_tokens_from_chain
 import { AllTokensFromChainSupportRemovedEvent } from './events/all_tokens_from_chain_supported_removed';
 import { TokenIDSupportRemovedEvent } from './events/token_id_supported_removed';
 
-interface TokenMethodConfig {
-	minBalances: MinBalance[];
-	ownChainID: Buffer;
-	userAccountInitializationFee: bigint;
-	escrowAccountInitializationFee: bigint;
-	feeTokenID: Buffer;
-}
-
 export class TokenMethod extends BaseMethod {
 	private readonly _moduleName: string;
-	private _config!: TokenMethodConfig;
+	private _config!: ModuleConfig;
 	private _interoperabilityMethod!: InteroperabilityMethod;
 
 	public constructor(stores: NamedRegistry, events: NamedRegistry, moduleName: string) {
@@ -67,7 +59,7 @@ export class TokenMethod extends BaseMethod {
 		this._moduleName = moduleName;
 	}
 
-	public init(config: TokenMethodConfig): void {
+	public init(config: ModuleConfig): void {
 		this._config = config;
 	}
 

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -31,7 +31,7 @@ import {
 } from './schemas';
 import { TokenMethod } from './method';
 import { TokenEndpoint } from './endpoint';
-import { GenesisTokenStore, InteroperabilityMethod, MinBalance, ModuleConfig } from './types';
+import { GenesisTokenStore, InteroperabilityMethod, MinBalance, ModuleConfigJSON } from './types';
 import { splitTokenID } from './utils';
 import { CCTransferCommand } from './commands/cc_transfer';
 import { BaseInteroperableModule } from '../interoperability/base_interoperable_module';
@@ -169,7 +169,7 @@ export class TokenModule extends BaseInteroperableModule {
 			defaultConfig,
 			{ feeTokenID: Buffer.concat([this._ownChainID, Buffer.alloc(4, 0)]).toString('hex') },
 			moduleConfig,
-		) as ModuleConfig;
+		) as ModuleConfigJSON;
 		validator.validate(configSchema, config);
 
 		this.stores.get(SupportedTokensStore).registerOwnChainID(this._ownChainID);
@@ -190,7 +190,7 @@ export class TokenModule extends BaseInteroperableModule {
 		this.endpoint.init(this.method);
 		this._transferCommand.init({
 			method: this.method,
-			accountInitializationFee: BigInt(config.accountInitializationFee),
+			accountInitializationFee: BigInt(config.userAccountInitializationFee),
 			feeTokenID: Buffer.from(config.feeTokenID, 'hex'),
 		});
 	}

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -31,7 +31,7 @@ import {
 } from './schemas';
 import { TokenMethod } from './method';
 import { TokenEndpoint } from './endpoint';
-import { GenesisTokenStore, InteroperabilityMethod, MinBalance, ModuleConfigJSON } from './types';
+import { GenesisTokenStore, InteroperabilityMethod, ModuleConfigJSON } from './types';
 import { splitTokenID } from './utils';
 import { CCTransferCommand } from './commands/cc_transfer';
 import { BaseInteroperableModule } from '../interoperability/base_interoperable_module';
@@ -71,7 +71,6 @@ export class TokenModule extends BaseInteroperableModule {
 		this.method,
 	);
 
-	private _minBalances!: MinBalance[];
 	private _ownChainID!: Buffer;
 	private readonly _transferCommand = new TransferCommand(this.stores, this.events);
 	private readonly _ccTransferCommand = new CCTransferCommand(this.stores, this.events);
@@ -175,12 +174,7 @@ export class TokenModule extends BaseInteroperableModule {
 		this.stores.get(SupportedTokensStore).registerOwnChainID(this._ownChainID);
 		this.crossChainTransferCommand.init({ ownChainID: this._ownChainID });
 
-		this._minBalances = config.minBalances.map(mb => ({
-			tokenID: Buffer.from(mb.tokenID, 'hex'),
-			amount: BigInt(mb.amount),
-		}));
 		this.method.init({
-			minBalances: this._minBalances,
 			ownChainID: this._ownChainID,
 			escrowAccountInitializationFee: BigInt('50000000'),
 			feeTokenID: Buffer.from(config.feeTokenID, 'hex'),

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -24,22 +24,6 @@ export const configSchema = {
 	$id: '/token/config',
 	type: 'object',
 	properties: {
-		minBalances: {
-			type: 'array',
-			items: {
-				type: 'object',
-				properties: {
-					tokenID: {
-						type: 'string',
-						format: 'hex',
-					},
-					amount: {
-						type: 'string',
-						format: 'uint64',
-					},
-				},
-			},
-		},
 		supportedTokenIDs: {
 			items: {
 				type: 'string',

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -46,17 +46,17 @@ export const configSchema = {
 				format: 'hex',
 			},
 		},
-		accountInitializationFee: {
-			type: 'string',
-			format: 'uint64',
-		},
 		feeTokenID: {
 			type: 'string',
 			format: 'hex',
 			minLength: TOKEN_ID_LENGTH * 2,
 			maxLength: TOKEN_ID_LENGTH * 2,
 		},
-		escrowInitializationFee: {
+		userAccountInitializationFee: {
+			type: 'string',
+			format: 'uint64',
+		},
+		escrowAccountInitializationFee: {
 			type: 'string',
 			format: 'uint64',
 		},

--- a/framework/src/modules/token/types.ts
+++ b/framework/src/modules/token/types.ts
@@ -19,7 +19,6 @@ import { JSONObject } from '../../types';
 export type TokenID = Buffer;
 
 export interface ModuleConfig {
-	ownChainID: Buffer;
 	userAccountInitializationFee: bigint;
 	escrowAccountInitializationFee: bigint;
 	feeTokenID: Buffer;

--- a/framework/src/modules/token/types.ts
+++ b/framework/src/modules/token/types.ts
@@ -14,23 +14,24 @@
 
 import { MethodContext, ImmutableMethodContext } from '../../state_machine';
 import { CCMsg } from '../interoperability/types';
+import { JSONObject } from '../../types';
 
 export type TokenID = Buffer;
-
-export interface ModuleConfig {
-	minBalances: {
-		tokenID: string;
-		amount: string;
-	}[];
-	feeTokenID: string;
-	accountInitializationFee: string;
-	escrowInitializationFee: string;
-}
 
 export interface MinBalance {
 	tokenID: Buffer;
 	amount: bigint;
 }
+
+export interface ModuleConfig {
+	minBalances: MinBalance[];
+	ownChainID: Buffer;
+	userAccountInitializationFee: bigint;
+	escrowAccountInitializationFee: bigint;
+	feeTokenID: Buffer;
+}
+
+export type ModuleConfigJSON = JSONObject<ModuleConfig>;
 
 export interface GenesisTokenStore {
 	userSubstore: {

--- a/framework/src/modules/token/types.ts
+++ b/framework/src/modules/token/types.ts
@@ -18,13 +18,7 @@ import { JSONObject } from '../../types';
 
 export type TokenID = Buffer;
 
-export interface MinBalance {
-	tokenID: Buffer;
-	amount: bigint;
-}
-
 export interface ModuleConfig {
-	minBalances: MinBalance[];
 	ownChainID: Buffer;
 	userAccountInitializationFee: bigint;
 	escrowAccountInitializationFee: bigint;

--- a/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
@@ -88,12 +88,6 @@ describe('CrossChain Transfer Command', () => {
 			escrowAccountInitializationFee: BigInt(50000000),
 			userAccountInitializationFee: BigInt(50000000),
 			feeTokenID: defaultTokenID,
-			minBalances: [
-				{
-					tokenID: Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]),
-					amount: BigInt(5000000),
-				},
-			],
 		});
 		command.init({
 			ownChainID,

--- a/framework/test/unit/modules/token/commands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/token/commands/cc_transfer.spec.ts
@@ -26,7 +26,6 @@ import { CCTransferCommand } from '../../../../../src/modules/token/commands/cc_
 import {
 	CCM_STATUS_OK,
 	CROSS_CHAIN_COMMAND_NAME_TRANSFER,
-	MIN_BALANCE,
 } from '../../../../../src/modules/token/constants';
 import { crossChainTransferParamsSchema } from '../../../../../src/modules/token/schemas';
 import { EventQueue } from '../../../../../src/state_machine';
@@ -54,8 +53,6 @@ describe('CCTransfer command', () => {
 	const defaultOwnChainID = Buffer.from([0, 0, 0, 1]);
 	const defaultReceivingChainID = Buffer.from([0, 0, 1, 0]);
 	const defaultTokenID = Buffer.concat([defaultOwnChainID, Buffer.alloc(4)]);
-	const localTokenID = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
-	const secondTokenID = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
 	const defaultEscrowFeeTokenId = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
 	const defaultUserAccountInitializationFee = BigInt('50000000');
 	const defaultEscrowAccountInitializationFee = BigInt('50000000');
@@ -136,10 +133,6 @@ describe('CCTransfer command', () => {
 			escrowAccountInitializationFee: defaultEscrowAccountInitializationFee,
 			userAccountInitializationFee: defaultUserAccountInitializationFee,
 			feeTokenID: defaultTokenID,
-			minBalances: [
-				{ tokenID: localTokenID, amount: BigInt(MIN_BALANCE) },
-				{ tokenID: secondTokenID, amount: BigInt(MIN_BALANCE) },
-			],
 		});
 
 		command.init({

--- a/framework/test/unit/modules/token/commands/transfer.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer.spec.ts
@@ -19,7 +19,7 @@ import { TokenModule, VerifyStatus } from '../../../../../src';
 import { TokenMethod } from '../../../../../src/modules/token/method';
 import { TransferCommand } from '../../../../../src/modules/token/commands/transfer';
 import {
-	TOKEN_ID_STORE_INITIALIZATION,
+	TOKEN_ID_LSK,
 	USER_SUBSTORE_INITIALIZATION_FEE,
 } from '../../../../../src/modules/token/constants';
 import { transferParamsSchema } from '../../../../../src/modules/token/schemas';
@@ -39,7 +39,7 @@ interface Params {
 }
 
 describe('Transfer command', () => {
-	const feeTokenID = TOKEN_ID_STORE_INITIALIZATION;
+	const feeTokenID = TOKEN_ID_LSK;
 	const tokenModule = new TokenModule();
 	const ownChainID = Buffer.from([0, 0, 0, 1]);
 	const defaultUserAccountInitFee = BigInt('50000000');
@@ -255,34 +255,6 @@ describe('Transfer command', () => {
 					amount + BigInt(USER_SUBSTORE_INITIALIZATION_FEE)
 				}`,
 			);
-		});
-
-		it('should pass if token balance for token ID TOKEN_ID_STORE_INITIALIZATION is at least the sum of configured initialization fee and transaction amount', async () => {
-			const amount = BigInt(100000000);
-
-			jest
-				.spyOn(command['_method'], 'getAvailableBalance')
-				.mockResolvedValue(amount + BigInt(USER_SUBSTORE_INITIALIZATION_FEE));
-
-			const context = createTransactionContext({
-				transaction: new Transaction({
-					module: 'token',
-					command: 'transfer',
-					fee: BigInt(5000000),
-					nonce: BigInt(0),
-					senderPublicKey: utils.getRandomBytes(32),
-					params: codec.encode(transferParamsSchema, {
-						tokenID: TOKEN_ID_STORE_INITIALIZATION,
-						amount: BigInt(100000000),
-						recipientAddress: utils.getRandomBytes(20),
-						data: '1'.repeat(64),
-						accountInitializationFee: BigInt(USER_SUBSTORE_INITIALIZATION_FEE),
-					}),
-					signatures: [utils.getRandomBytes(64)],
-				}),
-			});
-			const result = await command.verify(context.createCommandVerifyContext(transferParamsSchema));
-			expect(result.status).toEqual(VerifyStatus.OK);
 		});
 
 		it('should fail if balance for the provided tokenID is insufficient', async () => {

--- a/framework/test/unit/modules/token/commands/transfer.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer.spec.ts
@@ -19,7 +19,6 @@ import { TokenModule, VerifyStatus } from '../../../../../src';
 import { TokenMethod } from '../../../../../src/modules/token/method';
 import { TransferCommand } from '../../../../../src/modules/token/commands/transfer';
 import {
-	MIN_BALANCE,
 	TOKEN_ID_STORE_INITIALIZATION,
 	USER_SUBSTORE_INITIALIZATION_FEE,
 } from '../../../../../src/modules/token/constants';
@@ -47,8 +46,6 @@ describe('Transfer command', () => {
 	const defaultEscrowAccountInitFee = BigInt('50000000');
 
 	const defaultTokenID = Buffer.concat([ownChainID, Buffer.alloc(4)]);
-	const localTokenID = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
-	const secondTokenID = Buffer.from([1, 0, 0, 0, 0, 0, 0, 0]);
 	const method = new TokenMethod(tokenModule.stores, tokenModule.events, tokenModule.name);
 	let command: TransferCommand;
 	let interopMethod: {
@@ -93,10 +90,6 @@ describe('Transfer command', () => {
 			escrowAccountInitializationFee: defaultEscrowAccountInitFee,
 			userAccountInitializationFee: defaultUserAccountInitFee,
 			feeTokenID: defaultTokenID,
-			minBalances: [
-				{ tokenID: localTokenID, amount: BigInt(MIN_BALANCE) },
-				{ tokenID: secondTokenID, amount: BigInt(MIN_BALANCE) },
-			],
 		});
 
 		command.init({

--- a/framework/test/unit/modules/token/endpoint.spec.ts
+++ b/framework/test/unit/modules/token/endpoint.spec.ts
@@ -25,7 +25,6 @@ import {
 	createTransientModuleEndpointContext,
 } from '../../../../src/testing';
 import { InMemoryPrefixedStateDB } from '../../../../src/testing/in_memory_prefixed_state';
-import { DEFAULT_LOCAL_ID } from '../../../utils/mocks/transaction';
 
 describe('token endpoint', () => {
 	const tokenModule = new TokenModule();
@@ -54,12 +53,6 @@ describe('token endpoint', () => {
 		endpoint = new TokenEndpoint(tokenModule.stores, tokenModule.offchainStores);
 		method.init({
 			ownChainID: Buffer.from([0, 0, 0, 1]),
-			minBalances: [
-				{
-					tokenID: DEFAULT_LOCAL_ID,
-					amount: BigInt(5000000),
-				},
-			],
 			escrowAccountInitializationFee: BigInt(50000000),
 			userAccountInitializationFee: BigInt(50000000),
 			feeTokenID: defaultTokenID,

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -44,7 +44,6 @@ import { UserStore } from '../../../../src/modules/token/stores/user';
 import { MethodContext, createMethodContext, EventQueue } from '../../../../src/state_machine';
 import { PrefixedStateReadWriter } from '../../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../../src/testing/in_memory_prefixed_state';
-import { DEFAULT_LOCAL_ID } from '../../../utils/mocks/transaction';
 
 describe('token module', () => {
 	const tokenModule = new TokenModule();
@@ -93,12 +92,6 @@ describe('token module', () => {
 			escrowAccountInitializationFee: defaultEscrowAccountInitFee,
 			userAccountInitializationFee: defaultUserAccountInitFee,
 			feeTokenID: defaultTokenID,
-			minBalances: [
-				{
-					tokenID: DEFAULT_LOCAL_ID,
-					amount: BigInt(5000000),
-				},
-			],
 		});
 		await tokenModule.init({
 			genesisConfig: {

--- a/framework/test/unit/modules/token/token_module.spec.ts
+++ b/framework/test/unit/modules/token/token_module.spec.ts
@@ -37,11 +37,6 @@ describe('token module', () => {
 					generatorConfig: {},
 				}),
 			).toResolve();
-
-			expect(tokenModule['_minBalances'][0].amount.toString()).toEqual('5000000');
-			expect(tokenModule['_minBalances'][0].tokenID).toEqual(
-				Buffer.from('0000000000000000', 'hex'),
-			);
 		});
 
 		it('should initialize config with given value', async () => {
@@ -49,17 +44,11 @@ describe('token module', () => {
 				tokenModule.init({
 					genesisConfig: { chainID: '00000000' } as any,
 					moduleConfig: {
-						minBalances: [{ amount: '900000000', tokenID: '0000000100000000' }],
 						supportedTokenID: ['000000020000'],
 					},
 					generatorConfig: {},
 				}),
 			).toResolve();
-
-			expect(tokenModule['_minBalances'][0].amount.toString()).toEqual('900000000');
-			expect(tokenModule['_minBalances'][0].tokenID).toEqual(
-				Buffer.from('0000000100000000', 'hex'),
-			);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #7694

### How was it solved?

1. Removed redundant `ModuleConfig` from `types.ts` and moved and renamed `TokenMethodConfig` from `method.ts` to `types.ts`.
1. Cleaned up schema and constants

### How was it tested?

Unit and integration tests are passing.