### PR TITLE
Use max CCU size to collect CCM

### DIFF
--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
@@ -11,6 +11,9 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+
+import { MAX_CCM_SIZE } from 'lisk-sdk';
+
 // LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#liveness-condition
 export const CCU_FREQUENCY = 864000; // Approximately 10 days which is 33% of 1 month liveness condition
 export const EMPTY_BYTES = Buffer.alloc(0);
@@ -27,3 +30,13 @@ export const DB_KEY_CROSS_CHAIN_MESSAGES = Buffer.from([1]);
 export const DB_KEY_BLOCK_HEADERS = Buffer.from([2]);
 export const DB_KEY_AGGREGATE_COMMITS = Buffer.from([3]);
 export const DB_KEY_VALIDATORS_HASH_PREIMAGE = Buffer.from([4]);
+
+/**
+ * It’s not really MAX_CCU_SIZE, coz CCU includes other properties
+ * It’s more max size of a CCM to be included in a mainchain block
+ * MAX_CCM_SIZE
+
+ * Max size of total CCM which can be included in a CCU
+ * CCU_TOTAL_CCM_SIZE
+ */
+export const CCU_TOTAL_CCM_SIZE = MAX_CCM_SIZE;

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -58,6 +58,7 @@ export {
 	TokenModule,
 	TransferCommand,
 	genesisTokenStoreSchema as tokenGenesisStoreSchema,
+	CROSS_CHAIN_COMMAND_NAME_TRANSFER,
 } from './modules/token';
 export {
 	PoSMethod,
@@ -94,6 +95,9 @@ export {
 	OutboxRootWitness,
 	LIVENESS_LIMIT,
 	MESSAGE_TAG_CERTIFICATE,
+	MODULE_NAME_INTEROPERABILITY,
+	MAX_CCM_SIZE,
+	EMPTY_BYTES,
 	ChainStatus,
 	ccmSchema,
 	OwnChainAccount,

--- a/framework/src/modules/interoperability/index.ts
+++ b/framework/src/modules/interoperability/index.ts
@@ -38,6 +38,12 @@ export {
 	OwnChainAccountJSON,
 } from './types';
 // Common
-export { LIVENESS_LIMIT, MESSAGE_TAG_CERTIFICATE } from './constants';
+export {
+	LIVENESS_LIMIT,
+	MESSAGE_TAG_CERTIFICATE,
+	MODULE_NAME_INTEROPERABILITY,
+	MAX_CCM_SIZE,
+	EMPTY_BYTES,
+} from './constants';
 export { ChainStatus } from './stores/chain_account';
 export { ccmSchema } from './schemas';

--- a/framework/src/modules/token/index.ts
+++ b/framework/src/modules/token/index.ts
@@ -16,3 +16,4 @@ export { TokenModule } from './module';
 export { TransferCommand } from './commands/transfer';
 export { TokenMethod } from './method';
 export { genesisTokenStoreSchema } from './schemas';
+export { CROSS_CHAIN_COMMAND_NAME_TRANSFER } from './constants';


### PR DESCRIPTION
### What was the problem?

This PR resolves #7458

### How was it solved?

Cross chain messages are now grouped into a collection < MAX_CCM_SIZE, each group could be used to create a CCU

### How was it tested?
Test cases added
