### PR TITLE
Add `punishmentPeriod` property to all PoS endpoints that return validator account

### DIFF
--- a/framework/src/modules/pos/schemas.ts
+++ b/framework/src/modules/pos/schemas.ts
@@ -423,6 +423,7 @@ const validatorJSONSchema = {
 		'lastGeneratedHeight',
 		'isBanned',
 		'pomHeights',
+		'punishmentPeriods',
 		'consecutiveMissedBlocks',
 	],
 	properties: {
@@ -451,6 +452,23 @@ const validatorJSONSchema = {
 		pomHeights: {
 			type: 'array',
 			items: { type: 'integer', format: 'uint32' },
+		},
+		punishmentPeriods: {
+			type: 'array',
+			items: {
+				type: 'object',
+				required: ['start', 'end'],
+				properties: {
+					start: {
+						type: 'integer',
+						format: 'uint32',
+					},
+					end: {
+						type: 'integer',
+						format: 'uint32',
+					},
+				},
+			},
 		},
 		consecutiveMissedBlocks: {
 			type: 'integer',

--- a/framework/src/modules/pos/stores/validator.ts
+++ b/framework/src/modules/pos/stores/validator.ts
@@ -31,6 +31,15 @@ export interface ValidatorAccount {
 
 export type ValidatorAccountJSON = JSONObject<ValidatorAccount>;
 
+export type punishmentPeriod = {
+	start: number;
+	end: number;
+};
+
+export type ValidatorAccountEndpoint = JSONObject<ValidatorAccount> & { address: string } & {
+	punishmentPeriods: punishmentPeriod[];
+};
+
 export const validatorStoreSchema = {
 	$id: '/pos/validator',
 	type: 'object',

--- a/framework/src/modules/pos/types.ts
+++ b/framework/src/modules/pos/types.ts
@@ -291,10 +291,6 @@ export interface GetValidatorsByStakeRequest {
 	limit?: number;
 }
 
-export interface GetValidatorsByStakeResponse {
-	validators: (ValidatorAccountJSON & { address: string })[];
-}
-
 export interface GetLockedRewardRequest {
 	address: string;
 	tokenID: string;

--- a/framework/test/unit/modules/pos/endpoint.spec.ts
+++ b/framework/test/unit/modules/pos/endpoint.spec.ts
@@ -201,6 +201,7 @@ describe('PosModuleEndpoint', () => {
 							coefficient: validatorCoefficient2.toString('hex'),
 						},
 					],
+					punishmentPeriods: posEndpoint['_calculatePunishmentPeriods'](validatorData.pomHeights),
 				};
 
 				expect(validatorDataReturned).toStrictEqual(validatorDataJSON);
@@ -503,6 +504,7 @@ describe('PosModuleEndpoint', () => {
 					tokenID: co.tokenID.toString('hex'),
 					coefficient: co.coefficient.toString('hex'),
 				})),
+				punishmentPeriods: posEndpoint['_calculatePunishmentPeriods'](validatorData.pomHeights),
 			});
 		});
 
@@ -521,6 +523,7 @@ describe('PosModuleEndpoint', () => {
 					tokenID: co.tokenID.toString('hex'),
 					coefficient: co.coefficient.toString('hex'),
 				})),
+				punishmentPeriods: posEndpoint['_calculatePunishmentPeriods'](validatorData.pomHeights),
 			});
 			expect(resp.validators[1]).toEqual({
 				...validatorData,
@@ -532,6 +535,7 @@ describe('PosModuleEndpoint', () => {
 					tokenID: co.tokenID.toString('hex'),
 					coefficient: co.coefficient.toString('hex'),
 				})),
+				punishmentPeriods: posEndpoint['_calculatePunishmentPeriods'](validatorData.pomHeights),
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #7807

### How was it solved?

- Introduced `punishmentPeriod` property with start and end punishment block heights to all 3 PoS endpoints that return validator account: `pos_getValidator`, `pos_getAllValidators` and `pos_getValidatorsByStake`
- Introduced `ValidatorAccountEndpoint` to simplify the return type.

### How was it tested?

Added `punishmentPeriod` property to all the unit tests which test those 3 endpoints.