### PR TITLE
Fix config values flow to modules

### DIFF
--- a/commander/src/bootstrapping/commands/genesis-block/create.ts
+++ b/commander/src/bootstrapping/commands/genesis-block/create.ts
@@ -82,6 +82,7 @@ export abstract class BaseGenesisBlockCommand extends Command {
 				data: codec.fromJSON(a.schema, a.data),
 				schema: a.schema,
 			})),
+			chainID: Buffer.from(app.config.genesis.chainID, 'hex'),
 		});
 		fs.mkdirSync(configPath, { recursive: true });
 		fs.writeFileSync(resolve(configPath, 'genesis_block.blob'), genesisBlock.getBytes());

--- a/framework/src/abi_handler/abi_handler.ts
+++ b/framework/src/abi_handler/abi_handler.ts
@@ -76,6 +76,7 @@ export interface ABIHandlerConstructor {
 	moduleDB: Database;
 	modules: BaseModule[];
 	channel: BaseChannel;
+	chainID: Buffer;
 }
 
 interface ExecutionContext {
@@ -110,11 +111,12 @@ export class ABIHandler implements ABI {
 		this._moduleDB = args.moduleDB;
 		this._modules = args.modules;
 		this._channel = args.channel;
+		this._chainID = args.chainID;
 	}
 
 	public get chainID(): Buffer {
 		if (!this._chainID) {
-			throw new Error('Network identifier is not set.');
+			throw new Error('Chain ID is not set.');
 		}
 		return this._chainID;
 	}
@@ -145,6 +147,7 @@ export class ABIHandler implements ABI {
 			logger: this._logger,
 			stateStore,
 			assets: genesisBlock.assets,
+			chainID: this.chainID,
 		});
 
 		await this._stateMachine.executeGenesisBlock(context);
@@ -251,6 +254,7 @@ export class ABIHandler implements ABI {
 			logger: this._logger,
 			stateStore: this._executionContext.stateStore,
 			assets: genesisBlock.assets,
+			chainID: this.chainID,
 		});
 
 		await this._stateMachine.executeGenesisBlock(context);

--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -289,6 +289,7 @@ export class Application {
 				modules: this._registeredModules,
 				stateDB: this._stateDB,
 				stateMachine: this._stateMachine,
+				chainID: Buffer.from(this.config.genesis.chainID, 'hex'),
 			});
 			await this._abiHandler.cacheGenesisState();
 			const abiSocketPath = `ipc://${path.join(socketsPath, 'abi.ipc')}`;

--- a/framework/src/application.ts
+++ b/framework/src/application.ts
@@ -143,6 +143,7 @@ export class Application {
 		this._controller = new Controller({
 			appConfig: rootConfigs,
 			pluginConfigs: plugins,
+			chainID: Buffer.from(this.config.genesis.chainID, 'hex'),
 		});
 		this._stateMachine = new StateMachine();
 	}

--- a/framework/src/controller/bus.ts
+++ b/framework/src/controller/bus.ts
@@ -28,6 +28,7 @@ import { getEndpointPath } from '../endpoint';
 
 interface BusConfiguration {
 	readonly internalIPCServer: IPCServer;
+	readonly chainID: Buffer;
 }
 
 interface RegisterChannelOptions {

--- a/framework/src/controller/channels/in_memory_channel.ts
+++ b/framework/src/controller/channels/in_memory_channel.ts
@@ -29,6 +29,7 @@ export class InMemoryChannel extends BaseChannel {
 	private bus!: Bus;
 	private readonly _db: StateDB;
 	private readonly _moduleDB: Database;
+	private readonly _chainID: Buffer;
 
 	public constructor(
 		logger: Logger,
@@ -37,10 +38,12 @@ export class InMemoryChannel extends BaseChannel {
 		namespace: string,
 		events: ReadonlyArray<string>,
 		endpoints: EndpointHandlers,
+		chainID: Buffer,
 	) {
 		super(logger, namespace, events, endpoints);
 		this._db = db;
 		this._moduleDB = moduleDB;
+		this._chainID = chainID;
 	}
 
 	public async registerToBus(bus: Bus): Promise<void> {
@@ -119,6 +122,7 @@ export class InMemoryChannel extends BaseChannel {
 				},
 				getImmutableMethodContext: () =>
 					createImmutableMethodContext(new PrefixedStateReadWriter(this._db.newReadWriter())),
+				chainID: this._chainID,
 			}) as Promise<T>;
 		}
 

--- a/framework/src/controller/channels/ipc_channel.ts
+++ b/framework/src/controller/channels/ipc_channel.ts
@@ -32,16 +32,19 @@ export class IPCChannel extends BaseChannel {
 	private readonly _emitter: EventEmitter2;
 	private readonly _ipcClient: IPCClient;
 	private readonly _rpcRequestIds: Set<string>;
+	private readonly _chainID: Buffer;
 
 	public constructor(
 		logger: Logger,
 		namespace: string,
 		events: ReadonlyArray<string>,
 		endpoints: EndpointHandlers,
+		chainID: Buffer,
 		options: ChildProcessOptions,
 	) {
 		super(logger, namespace, events, endpoints);
 
+		this._chainID = chainID;
 		this._ipcClient = new IPCClient({
 			socketsDir: options.socketsPath,
 			name: namespace,
@@ -222,6 +225,7 @@ export class IPCChannel extends BaseChannel {
 				getOffchainStore: () => {
 					throw new Error('getOffchainStore cannot be called on IPC channel');
 				},
+				chainID: this._chainID,
 				logger: this._logger,
 			}) as Promise<T>;
 		}

--- a/framework/src/controller/child_process_loader.ts
+++ b/framework/src/controller/child_process_loader.ts
@@ -48,6 +48,7 @@ const _loadPlugin = async (
 		pluginName,
 		plugin.events,
 		plugin.endpoint ? getEndpointHandlers(plugin.endpoint) : {},
+		Buffer.from(appConfig.genesis.chainID, 'hex'),
 		{
 			socketsPath: dirs.sockets,
 		},

--- a/framework/src/controller/controller.ts
+++ b/framework/src/controller/controller.ts
@@ -29,6 +29,7 @@ import { IPCServer } from './ipc/ipc_server';
 export interface ControllerOptions {
 	readonly appConfig: ApplicationConfigForPlugin;
 	readonly pluginConfigs: Record<string, PluginConfig>;
+	readonly chainID: Buffer;
 }
 
 interface ControllerInitArg {
@@ -59,7 +60,7 @@ export class Controller {
 	private readonly _inMemoryPlugins: Record<string, { plugin: BasePlugin; channel: BaseChannel }>;
 	private readonly _plugins: { [key: string]: BasePlugin };
 	private readonly _endpointHandlers: { [namespace: string]: EndpointHandlers };
-
+	private readonly _chainID: Buffer;
 	private readonly _bus: Bus;
 	private readonly _internalIPCServer: IPCServer;
 
@@ -79,6 +80,7 @@ export class Controller {
 
 		this._appConfig = options.appConfig;
 		this._pluginConfigs = options.pluginConfigs ?? {};
+		this._chainID = options.chainID;
 		const dirs = systemDirs(options.appConfig.system.dataPath);
 		this._config = {
 			dataPath: dirs.dataPath,
@@ -92,6 +94,7 @@ export class Controller {
 
 		this._bus = new Bus({
 			internalIPCServer: this._internalIPCServer,
+			chainID: this._chainID,
 		});
 	}
 
@@ -122,6 +125,7 @@ export class Controller {
 			APP_IDENTIFIER,
 			arg.events,
 			arg.endpoints,
+			this._chainID,
 		);
 	}
 
@@ -165,6 +169,7 @@ export class Controller {
 				namespace,
 				[],
 				handlers,
+				this._chainID,
 			);
 			await channel.registerToBus(this._bus);
 		}
@@ -249,6 +254,7 @@ export class Controller {
 			name,
 			plugin.events,
 			plugin.endpoint ? getEndpointHandlers(plugin.endpoint) : {},
+			this._chainID,
 		);
 		await channel.registerToBus(this._bus);
 		this._logger.debug({ plugin: name }, 'Plugin is registered to bus');

--- a/framework/src/genesis_block.ts
+++ b/framework/src/genesis_block.ts
@@ -24,6 +24,7 @@ import { EventQueue, GenesisBlockContext, StateMachine } from './state_machine';
 import { PrefixedStateReadWriter } from './state_machine/prefixed_state_read_writer';
 
 export interface GenesisBlockGenerateInput {
+	chainID: Buffer;
 	height?: number;
 	timestamp?: number;
 	previousBlockID?: Buffer;
@@ -87,6 +88,7 @@ export const generateGenesisBlock = async (
 		assets,
 		logger,
 		stateStore,
+		chainID: input.chainID,
 	});
 
 	await stateMachine.executeGenesisBlock(blockCtx);

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -52,6 +52,7 @@ export type { EventsDefinition, EventCallback } from './controller/event';
 export * as testing from './testing';
 export * from './types';
 export { ValidatorsMethod, ValidatorsModule } from './modules/validators';
+export { AuthMethod, AuthModule, multisigRegMsgSchema } from './modules/auth';
 export {
 	TokenMethod,
 	TokenModule,

--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -15,6 +15,7 @@
 import { validator } from '@liskhq/lisk-validator';
 import { NotFoundError } from '@liskhq/lisk-chain';
 import { address as cryptoAddress } from '@liskhq/lisk-cryptography';
+import { Schema } from '@liskhq/lisk-codec';
 import { ModuleEndpointContext } from '../../types';
 import { VerifyStatus } from '../../state_machine';
 import { BaseEndpoint } from '../base_endpoint';
@@ -28,7 +29,7 @@ import {
 import { getTransactionFromParameter, verifyNonceStrict, verifySignatures } from './utils';
 import { AuthAccountStore } from './stores/auth_account';
 import { NamedRegistry } from '../named_registry';
-import { sortMultisignatureGroupSchema } from './schemas';
+import { multisigRegMsgSchema, sortMultisignatureGroupSchema } from './schemas';
 
 export class AuthEndpoint extends BaseEndpoint {
 	public constructor(_moduleName: string, stores: NamedRegistry, offchainStores: NamedRegistry) {
@@ -107,6 +108,13 @@ export class AuthEndpoint extends BaseEndpoint {
 
 		const verificationResult = verifyNonceStrict(transaction, account).status;
 		return { verified: verificationResult === VerifyStatus.OK };
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	public async getMultiSigRegMsgSchema(
+		_context: ModuleEndpointContext,
+	): Promise<{ schema: Schema }> {
+		return { schema: multisigRegMsgSchema };
 	}
 
 	public sortMultisignatureGroup(context: ModuleEndpointContext): SortedMultisignatureGroup {

--- a/framework/src/modules/auth/index.ts
+++ b/framework/src/modules/auth/index.ts
@@ -14,3 +14,4 @@
 
 export { AuthModule } from './module';
 export { AuthMethod } from './method';
+export { multisigRegMsgSchema } from './schemas';

--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -33,7 +33,6 @@ import { NamedRegistry } from './named_registry';
 export interface ModuleInitArgs {
 	genesisConfig: Omit<GenesisConfig, 'modules'>;
 	moduleConfig: Record<string, unknown>;
-	generatorConfig: Record<string, unknown>;
 }
 
 export interface ModuleMetadata {

--- a/framework/src/state_machine/genesis_block_context.ts
+++ b/framework/src/state_machine/genesis_block_context.ts
@@ -25,6 +25,7 @@ export interface ContextParams {
 	header: BlockHeader;
 	assets: BlockAssets;
 	eventQueue: EventQueue;
+	chainID: Buffer;
 }
 
 export class GenesisBlockContext {
@@ -33,6 +34,7 @@ export class GenesisBlockContext {
 	private readonly _header: BlockHeader;
 	private readonly _assets: BlockAssets;
 	private readonly _eventQueue: EventQueue;
+	private readonly _chainID: Buffer;
 	private _nextValidators?: {
 		precommitThreshold: bigint;
 		certificateThreshold: bigint;
@@ -45,6 +47,7 @@ export class GenesisBlockContext {
 		this._eventQueue = params.eventQueue;
 		this._header = params.header;
 		this._assets = params.assets;
+		this._chainID = params.chainID;
 	}
 
 	public createInitGenesisStateContext(): GenesisBlockExecuteContext {
@@ -58,6 +61,7 @@ export class GenesisBlockContext {
 			header: this._header,
 			logger: this._logger,
 			assets: this._assets,
+			chainID: this._chainID,
 			setNextValidators: (
 				precommitThreshold: bigint,
 				certificateThreshold: bigint,
@@ -86,6 +90,7 @@ export class GenesisBlockContext {
 			header: this._header,
 			logger: this._logger,
 			assets: this._assets,
+			chainID: this._chainID,
 			setNextValidators: (
 				precommitThreshold: bigint,
 				certificateThreshold: bigint,

--- a/framework/src/state_machine/state_machine.ts
+++ b/framework/src/state_machine/state_machine.ts
@@ -39,7 +39,6 @@ export class StateMachine {
 	public async init(
 		logger: Logger,
 		genesisConfig: GenesisConfig,
-		generatorConfig: Record<string, Record<string, unknown>> = {},
 		moduleConfig: Record<string, Record<string, unknown>> = {},
 	): Promise<void> {
 		this._logger = logger;
@@ -50,7 +49,6 @@ export class StateMachine {
 			if (mod.init) {
 				await mod.init({
 					moduleConfig: moduleConfig[mod.name] ?? {},
-					generatorConfig: generatorConfig[mod.name] ?? {},
 					genesisConfig,
 				});
 			}

--- a/framework/src/state_machine/types.ts
+++ b/framework/src/state_machine/types.ts
@@ -124,6 +124,7 @@ export interface GenesisBlockExecuteContext {
 		certificateThreshold: bigint,
 		validators: Validator[],
 	) => void;
+	chainID: Buffer;
 }
 
 export interface TransactionExecuteContext {

--- a/framework/src/testing/app_env.ts
+++ b/framework/src/testing/app_env.ts
@@ -57,6 +57,7 @@ export class ApplicationEnv {
 	public async startApplication(): Promise<void> {
 		const genesisBlock = await this._application.generateGenesisBlock({
 			assets: [],
+			chainID: Buffer.from(this._application.config.genesis.chainID, 'hex'),
 		});
 		this._application.config.genesis.block.blob = genesisBlock.getBytes().toString('hex');
 

--- a/framework/src/testing/block_processing_env.ts
+++ b/framework/src/testing/block_processing_env.ts
@@ -80,7 +80,7 @@ export interface BlockProcessingEnv {
 	getLastBlock: () => Block;
 	getNextValidatorKeys: (blockHeader: BlockHeader) => Promise<Keys>;
 	getDataAccess: () => DataAccess;
-	getNetworkId: () => Buffer;
+	getChainID: () => Buffer;
 	invoke: <T = void>(path: string, params?: Record<string, unknown>) => Promise<T>;
 	cleanup: (config: Options) => void;
 }
@@ -210,6 +210,7 @@ export const getBlockProcessingEnv = async (
 	const genesisBlock = await generateGenesisBlock(stateMachine, logger, {
 		timestamp: Math.floor(Date.now() / 1000) - 60 * 60,
 		assets: blockAssets,
+		chainID,
 	});
 	const abiHandler = new ABIHandler({
 		channel: channelMock,
@@ -219,6 +220,7 @@ export const getBlockProcessingEnv = async (
 		moduleDB,
 		modules,
 		stateMachine,
+		chainID,
 	});
 	appConfig.genesis.block.blob = genesisBlock.getBytes().toString('hex');
 	appConfig.generator.keys.fromFile = path.join(__dirname, './fixtures/keys_fixture.json');
@@ -306,7 +308,7 @@ export const getBlockProcessingEnv = async (
 
 			return result as T;
 		},
-		getNetworkId: () => chainID,
+		getChainID: () => chainID,
 		getDataAccess: () => engine['_chain'].dataAccess,
 		cleanup: (_val): void => {
 			engine['_closeDB']();

--- a/framework/src/testing/create_contexts.ts
+++ b/framework/src/testing/create_contexts.ts
@@ -79,6 +79,7 @@ export const createGenesisBlockContext = (params: {
 	eventQueue?: EventQueue;
 	assets?: BlockAssets;
 	logger?: Logger;
+	chainID?: Buffer;
 }): GenesisBlockContext => {
 	const logger = params.logger ?? loggerMock;
 	const stateStore =
@@ -91,6 +92,7 @@ export const createGenesisBlockContext = (params: {
 		header,
 		assets: params.assets ?? new BlockAssets(),
 		logger,
+		chainID: params.chainID ?? Buffer.from('10000000', 'hex'),
 	});
 	return ctx;
 };

--- a/framework/test/integration/controller/in_memory_channel.spec.ts
+++ b/framework/test/integration/controller/in_memory_channel.spec.ts
@@ -34,6 +34,9 @@ describe('InMemoryChannel', () => {
 				path: socketsDir,
 			},
 		},
+		genesis: {
+			chainID: '10000000',
+		},
 	};
 
 	const alpha = {
@@ -74,6 +77,7 @@ describe('InMemoryChannel', () => {
 				alpha.moduleName,
 				alpha.events,
 				alpha.endpoints,
+				config.genesis.chainID,
 			);
 
 			await inMemoryChannelAlpha.registerToBus(bus);
@@ -85,6 +89,7 @@ describe('InMemoryChannel', () => {
 				beta.moduleName,
 				beta.events,
 				beta.endpoints,
+				config.genesis.chainID,
 			);
 			// eslint-disable-next-line @typescript-eslint/no-floating-promises
 			await inMemoryChannelBeta.registerToBus(bus);
@@ -141,6 +146,7 @@ describe('InMemoryChannel', () => {
 					omegaName,
 					[omegaEventName],
 					{},
+					config.genesis.chainID,
 				);
 
 				const donePromise = new Promise<void>(resolve => {

--- a/framework/test/integration/controller/ipc_channel.spec.ts
+++ b/framework/test/integration/controller/ipc_channel.spec.ts
@@ -40,6 +40,9 @@ describe.skip('IPCChannel', () => {
 				path: socketsDir,
 			},
 		},
+		genesisConfig: {
+			chainID: '10000000',
+		},
 	};
 
 	const alpha = {
@@ -92,6 +95,7 @@ describe.skip('IPCChannel', () => {
 				alpha.events,
 				alpha.endpoints,
 				config,
+				config.genesisConfig.chainID,
 			);
 
 			betaChannel = new IPCChannel(
@@ -100,6 +104,7 @@ describe.skip('IPCChannel', () => {
 				beta.events,
 				beta.endpoints,
 				config,
+				config.genesisConfig.chainID,
 			);
 
 			await bus.start(logger);
@@ -168,6 +173,7 @@ describe.skip('IPCChannel', () => {
 					omegaName,
 					[omegaEventName],
 					{},
+					config.genesisConfig.chainID,
 				);
 
 				const donePromise = new Promise<void>(resolve => {

--- a/framework/test/integration/controller/ipc_channel_without_bus.spec.ts
+++ b/framework/test/integration/controller/ipc_channel_without_bus.spec.ts
@@ -32,6 +32,9 @@ describe.skip('IPCChannelWithoutBus', () => {
 
 	const config: any = {
 		socketsPath: socketsDir,
+		genesisConfig: {
+			chainID: '10000000',
+		},
 	};
 
 	const alpha = {
@@ -97,6 +100,7 @@ describe.skip('IPCChannelWithoutBus', () => {
 				alpha.events,
 				alpha.endpoints,
 				config,
+				config.genesisConfig.chainID,
 			);
 
 			betaChannel = new IPCChannel(
@@ -105,6 +109,7 @@ describe.skip('IPCChannelWithoutBus', () => {
 				beta.events,
 				beta.endpoints,
 				config,
+				config.genesisConfig.chainID,
 			);
 
 			await alphaChannel.startAndListen();

--- a/framework/test/integration/node/generator/transaction_pool.spec.ts
+++ b/framework/test/integration/node/generator/transaction_pool.spec.ts
@@ -46,7 +46,7 @@ describe('Transaction pool', () => {
 				nonce: BigInt(authData.nonce),
 				recipientAddress: account.address,
 				amount: BigInt('100000000000'),
-				chainID: processEnv.getNetworkId(),
+				chainID: processEnv.getChainID(),
 				privateKey: Buffer.from(genesis.privateKey, 'hex'),
 			});
 			await processEnv.getGenerator()['_pool'].add(transaction);

--- a/framework/test/integration/node/genesis_block.spec.ts
+++ b/framework/test/integration/node/genesis_block.spec.ts
@@ -35,7 +35,7 @@ describe('genesis block', () => {
 				databasePath,
 			},
 		});
-		chainID = processEnv.getNetworkId();
+		chainID = processEnv.getChainID();
 	});
 
 	afterAll(() => {
@@ -65,7 +65,7 @@ describe('genesis block', () => {
 					const balance = await processEnv.invoke<{ availableBalance: string }>(
 						'token_getBalance',
 						{
-							tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+							tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 							address: address.getLisk32AddressFromAddress(data.address),
 						},
 					);
@@ -104,7 +104,7 @@ describe('genesis block', () => {
 			recipientAddress = decoded.userSubstore[decoded.userSubstore.length - 1].address;
 			const recipient = await processEnv.invoke<{ availableBalance: string }>('token_getBalance', {
 				address: address.getLisk32AddressFromAddress(recipientAddress),
-				tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+				tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 			});
 			oldBalance = BigInt(recipient.availableBalance);
 			newBalance = oldBalance + BigInt('100000000000');
@@ -145,7 +145,7 @@ describe('genesis block', () => {
 				chain.init({
 					db: processEnv.getBlockchainDB(),
 					genesisBlock: processEnv.getGenesisBlock(),
-					chainID: processEnv.getNetworkId(),
+					chainID: processEnv.getChainID(),
 				});
 				await newConsensus.init({
 					db: consensus['_db'],
@@ -156,7 +156,7 @@ describe('genesis block', () => {
 
 				const balance = await processEnv.invoke<{ availableBalance: string }>('token_getBalance', {
 					address: address.getLisk32AddressFromAddress(recipientAddress),
-					tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+					tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 				});
 
 				// Arrange & Assert

--- a/framework/test/integration/node/processor/block_process/process_block.spec.ts
+++ b/framework/test/integration/node/processor/block_process/process_block.spec.ts
@@ -40,7 +40,7 @@ describe('Process block', () => {
 				databasePath,
 			},
 		});
-		chainID = processEnv.getNetworkId();
+		chainID = processEnv.getChainID();
 		dataAccess = processEnv.getDataAccess();
 		chain = processEnv.getChain();
 	});
@@ -74,7 +74,7 @@ describe('Process block', () => {
 			it('should save account state changes from the transaction', async () => {
 				const balance = await processEnv.invoke<{ availableBalance: string }>('token_getBalance', {
 					address: genesis.address,
-					tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+					tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 				});
 				const expected = originalBalance - transaction.fee - amount - BigInt(5000000);
 				expect(balance.availableBalance).toEqual(expected.toString());
@@ -146,7 +146,7 @@ describe('Process block', () => {
 				const generatorPrivateKey = getGeneratorPrivateKeyFromDefaultConfig(
 					invalidBlock.header.generatorAddress,
 				);
-				invalidBlock.header.sign(processEnv.getNetworkId(), generatorPrivateKey);
+				invalidBlock.header.sign(processEnv.getChainID(), generatorPrivateKey);
 				await expect(processEnv.process(invalidBlock)).rejects.toThrow(
 					'Failed to verify transaction',
 				);
@@ -198,7 +198,7 @@ describe('Process block', () => {
 				const generatorPrivateKey = getGeneratorPrivateKeyFromDefaultConfig(
 					newBlock.header.generatorAddress,
 				);
-				newBlock.header.sign(processEnv.getNetworkId(), generatorPrivateKey);
+				newBlock.header.sign(processEnv.getChainID(), generatorPrivateKey);
 			});
 
 			it('should discard the block', async () => {
@@ -240,7 +240,7 @@ describe('Process block', () => {
 					'token_getBalance',
 					{
 						address: address.getLisk32AddressFromAddress(account.address),
-						tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+						tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 					},
 				);
 				const voteAmount = BigInt('1000000000');
@@ -263,7 +263,7 @@ describe('Process block', () => {
 				// Assess
 				const balance = await processEnv.invoke<{ availableBalance: string }>('token_getBalance', {
 					address: address.getLisk32AddressFromAddress(account.address),
-					tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+					tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 				});
 				const votes = await processEnv.invoke<{ sentVotes: Record<string, unknown>[] }>(
 					'dpos_getVoter',
@@ -302,7 +302,7 @@ describe('Process block', () => {
 				const generatorPrivateKey = getGeneratorPrivateKeyFromDefaultConfig(
 					newBlock.header.generatorAddress,
 				);
-				invalidBlock.header.sign(processEnv.getNetworkId(), generatorPrivateKey);
+				invalidBlock.header.sign(processEnv.getChainID(), generatorPrivateKey);
 				try {
 					await processEnv.process(invalidBlock);
 				} catch (err) {

--- a/framework/test/integration/node/processor/delete_block.spec.ts
+++ b/framework/test/integration/node/processor/delete_block.spec.ts
@@ -49,7 +49,7 @@ describe('Delete block', () => {
 				databasePath,
 			},
 		});
-		chainID = processEnv.getNetworkId();
+		chainID = processEnv.getChainID();
 	});
 
 	afterAll(() => {
@@ -86,7 +86,7 @@ describe('Delete block', () => {
 					'token_getBalance',
 					{
 						address: genesis.address,
-						tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+						tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 					},
 				);
 				transaction = createTransferTransaction({
@@ -130,7 +130,7 @@ describe('Delete block', () => {
 					'token_getBalance',
 					{
 						address: genesis.address,
-						tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+						tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 					},
 				);
 				expect(afterBalance).toEqual(originalBalance);
@@ -141,7 +141,7 @@ describe('Delete block', () => {
 					'token_getBalance',
 					{
 						address: address.getLisk32AddressFromAddress(recipientAccount.address),
-						tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+						tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 					},
 				);
 				expect(recipientBalance.availableBalance).toEqual('0');
@@ -168,7 +168,7 @@ describe('Delete block', () => {
 					'token_getBalance',
 					{
 						address: genesis.address,
-						tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+						tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 					},
 				);
 				const recipientAccount = nodeUtils.createAccount();
@@ -187,7 +187,7 @@ describe('Delete block', () => {
 					'token_getBalance',
 					{
 						address: genesis.address,
-						tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+						tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 					},
 				);
 				expect(revertedBalance).toEqual(genesisBalance);

--- a/framework/test/integration/node/processor/report_misbehavior_transaction.spec.ts
+++ b/framework/test/integration/node/processor/report_misbehavior_transaction.spec.ts
@@ -37,7 +37,7 @@ describe('Transaction order', () => {
 				databasePath,
 			},
 		});
-		chainID = processEnv.getNetworkId();
+		chainID = processEnv.getChainID();
 		blockGenerator = await processEnv.getNextValidatorKeys(processEnv.getLastBlock().header);
 		// Fund sender account
 		const authData = await processEnv.invoke<{ nonce: string }>('auth_getAuthAccount', {
@@ -75,7 +75,7 @@ describe('Transaction order', () => {
 				'token_getBalance',
 				{
 					address: blockGenerator.address,
-					tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+					tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 				},
 			);
 
@@ -99,7 +99,7 @@ describe('Transaction order', () => {
 			expect(updatedDelegate.pomHeights).toHaveLength(1);
 			const balance = await processEnv.invoke<{ availableBalance: string }>('token_getBalance', {
 				address: blockGenerator.address,
-				tokenID: defaultTokenID(processEnv.getNetworkId()).toString('hex'),
+				tokenID: defaultTokenID(processEnv.getChainID()).toString('hex'),
 			});
 			expect(balance.availableBalance).toEqual(
 				(BigInt(originalBalance.availableBalance) - BigInt(100000000)).toString(),

--- a/framework/test/integration/node/processor/transaction_order.spec.ts
+++ b/framework/test/integration/node/processor/transaction_order.spec.ts
@@ -35,7 +35,7 @@ describe('Transaction order', () => {
 				databasePath,
 			},
 		});
-		chainID = processEnv.getNetworkId();
+		chainID = processEnv.getChainID();
 	});
 
 	afterAll(() => {

--- a/framework/test/integration/node/synchronizer/temp_block.spec.ts
+++ b/framework/test/integration/node/synchronizer/temp_block.spec.ts
@@ -36,7 +36,7 @@ describe('Temp block', () => {
 				databasePath,
 			},
 		});
-		chainID = processEnv.getNetworkId();
+		chainID = processEnv.getChainID();
 		chain = processEnv.getChain();
 	});
 

--- a/framework/test/unit/abi_handler/abi_client.spec.ts
+++ b/framework/test/unit/abi_handler/abi_client.spec.ts
@@ -47,6 +47,7 @@ describe('ABI client', () => {
 				...applicationConfigSchema.default,
 				genesis: { ...applicationConfigSchema.default.genesis, chainID: '00000000' },
 			},
+			chainID: Buffer.from('10000000', 'hex'),
 		});
 
 		client = new ABIClient(fakeLogger, '/path/to/ipc');

--- a/framework/test/unit/abi_handler/abi_handler.spec.ts
+++ b/framework/test/unit/abi_handler/abi_handler.spec.ts
@@ -62,6 +62,7 @@ describe('abi handler', () => {
 				...applicationConfigSchema.default,
 				genesis: { ...applicationConfigSchema.default.genesis, chainID: '10000000' },
 			},
+			chainID: Buffer.from('10000000', 'hex'),
 		});
 		abiHandler['_chainID'] = utils.getRandomBytes(32);
 		await stateMachine.init(loggerMock, {
@@ -88,6 +89,7 @@ describe('abi handler', () => {
 					...applicationConfigSchema.default,
 					genesis: { ...applicationConfigSchema.default.genesis, chainID: '10000000' },
 				},
+				chainID: Buffer.from('10000000', 'hex'),
 			});
 			(stateDBMock.getCurrentState as jest.Mock).mockResolvedValue({ root, version: 21 });
 

--- a/framework/test/unit/abi_handler/abi_server.spec.ts
+++ b/framework/test/unit/abi_handler/abi_server.spec.ts
@@ -47,6 +47,7 @@ describe('ABI server', () => {
 				...applicationConfigSchema.default,
 				genesis: { ...applicationConfigSchema.default.genesis, chainID: '00000000' },
 			},
+			chainID: Buffer.from('10000000', 'hex'),
 		});
 
 		server = new ABIServer(fakeLogger, '/path/to/ipc', abiHandler);

--- a/framework/test/unit/controller/bus.spec.ts
+++ b/framework/test/unit/controller/bus.spec.ts
@@ -35,6 +35,7 @@ jest.mock('zeromq', () => {
 
 describe('Bus', () => {
 	const channelMock: any = {};
+	const chainID = Buffer.from('10000000', 'hex');
 
 	const channelOptions = {
 		type: 'inMemory',
@@ -47,7 +48,10 @@ describe('Bus', () => {
 		debug: jest.fn(),
 	};
 
-	const busConfig = { internalIPCServer: new IPCServer({ socketsDir: '/unit/bus', name: 'bus' }) };
+	const busConfig = {
+		internalIPCServer: new IPCServer({ socketsDir: '/unit/bus', name: 'bus' }),
+		chainID,
+	};
 
 	let bus: Bus;
 

--- a/framework/test/unit/controller/channels/in_memory_channel.spec.ts
+++ b/framework/test/unit/controller/channels/in_memory_channel.spec.ts
@@ -42,6 +42,7 @@ describe('InMemoryChannel Channel', () => {
 	const config: any = {};
 	let inMemoryChannel: InMemoryChannel;
 	const bus: Bus = new Bus(config);
+	const chainID = Buffer.from('10000000', 'hex');
 
 	beforeEach(() => {
 		// Act
@@ -52,6 +53,7 @@ describe('InMemoryChannel Channel', () => {
 			params.namespace,
 			params.events,
 			params.endpoints,
+			chainID,
 		);
 	});
 

--- a/framework/test/unit/controller/channels/ipc_channel.spec.ts
+++ b/framework/test/unit/controller/channels/ipc_channel.spec.ts
@@ -109,6 +109,7 @@ describe.skip('IPCChannel Channel', () => {
 			params.namespace,
 			params.events,
 			params.endpoints,
+			Buffer.from('10000000', 'hex'),
 			params.options,
 		);
 	});

--- a/framework/test/unit/controller/controller.spec.ts
+++ b/framework/test/unit/controller/controller.spec.ts
@@ -83,6 +83,8 @@ describe('Controller Class', () => {
 		dataPath: '/user/.lisk/#LABEL',
 		dirs: systemDirs,
 	};
+	const chainID = Buffer.from('10000000', 'hex');
+
 	const appConfig = {
 		...testing.fixtures.defaultConfig,
 		system: {
@@ -95,6 +97,7 @@ describe('Controller Class', () => {
 	const params = {
 		appConfig,
 		pluginConfigs,
+		chainID,
 	};
 
 	const initParams = {

--- a/framework/test/unit/modules/auth/endpoint.spec.ts
+++ b/framework/test/unit/modules/auth/endpoint.spec.ts
@@ -489,6 +489,19 @@ describe('AuthEndpoint', () => {
 		});
 	});
 
+	describe('getMultiSigRegMsgSchema', () => {
+		it('should return multiSigRegMsgSchema from the endpoint', async () => {
+			// Arrange
+			const context = createTransientModuleEndpointContext({});
+
+			// Act
+			const result = await authEndpoint.getMultiSigRegMsgSchema(context);
+
+			// Assert
+			expect(result.schema).toEqual(multisigRegMsgSchema);
+		});
+	});
+
 	describe('sortMultisignatureGroup', () => {
 		it('should sort signatures when provided mandatory and optional keys', () => {
 			// Arrange

--- a/framework/test/unit/modules/dpos_v2/module.spec.ts
+++ b/framework/test/unit/modules/dpos_v2/module.spec.ts
@@ -77,9 +77,7 @@ describe('DPoS module', () => {
 		});
 
 		it('should initialize config with default value when module config is empty', async () => {
-			await expect(
-				dpos.init({ genesisConfig: {} as any, moduleConfig: {}, generatorConfig: {} }),
-			).toResolve();
+			await expect(dpos.init({ genesisConfig: {} as any, moduleConfig: {} })).toResolve();
 
 			expect(dpos['_moduleConfig']).toEqual({
 				...defaultConfigs,
@@ -93,7 +91,6 @@ describe('DPoS module', () => {
 				dpos.init({
 					genesisConfig: {} as any,
 					moduleConfig: { ...defaultConfigs, maxLengthName: 50 },
-					generatorConfig: {},
 				}),
 			).toResolve();
 
@@ -132,7 +129,6 @@ describe('DPoS module', () => {
 			dpos.addDependencies(randomMethod, validatorMethod, tokenMethod);
 
 			await dpos.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: defaultConfigs,
 			});
@@ -314,7 +310,6 @@ describe('DPoS module', () => {
 		beforeEach(async () => {
 			dpos = new DPoSModule();
 			await dpos.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: defaultConfigs,
 			});
@@ -636,7 +631,6 @@ describe('DPoS module', () => {
 		beforeEach(async () => {
 			dpos = new DPoSModule();
 			await dpos.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: defaultConfigs,
 			});
@@ -845,7 +839,6 @@ describe('DPoS module', () => {
 		beforeEach(async () => {
 			dpos = new DPoSModule();
 			await dpos.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: defaultConfigs,
 			});
@@ -1258,7 +1251,6 @@ describe('DPoS module', () => {
 		beforeEach(async () => {
 			dpos = new DPoSModule();
 			await dpos.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: defaultConfigs,
 			});

--- a/framework/test/unit/modules/fee/fee_module.spec.ts
+++ b/framework/test/unit/modules/fee/fee_module.spec.ts
@@ -22,7 +22,6 @@ describe('FeeModule', () => {
 	let feeModule!: FeeModule;
 	let genesisConfig: any;
 	let moduleConfig: any;
-	let generatorConfig: any;
 
 	beforeEach(async () => {
 		genesisConfig = {
@@ -31,9 +30,8 @@ describe('FeeModule', () => {
 		moduleConfig = {
 			feeTokenID: { chainID: utils.intToBuffer(0, 4), localID: utils.intToBuffer(0, 4) },
 		};
-		generatorConfig = {};
 		feeModule = new FeeModule();
-		await feeModule.init({ genesisConfig, moduleConfig, generatorConfig });
+		await feeModule.init({ genesisConfig, moduleConfig });
 		feeModule.addDependencies({
 			burn: jest.fn(),
 			transfer: jest.fn(),
@@ -45,9 +43,7 @@ describe('FeeModule', () => {
 	describe('init', () => {
 		it('should initialize config with default value when module config is empty', async () => {
 			feeModule = new FeeModule();
-			await expect(
-				feeModule.init({ genesisConfig, moduleConfig: {}, generatorConfig: {} }),
-			).toResolve();
+			await expect(feeModule.init({ genesisConfig, moduleConfig: {} })).toResolve();
 
 			expect(feeModule['_tokenID']).toEqual(Buffer.alloc(8, 0));
 		});

--- a/framework/test/unit/modules/random/random_module.spec.ts
+++ b/framework/test/unit/modules/random/random_module.spec.ts
@@ -77,7 +77,6 @@ describe('RandomModule', () => {
 				randomModule.init({
 					genesisConfig: {} as any,
 					moduleConfig: {},
-					generatorConfig: undefined as any,
 				}),
 			).toResolve();
 
@@ -86,7 +85,6 @@ describe('RandomModule', () => {
 
 		it('should assign config values', async () => {
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: { maxLengthReveals: 20 },
 			});
@@ -156,7 +154,6 @@ describe('RandomModule', () => {
 
 			// Act
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: {},
 			});
@@ -201,7 +198,6 @@ describe('RandomModule', () => {
 
 			// Act
 			await randomModule.init({
-				generatorConfig: { hashOnions: convertDelegateFixture(genesisDelegates.delegates) },
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: {},
 			});
@@ -261,7 +257,6 @@ describe('RandomModule', () => {
 
 			// Act
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: {},
 			});
@@ -307,7 +302,6 @@ describe('RandomModule', () => {
 
 			// Act
 			await randomModule.init({
-				generatorConfig: { hashOnions: convertDelegateFixture(genesisDelegates.delegates) },
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: {},
 			});
@@ -379,7 +373,6 @@ describe('RandomModule', () => {
 
 			// Act
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: {},
 			});
@@ -418,7 +411,6 @@ describe('RandomModule', () => {
 
 			// Act
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as GenesisConfig,
 				moduleConfig: {},
 			});
@@ -441,7 +433,6 @@ describe('RandomModule', () => {
 		let stateStore: PrefixedStateReadWriter;
 		beforeEach(async () => {
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as never,
 				moduleConfig: {
 					maxLengthReveals: 206,
@@ -468,7 +459,6 @@ describe('RandomModule', () => {
 	describe('verifyAssets', () => {
 		beforeEach(async () => {
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as never,
 				moduleConfig: {
 					maxLengthReveals: 206,
@@ -534,7 +524,6 @@ describe('RandomModule', () => {
 
 		beforeEach(async () => {
 			await randomModule.init({
-				generatorConfig: {},
 				genesisConfig: {} as never,
 				moduleConfig: {
 					maxLengthReveals: 6,

--- a/framework/test/unit/modules/reward/endpoint.spec.ts
+++ b/framework/test/unit/modules/reward/endpoint.spec.ts
@@ -28,13 +28,12 @@ describe('RewardModuleEndpoint', () => {
 		],
 		tokenID: '0000000000000000',
 	};
-	const generatorConfig: any = {};
 
 	let rewardModule: RewardModule;
 
 	beforeAll(async () => {
 		rewardModule = new RewardModule();
-		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
+		await rewardModule.init({ genesisConfig, moduleConfig });
 		rewardModule.addDependencies(
 			{ mint: jest.fn() } as any,
 			{ isSeedRevealValid: jest.fn() } as any,

--- a/framework/test/unit/modules/reward/method.spec.ts
+++ b/framework/test/unit/modules/reward/method.spec.ts
@@ -32,7 +32,6 @@ describe('RewardModuleMethod', () => {
 		],
 		tokenID: '0000000000000000',
 	};
-	const generatorConfig: any = {};
 
 	const { offset, distance } = moduleConfig;
 	const brackets = moduleConfig.brackets.map(v => BigInt(v));
@@ -47,7 +46,7 @@ describe('RewardModuleMethod', () => {
 			getAsset: jest.fn(),
 		};
 		rewardModule = new RewardModule();
-		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
+		await rewardModule.init({ genesisConfig, moduleConfig });
 	});
 
 	describe.each(Object.entries(brackets))('test for brackets', (index, rewardFromConfig) => {

--- a/framework/test/unit/modules/reward/reward_module.spec.ts
+++ b/framework/test/unit/modules/reward/reward_module.spec.ts
@@ -35,14 +35,13 @@ describe('RewardModule', () => {
 		],
 		tokenID: '0000000000000000',
 	};
-	const generatorConfig: any = {};
 
 	let rewardModule: RewardModule;
 	let mint: any;
 	beforeEach(async () => {
 		mint = jest.fn();
 		rewardModule = new RewardModule();
-		await rewardModule.init({ genesisConfig, moduleConfig, generatorConfig });
+		await rewardModule.init({ genesisConfig, moduleConfig });
 		rewardModule.addDependencies(
 			{ mint } as any,
 			{ isSeedRevealValid: jest.fn().mockReturnValue(true) } as any,
@@ -52,9 +51,7 @@ describe('RewardModule', () => {
 	describe('init', () => {
 		it('should initialize config with default value when module config is empty', async () => {
 			rewardModule = new RewardModule();
-			await expect(
-				rewardModule.init({ genesisConfig: {} as any, moduleConfig: {}, generatorConfig: {} }),
-			).toResolve();
+			await expect(rewardModule.init({ genesisConfig: {} as any, moduleConfig: {} })).toResolve();
 
 			expect(rewardModule['_moduleConfig']).toEqual({ ...moduleConfig });
 		});
@@ -65,7 +62,6 @@ describe('RewardModule', () => {
 				rewardModule.init({
 					genesisConfig: {} as any,
 					moduleConfig: { offset: 1000 },
-					generatorConfig: {},
 				}),
 			).toResolve();
 
@@ -80,7 +76,6 @@ describe('RewardModule', () => {
 					moduleConfig: {
 						tokenID: '00000000000000000',
 					},
-					generatorConfig: {},
 				});
 			} catch (error: any) {
 				// eslint-disable-next-line jest/no-try-expect

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -97,7 +97,6 @@ describe('token module', () => {
 			genesisConfig: {
 				chainID: '00000001',
 			} as never,
-			generatorConfig: {},
 			moduleConfig: {
 				accountInitializationFee: USER_SUBSTORE_INITIALIZATION_FEE,
 			},

--- a/framework/test/unit/modules/token/token_module.spec.ts
+++ b/framework/test/unit/modules/token/token_module.spec.ts
@@ -34,7 +34,6 @@ describe('token module', () => {
 				tokenModule.init({
 					genesisConfig: { chainID: '00000000' } as any,
 					moduleConfig: {},
-					generatorConfig: {},
 				}),
 			).toResolve();
 		});
@@ -46,7 +45,6 @@ describe('token module', () => {
 					moduleConfig: {
 						supportedTokenID: ['000000020000'],
 					},
-					generatorConfig: {},
 				}),
 			).toResolve();
 		});
@@ -57,7 +55,6 @@ describe('token module', () => {
 			await tokenModule.init({
 				genesisConfig: { chainID: '00000000' } as any,
 				moduleConfig: {},
-				generatorConfig: {},
 			});
 		});
 

--- a/framework/test/unit/modules/validators/method.spec.ts
+++ b/framework/test/unit/modules/validators/method.spec.ts
@@ -58,7 +58,6 @@ describe('ValidatorsModuleMethod', () => {
 	const moduleConfig: any = {
 		blockTime: 10,
 	};
-	const generatorConfig: any = {};
 	const address = utils.getRandomBytes(48);
 	const generatorKey = utils.getRandomBytes(48);
 	const genesisTimestamp = 1610643809;
@@ -72,7 +71,7 @@ describe('ValidatorsModuleMethod', () => {
 	);
 	beforeAll(async () => {
 		validatorsModule = new ValidatorsModule();
-		await validatorsModule.init({ genesisConfig, moduleConfig, generatorConfig });
+		await validatorsModule.init({ genesisConfig, moduleConfig });
 	});
 
 	beforeEach(() => {

--- a/framework/test/unit/modules/validators/module.spec.ts
+++ b/framework/test/unit/modules/validators/module.spec.ts
@@ -31,7 +31,7 @@ describe('ValidatorsModule', () => {
 	describe('init', () => {
 		it('should initialize config with default value when module config is empty', async () => {
 			await expect(
-				validatorsModule.init({ genesisConfig: {} as any, moduleConfig: {}, generatorConfig: {} }),
+				validatorsModule.init({ genesisConfig: {} as any, moduleConfig: {} }),
 			).toResolve();
 
 			expect(validatorsModule['_blockTime']).toEqual(10);
@@ -42,7 +42,6 @@ describe('ValidatorsModule', () => {
 				validatorsModule.init({
 					genesisConfig: {} as any,
 					moduleConfig: { blockTime: 3 },
-					generatorConfig: {},
 				}),
 			).toResolve();
 

--- a/framework/test/unit/state_machine/state_machine.spec.ts
+++ b/framework/test/unit/state_machine/state_machine.spec.ts
@@ -43,7 +43,7 @@ describe('state_machine', () => {
 	const assets = new BlockAssets();
 	let stateStore: PrefixedStateReadWriter;
 	let eventQueue: EventQueue;
-	const chainID = Buffer.from('network identifier', 'utf8');
+	const chainID = Buffer.from('10000000', 'utf8');
 	const transaction = {
 		module: 'customModule0',
 		command: 'customCommand0',
@@ -72,6 +72,7 @@ describe('state_machine', () => {
 				assets,
 				logger,
 				stateStore,
+				chainID,
 			});
 			await stateMachine.executeGenesisBlock(ctx);
 			expect(mod.initGenesisState).toHaveBeenCalledTimes(1);
@@ -83,6 +84,7 @@ describe('state_machine', () => {
 				header: genesisHeader,
 				assets,
 				setNextValidators: expect.any(Function),
+				chainID,
 			});
 		});
 
@@ -94,6 +96,7 @@ describe('state_machine', () => {
 				assets,
 				logger,
 				stateStore,
+				chainID,
 			});
 			await stateMachine.executeGenesisBlock(ctx);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #7728 , #7738, #7739

### How was it solved?

- [Pass `ModuleConfig` to `stateMachine init`](https://github.com/LiskHQ/lisk-sdk/commit/59dae067d39ac5cb1cc87631c9a2bac7e5f76f20)
- [Expose and add endpoint to expose `multisigRegMsgSchema`](https://github.com/LiskHQ/lisk-sdk/commit/f79288bc20805df40372a220c911dfd61116f224)

### How was it tested?

- Run `dpos-mainchain` app and add in the config to test if module config is flowing to the modules or not
```js
{ modules: "fee": {
			"feeTokenID": "0200000000000000"
		}, }
```
- To test the endpoint, call `auth_getMultiSigRegMsgSchema`