### PR TITLE
Fix `isValidNonce()` endpoint response and remove `verifyNonceStrict()`

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -26,7 +26,7 @@ import {
 	KeySignaturePair,
 	SortedMultisignatureGroup,
 } from './types';
-import { getTransactionFromParameter, verifyNonceStrict, verifySignatures } from './utils';
+import { getTransactionFromParameter, verifyNonce, verifySignatures } from './utils';
 import { AuthAccountStore } from './stores/auth_account';
 import { NamedRegistry } from '../named_registry';
 import { multisigRegMsgSchema, sortMultisignatureGroupSchema } from './schemas';
@@ -102,7 +102,7 @@ export class AuthEndpoint extends BaseEndpoint {
 		const store = this.stores.get(AuthAccountStore);
 		const account = await store.get(context, accountAddress);
 
-		const verificationResult = verifyNonceStrict(transaction, account).status;
+		const verificationResult = verifyNonce(transaction, account).status;
 		return { verified: verificationResult === VerifyStatus.OK };
 	}
 

--- a/framework/src/modules/auth/utils.ts
+++ b/framework/src/modules/auth/utils.ts
@@ -17,7 +17,6 @@ import { codec, Schema } from '@liskhq/lisk-codec';
 import { ed } from '@liskhq/lisk-cryptography';
 import { isHexString } from '@liskhq/lisk-validator';
 import { VerificationResult, VerifyStatus } from '../../state_machine';
-import { InvalidNonceError } from './errors';
 import { Keys } from './types';
 import { AuthAccount } from './stores/auth_account';
 
@@ -199,35 +198,13 @@ export const verifySignatures = (
 	}
 };
 
-export const verifyNonceStrict = (
-	transaction: Transaction,
-	senderAccount: AuthAccount,
-): VerificationResult => {
-	if (transaction.nonce !== senderAccount.nonce) {
-		throw new InvalidNonceError(
-			`Transaction with id:${transaction.id.toString('hex')} nonce is not equal to account nonce.`,
-			transaction.nonce,
-			senderAccount.nonce,
-		);
-	}
-
-	return {
-		status: VerifyStatus.OK,
-	};
-};
-
 export const verifyNonce = (
 	transaction: Transaction,
 	senderAccount: AuthAccount,
 ): VerificationResult => {
 	if (transaction.nonce < senderAccount.nonce) {
-		throw new InvalidNonceError(
-			`Transaction with id:${transaction.id.toString('hex')} nonce is lower than account nonce.`,
-			transaction.nonce,
-			senderAccount.nonce,
-		);
+		return { status: VerifyStatus.FAIL };
 	}
-
 	return {
 		status: transaction.nonce > senderAccount.nonce ? VerifyStatus.PENDING : VerifyStatus.OK,
 	};

--- a/framework/test/unit/modules/auth/endpoint.spec.ts
+++ b/framework/test/unit/modules/auth/endpoint.spec.ts
@@ -9,7 +9,6 @@ import {
 	MESSAGE_TAG_MULTISIG_REG,
 } from '../../../../src/modules/auth/constants';
 import { AuthEndpoint } from '../../../../src/modules/auth/endpoint';
-import { InvalidNonceError } from '../../../../src/modules/auth/errors';
 import {
 	multisigRegMsgSchema,
 	registerMultisignatureParamsSchema,
@@ -436,8 +435,6 @@ describe('AuthEndpoint', () => {
 
 		it('should fail to verify greater transaction nonce than account nonce', async () => {
 			// Arrange
-			const accountNonce = BigInt(2);
-
 			const transaction = new Transaction({
 				module: 'token',
 				command: 'transfer',
@@ -465,22 +462,15 @@ describe('AuthEndpoint', () => {
 					numberOfSignatures: 0,
 				});
 
+			// Act
+			const isValidNonceResponse = (await authEndpoint.isValidNonce(context)).verified;
+
 			// Assert
-			return expect(authEndpoint.isValidNonce(context)).rejects.toThrow(
-				new InvalidNonceError(
-					`Transaction with id:${transaction.id.toString(
-						'hex',
-					)} nonce is not equal to account nonce.`,
-					transaction.nonce,
-					accountNonce,
-				),
-			);
+			expect(isValidNonceResponse).toBeFalse();
 		});
 
 		it('should fail to verify lower transaction nonce than account nonce', async () => {
 			// Arrange
-			const accountNonce = BigInt(2);
-
 			const transaction = new Transaction({
 				module: 'token',
 				command: 'transfer',
@@ -504,20 +494,15 @@ describe('AuthEndpoint', () => {
 				.mockReturnValue({
 					mandatoryKeys: [],
 					optionalKeys: [],
-					nonce: accountNonce,
+					nonce: BigInt(2),
 					numberOfSignatures: 0,
 				});
 
+			// Act
+			const isValidNonceResponse = (await authEndpoint.isValidNonce(context)).verified;
+
 			// Assert
-			return expect(authEndpoint.isValidNonce(context)).rejects.toThrow(
-				new InvalidNonceError(
-					`Transaction with id:${transaction.id.toString(
-						'hex',
-					)} nonce is not equal to account nonce.`,
-					transaction.nonce,
-					accountNonce,
-				),
-			);
+			expect(isValidNonceResponse).toBeFalse();
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #7891

### How was it solved?

* removed `verifyNonceStrict()` and replaced its usage with `verifyNonce()`
* `verifyNonce()` no longer throws `InvalidNonceError` if nonce is invalid, but returns `VerifyStatus.FAIL`
* `verifyTransaction()` hook now throws `InvalidNonceError`
* updated endpoint unit tests to expect false instead of expecting a throw

### How was it tested?

All tests OK 👌🏻 
