### PR TITLE
Consistently retrieve `AuthAccount` from the store

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -48,23 +48,14 @@ export class AuthEndpoint extends BaseEndpoint {
 
 		const accountAddress = cryptoAddress.getAddressFromLisk32Address(address);
 		const store = this.stores.get(AuthAccountStore);
+		const authAccount = await store.getOrDefault(context, accountAddress);
 
-		try {
-			const authAccount = await store.get(context, accountAddress);
-
-			return {
-				nonce: authAccount.nonce.toString(),
-				numberOfSignatures: authAccount.numberOfSignatures,
-				mandatoryKeys: authAccount.mandatoryKeys.map(key => key.toString('hex')),
-				optionalKeys: authAccount.optionalKeys.map(key => key.toString('hex')),
-			};
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
-
-			return { nonce: '0', numberOfSignatures: 0, mandatoryKeys: [], optionalKeys: [] };
-		}
+		return {
+			nonce: authAccount.nonce.toString(),
+			numberOfSignatures: authAccount.numberOfSignatures,
+			mandatoryKeys: authAccount.mandatoryKeys.map(key => key.toString('hex')),
+			optionalKeys: authAccount.optionalKeys.map(key => key.toString('hex')),
+		};
 	}
 
 	/**

--- a/framework/src/modules/auth/method.ts
+++ b/framework/src/modules/auth/method.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { NotFoundError } from '@liskhq/lisk-chain';
 import { BaseMethod } from '../base_method';
 import { ImmutableMethodContext } from '../../state_machine';
 import { AuthAccount, AuthAccountStore } from './stores/auth_account';
@@ -22,17 +21,8 @@ export class AuthMethod extends BaseMethod {
 		methodContext: ImmutableMethodContext,
 		address: Buffer,
 	): Promise<AuthAccount> {
-		const authDataStore = this.stores.get(AuthAccountStore);
-		try {
-			const authData = await authDataStore.get(methodContext, address);
+		const authAccountStore = this.stores.get(AuthAccountStore);
 
-			return authData;
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
-
-			return { nonce: BigInt(0), numberOfSignatures: 0, mandatoryKeys: [], optionalKeys: [] };
-		}
+		return authAccountStore.getOrDefault(methodContext, address);
 	}
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves #7885

### How was it solved?

Updated the following 2 methods to retrieve `AuthAccount` using `AuthAccountStore.getOrDefault()`:

* `AuthModule.verifyTransaction()`
* `AuthMethod.getAuthAccount()`

### How was it tested?

All tests OK