### PR TITLE
Fix `isValidSignature()` endpoint response

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -67,6 +67,11 @@ export class AuthEndpoint extends BaseEndpoint {
 		}
 	}
 
+	/**
+	 * Validates signatures of the provided transaction, including transactions from multisignature accounts.
+	 *
+	 * https://github.com/LiskHQ/lips/blob/main/proposals/lip-0041.md#isvalidsignature
+	 */
 	public async isValidSignature(context: ModuleEndpointContext): Promise<VerifyEndpointResultJSON> {
 		const {
 			params: { transaction: transactionParameter },
@@ -86,13 +91,13 @@ export class AuthEndpoint extends BaseEndpoint {
 			accountAddress,
 		);
 
-		return verifySignatures(
-			transaction,
-			transactionBytes,
-			chainID,
-			account,
-			isMultisignatureAccount,
-		);
+		try {
+			verifySignatures(transaction, transactionBytes, chainID, account, isMultisignatureAccount);
+		} catch (error) {
+			return { verified: false };
+		}
+
+		return { verified: true };
 	}
 
 	public async isValidNonce(context: ModuleEndpointContext): Promise<VerifyEndpointResultJSON> {

--- a/framework/src/modules/auth/utils.ts
+++ b/framework/src/modules/auth/utils.ts
@@ -197,7 +197,6 @@ export const verifySignatures = (
 	} else {
 		verifySingleSignatureTransaction(TAG_TRANSACTION, transaction, transactionBytes, chainID);
 	}
-	return { verified: true };
 };
 
 export const verifyNonceStrict = (


### PR DESCRIPTION
### What was the problem?

This PR resolves #7880

### How was it solved?

* `verifySignatures()` no longer returns any value
* `isValidSignature()` catches and handles an exception that is propagated from `verifyMessageSig()` to `verifySignatures()`

### How was it tested?

Added missing unit test for scenario when signature is invalid.