### PR TITLE
Refactor chainConnector db to be a class with setters/getters

### DIFF
--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/chain_connector_plugin.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/chain_connector_plugin.ts
@@ -361,8 +361,8 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 			const { modules } = await this._sidechainAPIClient.invoke<{ modules: ModuleMetadata }>(
 				'system_getMetadata',
 			);
-			const interoperabilityMetadata = modules.find(m => m.name === MODULE_NAME_INTEROPERABILITY);
-			const store = interoperabilityMetadata?.stores.find(
+			const interopModuleMetadata = modules.find(m => m.name === MODULE_NAME_INTEROPERABILITY);
+			const store = interopModuleMetadata?.stores.find(
 				s => s.data.$id === '/modules/interoperability/outbox',
 			);
 
@@ -397,18 +397,15 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 		const validatorsDataIndex = validatorsHashPreimage.findIndex(v =>
 			v.validatorsHash.equals(bftParameters?.validatorsHash),
 		);
+		const validatorsHashPreimageData = {
+			certificateThreshold: bftParameters?.certificateThreshold,
+			validators: bftParameters?.validators,
+			validatorsHash: bftParameters?.validatorsHash,
+		};
 		if (validatorsDataIndex > -1) {
-			validatorsHashPreimage[validatorsDataIndex] = {
-				certificateThreshold: bftParameters?.certificateThreshold,
-				validators: bftParameters?.validators,
-				validatorsHash: bftParameters?.validatorsHash,
-			};
+			validatorsHashPreimage[validatorsDataIndex] = validatorsHashPreimageData;
 		} else {
-			validatorsHashPreimage.push({
-				certificateThreshold: bftParameters?.certificateThreshold,
-				validators: bftParameters?.validators,
-				validatorsHash: bftParameters?.validatorsHash,
-			});
+			validatorsHashPreimage.push(validatorsHashPreimageData);
 		}
 
 		if (newBlockHeader.aggregateCommit) {
@@ -441,7 +438,6 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 		aggregateCommit: AggregateCommit,
 	): Promise<Certificate> {
 		const blockHeaders = await this._sidechainChainConnectorStore.getBlockHeaders();
-		// console.log(blockHeaders, aggregateCommit.height)
 		const blockHeader = blockHeaders.find(header => header.height === aggregateCommit.height);
 
 		if (!blockHeader) {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
@@ -11,11 +11,16 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-
-export const CCM_BASED_CCU_FREQUENCY = 10;
 export const LIVENESS_BASED_CCU_FREQUENCY = 864000; // Approximately 10 days which is 33% of 1 month liveness condition
 export const EMPTY_BYTES = Buffer.alloc(0);
 export const MODULE_NAME_INTEROPERABILITY = 'interoperability';
 export const CROSS_CHAIN_COMMAND_NAME_TRANSFER = 'crossChainTransfer';
 export const CCM_SEND_SUCCESS = 'ccmSendSuccess';
-export const DB_KEY_CROSS_CHAIN_MESSAGES = Buffer.from([0]);
+
+export const DB_KEY_MAINCHAIN = Buffer.from([0]);
+export const DB_KEY_SIDECHAIN = Buffer.from([1]);
+
+export const DB_KEY_CROSS_CHAIN_MESSAGES = Buffer.from([1]);
+export const DB_KEY_BLOCK_HEADERS = Buffer.from([2]);
+export const DB_KEY_AGGREGATE_COMMITS = Buffer.from([3]);
+export const DB_KEY_VALIDATORS_PREIMAGE = Buffer.from([4]);

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
@@ -11,11 +11,14 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+// LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#liveness-condition
 export const CCU_FREQUENCY = 864000; // Approximately 10 days which is 33% of 1 month liveness condition
 export const EMPTY_BYTES = Buffer.alloc(0);
 export const MODULE_NAME_INTEROPERABILITY = 'interoperability';
 export const CROSS_CHAIN_COMMAND_NAME_TRANSFER = 'crossChainTransfer';
 export const CCM_SEND_SUCCESS = 'ccmSendSuccess';
+export const ADDRESS_LENGTH = 20;
+export const BLS_PUBLIC_KEY_LENGTH = 48;
 
 export const DB_KEY_MAINCHAIN = Buffer.from([0]);
 export const DB_KEY_SIDECHAIN = Buffer.from([1]);

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
@@ -11,7 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-export const LIVENESS_BASED_CCU_FREQUENCY = 864000; // Approximately 10 days which is 33% of 1 month liveness condition
+export const CCU_FREQUENCY = 864000; // Approximately 10 days which is 33% of 1 month liveness condition
 export const EMPTY_BYTES = Buffer.alloc(0);
 export const MODULE_NAME_INTEROPERABILITY = 'interoperability';
 export const CROSS_CHAIN_COMMAND_NAME_TRANSFER = 'crossChainTransfer';
@@ -23,4 +23,4 @@ export const DB_KEY_SIDECHAIN = Buffer.from([1]);
 export const DB_KEY_CROSS_CHAIN_MESSAGES = Buffer.from([1]);
 export const DB_KEY_BLOCK_HEADERS = Buffer.from([2]);
 export const DB_KEY_AGGREGATE_COMMITS = Buffer.from([3]);
-export const DB_KEY_VALIDATORS_PREIMAGE = Buffer.from([4]);
+export const DB_KEY_VALIDATORS_HASH_PREIMAGE = Buffer.from([4]);

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/db.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/db.ts
@@ -82,21 +82,19 @@ export class ChainConnectorStore {
 	}
 
 	public async getBlockHeaders(): Promise<BlockHeader[]> {
+		let blockHeaders: BlockHeader[] = [];
 		try {
 			const encodedInfo = await this._db.get(this._blockHeadersDBKey);
-
-			return codec.decode<BlockHeadersInfo>(blockHeadersInfoSchema, encodedInfo).blockHeaders;
+			blockHeaders = codec.decode<BlockHeadersInfo>(
+				blockHeadersInfoSchema,
+				encodedInfo,
+			).blockHeaders;
 		} catch (error) {
 			if (!(error instanceof liskDB.NotFoundError)) {
 				throw error;
 			}
-
-			// Set initial value
-			const encodedInitialData = codec.encode(blockHeadersInfoSchema, { blockHeaders: [] });
-			await this._db.set(this._blockHeadersDBKey, encodedInitialData);
-
-			return [];
 		}
+		return blockHeaders;
 	}
 
 	public async setBlockHeaders(blockHeaders: BlockHeader[]) {
@@ -106,21 +104,19 @@ export class ChainConnectorStore {
 	}
 
 	public async getAggregateCommits(): Promise<AggregateCommit[]> {
+		let aggregateCommits: AggregateCommit[] = [];
 		try {
 			const encodedInfo = await this._db.get(this._aggregateCommitsDBKey);
-
-			return codec.decode<AggregateCommitsInfo>(aggregateCommitsInfoSchema, encodedInfo)
-				.aggregateCommits;
+			aggregateCommits = codec.decode<AggregateCommitsInfo>(
+				aggregateCommitsInfoSchema,
+				encodedInfo,
+			).aggregateCommits;
 		} catch (error) {
 			if (!(error instanceof liskDB.NotFoundError)) {
 				throw error;
 			}
-			// Set initial value
-			const encodedInitialData = codec.encode(aggregateCommitsInfoSchema, { aggregateCommits: [] });
-			await this._db.set(this._aggregateCommitsDBKey, encodedInitialData);
-
-			return [];
 		}
+		return aggregateCommits;
 	}
 
 	public async setAggregateCommits(aggregateCommits: AggregateCommit[]) {
@@ -129,23 +125,19 @@ export class ChainConnectorStore {
 	}
 
 	public async getValidatorsHashPreimage(): Promise<ValidatorsData[]> {
+		let validatorsHashPreimage: ValidatorsData[] = [];
 		try {
 			const encodedInfo = await this._db.get(this._validatorsHashPreimageDBKey);
-
-			return codec.decode<ValidatorsHashPreimage>(validatorsHashPreimageInfoSchema, encodedInfo)
-				.validatorsHashPreimage;
+			validatorsHashPreimage = codec.decode<ValidatorsHashPreimage>(
+				validatorsHashPreimageInfoSchema,
+				encodedInfo,
+			).validatorsHashPreimage;
 		} catch (error) {
 			if (!(error instanceof liskDB.NotFoundError)) {
 				throw error;
 			}
-			// Set initial value
-			const encodedInitialData = codec.encode(validatorsHashPreimageInfoSchema, {
-				validatorsHashPreimage: [],
-			});
-			await this._db.set(this._validatorsHashPreimageDBKey, encodedInitialData);
-
-			return [];
 		}
+		return validatorsHashPreimage;
 	}
 
 	public async setValidatorsHashPreimage(validatorsHashInput: ValidatorsData[]) {
@@ -156,19 +148,19 @@ export class ChainConnectorStore {
 	}
 
 	public async getCrossChainMessages(): Promise<CrossChainMessagesFromEvents[]> {
+		let crossChainMessages: CrossChainMessagesFromEvents[] = [];
 		try {
 			const encodedInfo = await this._db.get(this._crossChainMessagesDBKey);
-			return codec.decode<CrossChainMessagesInfo>(ccmsFromEventsSchema, encodedInfo).ccmsFromEvents;
+			crossChainMessages = codec.decode<CrossChainMessagesInfo>(
+				ccmsFromEventsSchema,
+				encodedInfo,
+			).ccmsFromEvents;
 		} catch (error) {
 			if (!(error instanceof liskDB.NotFoundError)) {
 				throw error;
 			}
-			// Set initial value
-			const encodedInitialData = codec.encode(ccmsFromEventsSchema, { ccmsFromEvents: [] });
-			await this._db.set(this._crossChainMessagesDBKey, encodedInitialData);
-
-			return [];
 		}
+		return crossChainMessages;
 	}
 
 	public async setCrossChainMessages(ccms: CrossChainMessagesFromEvents[]) {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/db.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/db.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { codec, db as liskDB, AggregateCommit, chain } from 'lisk-sdk';
+import { codec, db as liskDB, AggregateCommit } from 'lisk-sdk';
 import * as os from 'os';
 import { join } from 'path';
 import { ensureDir } from 'fs-extra';
@@ -28,7 +28,7 @@ import {
 	ccmsFromEventsSchema,
 	validatorsHashPreimageInfoSchema,
 } from './schemas';
-import { CrossChainMessagesFromEvents, ValidatorsData } from './types';
+import { BlockHeader, CrossChainMessagesFromEvents, ValidatorsData } from './types';
 
 const { Database } = liskDB;
 type KVStore = liskDB.Database;
@@ -53,15 +53,13 @@ export class ChainConnectorStore {
 		this._db.close();
 	}
 
-	public async getBlockHeaders(): Promise<chain.BlockHeaderAttrs[]> {
+	public async getBlockHeaders(): Promise<BlockHeader[]> {
 		const dbKey = Buffer.concat([this._chainType, DB_KEY_BLOCK_HEADERS]);
 		try {
 			const encodedInfo = await this._db.get(dbKey);
 
-			return codec.decode<{ blockHeaders: chain.BlockHeaderAttrs[] }>(
-				blockHeadersInfoSchema,
-				encodedInfo,
-			).blockHeaders;
+			return codec.decode<{ blockHeaders: BlockHeader[] }>(blockHeadersInfoSchema, encodedInfo)
+				.blockHeaders;
 		} catch (error) {
 			if (!(error instanceof liskDB.NotFoundError)) {
 				throw error;
@@ -75,7 +73,7 @@ export class ChainConnectorStore {
 		}
 	}
 
-	public async setBlockHeaders(blockHeaders: chain.BlockHeaderAttrs[]) {
+	public async setBlockHeaders(blockHeaders: BlockHeader[]) {
 		const concatedDBKey = Buffer.concat([this._chainType, DB_KEY_BLOCK_HEADERS]);
 		const encodedInfo = codec.encode(blockHeadersInfoSchema, { blockHeaders });
 

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/endpoint.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/endpoint.ts
@@ -12,18 +12,21 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { BasePluginEndpoint, PluginEndpointContext, db as liskDB } from 'lisk-sdk';
-import { getChainConnectorInfo } from './db';
+import { BasePluginEndpoint, PluginEndpointContext } from 'lisk-sdk';
+import { ChainConnectorStore } from './db';
 import { AggregateCommitJSON, SentCCUs, SentCCUsJSON, ValidatorsDataJSON } from './types';
 import { aggregateCommitToJSON, validatorsHashPreimagetoJSON } from './utils';
 
 export class Endpoint extends BasePluginEndpoint {
-	private _db!: liskDB.Database;
+	private _chainConnectorDB!: ChainConnectorStore;
 	private _sentCCUs!: SentCCUs;
 
-	public init(db: liskDB.Database, sentCCUs: SentCCUs) {
-		this._db = db;
+	public init(sentCCUs: SentCCUs) {
 		this._sentCCUs = sentCCUs;
+	}
+
+	public load(db: ChainConnectorStore) {
+		this._chainConnectorDB = db;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
@@ -34,16 +37,14 @@ export class Endpoint extends BasePluginEndpoint {
 	public async getAggregateCommits(
 		_context: PluginEndpointContext,
 	): Promise<AggregateCommitJSON[]> {
-		const chainConnectorInfo = await getChainConnectorInfo(this._db);
-		return chainConnectorInfo.aggregateCommits.map(aggregateCommit =>
-			aggregateCommitToJSON(aggregateCommit),
-		);
+		const aggregateCommits = await this._chainConnectorDB.getAggregateCommits();
+		return aggregateCommits.map(aggregateCommit => aggregateCommitToJSON(aggregateCommit));
 	}
 
 	public async getValidatorsInfoFromPreimage(
 		_context: PluginEndpointContext,
 	): Promise<ValidatorsDataJSON[]> {
-		const chainConnectorInfo = await getChainConnectorInfo(this._db);
-		return validatorsHashPreimagetoJSON(chainConnectorInfo.validatorsHashPreimage);
+		const validatorsHashPreimages = await this._chainConnectorDB.getValidatorsHashPreImage();
+		return validatorsHashPreimagetoJSON(validatorsHashPreimages);
 	}
 }

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/endpoint.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/endpoint.ts
@@ -18,15 +18,15 @@ import { AggregateCommitJSON, SentCCUs, SentCCUsJSON, ValidatorsDataJSON } from 
 import { aggregateCommitToJSON, validatorsHashPreimagetoJSON } from './utils';
 
 export class Endpoint extends BasePluginEndpoint {
-	private _chainConnectorDB!: ChainConnectorStore;
+	private _chainConnectorStore!: ChainConnectorStore;
 	private _sentCCUs!: SentCCUs;
 
 	public init(sentCCUs: SentCCUs) {
 		this._sentCCUs = sentCCUs;
 	}
 
-	public load(db: ChainConnectorStore) {
-		this._chainConnectorDB = db;
+	public load(store: ChainConnectorStore) {
+		this._chainConnectorStore = store;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
@@ -37,14 +37,14 @@ export class Endpoint extends BasePluginEndpoint {
 	public async getAggregateCommits(
 		_context: PluginEndpointContext,
 	): Promise<AggregateCommitJSON[]> {
-		const aggregateCommits = await this._chainConnectorDB.getAggregateCommits();
+		const aggregateCommits = await this._chainConnectorStore.getAggregateCommits();
 		return aggregateCommits.map(aggregateCommit => aggregateCommitToJSON(aggregateCommit));
 	}
 
 	public async getValidatorsInfoFromPreimage(
 		_context: PluginEndpointContext,
 	): Promise<ValidatorsDataJSON[]> {
-		const validatorsHashPreimages = await this._chainConnectorDB.getValidatorsHashPreImage();
+		const validatorsHashPreimages = await this._chainConnectorStore.getValidatorsHashPreimage();
 		return validatorsHashPreimagetoJSON(validatorsHashPreimages);
 	}
 }

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/endpoint.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/endpoint.ts
@@ -44,7 +44,7 @@ export class Endpoint extends BasePluginEndpoint {
 	public async getValidatorsInfoFromPreimage(
 		_context: PluginEndpointContext,
 	): Promise<ValidatorsDataJSON[]> {
-		const validatorsHashPreimages = await this._chainConnectorStore.getValidatorsHashPreimage();
-		return validatorsHashPreimagetoJSON(validatorsHashPreimages);
+		const validatorsHashPreimage = await this._chainConnectorStore.getValidatorsHashPreimage();
+		return validatorsHashPreimagetoJSON(validatorsHashPreimage);
 	}
 }

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
@@ -15,7 +15,7 @@
 import { chain, aggregateCommitSchema, ccmSchema } from 'lisk-sdk';
 
 export const configSchema = {
-	$id: '#/plugins/chainConnector/config',
+	$id: '/lisk/plugins/chainConnector/config',
 	type: 'object',
 	properties: {
 		mainchainIPCPath: {
@@ -43,7 +43,7 @@ export const configSchema = {
 };
 
 export const validatorsDataSchema = {
-	$id: '/modules/bft/validatorsHashInput',
+	$id: '/lisk/plugins/chainConnector/validatorsHashInput',
 	type: 'object',
 	required: ['validators', 'certificateThreshold'],
 	properties: {
@@ -65,8 +65,8 @@ export const validatorsDataSchema = {
 	},
 };
 
-export const chainConnectorInfoSchema = {
-	$id: '#/plugins/chainConnector/info',
+export const blockHeadersInfoSchema = {
+	$id: '/lisk/plugins/chainConnector/blockHeader',
 	type: 'object',
 	properties: {
 		blockHeaders: {
@@ -76,54 +76,73 @@ export const chainConnectorInfoSchema = {
 				...chain.blockHeaderSchema,
 			},
 		},
+	},
+};
+
+export const aggregateCommitsInfoSchema = {
+	$id: '/lisk/plugins/chainConnector/aggregateCommits',
+	type: 'object',
+	properties: {
 		aggregateCommits: {
 			type: 'array',
-			fieldNumber: 2,
+			fieldNumber: 1,
 			items: {
 				...aggregateCommitSchema,
 			},
 		},
+	},
+};
+
+export const validatorsHashPreimageInfoSchema = {
+	$id: '/lisk/plugins/chainConnector/validatorsHashPreimage',
+	type: 'object',
+	properties: {
 		validatorsHashPreimage: {
 			type: 'array',
-			fieldNumber: 3,
+			fieldNumber: 1,
 			items: {
 				...validatorsDataSchema,
 			},
 		},
-		crossChainMessages: {
-			type: 'array',
-			fieldNumber: 4,
-			items: {
-				type: 'object',
-				required: ['ccm', 'height'],
-				properties: {
-					ccm: {
-						type: 'object',
-						required: [...ccmSchema.required],
-						properties: { ...ccmSchema.properties },
-						fieldNumber: 1,
-					},
-					height: {
-						dataType: 'uint32',
-						fieldNumber: 2,
-					},
-				},
-			},
-		},
 	},
-	required: ['blockHeaders', 'aggregateCommits', 'validatorsHashPreimage', 'crossChainMessages'],
 };
 
-export const crossChainMessagesSchema = {
-	$id: '/lisk/plugins/chainConnector/crossChainMessages',
+export const ccmsFromEventsSchema = {
+	$id: '/lisk/plugins/chainConnector/ccmsFromEvents',
 	type: 'object',
-	required: ['crossChainMessages'],
 	properties: {
-		crossChainMessages: {
+		ccmsFromEvents: {
 			type: 'array',
 			fieldNumber: 1,
 			items: {
-				...ccmSchema,
+				type: 'object',
+				properties: {
+					ccms: {
+						type: 'array',
+						fieldNumber: 1,
+						items: {
+							...ccmSchema,
+						},
+					},
+					height: { dataType: 'uint32', fieldNumber: 2 },
+					inclusionProof: {
+						type: 'object',
+						fieldNumber: 3,
+						properties: {
+							siblingHashes: {
+								type: 'array',
+								fieldNumber: 1,
+								items: {
+									dataType: 'bytes',
+								},
+							},
+							bitmap: {
+								dataType: 'bytes',
+								fieldNumber: 2,
+							},
+						},
+					},
+				},
 			},
 		},
 	},

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
@@ -41,7 +41,7 @@ export const configSchema = {
 };
 
 export const validatorsDataSchema = {
-	$id: `${pluginSchemaIDPrefix}/validatorsHashInput`,
+	$id: `${pluginSchemaIDPrefix}/validatorsData`,
 	type: 'object',
 	required: ['validators', 'certificateThreshold'],
 	properties: {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
@@ -14,8 +14,10 @@
 
 import { chain, aggregateCommitSchema, ccmSchema } from 'lisk-sdk';
 
+const pluginSchemaIDPrefix = '/lisk/plugins/chainConnector';
+
 export const configSchema = {
-	$id: '/lisk/plugins/chainConnector/config',
+	$id: `${pluginSchemaIDPrefix}/config`,
 	type: 'object',
 	properties: {
 		mainchainIPCPath: {
@@ -26,11 +28,7 @@ export const configSchema = {
 			type: 'string',
 			description: 'The IPC path to a sidechain node',
 		},
-		ccmBasedFrequency: {
-			type: 'integer',
-			description: 'Number of Cross chain messages after which a CCU should be created',
-		},
-		livenessBasedFrequency: {
+		ccuFrequency: {
 			type: 'integer',
 			description: 'Number of blocks after which a CCU should be created',
 		},
@@ -43,7 +41,7 @@ export const configSchema = {
 };
 
 export const validatorsDataSchema = {
-	$id: '/lisk/plugins/chainConnector/validatorsHashInput',
+	$id: `${pluginSchemaIDPrefix}/validatorsHashInput`,
 	type: 'object',
 	required: ['validators', 'certificateThreshold'],
 	properties: {
@@ -66,7 +64,7 @@ export const validatorsDataSchema = {
 };
 
 export const blockHeadersInfoSchema = {
-	$id: '/lisk/plugins/chainConnector/blockHeader',
+	$id: `${pluginSchemaIDPrefix}/blockHeaders`,
 	type: 'object',
 	properties: {
 		blockHeaders: {
@@ -80,7 +78,7 @@ export const blockHeadersInfoSchema = {
 };
 
 export const aggregateCommitsInfoSchema = {
-	$id: '/lisk/plugins/chainConnector/aggregateCommits',
+	$id: `${pluginSchemaIDPrefix}/aggregateCommits`,
 	type: 'object',
 	properties: {
 		aggregateCommits: {
@@ -94,7 +92,7 @@ export const aggregateCommitsInfoSchema = {
 };
 
 export const validatorsHashPreimageInfoSchema = {
-	$id: '/lisk/plugins/chainConnector/validatorsHashPreimage',
+	$id: `${pluginSchemaIDPrefix}/validatorsHashPreimage`,
 	type: 'object',
 	properties: {
 		validatorsHashPreimage: {
@@ -108,7 +106,7 @@ export const validatorsHashPreimageInfoSchema = {
 };
 
 export const ccmsFromEventsSchema = {
-	$id: '/lisk/plugins/chainConnector/ccmsFromEvents',
+	$id: `${pluginSchemaIDPrefix}/ccmsFromEvents`,
 	type: 'object',
 	properties: {
 		ccmsFromEvents: {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
@@ -12,14 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import {
-	Transaction,
-	chain,
-	AggregateCommit,
-	CCMsg,
-	ActiveValidator,
-	OutboxRootWitness,
-} from 'lisk-sdk';
+import { Transaction, chain, CCMsg, ActiveValidator, OutboxRootWitness } from 'lisk-sdk';
+
+export interface BlockHeader extends chain.BlockHeaderAttrs {
+	validatorsHash: Buffer;
+}
 
 export interface ChainConnectorPluginConfig {
 	mainchainIPCPath: string;
@@ -38,21 +35,9 @@ export interface Validator {
 }
 
 export interface ValidatorsData {
-	certificateThreshold: BigInt;
+	certificateThreshold: bigint;
 	validators: Validator[];
 	validatorsHash: Buffer;
-}
-
-interface CcmWithHeight {
-	ccm: CCMsg;
-	height: number;
-}
-
-export interface ChainConnectorInfo {
-	blockHeaders: chain.BlockHeader[];
-	aggregateCommits: AggregateCommit[];
-	validatorsHashPreimage: ValidatorsData[];
-	crossChainMessages: CcmWithHeight[];
 }
 
 export interface CrossChainMessagesFromEvents {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
@@ -21,8 +21,7 @@ export interface BlockHeader extends chain.BlockHeaderAttrs {
 export interface ChainConnectorPluginConfig {
 	mainchainIPCPath: string;
 	sidechainIPCPath: string;
-	ccmBasedFrequency: number;
-	livenessBasedFrequency: number;
+	ccuFrequency: number;
 }
 
 export type SentCCUs = Transaction[];

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
@@ -55,8 +55,10 @@ export interface ChainConnectorInfo {
 	crossChainMessages: CcmWithHeight[];
 }
 
-export interface CrossChainMessages {
-	crossChainMessages: CCMsg[];
+export interface CrossChainMessagesFromEvents {
+	ccms: CCMsg[];
+	height: number;
+	inclusionProof: OutboxRootWitness;
 }
 
 export interface AggregateCommitJSON {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
@@ -73,16 +73,12 @@ describe('Plugins DB', () => {
 			let sampleBlockHeaders: BlockHeader[];
 
 			beforeEach(() => {
-				sampleBlockHeaders = [
-					testing.createFakeBlockHeader().toObject(),
-					testing.createFakeBlockHeader().toObject(),
-					testing.createFakeBlockHeader().toObject(),
-					testing.createFakeBlockHeader().toObject(),
-				].map(b => {
-					const { id, ...block } = b;
+				sampleBlockHeaders = new Array(4).fill(0).map(() => {
+					const { id, ...block } = testing.createFakeBlockHeader().toObject();
 
 					return block;
 				});
+
 				chainConnectorStore = new ChainConnectorStore(
 					new db.InMemoryDatabase() as never,
 					DB_KEY_SIDECHAIN,
@@ -139,40 +135,23 @@ describe('Plugins DB', () => {
 			let sampleValidatorsData: ValidatorsData[];
 
 			beforeEach(() => {
-				sampleValidatorsData = [
-					{
-						certificateThreshold: BigInt(68),
-						validators: [
-							{
-								address: cryptography.utils.getRandomBytes(20),
-								bftWeight: BigInt(1),
-								blsKey: cryptography.utils.getRandomBytes(48),
-							},
-							{
-								address: cryptography.utils.getRandomBytes(20),
-								bftWeight: BigInt(1),
-								blsKey: cryptography.utils.getRandomBytes(48),
-							},
-						],
-						validatorsHash: cryptography.utils.getRandomBytes(54),
-					},
-					{
-						certificateThreshold: BigInt(68),
-						validators: [
-							{
-								address: cryptography.utils.getRandomBytes(20),
-								bftWeight: BigInt(1),
-								blsKey: cryptography.utils.getRandomBytes(48),
-							},
-							{
-								address: cryptography.utils.getRandomBytes(20),
-								bftWeight: BigInt(1),
-								blsKey: cryptography.utils.getRandomBytes(48),
-							},
-						],
-						validatorsHash: cryptography.utils.getRandomBytes(54),
-					},
-				];
+				sampleValidatorsData = new Array(2).fill(0).map(() => ({
+					certificateThreshold: BigInt(68),
+					validators: [
+						{
+							address: cryptography.utils.getRandomBytes(20),
+							bftWeight: BigInt(1),
+							blsKey: cryptography.utils.getRandomBytes(48),
+						},
+						{
+							address: cryptography.utils.getRandomBytes(20),
+							bftWeight: BigInt(1),
+							blsKey: cryptography.utils.getRandomBytes(48),
+						},
+					],
+					validatorsHash: cryptography.utils.getRandomBytes(54),
+				}));
+
 				chainConnectorStore = new ChainConnectorStore(
 					new db.InMemoryDatabase() as never,
 					DB_KEY_SIDECHAIN,
@@ -180,13 +159,13 @@ describe('Plugins DB', () => {
 			});
 
 			it('should return empty array when there is no record', async () => {
-				await expect(chainConnectorStore.getValidatorsHashPreImage()).resolves.toEqual([]);
+				await expect(chainConnectorStore.getValidatorsHashPreimage()).resolves.toEqual([]);
 			});
 
 			it('should return list of validatorsHashPreImage', async () => {
-				await chainConnectorStore.setValidatorsHashPreImage(sampleValidatorsData);
+				await chainConnectorStore.setValidatorsHashPreimage(sampleValidatorsData);
 
-				await expect(chainConnectorStore.getValidatorsHashPreImage()).resolves.toEqual(
+				await expect(chainConnectorStore.getValidatorsHashPreimage()).resolves.toEqual(
 					sampleValidatorsData,
 				);
 			});

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs-extra';
 import { homedir } from 'os';
 import { join } from 'path';
 import { ChainConnectorStore, getDBInstance } from '../../src/db';
-import { DB_KEY_SIDECHAIN } from '../../src/constants';
+import { ADDRESS_LENGTH, BLS_PUBLIC_KEY_LENGTH, DB_KEY_SIDECHAIN } from '../../src/constants';
 import { BlockHeader, CrossChainMessagesFromEvents, ValidatorsData } from '../../src/types';
 
 jest.mock('fs-extra');
@@ -52,14 +52,14 @@ describe('Plugins DB', () => {
 	describe('ChainConnectorStore', () => {
 		let chainConnectorStore: ChainConnectorStore;
 
-		describe('constructor', () => {
-			beforeEach(() => {
-				chainConnectorStore = new ChainConnectorStore(
-					new db.InMemoryDatabase() as never,
-					DB_KEY_SIDECHAIN,
-				);
-			});
+		beforeEach(() => {
+			chainConnectorStore = new ChainConnectorStore(
+				new db.InMemoryDatabase() as never,
+				DB_KEY_SIDECHAIN,
+			);
+		});
 
+		describe('constructor', () => {
 			it('should assign DB in the constructor', () => {
 				expect(chainConnectorStore['_db']).toBeInstanceOf(db.InMemoryDatabase);
 			});
@@ -78,11 +78,6 @@ describe('Plugins DB', () => {
 
 					return block;
 				});
-
-				chainConnectorStore = new ChainConnectorStore(
-					new db.InMemoryDatabase() as never,
-					DB_KEY_SIDECHAIN,
-				);
 			});
 
 			it('should return empty array when there is no record', async () => {
@@ -112,10 +107,6 @@ describe('Plugins DB', () => {
 						height: 2,
 					},
 				];
-				chainConnectorStore = new ChainConnectorStore(
-					new db.InMemoryDatabase() as never,
-					DB_KEY_SIDECHAIN,
-				);
 			});
 
 			it('should return empty array when there is no record', async () => {
@@ -139,23 +130,18 @@ describe('Plugins DB', () => {
 					certificateThreshold: BigInt(68),
 					validators: [
 						{
-							address: cryptography.utils.getRandomBytes(20),
+							address: cryptography.utils.getRandomBytes(ADDRESS_LENGTH),
 							bftWeight: BigInt(1),
-							blsKey: cryptography.utils.getRandomBytes(48),
+							blsKey: cryptography.utils.getRandomBytes(BLS_PUBLIC_KEY_LENGTH),
 						},
 						{
-							address: cryptography.utils.getRandomBytes(20),
+							address: cryptography.utils.getRandomBytes(ADDRESS_LENGTH),
 							bftWeight: BigInt(1),
-							blsKey: cryptography.utils.getRandomBytes(48),
+							blsKey: cryptography.utils.getRandomBytes(BLS_PUBLIC_KEY_LENGTH),
 						},
 					],
 					validatorsHash: cryptography.utils.getRandomBytes(54),
 				}));
-
-				chainConnectorStore = new ChainConnectorStore(
-					new db.InMemoryDatabase() as never,
-					DB_KEY_SIDECHAIN,
-				);
 			});
 
 			it('should return empty array when there is no record', async () => {
@@ -225,10 +211,6 @@ describe('Plugins DB', () => {
 						},
 					},
 				];
-				chainConnectorStore = new ChainConnectorStore(
-					new db.InMemoryDatabase() as never,
-					DB_KEY_SIDECHAIN,
-				);
 			});
 
 			it('should return empty array when there is no record', async () => {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
@@ -12,14 +12,15 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { db } from 'lisk-sdk';
+import { AggregateCommit, db, testing, cryptography, chain } from 'lisk-sdk';
 import * as fs from 'fs-extra';
 import { homedir } from 'os';
 import { join } from 'path';
-import { getDBInstance } from '../../src/db';
+import { ChainConnectorStore, getDBInstance } from '../../src/db';
+import { DB_KEY_SIDECHAIN } from '../../src/constants';
+import { CrossChainMessagesFromEvents, ValidatorsData } from '../../src/types';
 
 jest.mock('fs-extra');
-jest.mock('@liskhq/lisk-db');
 const mockedFsExtra = fs as jest.Mocked<typeof fs>;
 
 describe('Plugins DB', () => {
@@ -46,5 +47,222 @@ describe('Plugins DB', () => {
 		const dirPath = join(rootPath, 'plugins/data', dbName);
 
 		expect(mockedFsExtra.ensureDir).toHaveBeenCalledWith(dirPath);
+	});
+
+	describe('ChainConnectorStore', () => {
+		let chainConnectorStore: ChainConnectorStore;
+
+		describe('constructor', () => {
+			beforeEach(async () => {
+				chainConnectorStore = new ChainConnectorStore(
+					new db.InMemoryDatabase() as never,
+					DB_KEY_SIDECHAIN,
+				);
+			});
+
+			it('should assign DB in the constructor', () => {
+				expect(chainConnectorStore['_db']).toBeInstanceOf(db.InMemoryDatabase);
+			});
+
+			it('should assign chainType in the constructor', () => {
+				expect(chainConnectorStore['_chainType']).toEqual(DB_KEY_SIDECHAIN);
+			});
+		});
+
+		describe('blockHeaders', () => {
+			let sampleBlockHeaders: chain.BlockHeaderAttrs[];
+
+			beforeEach(async () => {
+				sampleBlockHeaders = [
+					testing.createFakeBlockHeader().toObject(),
+					testing.createFakeBlockHeader().toObject(),
+					testing.createFakeBlockHeader().toObject(),
+					testing.createFakeBlockHeader().toObject(),
+				].map(b => {
+					const { id, ...block } = b;
+
+					return block;
+				});
+				chainConnectorStore = new ChainConnectorStore(
+					new db.InMemoryDatabase() as never,
+					DB_KEY_SIDECHAIN,
+				);
+			});
+
+			it('should return empty array when there is no record', async () => {
+				await expect(chainConnectorStore.getBlockHeaders()).resolves.toEqual([]);
+			});
+
+			it('should return list of blockHeaders', async () => {
+				await chainConnectorStore.setBlockHeaders(sampleBlockHeaders);
+
+				await expect(chainConnectorStore.getBlockHeaders()).resolves.toEqual(sampleBlockHeaders);
+			});
+		});
+
+		describe('aggregatecommits', () => {
+			let sampleAggregateCommits: AggregateCommit[];
+
+			beforeEach(async () => {
+				sampleAggregateCommits = [
+					{
+						aggregationBits: Buffer.alloc(1),
+						certificateSignature: cryptography.utils.getRandomBytes(32),
+						height: 2,
+					},
+					{
+						aggregationBits: Buffer.alloc(1),
+						certificateSignature: cryptography.utils.getRandomBytes(32),
+						height: 2,
+					},
+				];
+				chainConnectorStore = new ChainConnectorStore(
+					new db.InMemoryDatabase() as never,
+					DB_KEY_SIDECHAIN,
+				);
+			});
+
+			it('should return empty array when there is no record', async () => {
+				await expect(chainConnectorStore.getAggregateCommits()).resolves.toEqual([]);
+			});
+
+			it('should return list of aggregateCommits', async () => {
+				await chainConnectorStore.setAggregateCommits(sampleAggregateCommits);
+
+				await expect(chainConnectorStore.getAggregateCommits()).resolves.toEqual(
+					sampleAggregateCommits,
+				);
+			});
+		});
+
+		describe('validatorsHashPreimage', () => {
+			let sampleValidatorsData: ValidatorsData[];
+
+			beforeEach(async () => {
+				sampleValidatorsData = [
+					{
+						certificateThreshold: BigInt(68),
+						validators: [
+							{
+								address: cryptography.utils.getRandomBytes(20),
+								bftWeight: BigInt(1),
+								blsKey: cryptography.utils.getRandomBytes(48),
+							},
+							{
+								address: cryptography.utils.getRandomBytes(20),
+								bftWeight: BigInt(1),
+								blsKey: cryptography.utils.getRandomBytes(48),
+							},
+						],
+						validatorsHash: cryptography.utils.getRandomBytes(54),
+					},
+					{
+						certificateThreshold: BigInt(68),
+						validators: [
+							{
+								address: cryptography.utils.getRandomBytes(20),
+								bftWeight: BigInt(1),
+								blsKey: cryptography.utils.getRandomBytes(48),
+							},
+							{
+								address: cryptography.utils.getRandomBytes(20),
+								bftWeight: BigInt(1),
+								blsKey: cryptography.utils.getRandomBytes(48),
+							},
+						],
+						validatorsHash: cryptography.utils.getRandomBytes(54),
+					},
+				];
+				chainConnectorStore = new ChainConnectorStore(
+					new db.InMemoryDatabase() as never,
+					DB_KEY_SIDECHAIN,
+				);
+			});
+
+			it('should return empty array when there is no record', async () => {
+				await expect(chainConnectorStore.getValidatorsHashPreImage()).resolves.toEqual([]);
+			});
+
+			it('should return list of validatorsHashPreImage', async () => {
+				await chainConnectorStore.setValidatorsHashPreImage(sampleValidatorsData);
+
+				await expect(chainConnectorStore.getValidatorsHashPreImage()).resolves.toEqual(
+					sampleValidatorsData,
+				);
+			});
+		});
+
+		describe('crossChainMessages', () => {
+			let sampleCrossChainMessages: CrossChainMessagesFromEvents[];
+
+			beforeEach(async () => {
+				sampleCrossChainMessages = [
+					{
+						ccms: [
+							{
+								crossChainCommand: 'transfer',
+								fee: BigInt(1),
+								module: 'token',
+								nonce: BigInt(10),
+								params: Buffer.alloc(2),
+								receivingChainID: Buffer.from('10000000', 'hex'),
+								sendingChainID: Buffer.from('10000001', 'hex'),
+								status: 1,
+							},
+						],
+						height: 10,
+						inclusionProof: {
+							bitmap: Buffer.alloc(1),
+							siblingHashes: [Buffer.alloc(2)],
+						},
+					},
+					{
+						ccms: [
+							{
+								crossChainCommand: 'transfer',
+								fee: BigInt(2),
+								module: 'token',
+								nonce: BigInt(12),
+								params: Buffer.alloc(2),
+								receivingChainID: Buffer.from('01000000', 'hex'),
+								sendingChainID: Buffer.from('00000001', 'hex'),
+								status: 1,
+							},
+							{
+								crossChainCommand: 'transfer',
+								fee: BigInt(2),
+								module: 'token',
+								nonce: BigInt(13),
+								params: Buffer.alloc(1),
+								receivingChainID: Buffer.from('01000000', 'hex'),
+								sendingChainID: Buffer.from('00000001', 'hex'),
+								status: 1,
+							},
+						],
+						height: 11,
+						inclusionProof: {
+							bitmap: Buffer.alloc(1),
+							siblingHashes: [Buffer.alloc(2)],
+						},
+					},
+				];
+				chainConnectorStore = new ChainConnectorStore(
+					new db.InMemoryDatabase() as never,
+					DB_KEY_SIDECHAIN,
+				);
+			});
+
+			it('should return empty array when there is no record', async () => {
+				await expect(chainConnectorStore.getCrossChainMessages()).resolves.toEqual([]);
+			});
+
+			it('should return list of crossChainMessages', async () => {
+				await chainConnectorStore.setCrossChainMessages(sampleCrossChainMessages);
+
+				await expect(chainConnectorStore.getCrossChainMessages()).resolves.toEqual(
+					sampleCrossChainMessages,
+				);
+			});
+		});
 	});
 });

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/db.spec.ts
@@ -12,13 +12,13 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { AggregateCommit, db, testing, cryptography, chain } from 'lisk-sdk';
+import { AggregateCommit, db, testing, cryptography } from 'lisk-sdk';
 import * as fs from 'fs-extra';
 import { homedir } from 'os';
 import { join } from 'path';
 import { ChainConnectorStore, getDBInstance } from '../../src/db';
 import { DB_KEY_SIDECHAIN } from '../../src/constants';
-import { CrossChainMessagesFromEvents, ValidatorsData } from '../../src/types';
+import { BlockHeader, CrossChainMessagesFromEvents, ValidatorsData } from '../../src/types';
 
 jest.mock('fs-extra');
 const mockedFsExtra = fs as jest.Mocked<typeof fs>;
@@ -53,7 +53,7 @@ describe('Plugins DB', () => {
 		let chainConnectorStore: ChainConnectorStore;
 
 		describe('constructor', () => {
-			beforeEach(async () => {
+			beforeEach(() => {
 				chainConnectorStore = new ChainConnectorStore(
 					new db.InMemoryDatabase() as never,
 					DB_KEY_SIDECHAIN,
@@ -70,9 +70,9 @@ describe('Plugins DB', () => {
 		});
 
 		describe('blockHeaders', () => {
-			let sampleBlockHeaders: chain.BlockHeaderAttrs[];
+			let sampleBlockHeaders: BlockHeader[];
 
-			beforeEach(async () => {
+			beforeEach(() => {
 				sampleBlockHeaders = [
 					testing.createFakeBlockHeader().toObject(),
 					testing.createFakeBlockHeader().toObject(),
@@ -103,7 +103,7 @@ describe('Plugins DB', () => {
 		describe('aggregatecommits', () => {
 			let sampleAggregateCommits: AggregateCommit[];
 
-			beforeEach(async () => {
+			beforeEach(() => {
 				sampleAggregateCommits = [
 					{
 						aggregationBits: Buffer.alloc(1),
@@ -138,7 +138,7 @@ describe('Plugins DB', () => {
 		describe('validatorsHashPreimage', () => {
 			let sampleValidatorsData: ValidatorsData[];
 
-			beforeEach(async () => {
+			beforeEach(() => {
 				sampleValidatorsData = [
 					{
 						certificateThreshold: BigInt(68),
@@ -195,7 +195,7 @@ describe('Plugins DB', () => {
 		describe('crossChainMessages', () => {
 			let sampleCrossChainMessages: CrossChainMessagesFromEvents[];
 
-			beforeEach(async () => {
+			beforeEach(() => {
 				sampleCrossChainMessages = [
 					{
 						ccms: [

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/endpoint.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/endpoint.spec.ts
@@ -115,8 +115,10 @@ describe('getSentCCUs', () => {
 		});
 		(chainConnectorPlugin as any)['_sidechainAPIClient'] = sidechainAPIClientMock;
 		await chainConnectorPlugin.load();
-		await chainConnectorPlugin['_sidechainChainConnectorDB'].setAggregateCommits([aggregateCommit]);
-		await chainConnectorPlugin['_sidechainChainConnectorDB'].setValidatorsHashPreImage([
+		await chainConnectorPlugin['_sidechainChainConnectorStore'].setAggregateCommits([
+			aggregateCommit,
+		]);
+		await chainConnectorPlugin['_sidechainChainConnectorStore'].setValidatorsHashPreimage([
 			validatorsData,
 		]);
 	});
@@ -129,11 +131,11 @@ describe('getSentCCUs', () => {
 			disconnect: jest.fn(),
 		};
 
-		await chainConnectorPlugin['_sidechainChainConnectorDB']['_db'].clear();
+		await chainConnectorPlugin['_sidechainChainConnectorStore']['_db'].clear();
 	});
 
 	afterAll(() => {
-		chainConnectorPlugin['_sidechainChainConnectorDB']['_db'].close();
+		chainConnectorPlugin['_sidechainChainConnectorStore']['_db'].close();
 
 		removeSync(chainConnectorPlugin['dataPath']);
 	});

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/plugin.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/plugin.spec.ts
@@ -41,6 +41,7 @@ import {
 import * as plugins from '../../src/chain_connector_plugin';
 import * as dbApi from '../../src/db';
 import * as utils from '../../src/utils';
+import { BlockHeader, CrossChainUpdateTransactionParams } from '../../src/types';
 
 const appConfigForPlugin: ApplicationConfigForPlugin = {
 	system: {
@@ -653,6 +654,7 @@ describe('ChainConnectorPlugin', () => {
 						},
 						{
 							...block.header,
+							height: aggregateCommit.height - 1,
 						},
 					] as never);
 
@@ -724,9 +726,9 @@ describe('ChainConnectorPlugin', () => {
 		});
 
 		describe('deleteBlockHeaders', () => {
-			let block1: chain.BlockHeaderAttrs;
-			let block2: chain.BlockHeaderAttrs;
-			beforeEach(async () => {
+			let block1: BlockHeader;
+			let block2: BlockHeader;
+			beforeEach(() => {
 				block1 = testing.createFakeBlockHeader({ height: 5 }).toObject();
 				block2 = testing.createFakeBlockHeader({ height: 6 }).toObject();
 				chainConnectorInfoDBMock.getBlockHeaders.mockResolvedValue([block1, block2] as never);
@@ -838,7 +840,7 @@ describe('ChainConnectorPlugin', () => {
 		it('should not validate if chain is terminated', async () => {
 			const certificateBytes = Buffer.from('10');
 			const certificate = { height: 5 } as Certificate;
-			const blockHeader = {} as chain.BlockHeader;
+			const blockHeader = {} as BlockHeader;
 			const chainAccount = { status: ChainStatus.TERMINATED } as ChainAccount;
 			const sendingChainID = Buffer.from('01');
 
@@ -856,7 +858,7 @@ describe('ChainConnectorPlugin', () => {
 		it('should not validate if certificate height is not greater than height of last certificate', async () => {
 			const certificateBytes = Buffer.from('10');
 			const certificate = { height: 5 } as Certificate;
-			const blockHeader = {} as chain.BlockHeader;
+			const blockHeader = {} as BlockHeader;
 			const chainAccout = {
 				status: ChainStatus.ACTIVE,
 				lastCertificate: { height: 5 },
@@ -881,7 +883,7 @@ describe('ChainConnectorPlugin', () => {
 
 			const certificateBytes = Buffer.from('10');
 			const certificate = { height: 5 } as Certificate;
-			const blockHeader = {} as chain.BlockHeader;
+			const blockHeader = {} as BlockHeader;
 			const chainAccount = {
 				status: ChainStatus.ACTIVE,
 				lastCertificate: { height: 4 },
@@ -906,7 +908,7 @@ describe('ChainConnectorPlugin', () => {
 
 			const certificateBytes = Buffer.from('10');
 			const certificate = { height: 5 } as Certificate;
-			const blockHeader = {} as chain.BlockHeader;
+			const blockHeader = {} as BlockHeader;
 			const chainAccount = {
 				status: ChainStatus.ACTIVE,
 				lastCertificate: { height: 4 },
@@ -951,7 +953,7 @@ describe('ChainConnectorPlugin', () => {
 				aggregationBits: Buffer.from('10'),
 				signature: Buffer.from('10'),
 			} as Certificate;
-			const blockHeader = { validatorsHash: Buffer.from('10') } as chain.BlockHeader;
+			const blockHeader = { validatorsHash: Buffer.from('10') } as BlockHeader;
 			const sendingChainID = Buffer.from('01');
 
 			const chainAccount = {
@@ -997,7 +999,7 @@ describe('ChainConnectorPlugin', () => {
 				aggregationBits: Buffer.from('10'),
 				signature: Buffer.from('10'),
 			} as Certificate;
-			const blockHeader = { validatorsHash: Buffer.from('11') } as chain.BlockHeader;
+			const blockHeader = { validatorsHash: Buffer.from('11') } as BlockHeader;
 			const chainAccount = {
 				status: 0,
 				name: 'chain1',
@@ -1217,23 +1219,23 @@ describe('ChainConnectorPlugin', () => {
 			});
 
 			it('should return CCUTxParams with activeValidatorsUpdate set to []', async () => {
-				const ccuTxParams = await chainConnectorPlugin.calculateCCUParams(
+				const ccuTxParams = (await chainConnectorPlugin.calculateCCUParams(
 					sendingChainID,
 					certificate as never,
 					newCertificateThreshold,
-				);
+				)) as CrossChainUpdateTransactionParams;
 
-				expect(ccuTxParams!.activeValidatorsUpdate).toEqual([]);
+				expect(ccuTxParams.activeValidatorsUpdate).toEqual([]);
 			});
 
 			it('should return CCUTxParams with newCertificateThreshold set to provided newCertificateThreshold', async () => {
-				const ccuTxParams = await chainConnectorPlugin.calculateCCUParams(
+				const ccuTxParams = (await chainConnectorPlugin.calculateCCUParams(
 					sendingChainID,
 					certificate as never,
 					newCertificateThreshold,
-				);
+				)) as CrossChainUpdateTransactionParams;
 
-				expect(ccuTxParams!.certificateThreshold).toEqual(newCertificateThreshold);
+				expect(ccuTxParams.certificateThreshold).toEqual(newCertificateThreshold);
 			});
 		});
 
@@ -1246,13 +1248,13 @@ describe('ChainConnectorPlugin', () => {
 			});
 
 			it('should return CCUTxParams with newCertificate set to zero if validatorsHash of block header at certificate height is equal to that of last certificate', async () => {
-				const ccuTxParams = await chainConnectorPlugin.calculateCCUParams(
+				const ccuTxParams = (await chainConnectorPlugin.calculateCCUParams(
 					sendingChainID,
 					certificate as never,
 					newCertificateThreshold,
-				);
+				)) as CrossChainUpdateTransactionParams;
 
-				expect(ccuTxParams!.certificateThreshold).toEqual(BigInt(0));
+				expect(ccuTxParams.certificateThreshold).toEqual(BigInt(0));
 			});
 
 			it('should return CCUTxParams with newCertificateThreshold set to provided newCertificateThreshold if validatorsHash of block header at certificate height is not equal to that of last certificate', async () => {
@@ -1284,13 +1286,13 @@ describe('ChainConnectorPlugin', () => {
 						},
 					] as never);
 
-				const ccuTxParams = await chainConnectorPlugin.calculateCCUParams(
+				const ccuTxParams = (await chainConnectorPlugin.calculateCCUParams(
 					sendingChainID,
 					certificate as never,
 					newCertificateThreshold,
-				);
+				)) as CrossChainUpdateTransactionParams;
 
-				expect(ccuTxParams!.certificateThreshold).toEqual(newCertificateThreshold);
+				expect(ccuTxParams.certificateThreshold).toEqual(newCertificateThreshold);
 			});
 
 			it('should call getActiveValidatorsDiff', async () => {

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -96,6 +96,8 @@ export {
 	MESSAGE_TAG_CERTIFICATE,
 	ChainStatus,
 	ccmSchema,
+	OwnChainAccount,
+	OwnChainAccountJSON,
 } from './modules/interoperability';
 export { RewardMethod, RewardModule } from './modules/reward';
 export { FeeMethod, FeeModule } from './modules/fee';

--- a/framework/src/modules/interoperability/index.ts
+++ b/framework/src/modules/interoperability/index.ts
@@ -34,6 +34,8 @@ export {
 	CrossChainUpdateTransactionParams,
 	ActiveValidator,
 	OutboxRootWitness,
+	OwnChainAccount,
+	OwnChainAccountJSON,
 } from './types';
 // Common
 export { LIVENESS_LIMIT, MESSAGE_TAG_CERTIFICATE } from './constants';


### PR DESCRIPTION
### What was the problem?

This PR resolves #7888 & #7889 

### How was it solved?

- Refactor chainConnector db to be a class with setters/getters
- Update `crossChainMessages` schema to have `height` and `inclusionProof`
- Remove `ccmFrequency` and use liveness frequency for CCU frequency

### How was it tested?

`npm run test`
