### PR TITLE
Move multi-signature account check to `AuthAccountStore`

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -97,8 +97,8 @@ export class AuthEndpoint extends BaseEndpoint {
 		const transaction = getTransactionFromParameter(transactionParameter);
 		const accountAddress = cryptoAddress.getAddressFromPublicKey(transaction.senderPublicKey);
 
-		const store = this.stores.get(AuthAccountStore);
-		const account = await store.get(context, accountAddress);
+		const authAccountStore = this.stores.get(AuthAccountStore);
+		const account = await authAccountStore.get(context, accountAddress);
 
 		const verificationResult = verifyNonce(transaction, account).status;
 		return { verified: verificationResult === VerifyStatus.OK };

--- a/framework/src/modules/auth/module.ts
+++ b/framework/src/modules/auth/module.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { NotFoundError } from '@liskhq/lisk-chain';
 import { objects as objectUtils } from '@liskhq/lisk-utils';
 import { codec } from '@liskhq/lisk-codec';
 import { validator } from '@liskhq/lisk-validator';
@@ -28,7 +27,7 @@ import { AuthMethod } from './method';
 import { MAX_NUMBER_OF_SIGNATURES } from './constants';
 import { AuthEndpoint } from './endpoint';
 import { configSchema, genesisAuthStoreSchema } from './schemas';
-import { GenesisAuthStore, ImmutableStoreCallback } from './types';
+import { GenesisAuthStore } from './types';
 import { verifyNonce, verifySignatures } from './utils';
 import { authAccountSchema, AuthAccountStore } from './stores/auth_account';
 import { MultisignatureRegistrationEvent } from './events/multisignature_registration';
@@ -159,8 +158,8 @@ export class AuthModule extends BaseModule {
 			);
 		}
 
-		const isMultisignatureAccount = await this._isMultisignatureAccount(
-			context.getStore,
+		const isMultisignatureAccount = await authAccountStore.isMultisignatureAccount(
+			context,
 			transaction.senderAddress,
 		);
 		verifySignatures(
@@ -186,22 +185,5 @@ export class AuthModule extends BaseModule {
 			mandatoryKeys: senderAccount.mandatoryKeys,
 			optionalKeys: senderAccount.optionalKeys,
 		});
-	}
-
-	private async _isMultisignatureAccount(
-		getStore: ImmutableStoreCallback,
-		address: Buffer,
-	): Promise<boolean> {
-		const authSubstore = this.stores.get(AuthAccountStore);
-		try {
-			const authAccount = await authSubstore.get({ getStore }, address);
-
-			return authAccount.numberOfSignatures !== 0;
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
-			return false;
-		}
 	}
 }

--- a/framework/src/modules/auth/stores/auth_account.ts
+++ b/framework/src/modules/auth/stores/auth_account.ts
@@ -82,4 +82,20 @@ export class AuthAccountStore extends BaseStore<AuthAccount> {
 			};
 		}
 	}
+
+	public async isMultisignatureAccount(
+		context: ImmutableStoreGetter,
+		address: Buffer,
+	): Promise<boolean> {
+		try {
+			const authAccount = await this.get(context, address);
+
+			return authAccount.numberOfSignatures !== 0;
+		} catch (error) {
+			if (!(error instanceof NotFoundError)) {
+				throw error;
+			}
+			return false;
+		}
+	}
 }

--- a/framework/test/unit/modules/auth/stores/auth_account.spec.ts
+++ b/framework/test/unit/modules/auth/stores/auth_account.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { utils } from '@liskhq/lisk-cryptography';
+import { StoreGetter } from '../../../../../src';
+import { AuthAccount, AuthAccountStore } from '../../../../../src/modules/auth/stores/auth_account';
+import { PrefixedStateReadWriter } from '../../../../../src/state_machine/prefixed_state_read_writer';
+import { InMemoryPrefixedStateDB } from '../../../../../src/testing/in_memory_prefixed_state';
+import { createStoreGetter } from '../../../../../src/testing/utils';
+
+describe('AuthAccountStore', () => {
+	const address = utils.getRandomBytes(20);
+	const authAccount: AuthAccount = {
+		nonce: BigInt(3),
+		numberOfSignatures: 2,
+		mandatoryKeys: [utils.getRandomBytes(64)],
+		optionalKeys: [utils.getRandomBytes(64), utils.getRandomBytes(64)],
+	};
+
+	let authAccountStore: AuthAccountStore;
+	let context: StoreGetter;
+
+	beforeEach(async () => {
+		authAccountStore = new AuthAccountStore('auth');
+		const db = new InMemoryPrefixedStateDB();
+		const stateStore = new PrefixedStateReadWriter(db);
+		context = createStoreGetter(stateStore);
+		await authAccountStore.set(context, address, authAccount);
+	});
+
+	describe('getOrDefault', () => {
+		it('should return existing account from the store', async () => {
+			const account = await authAccountStore.getOrDefault(context, address);
+
+			expect(account).toEqual<AuthAccount>(authAccount);
+		});
+
+		it('should return a new account for an address not previously registered in the store', async () => {
+			const newAccount: AuthAccount = {
+				nonce: BigInt(0),
+				numberOfSignatures: 0,
+				mandatoryKeys: [],
+				optionalKeys: [],
+			};
+
+			const account = await authAccountStore.getOrDefault(context, utils.getRandomBytes(20));
+
+			expect(account).toEqual<AuthAccount>(newAccount);
+		});
+	});
+
+	describe('isMultisignatureAccount', () => {
+		it('should return true for a multi-sig account', async () => {
+			const isMultiSig = await authAccountStore.isMultisignatureAccount(context, address);
+
+			expect(isMultiSig).toBe(true);
+		});
+
+		it('should return false for a non registered single-sig account', async () => {
+			const isMultiSig = await authAccountStore.isMultisignatureAccount(
+				context,
+				utils.getRandomBytes(20),
+			);
+
+			expect(isMultiSig).toBe(false);
+		});
+
+		it('should return false for a registered single-sig account', async () => {
+			const singleSigAddress = utils.getRandomBytes(20);
+			const singleSigAccount: AuthAccount = {
+				nonce: BigInt(2),
+				numberOfSignatures: 0,
+				mandatoryKeys: [],
+				optionalKeys: [],
+			};
+
+			await authAccountStore.set(context, singleSigAddress, singleSigAccount);
+
+			const isMultiSig = await authAccountStore.isMultisignatureAccount(context, singleSigAddress);
+
+			expect(isMultiSig).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #7893

### How was it solved?

* Removed duplicated private method `_isMultisignatureAccount()` from `AuthModule` and `AuthEndpoint`
* Added public method `isMultisignatureAccount()` to `AuthAccountStore`

### How was it tested?

All existing tests passed 👌🏻 
