### PR TITLE
Fix API Client min fee calculation

### DIFF
--- a/elements/lisk-api-client/src/transaction.ts
+++ b/elements/lisk-api-client/src/transaction.ts
@@ -272,7 +272,7 @@ export class Transaction {
 		return encodeTransaction(transaction, this._schema, this._metadata);
 	}
 
-	public computeMinFee(transaction: Omit<DecodedTransactionJSON, 'id'>, options: Options): bigint {
+	public computeMinFee(transaction: Omit<DecodedTransactionJSON, 'id'>, options?: Options): bigint {
 		const decodedTx = this.fromJSON(transaction as DecodedTransactionJSON);
 		this._validateTransaction(decodedTx);
 		const commandSchema = getTransactionParamsSchema(transaction, this._metadata);

--- a/elements/lisk-api-client/src/transaction.ts
+++ b/elements/lisk-api-client/src/transaction.ts
@@ -17,6 +17,7 @@ import {
 	signMultiSignatureTransaction,
 	computeMinFee,
 } from '@liskhq/lisk-transactions';
+import { Options } from '@liskhq/lisk-transactions/src/fee';
 import { address as cryptoAddress, ed } from '@liskhq/lisk-cryptography';
 import { validator } from '@liskhq/lisk-validator';
 import { codec } from '@liskhq/lisk-codec';
@@ -37,10 +38,6 @@ import {
 	Transaction as ITransaction,
 	DecodedTransactionJSON,
 } from './types';
-
-interface Options {
-	readonly numberOfSignatures: number;
-}
 
 interface AuthAccount {
 	nonce: string;
@@ -275,14 +272,10 @@ export class Transaction {
 		return encodeTransaction(transaction, this._schema, this._metadata);
 	}
 
-	public computeMinFee(transaction: Omit<DecodedTransactionJSON, 'id'>): bigint {
+	public computeMinFee(transaction: Omit<DecodedTransactionJSON, 'id'>, options: Options): bigint {
 		const decodedTx = this.fromJSON(transaction as DecodedTransactionJSON);
 		this._validateTransaction(decodedTx);
 		const commandSchema = getTransactionParamsSchema(transaction, this._metadata);
-		const numberOfSignatures = decodedTx.signatures ? decodedTx.signatures.length : 1;
-		const options: Options = {
-			numberOfSignatures,
-		};
 
 		return computeMinFee(decodedTx, commandSchema, options);
 	}

--- a/elements/lisk-api-client/src/transaction.ts
+++ b/elements/lisk-api-client/src/transaction.ts
@@ -16,8 +16,8 @@ import {
 	signTransaction,
 	signMultiSignatureTransaction,
 	computeMinFee,
+	Options,
 } from '@liskhq/lisk-transactions';
-import { Options } from '@liskhq/lisk-transactions/src/fee';
 import { address as cryptoAddress, ed } from '@liskhq/lisk-cryptography';
 import { validator } from '@liskhq/lisk-validator';
 import { codec } from '@liskhq/lisk-codec';
@@ -266,6 +266,7 @@ export class Transaction {
 		this._validateTransaction(decodedTx);
 		const commandSchema = getTransactionParamsSchema(transaction, this._metadata);
 
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		return computeMinFee(decodedTx, commandSchema, options);
 	}
 

--- a/elements/lisk-api-client/src/transaction.ts
+++ b/elements/lisk-api-client/src/transaction.ts
@@ -134,7 +134,10 @@ export class Transaction {
 				? codec.fromJSON(commandSchema, txInput.params as Record<string, unknown>)
 				: {},
 		};
-		if (authAccount.numberOfSignatures > 0) {
+		if (
+			authAccount.numberOfSignatures > 0 ||
+			(options?.multisignatureKeys && options?.includeSenderSignature)
+		) {
 			const signedTx = signMultiSignatureTransaction(
 				rawTx,
 				chainID,
@@ -145,20 +148,6 @@ export class Transaction {
 				},
 				commandSchema,
 				options?.includeSenderSignature,
-			);
-			return this.toJSON(signedTx) as DecodedTransactionJSON<T>;
-		}
-		if (options?.multisignatureKeys && options?.includeSenderSignature) {
-			const signedTx = signMultiSignatureTransaction(
-				rawTx,
-				chainID,
-				privateKey,
-				{
-					mandatoryKeys: authAccount.mandatoryKeys.map(k => Buffer.from(k, 'hex')),
-					optionalKeys: authAccount.optionalKeys.map(k => Buffer.from(k, 'hex')),
-				},
-				commandSchema,
-				options.includeSenderSignature,
 			);
 			return this.toJSON(signedTx) as DecodedTransactionJSON<T>;
 		}

--- a/elements/lisk-api-client/test/unit/transaction.spec.ts
+++ b/elements/lisk-api-client/test/unit/transaction.spec.ts
@@ -70,8 +70,6 @@ describe('transaction', () => {
 	const txId = Buffer.from(tx.id, 'hex');
 	const txJSON = {
 		...tx,
-		module: tx.module,
-		command: tx.command,
 		nonce: tx.nonce.toString(),
 		fee: tx.fee.toString(),
 		senderPublicKey: tx.senderPublicKey.toString('hex'),
@@ -288,13 +286,13 @@ describe('transaction', () => {
 
 		describe('send', () => {
 			it('should invoke txpool_postTransaction', async () => {
-				const { transactionId: trxId } = await transaction.send(txJSON);
+				const { transactionId } = await transaction.send(txJSON);
 
 				expect(channelMock.invoke).toHaveBeenCalledTimes(1);
 				expect(channelMock.invoke).toHaveBeenCalledWith('txpool_postTransaction', {
 					transaction: txHex,
 				});
-				expect(trxId).toEqual(tx.id);
+				expect(transactionId).toEqual(tx.id);
 			});
 		});
 
@@ -318,13 +316,6 @@ describe('transaction', () => {
 			it('should return encoded transaction', () => {
 				const returnedTx = transaction.encode(tx);
 				expect(returnedTx).toEqual(encodedTx);
-			});
-		});
-
-		describe('computeMinFee', () => {
-			it('should return some value', () => {
-				const fee = transaction.computeMinFee(txJSON);
-				expect(fee).toBeDefined();
 			});
 		});
 

--- a/elements/lisk-transactions/src/fee.ts
+++ b/elements/lisk-transactions/src/fee.ts
@@ -25,7 +25,7 @@ const DEFAULT_MIN_FEE_PER_BYTE = 1000;
 const DEFAULT_NUMBER_OF_SIGNATURES = 1;
 const DEFAULT_SIGNATURE_BYTE_SIZE = 64;
 
-const computeTransactionMinFee = (
+export const computeMinFee = (
 	trx: Record<string, unknown>,
 	assetSchema?: object,
 	options?: Options,
@@ -38,30 +38,18 @@ const computeTransactionMinFee = (
 			...new Array<Buffer>(options.numberOfEmptySignatures).fill(Buffer.alloc(0)),
 		);
 	}
-	const size = getBytes(
-		{
-			...trx,
-			signatures: mockSignatures,
-		},
-		assetSchema,
-	).length;
 
-	return BigInt(size * (options?.minFeePerByte ?? DEFAULT_MIN_FEE_PER_BYTE));
-};
+	const { ...transaction } = trx;
+	transaction.signatures = mockSignatures;
+	transaction.fee = BigInt(0);
 
-export const computeMinFee = (
-	trx: Record<string, unknown>,
-	assetSchema?: object,
-	options?: Options,
-): bigint => {
-	const { fee, ...trxWithoutFee } = trx;
-	trxWithoutFee.fee = BigInt(0);
-	let minFee = computeTransactionMinFee(trxWithoutFee, assetSchema, options);
+	let minFee = BigInt(0);
 
-	while (minFee > BigInt(trxWithoutFee.fee as bigint)) {
-		// eslint-disable-next-line no-param-reassign
-		trxWithoutFee.fee = minFee;
-		minFee = computeTransactionMinFee(trxWithoutFee, assetSchema, options);
-	}
+	do {
+		transaction.fee = minFee;
+		const size = getBytes(transaction, assetSchema).length;
+		minFee = BigInt(size * (options?.minFeePerByte ?? DEFAULT_MIN_FEE_PER_BYTE));
+	} while (minFee > BigInt(transaction.fee as bigint));
+
 	return minFee;
 };

--- a/elements/lisk-transactions/src/fee.ts
+++ b/elements/lisk-transactions/src/fee.ts
@@ -15,7 +15,7 @@
 
 import { getBytes } from './sign';
 
-interface Options {
+export interface Options {
 	readonly minFeePerByte?: number;
 	readonly numberOfSignatures?: number;
 	readonly numberOfEmptySignatures?: number;

--- a/elements/lisk-transactions/src/fee.ts
+++ b/elements/lisk-transactions/src/fee.ts
@@ -47,8 +47,8 @@ export const computeMinFee = (
 
 	do {
 		transaction.fee = minFee;
-		const size = getBytes(transaction, assetSchema).length;
-		minFee = BigInt(size * (options?.minFeePerByte ?? DEFAULT_MIN_FEE_PER_BYTE));
+		const transactionSize = getBytes(transaction, assetSchema).length;
+		minFee = BigInt(transactionSize * (options?.minFeePerByte ?? DEFAULT_MIN_FEE_PER_BYTE));
 	} while (minFee > BigInt(transaction.fee as bigint));
 
 	return minFee;

--- a/elements/lisk-transactions/src/index.ts
+++ b/elements/lisk-transactions/src/index.ts
@@ -13,7 +13,7 @@
  *
  */
 
-export { computeMinFee } from './fee';
+export { computeMinFee, Options } from './fee';
 export { convertBeddowsToLSK, convertLSKToBeddows } from './format';
 export {
 	getBytes,

--- a/elements/lisk-transactions/test/fee.spec.ts
+++ b/elements/lisk-transactions/test/fee.spec.ts
@@ -106,7 +106,7 @@ describe('fee', () => {
 			const txBytes = getBytes({ ...transaction, fee: minFee }, validParamsSchema);
 
 			// Assert
-			expect(minFee.toString()).toEqual(BigInt(txBytes.length * 1000).toString());
+			expect(minFee).toBe(BigInt(txBytes.length * 1000));
 		});
 
 		it('should calculate minimum fee for validator registration transaction', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #7010

### How was it solved?

Implemented solution proposed by @shuse2:

`lisk-api-client` method `Transaction.computeMinFee()` no longer calculates options, but takes them as argument. The options are then passed on to util function with the same name `computeMinFee()` [from `lisk-transactions` package] to correctly calculate min fee.

In order not to have too many potentially conflicting interfaces, `lisk-api-client` no longer defines yet another version of `Options` interface, but imports it from `lisk-transactions`.

### How was it tested?

Nothing really to be tested here. API Client `computeMinFee()` doesn't do anything else but validates input and passes it on to `lisk-transaction` util function `computeMinFee()`, and that one has all the tests.