### PR TITLE
Allow multisig update

### DIFF
--- a/framework/src/modules/auth/commands/register_multisignature.ts
+++ b/framework/src/modules/auth/commands/register_multisignature.ts
@@ -183,11 +183,6 @@ export class RegisterMultisignatureCommand extends BaseCommand {
 		const authSubstore = this.stores.get(AuthAccountStore);
 		const senderAccount = await authSubstore.get(context, transaction.senderAddress);
 
-		// Check if multisignatures already exists on account
-		if (senderAccount.numberOfSignatures > 0) {
-			throw new Error('Register multisignature only allowed once per account.');
-		}
-
 		senderAccount.mandatoryKeys = params.mandatoryKeys;
 		senderAccount.optionalKeys = params.optionalKeys;
 		senderAccount.numberOfSignatures = params.numberOfSignatures;

--- a/framework/test/unit/modules/auth/register_multisignature.spec.ts
+++ b/framework/test/unit/modules/auth/register_multisignature.spec.ts
@@ -513,29 +513,5 @@ describe('Register Multisignature command', () => {
 				},
 			);
 		});
-
-		it('should throw error when account is already multisignature', async () => {
-			await authStore.set(
-				{
-					getStore: (storePrefix: Buffer, substorePrefix: Buffer) =>
-						stateStore.getStore(storePrefix, substorePrefix),
-				},
-				transaction.senderAddress,
-				{ ...decodedParams, nonce: BigInt(0) },
-			);
-			const context = testing
-				.createTransactionContext({
-					stateStore,
-					transaction,
-					chainID,
-				})
-				.createCommandExecuteContext<RegisterMultisignatureParams>(
-					registerMultisignatureParamsSchema,
-				);
-
-			await expect(registerMultisignatureCommand.execute(context)).rejects.toThrow(
-				'Register multisignature only allowed once per account.',
-			);
-		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #7837

### How was it solved?

Removed the logic which checks if account is already multisig.

### How was it tested?

Removed the test case which fails when register multisig command is used on a multisig account.
