### PR TITLE
Update Token module endpoints - Closes #7579 #7660

### DIFF
--- a/framework/src/modules/token/endpoint.ts
+++ b/framework/src/modules/token/endpoint.ts
@@ -22,7 +22,7 @@ import { CHAIN_ID_LENGTH, TOKEN_ID_LENGTH } from './constants';
 import {
 	getBalanceRequestSchema,
 	getBalancesRequestSchema,
-	isSupportedSchema,
+	isSupportedRequestSchema,
 	SupplyStoreData,
 	UserStoreData,
 } from './schemas';
@@ -121,7 +121,7 @@ export class TokenEndpoint extends BaseEndpoint {
 	}
 
 	public async isSupported(context: ModuleEndpointContext) {
-		validator.validate<{ tokenID: string }>(isSupportedSchema, context.params);
+		validator.validate<{ tokenID: string }>(isSupportedRequestSchema, context.params);
 
 		const tokenID = Buffer.from(context.params.tokenID, 'hex');
 		const supportedTokensStore = this.stores.get(SupportedTokensStore);

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -188,7 +188,7 @@ export class TokenModule extends BaseInteroperableModule {
 		this.stores.get(SupportedTokensStore).registerOwnChainID(this._ownChainID);
 		this.crossChainTransferCommand.init({ ownChainID: this._ownChainID });
 
-		this.method.init(Object.assign(config, { ownChainID: this._ownChainID }));
+		this.method.init({ ...config, ownChainID: this._ownChainID });
 		this.crossChainMethod.init(this._ownChainID);
 		this.endpoint.init(config);
 		this._transferCommand.init({

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -25,8 +25,11 @@ import {
 	getBalanceRequestSchema,
 	getBalanceResponseSchema,
 	getBalancesRequestSchema,
+	getBalancesResponseSchema,
 	getEscrowedAmountsResponseSchema,
 	getSupportedTokensResponseSchema,
+	isSupportedRequestSchema,
+	isSupportedResponseSchema,
 	getTotalSupplyResponseSchema,
 } from './schemas';
 import { TokenMethod } from './method';
@@ -126,7 +129,7 @@ export class TokenModule extends BaseInteroperableModule {
 				{
 					name: this.endpoint.getBalances.name,
 					request: getBalancesRequestSchema,
-					response: getBalancesRequestSchema,
+					response: getBalancesResponseSchema,
 				},
 				{
 					name: this.endpoint.getTotalSupply.name,
@@ -135,6 +138,11 @@ export class TokenModule extends BaseInteroperableModule {
 				{
 					name: this.endpoint.getSupportedTokens.name,
 					response: getSupportedTokensResponseSchema,
+				},
+				{
+					name: this.endpoint.isSupported.name,
+					request: isSupportedRequestSchema,
+					response: isSupportedResponseSchema,
 				},
 				{
 					name: this.endpoint.getEscrowedAmounts.name,

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -31,7 +31,7 @@ import {
 } from './schemas';
 import { TokenMethod } from './method';
 import { TokenEndpoint } from './endpoint';
-import { GenesisTokenStore, InteroperabilityMethod, ModuleConfigJSON } from './types';
+import { GenesisTokenStore, InteroperabilityMethod, ModuleConfig, ModuleConfigJSON } from './types';
 import { splitTokenID } from './utils';
 import { CCTransferCommand } from './commands/cc_transfer';
 import { BaseInteroperableModule } from '../interoperability/base_interoperable_module';
@@ -163,29 +163,30 @@ export class TokenModule extends BaseInteroperableModule {
 		const { moduleConfig, genesisConfig } = args;
 		this._ownChainID = Buffer.from(genesisConfig.chainID, 'hex');
 
-		const config = objects.mergeDeep(
+		const rawConfig = objects.mergeDeep(
 			{},
 			defaultConfig,
 			{ feeTokenID: Buffer.concat([this._ownChainID, Buffer.alloc(4, 0)]).toString('hex') },
 			moduleConfig,
 		) as ModuleConfigJSON;
-		validator.validate(configSchema, config);
+		validator.validate(configSchema, rawConfig);
+
+		const config: ModuleConfig = {
+			userAccountInitializationFee: BigInt(rawConfig.userAccountInitializationFee),
+			escrowAccountInitializationFee: BigInt(rawConfig.escrowAccountInitializationFee),
+			feeTokenID: Buffer.from(rawConfig.feeTokenID, 'hex'),
+		};
 
 		this.stores.get(SupportedTokensStore).registerOwnChainID(this._ownChainID);
 		this.crossChainTransferCommand.init({ ownChainID: this._ownChainID });
 
-		this.method.init({
-			ownChainID: this._ownChainID,
-			escrowAccountInitializationFee: BigInt('50000000'),
-			feeTokenID: Buffer.from(config.feeTokenID, 'hex'),
-			userAccountInitializationFee: BigInt('50000000'),
-		});
+		this.method.init(Object.assign(config, { ownChainID: this._ownChainID }));
 		this.crossChainMethod.init(this._ownChainID);
-		this.endpoint.init(this.method);
+		this.endpoint.init(config);
 		this._transferCommand.init({
 			method: this.method,
-			accountInitializationFee: BigInt(config.userAccountInitializationFee),
-			feeTokenID: Buffer.from(config.feeTokenID, 'hex'),
+			accountInitializationFee: config.userAccountInitializationFee,
+			feeTokenID: config.feeTokenID,
 		});
 	}
 

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -620,8 +620,8 @@ export const getEscrowedAmountsResponseSchema = {
 	},
 };
 
-export const isSupportedSchema = {
-	$id: '/token/endpoint/isSupported',
+export const isSupportedRequestSchema = {
+	$id: '/token/endpoint/isSupportedRequest',
 	type: 'object',
 	properties: {
 		tokenID: {
@@ -632,4 +632,15 @@ export const isSupportedSchema = {
 		},
 	},
 	required: ['tokenID'],
+};
+
+export const isSupportedResponseSchema = {
+	$id: '/token/endpoint/isSupportedResponse',
+	type: 'object',
+	properties: {
+		supported: {
+			dataType: 'boolean',
+		},
+	},
+	required: ['supported'],
 };

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -619,3 +619,17 @@ export const getEscrowedAmountsResponseSchema = {
 		},
 	},
 };
+
+export const isSupportedSchema = {
+	$id: '/token/endpoint/isSupported',
+	type: 'object',
+	properties: {
+		tokenID: {
+			type: 'string',
+			format: 'hex',
+			minLength: TOKEN_ID_LENGTH * 2,
+			maxLength: TOKEN_ID_LENGTH * 2,
+		},
+	},
+	required: ['tokenID'],
+};

--- a/framework/src/modules/token/stores/supported_tokens.ts
+++ b/framework/src/modules/token/stores/supported_tokens.ts
@@ -37,7 +37,7 @@ export const supportedTokensStoreSchema = {
 	},
 };
 
-export const ALL_SUPPORTED_TOKENS_KEY = Buffer.from([0, 0, 0, 0]);
+export const ALL_SUPPORTED_TOKENS_KEY = Buffer.alloc(0);
 
 export class SupportedTokensStore extends BaseStore<SupportedTokensStoreData> {
 	public schema = supportedTokensStoreSchema;

--- a/framework/src/modules/token/stores/supported_tokens.ts
+++ b/framework/src/modules/token/stores/supported_tokens.ts
@@ -77,25 +77,25 @@ export class SupportedTokensStore extends BaseStore<SupportedTokensStoreData> {
 		return false;
 	}
 
-	public async removeAll(context: StoreGetter): Promise<void> {
-		// check if exist
-		const allSupportedTokens = await this.iterate(context, {
-			gte: Buffer.alloc(4, 0),
-			lte: Buffer.alloc(4, 255),
+	public async getAll(
+		context: ImmutableStoreGetter,
+	): Promise<{ key: Buffer; value: SupportedTokensStoreData }[]> {
+		return this.iterate(context, {
+			gte: Buffer.alloc(TOKEN_ID_LENGTH, 0),
+			lte: Buffer.alloc(TOKEN_ID_LENGTH, 255),
 		});
+	}
+
+	public async removeAll(context: StoreGetter): Promise<void> {
+		const allSupportedTokens = await this.getAll(context);
+
 		for (const { key } of allSupportedTokens) {
 			await this.del(context, key);
 		}
 	}
 
 	public async supportAll(context: StoreGetter): Promise<void> {
-		const allSupportedTokens = await this.iterate(context, {
-			gte: Buffer.alloc(4, 0),
-			lte: Buffer.alloc(4, 255),
-		});
-		for (const { key } of allSupportedTokens) {
-			await this.del(context, key);
-		}
+		await this.removeAll(context);
 		await this.set(context, ALL_SUPPORTED_TOKENS_KEY, { supportedTokenIDs: [] });
 	}
 

--- a/framework/test/unit/modules/token/endpoint.spec.ts
+++ b/framework/test/unit/modules/token/endpoint.spec.ts
@@ -52,6 +52,7 @@ describe('token endpoint', () => {
 		Buffer.from('0000000000000000', 'hex'),
 		Buffer.from('0000000200000000', 'hex'),
 	];
+	let supportedTokensStore: SupportedTokensStore;
 
 	let endpoint: TokenEndpoint;
 	let stateStore: PrefixedStateReadWriter;
@@ -92,7 +93,7 @@ describe('token endpoint', () => {
 			{ amount: defaultEscrowAmount },
 		);
 
-		const supportedTokensStore = tokenModule.stores.get(SupportedTokensStore);
+		supportedTokensStore = tokenModule.stores.get(SupportedTokensStore);
 		supportedTokensStore.registerOwnChainID(defaultTokenID.slice(CHAIN_ID_LENGTH));
 		await supportedTokensStore.set(methodContext, defaultTokenID, { supportedTokenIDs });
 	});
@@ -279,6 +280,17 @@ describe('token endpoint', () => {
 			});
 
 			expect(await endpoint.isSupported(moduleEndpointContext)).toEqual({ supported: false });
+		});
+
+		it('should return true for a token from a foreign chain, when all tokens are supported', async () => {
+			await supportedTokensStore.supportAll(methodContext);
+
+			const moduleEndpointContext = createTransientModuleEndpointContext({
+				stateStore,
+				params: { tokenID: '8888888888888888' },
+			});
+
+			expect(await endpoint.isSupported(moduleEndpointContext)).toEqual({ supported: true });
 		});
 	});
 

--- a/framework/test/unit/modules/token/endpoint.spec.ts
+++ b/framework/test/unit/modules/token/endpoint.spec.ts
@@ -88,10 +88,7 @@ describe('token endpoint', () => {
 		const escrowStore = tokenModule.stores.get(EscrowStore);
 		await escrowStore.set(
 			methodContext,
-			Buffer.concat([
-				defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
-				defaultTokenID.slice(CHAIN_ID_LENGTH),
-			]),
+			Buffer.concat([defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH), defaultTokenID]),
 			{ amount: defaultEscrowAmount },
 		);
 

--- a/framework/test/unit/modules/token/endpoint.spec.ts
+++ b/framework/test/unit/modules/token/endpoint.spec.ts
@@ -81,7 +81,7 @@ describe('token endpoint', () => {
 		await userStore.save(methodContext, defaultAddress, defaultForeignTokenID, defaultAccount);
 
 		const supplyStore = tokenModule.stores.get(SupplyStore);
-		await supplyStore.set(methodContext, defaultTokenID.slice(CHAIN_ID_LENGTH), {
+		await supplyStore.set(methodContext, defaultTokenID, {
 			totalSupply: defaultTotalSupply,
 		});
 
@@ -97,9 +97,7 @@ describe('token endpoint', () => {
 
 		const supportedTokensStore = tokenModule.stores.get(SupportedTokensStore);
 		supportedTokensStore.registerOwnChainID(defaultTokenID.slice(CHAIN_ID_LENGTH));
-		await supportedTokensStore.set(methodContext, defaultTokenID.slice(CHAIN_ID_LENGTH), {
-			supportedTokenIDs,
-		});
+		await supportedTokensStore.set(methodContext, defaultTokenID, { supportedTokenIDs });
 	});
 
 	describe('getBalances', () => {
@@ -277,8 +275,7 @@ describe('token endpoint', () => {
 			expect(await endpoint.isSupported(moduleEndpointContext)).toEqual({ supported: true });
 		});
 
-		// eslint-disable-next-line jest/no-disabled-tests
-		it.skip('should return false for a non-supported token', async () => {
+		it('should return false for a non-supported token', async () => {
 			const moduleEndpointContext = createTransientModuleEndpointContext({
 				stateStore,
 				params: { tokenID: '8888888888888888' },


### PR DESCRIPTION
### What was the problem?

This PR resolves #7579 #7660

### How was it solved?

* Fixed `TokenModule.init()` to get config from a `ModuleConfig` object
* Implemented `isSupported` endpoint
* Implemented `getInitializationFees` endpoint
* Partially implemented `getSupportedTokens` endpoint

### How was it tested?

Added unit tests. Skipped the one that should return false when checking if a not-supported token is supported.
