### PR TITLE
Update dryRunTransaction response to return errorMessage

### DIFF
--- a/framework/src/abi/abi.ts
+++ b/framework/src/abi/abi.ts
@@ -172,6 +172,7 @@ export interface VerifyTransactionRequest {
 
 export interface VerifyTransactionResponse {
 	result: number;
+	errorMessage: string;
 }
 
 export interface ExecuteTransactionRequest {

--- a/framework/src/abi/schema.ts
+++ b/framework/src/abi/schema.ts
@@ -358,6 +358,10 @@ export const verifyTransactionResponseSchema = {
 			fieldNumber: 1,
 			dataType: 'sint32',
 		},
+		errorMessage: {
+			fieldNumber: 2,
+			dataType: 'string',
+		},
 	},
 };
 

--- a/framework/src/abi_handler/abi_handler.ts
+++ b/framework/src/abi_handler/abi_handler.ts
@@ -392,6 +392,7 @@ export class ABIHandler implements ABI {
 
 		return {
 			result: result.status,
+			errorMessage: result.error?.message ?? '',
 		};
 	}
 

--- a/framework/src/engine/generator/schemas.ts
+++ b/framework/src/engine/generator/schemas.ts
@@ -256,8 +256,9 @@ export interface DryRunTransactionRequest {
 }
 
 export interface DryRunTransactionResponse {
-	success: boolean;
+	result: number;
 	events: EventJSON[];
+	errorMessage?: string;
 }
 
 export const dryRunTransactionRequestSchema = {

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -594,6 +594,7 @@ describe('consensus', () => {
 			});
 			jest.spyOn(abi, 'verifyTransaction').mockResolvedValue({
 				result: TransactionVerifyResult.OK,
+				errorMessage: '',
 			});
 		});
 

--- a/framework/test/unit/engine/endpoint/txpool.spec.ts
+++ b/framework/test/unit/engine/endpoint/txpool.spec.ts
@@ -22,6 +22,7 @@ import { Broadcaster } from '../../../../src/engine/generator/broadcaster';
 import { InvalidTransactionError } from '../../../../src/engine/generator/errors';
 import { fakeLogger } from '../../../utils/mocks';
 import { TxpoolEndpoint } from '../../../../src/engine/endpoint/txpool';
+import { VerifyStatus } from '../../../../src';
 
 describe('generator endpoint', () => {
 	const logger: Logger = fakeLogger;
@@ -234,8 +235,9 @@ describe('generator endpoint', () => {
 						chainID,
 					}),
 				).resolves.toEqual({
-					success: false,
+					result: TransactionVerifyResult.INVALID,
 					events: [],
+					errorMessage: undefined,
 				});
 			});
 		});
@@ -255,7 +257,7 @@ describe('generator endpoint', () => {
 						chainID,
 					}),
 				).resolves.toEqual({
-					success: false,
+					result: TransactionVerifyResult.INVALID,
 					events: eventsJson,
 				});
 			});
@@ -276,7 +278,7 @@ describe('generator endpoint', () => {
 						chainID,
 					}),
 				).resolves.toEqual({
-					success: false,
+					result: TransactionExecutionResult.FAIL,
 					events: eventsJson,
 				});
 			});
@@ -321,7 +323,7 @@ describe('generator endpoint', () => {
 						chainID,
 					}),
 				).resolves.toEqual({
-					success: true,
+					result: VerifyStatus.OK,
 					events: eventsJson,
 				});
 			});

--- a/framework/test/unit/modules/dynamic_rewards/module.spec.ts
+++ b/framework/test/unit/modules/dynamic_rewards/module.spec.ts
@@ -59,7 +59,6 @@ describe('DynamicRewardModule', () => {
 	beforeEach(async () => {
 		rewardModule = new DynamicRewardModule();
 		await rewardModule.init({
-			generatorConfig: {},
 			genesisConfig: { chainID: '00000000' } as any,
 			moduleConfig: {},
 		});
@@ -85,7 +84,6 @@ describe('DynamicRewardModule', () => {
 				rewardModule.init({
 					genesisConfig: { chainID: '00000000' } as any,
 					moduleConfig: {},
-					generatorConfig: {},
 				}),
 			).toResolve();
 
@@ -102,7 +100,6 @@ describe('DynamicRewardModule', () => {
 				rewardModule.init({
 					genesisConfig: { chainID: '00000000' } as any,
 					moduleConfig: { offset: 1000 },
-					generatorConfig: {},
 				}),
 			).toResolve();
 
@@ -117,7 +114,6 @@ describe('DynamicRewardModule', () => {
 					moduleConfig: {
 						tokenID: '00000000000000000',
 					},
-					generatorConfig: {},
 				});
 			} catch (error: any) {
 				// eslint-disable-next-line jest/no-try-expect


### PR DESCRIPTION
### What was the problem?

This PR resolves #7808 

### How was it solved?

- Add errorMessage to the response
- Rename success->result


### How was it tested?

Run a node and then create a transaction and call `txpool_dryRunTransaction` RPC to see the result
