### PR TITLE
Refactor multi-signature account check

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -13,7 +13,6 @@
  */
 
 import { validator } from '@liskhq/lisk-validator';
-import { NotFoundError } from '@liskhq/lisk-chain';
 import { address as cryptoAddress } from '@liskhq/lisk-cryptography';
 import { Schema } from '@liskhq/lisk-codec';
 import { ModuleEndpointContext } from '../../types';
@@ -21,7 +20,6 @@ import { VerifyStatus } from '../../state_machine';
 import { BaseEndpoint } from '../base_endpoint';
 import {
 	AuthAccountJSON,
-	ImmutableStoreCallback,
 	VerifyEndpointResultJSON,
 	KeySignaturePair,
 	SortedMultisignatureGroup,
@@ -74,16 +72,11 @@ export class AuthEndpoint extends BaseEndpoint {
 
 		const accountAddress = cryptoAddress.getAddressFromPublicKey(transaction.senderPublicKey);
 
-		const store = this.stores.get(AuthAccountStore);
-		const account = await store.get(context, accountAddress);
-
-		const isMultisignatureAccount = await this._isMultisignatureAccount(
-			context.getStore,
-			accountAddress,
-		);
+		const authAccountStore = this.stores.get(AuthAccountStore);
+		const account = await authAccountStore.getOrDefault(context, accountAddress);
 
 		try {
-			verifySignatures(transaction, transactionBytes, chainID, account, isMultisignatureAccount);
+			verifySignatures(transaction, transactionBytes, chainID, account);
 		} catch (error) {
 			return { verified: false };
 		}
@@ -99,8 +92,8 @@ export class AuthEndpoint extends BaseEndpoint {
 		const transaction = getTransactionFromParameter(transactionParameter);
 		const accountAddress = cryptoAddress.getAddressFromPublicKey(transaction.senderPublicKey);
 
-		const store = this.stores.get(AuthAccountStore);
-		const account = await store.get(context, accountAddress);
+		const authAccountStore = this.stores.get(AuthAccountStore);
+		const account = await authAccountStore.getOrDefault(context, accountAddress);
 
 		const verificationResult = verifyNonce(transaction, account).status;
 		return { verified: verificationResult === VerifyStatus.OK };
@@ -139,22 +132,5 @@ export class AuthEndpoint extends BaseEndpoint {
 				.map(keySignaturePair => keySignaturePair.signature)
 				.concat(sortedOptional.map(keySignaturePair => keySignaturePair.signature)),
 		};
-	}
-
-	private async _isMultisignatureAccount(
-		getStore: ImmutableStoreCallback,
-		address: Buffer,
-	): Promise<boolean> {
-		const authSubstore = this.stores.get(AuthAccountStore);
-		try {
-			const authAccount = await authSubstore.get({ getStore }, address);
-
-			return authAccount.numberOfSignatures !== 0;
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
-			return false;
-		}
 	}
 }

--- a/framework/src/modules/auth/module.ts
+++ b/framework/src/modules/auth/module.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { NotFoundError } from '@liskhq/lisk-chain';
 import { objects as objectUtils } from '@liskhq/lisk-utils';
 import { codec } from '@liskhq/lisk-codec';
 import { validator } from '@liskhq/lisk-validator';
@@ -28,7 +27,7 @@ import { AuthMethod } from './method';
 import { MAX_NUMBER_OF_SIGNATURES } from './constants';
 import { AuthEndpoint } from './endpoint';
 import { configSchema, genesisAuthStoreSchema } from './schemas';
-import { GenesisAuthStore, ImmutableStoreCallback } from './types';
+import { GenesisAuthStore } from './types';
 import { verifyNonce, verifySignatures } from './utils';
 import { authAccountSchema, AuthAccountStore } from './stores/auth_account';
 import { MultisignatureRegistrationEvent } from './events/multisignature_registration';
@@ -159,17 +158,7 @@ export class AuthModule extends BaseModule {
 			);
 		}
 
-		const isMultisignatureAccount = await this._isMultisignatureAccount(
-			context.getStore,
-			transaction.senderAddress,
-		);
-		verifySignatures(
-			transaction,
-			transaction.getSigningBytes(),
-			chainID,
-			senderAccount,
-			isMultisignatureAccount,
-		);
+		verifySignatures(transaction, transaction.getSigningBytes(), chainID, senderAccount);
 
 		return nonceStatus;
 	}
@@ -186,22 +175,5 @@ export class AuthModule extends BaseModule {
 			mandatoryKeys: senderAccount.mandatoryKeys,
 			optionalKeys: senderAccount.optionalKeys,
 		});
-	}
-
-	private async _isMultisignatureAccount(
-		getStore: ImmutableStoreCallback,
-		address: Buffer,
-	): Promise<boolean> {
-		const authSubstore = this.stores.get(AuthAccountStore);
-		try {
-			const authAccount = await authSubstore.get({ getStore }, address);
-
-			return authAccount.numberOfSignatures !== 0;
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
-			return false;
-		}
 	}
 }

--- a/framework/src/modules/auth/utils.ts
+++ b/framework/src/modules/auth/utils.ts
@@ -181,10 +181,8 @@ export const verifySignatures = (
 	transactionBytes: Buffer,
 	chainID: Buffer,
 	account: AuthAccount,
-	isMultisignatureAccount: boolean,
 ) => {
-	// Verify multi signature registration transaction
-	if (isMultisignatureAccount) {
+	if (account.numberOfSignatures !== 0) {
 		verifyMultiSignatureTransaction(
 			TAG_TRANSACTION,
 			chainID,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7893 

### How was it solved?

* There is no need for high-level methods [hooks and endpoints] to fetch account from the store based on the address, because they already have access to the account.
* High-level functions already pass account instance to `verifySignatures()`. The check whether an account is multi-sig is now handled in there.

### How was it tested?

All tests passing 👌🏻 
