### PR TITLE
Fix command names to be consistently verb

### DIFF
--- a/examples/pos-mainchain/src/app/app.ts
+++ b/examples/pos-mainchain/src/app/app.ts
@@ -3,7 +3,7 @@ import { registerModules } from './modules';
 import { registerPlugins } from './plugins';
 
 export const getApplication = (config: PartialApplicationConfig): Application => {
-	const { app } = Application.defaultApplication(config);
+	const { app } = Application.defaultApplication(config, true);
 	registerModules(app);
 	registerPlugins(app);
 

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -70,15 +70,18 @@ export {
 	genesisStoreSchema as posGenesisStoreSchema,
 } from './modules/pos';
 export {
-	MainchainCCUpdateCommand,
+	SubmitMainchainCrossChainUpdateCommand,
 	MainchainInteroperabilityMethod,
 	MainchainInteroperabilityModule,
-	MainchainMessageRecoveryCommand,
-	MainchainRegistrationCommand,
-	SidechainCCUpdateCommand,
+	RecoverMessageCommand,
+	RegisterMainchainCommand,
+	SubmitSidechainCrossChainUpdateCommand,
 	SidechainInteroperabilityMethod,
 	SidechainInteroperabilityModule,
-	SidechainRegistrationCommand,
+	RegisterSidechainCommand,
+	InitializeStateRecoveryCommand,
+	RecoverStateCommand,
+	TerminateSidechainForLivenessCommand,
 } from './modules/interoperability';
 export { RewardMethod, RewardModule } from './modules/reward';
 export { FeeMethod, FeeModule } from './modules/fee';

--- a/framework/src/modules/interoperability/constants.ts
+++ b/framework/src/modules/interoperability/constants.ts
@@ -73,11 +73,11 @@ export const CROSS_CHAIN_COMMAND_REGISTRATION = 'crossChainCommandRegistration';
 export const CCM_SENT_STATUS_SUCCESS = 0;
 
 // Commands
-export const COMMAND_NAME_SIDECHAIN_REG = 'sidechainRegistration';
-export const COMMAND_NAME_MAINCHAIN_REG = 'mainchainRegistration';
-export const COMMAND_NAME_STATE_RECOVERY = 'stateRecovery';
-export const COMMAND_NAME_MESSAGE_RECOVERY = 'messageRecovery';
-export const COMMAND_NAME_STATE_RECOVERY_INIT = 'stateRecoveryInitialization';
+export const COMMAND_NAME_SIDECHAIN_REG = 'registerSidechain';
+export const COMMAND_NAME_MAINCHAIN_REG = 'registerMainchain';
+export const COMMAND_NAME_STATE_RECOVERY = 'recoverState';
+export const COMMAND_NAME_MESSAGE_RECOVERY = 'recoverMessage';
+export const COMMAND_NAME_STATE_RECOVERY_INIT = 'initializeStateRecovery';
 export const COMMAND_NAME_LIVENESS_TERMINATION = 'terminateSidechainForLiveness';
 
 // Events

--- a/framework/src/modules/interoperability/mainchain/commands/index.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/index.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export { MainchainCCUpdateCommand } from './cc_update';
-export { SidechainRegistrationCommand } from './sidechain_registration';
-export { MainchainMessageRecoveryCommand } from './message_recovery';
+export { SubmitMainchainCrossChainUpdateCommand } from './submit_mainchain_cross_chain_update';
+export { RegisterSidechainCommand } from './register_sidechain';
+export { RecoverMessageCommand } from './recover_message';
 export { TerminateSidechainForLivenessCommand } from './terminate_sidechain_for_liveness';

--- a/framework/src/modules/interoperability/mainchain/commands/initialize_message_recovery.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/initialize_message_recovery.ts
@@ -41,7 +41,7 @@ export interface MessageRecoveryInitializationParams {
 }
 
 // LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#message-recovery-initialization-command
-export class MessageRecoveryInitializationCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
+export class InitializeMessageRecoveryCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
 	public schema = messageRecoveryInitializationParamsSchema;
 
 	public async verify(

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -26,7 +26,7 @@ import { CCMsg, CrossChainMessageContext, MessageRecoveryParams } from '../../ty
 import { BaseInteroperabilityCommand } from '../../base_interoperability_command';
 import { MainchainInteroperabilityInternalMethod } from '../internal_method';
 import { getMainchainID, validateFormat } from '../../utils';
-import { CCMStatusCode, COMMAND_NAME_MESSAGE_RECOVERY } from '../../constants';
+import { CCMStatusCode } from '../../constants';
 import { ccmSchema, messageRecoveryParamsSchema } from '../../schemas';
 import { TerminatedOutboxAccount, TerminatedOutboxStore } from '../../stores/terminated_outbox';
 import {
@@ -36,12 +36,8 @@ import {
 } from '../../events/ccm_processed';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#message-recovery-command
-export class MainchainMessageRecoveryCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
+export class RecoverMessageCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
 	public schema = messageRecoveryParamsSchema;
-
-	public get name(): string {
-		return COMMAND_NAME_MESSAGE_RECOVERY;
-	}
 
 	// https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#verification-1
 	public async verify(

--- a/framework/src/modules/interoperability/mainchain/commands/recover_state.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_state.ts
@@ -12,6 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { BaseStateRecoveryCommand } from '../../base_state_recovery';
-import { SidechainInteroperabilityInternalMethod } from '../internal_method';
+import { MainchainInteroperabilityInternalMethod } from '../internal_method';
 
-export class StateRecoveryCommand extends BaseStateRecoveryCommand<SidechainInteroperabilityInternalMethod> {}
+export class RecoverStateCommand extends BaseStateRecoveryCommand<MainchainInteroperabilityInternalMethod> {}

--- a/framework/src/modules/interoperability/mainchain/commands/register_sidechain.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/register_sidechain.ts
@@ -45,7 +45,7 @@ import { ChainAccountUpdatedEvent } from '../../events/chain_account_updated';
 import { OwnChainAccountStore } from '../../stores/own_chain_account';
 import { CcmSendSuccessEvent } from '../../events/ccm_send_success';
 
-export class SidechainRegistrationCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
+export class RegisterSidechainCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
 	public schema = sidechainRegParams;
 	private _tokenMethod!: TokenMethod;
 	private _feeMethod!: FeeMethod;

--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -48,7 +48,7 @@ import { CrossChainMessageContext, CrossChainUpdateTransactionParams } from '../
 import { getMainchainID, isInboxUpdateEmpty } from '../../utils';
 import { MainchainInteroperabilityInternalMethod } from '../internal_method';
 
-export class MainchainCCUpdateCommand extends BaseCrossChainUpdateCommand<MainchainInteroperabilityInternalMethod> {
+export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdateCommand<MainchainInteroperabilityInternalMethod> {
 	public async verify(
 		context: CommandVerifyContext<CrossChainUpdateTransactionParams>,
 	): Promise<VerificationResult> {

--- a/framework/src/modules/interoperability/mainchain/module.ts
+++ b/framework/src/modules/interoperability/mainchain/module.ts
@@ -35,9 +35,9 @@ import { terminatedStateSchema } from '../stores/terminated_state';
 import { terminatedOutboxSchema } from '../stores/terminated_outbox';
 import { TokenMethod } from '../../token';
 import {
-	MainchainCCUpdateCommand,
-	MainchainMessageRecoveryCommand,
-	SidechainRegistrationCommand,
+	SubmitMainchainCrossChainUpdateCommand,
+	RecoverMessageCommand,
+	RegisterSidechainCommand,
 	TerminateSidechainForLivenessCommand,
 } from './commands';
 import { CcmProcessedEvent } from '../events/ccm_processed';
@@ -49,10 +49,10 @@ import { CcmSendSuccessEvent } from '../events/ccm_send_success';
 import { TerminatedStateCreatedEvent } from '../events/terminated_state_created';
 import { TerminatedOutboxCreatedEvent } from '../events/terminated_outbox_created';
 import { MainchainInteroperabilityInternalMethod } from './internal_method';
-import { MessageRecoveryInitializationCommand } from './commands/message_recovery_initialization';
+import { InitializeMessageRecoveryCommand } from './commands/initialize_message_recovery';
 import { FeeMethod } from '../types';
 import { MainchainCCChannelTerminatedCommand, MainchainCCRegistrationCommand } from './cc_commands';
-import { StateRecoveryCommand } from './commands/state_recovery';
+import { RecoverStateCommand } from './commands/recover_state';
 
 export class MainchainInteroperabilityModule extends BaseInteroperabilityModule {
 	public crossChainMethod = new MainchainCCMethod(this.stores, this.events);
@@ -71,7 +71,7 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 	// eslint-disable-next-line @typescript-eslint/member-ordering
 	public endpoint = new MainchainInteroperabilityEndpoint(this.stores, this.offchainStores);
 
-	private readonly _sidechainRegistrationCommand = new SidechainRegistrationCommand(
+	private readonly _sidechainRegistrationCommand = new RegisterSidechainCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,
@@ -79,28 +79,28 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 		this.internalMethod,
 	);
 
-	private readonly _messageRecoveryInitializationCommand = new MessageRecoveryInitializationCommand(
+	private readonly _messageRecoveryInitializationCommand = new InitializeMessageRecoveryCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,
 		this.interoperableCCCommands,
 		this.internalMethod,
 	);
-	private readonly _crossChainUpdateCommand = new MainchainCCUpdateCommand(
+	private readonly _crossChainUpdateCommand = new SubmitMainchainCrossChainUpdateCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,
 		this.interoperableCCCommands,
 		this.internalMethod,
 	);
-	private readonly _messageRecoveryCommand = new MainchainMessageRecoveryCommand(
+	private readonly _messageRecoveryCommand = new RecoverMessageCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,
 		this.interoperableCCCommands,
 		this.internalMethod,
 	);
-	private readonly _stateRecoveryCommand = new StateRecoveryCommand(
+	private readonly _stateRecoveryCommand = new RecoverStateCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,

--- a/framework/src/modules/interoperability/sidechain/commands/index.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/index.ts
@@ -12,5 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export { SidechainCCUpdateCommand } from './cc_update';
-export { MainchainRegistrationCommand } from './mainchain_registration';
+export { SubmitSidechainCrossChainUpdateCommand } from './submit_sidechain_cross_chain_update';
+export { RegisterMainchainCommand } from './register_mainchain';
+export { InitializeStateRecoveryCommand } from './initialize_state_recovery';
+export { RecoverStateCommand } from './recover_state';

--- a/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
@@ -31,7 +31,7 @@ import { ChainAccount, StateRecoveryInitParams } from '../../types';
 import { getMainchainID } from '../../utils';
 import { MainchainInteroperabilityInternalMethod } from '../../mainchain/internal_method';
 
-export class StateRecoveryInitializationCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
+export class InitializeStateRecoveryCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
 	public schema = stateRecoveryInitParamsSchema;
 
 	// LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#verification-3

--- a/framework/src/modules/interoperability/sidechain/commands/recover_state.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/recover_state.ts
@@ -12,6 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 import { BaseStateRecoveryCommand } from '../../base_state_recovery';
-import { MainchainInteroperabilityInternalMethod } from '../internal_method';
+import { SidechainInteroperabilityInternalMethod } from '../internal_method';
 
-export class StateRecoveryCommand extends BaseStateRecoveryCommand<MainchainInteroperabilityInternalMethod> {}
+export class RecoverStateCommand extends BaseStateRecoveryCommand<SidechainInteroperabilityInternalMethod> {}

--- a/framework/src/modules/interoperability/sidechain/commands/register_mainchain.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/register_mainchain.ts
@@ -56,7 +56,7 @@ import { InvalidRegistrationSignatureEvent } from '../../events/invalid_registra
 import { CcmSendSuccessEvent } from '../../events/ccm_send_success';
 import { SidechainInteroperabilityInternalMethod } from '../internal_method';
 
-export class MainchainRegistrationCommand extends BaseInteroperabilityCommand<SidechainInteroperabilityInternalMethod> {
+export class RegisterMainchainCommand extends BaseInteroperabilityCommand<SidechainInteroperabilityInternalMethod> {
 	public schema = mainchainRegParams;
 
 	private _validatorsMethod!: ValidatorsMethod;

--- a/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
@@ -26,7 +26,7 @@ import { CrossChainUpdateTransactionParams } from '../../types';
 import { getMainchainID } from '../../utils';
 import { SidechainInteroperabilityInternalMethod } from '../internal_method';
 
-export class SidechainCCUpdateCommand extends BaseCrossChainUpdateCommand<SidechainInteroperabilityInternalMethod> {
+export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdateCommand<SidechainInteroperabilityInternalMethod> {
 	public async verify(
 		context: CommandVerifyContext<CrossChainUpdateTransactionParams>,
 	): Promise<VerificationResult> {

--- a/framework/src/modules/interoperability/sidechain/module.ts
+++ b/framework/src/modules/interoperability/sidechain/module.ts
@@ -15,7 +15,7 @@ import { ModuleInitArgs, ModuleMetadata } from '../../base_module';
 import { BaseInteroperabilityModule } from '../base_interoperability_module';
 import { SidechainInteroperabilityMethod } from './method';
 import { SidechainCCMethod } from './cc_method';
-import { MainchainRegistrationCommand } from './commands/mainchain_registration';
+import { RegisterMainchainCommand } from './commands/register_mainchain';
 import { SidechainInteroperabilityEndpoint } from './endpoint';
 import {
 	getChainAccountRequestSchema,
@@ -42,9 +42,9 @@ import { CcmSendSuccessEvent } from '../events/ccm_send_success';
 import { BaseCCMethod } from '../base_cc_method';
 import { TokenMethod, ValidatorsMethod } from '../types';
 import { SidechainInteroperabilityInternalMethod } from './internal_method';
-import { SidechainCCUpdateCommand } from './commands';
-import { StateRecoveryInitializationCommand } from './commands/state_recovery_init';
-import { StateRecoveryCommand } from './commands/state_recovery';
+import { SubmitSidechainCrossChainUpdateCommand } from './commands';
+import { InitializeStateRecoveryCommand } from './commands/initialize_state_recovery';
+import { RecoverStateCommand } from './commands/recover_state';
 import { SidechainCCChannelTerminatedCommand, SidechainCCRegistrationCommand } from './cc_commands';
 
 export class SidechainInteroperabilityModule extends BaseInteroperabilityModule {
@@ -64,28 +64,28 @@ export class SidechainInteroperabilityModule extends BaseInteroperabilityModule 
 	// eslint-disable-next-line @typescript-eslint/member-ordering
 	public endpoint = new SidechainInteroperabilityEndpoint(this.stores, this.offchainStores);
 
-	private readonly _mainchainRegistrationCommand = new MainchainRegistrationCommand(
+	private readonly _mainchainRegistrationCommand = new RegisterMainchainCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,
 		this.interoperableCCCommands,
 		this.internalMethod,
 	);
-	private readonly _crossChainUpdateCommand = new SidechainCCUpdateCommand(
+	private readonly _crossChainUpdateCommand = new SubmitSidechainCrossChainUpdateCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,
 		this.interoperableCCCommands,
 		this.internalMethod,
 	);
-	private readonly _stateRecoveryInitCommand = new StateRecoveryInitializationCommand(
+	private readonly _stateRecoveryInitCommand = new InitializeStateRecoveryCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,
 		this.interoperableCCCommands,
 		this.internalMethod,
 	);
-	private readonly _stateRecoveryCommand = new StateRecoveryCommand(
+	private readonly _stateRecoveryCommand = new RecoverStateCommand(
 		this.stores,
 		this.events,
 		this.interoperableCCMethods,

--- a/framework/src/modules/token/commands/transfer_cross_chain.ts
+++ b/framework/src/modules/token/commands/transfer_cross_chain.ts
@@ -42,7 +42,7 @@ interface Params {
 	messageFee: bigint;
 }
 
-export class CrossChainTransferCommand extends BaseCommand {
+export class TransferCrossChainCommand extends BaseCommand {
 	public schema = crossChainTransferParamsSchema;
 	private _moduleName!: string;
 	private _method!: TokenMethod;

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -68,7 +68,7 @@ import { AllTokensFromChainSupportRemovedEvent } from './events/all_tokens_from_
 import { TokenIDSupportedEvent } from './events/token_id_supported';
 import { TokenIDSupportRemovedEvent } from './events/token_id_supported_removed';
 import { CrossChainTransferCommand as CrossChainTransferMessageCommand } from './cc_commands/cc_transfer';
-import { CrossChainTransferCommand } from './commands/cc_transfer';
+import { TransferCrossChainCommand } from './commands/transfer_cross_chain';
 import { InternalMethod } from './internal_method';
 
 export class TokenModule extends BaseInteroperableModule {
@@ -80,7 +80,7 @@ export class TokenModule extends BaseInteroperableModule {
 
 	private _ownChainID!: Buffer;
 	private readonly _transferCommand = new TransferCommand(this.stores, this.events);
-	private readonly _ccTransferCommand = new CrossChainTransferCommand(this.stores, this.events);
+	private readonly _ccTransferCommand = new TransferCrossChainCommand(this.stores, this.events);
 	private readonly _internalMethod = new InternalMethod(this.stores, this.events);
 
 	// eslint-disable-next-line @typescript-eslint/member-ordering

--- a/framework/test/unit/modules/interoperability/mainchain/commands/initialize_message_recovery.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/initialize_message_recovery.spec.ts
@@ -23,9 +23,9 @@ import {
 } from '../../../../../../src';
 import { EMPTY_BYTES, EMPTY_HASH } from '../../../../../../src/modules/interoperability/constants';
 import {
-	MessageRecoveryInitializationCommand,
+	InitializeMessageRecoveryCommand,
 	MessageRecoveryInitializationParams,
-} from '../../../../../../src/modules/interoperability/mainchain/commands/message_recovery_initialization';
+} from '../../../../../../src/modules/interoperability/mainchain/commands/initialize_message_recovery';
 import {
 	ChainAccountStore,
 	ChainStatus,
@@ -41,7 +41,7 @@ import { OwnChainAccount } from '../../../../../../src/modules/interoperability/
 import { PrefixedStateReadWriter } from '../../../../../../src/state_machine/prefixed_state_read_writer';
 import { createTransactionContext, InMemoryPrefixedStateDB } from '../../../../../../src/testing';
 
-describe('MessageRecoveryInitializationCommand', () => {
+describe('InitializeMessageRecoveryCommand', () => {
 	const interopMod = new MainchainInteroperabilityModule();
 	const targetChainID = Buffer.from([0, 0, 3, 0]);
 	const ownChainAccount: OwnChainAccount = {
@@ -96,12 +96,12 @@ describe('MessageRecoveryInitializationCommand', () => {
 		mainchainStateRoot: EMPTY_HASH,
 	};
 
-	let command: MessageRecoveryInitializationCommand;
+	let command: InitializeMessageRecoveryCommand;
 	let stateStore: PrefixedStateReadWriter;
 
 	beforeEach(async () => {
 		stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
-		command = new MessageRecoveryInitializationCommand(
+		command = new InitializeMessageRecoveryCommand(
 			interopMod.stores,
 			interopMod.events,
 			new Map(),

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -27,7 +27,7 @@ import {
 	CROSS_CHAIN_COMMAND_NAME_REGISTRATION,
 	MODULE_NAME_INTEROPERABILITY,
 } from '../../../../../../src/modules/interoperability/constants';
-import { MainchainMessageRecoveryCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/message_recovery';
+import { RecoverMessageCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/recover_message';
 import {
 	ccmSchema,
 	messageRecoveryParamsSchema,
@@ -94,13 +94,13 @@ const generateProof = async (ccms: Buffer[]): Promise<Proof> => {
 	return merkleTree.generateProof(queryHashes);
 };
 
-describe('Mainchain MessageRecoveryCommand', () => {
+describe('Mainchain InitializeMessageRecoveryCommand', () => {
 	const interopModule = new MainchainInteroperabilityModule();
 
-	let command: MainchainMessageRecoveryCommand;
+	let command: RecoverMessageCommand;
 
 	beforeEach(() => {
-		command = new MainchainMessageRecoveryCommand(
+		command = new RecoverMessageCommand(
 			interopModule.stores,
 			interopModule.events,
 			new Map(),

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_state.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_state.spec.ts
@@ -24,7 +24,7 @@ import {
 import { BaseCCCommand } from '../../../../../../src/modules/interoperability/base_cc_command';
 import { BaseCCMethod } from '../../../../../../src/modules/interoperability/base_cc_method';
 import { COMMAND_NAME_STATE_RECOVERY } from '../../../../../../src/modules/interoperability/constants';
-import { StateRecoveryCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/state_recovery';
+import { RecoverStateCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/recover_state';
 import { stateRecoveryParamsSchema } from '../../../../../../src/modules/interoperability/schemas';
 import {
 	TerminatedStateAccount,
@@ -37,11 +37,11 @@ import { createTransactionContext } from '../../../../../../src/testing';
 import { InMemoryPrefixedStateDB } from '../../../../../../src/testing/in_memory_prefixed_state';
 import { createStoreGetter } from '../../../../../../src/testing/utils';
 
-describe('Mainchain StateRecoveryCommand', () => {
+describe('Mainchain RecoverStateCommand', () => {
 	const interopMod = new MainchainInteroperabilityModule();
 	const module = 'module';
 	let chainIDAsBuffer: Buffer;
-	let stateRecoveryCommand: StateRecoveryCommand;
+	let stateRecoveryCommand: RecoverStateCommand;
 	let commandVerifyContext: CommandVerifyContext<StateRecoveryParams>;
 	let commandExecuteContext: CommandExecuteContext<StateRecoveryParams>;
 	let interoperableCCMethods: Map<string, BaseCCMethod>;
@@ -63,7 +63,7 @@ describe('Mainchain StateRecoveryCommand', () => {
 		};
 		interoperableCCMethods.set('module', interoperableMethod);
 		ccCommands = new Map();
-		stateRecoveryCommand = new StateRecoveryCommand(
+		stateRecoveryCommand = new RecoverStateCommand(
 			interopMod.stores,
 			interopMod.events,
 			interoperableCCMethods,

--- a/framework/test/unit/modules/interoperability/mainchain/commands/register_sidechain.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/register_sidechain.spec.ts
@@ -16,7 +16,7 @@ import { utils } from '@liskhq/lisk-cryptography';
 import { Transaction } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import * as testing from '../../../../../../src/testing';
-import { SidechainRegistrationCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/sidechain_registration';
+import { RegisterSidechainCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/register_sidechain';
 import {
 	EMPTY_HASH,
 	MAX_UINT64,
@@ -64,7 +64,7 @@ import { EMPTY_BYTES } from '../../../../../../src/modules/token/constants';
 import { ChainAccountUpdatedEvent } from '../../../../../../src/modules/interoperability/events/chain_account_updated';
 import { CcmSendSuccessEvent } from '../../../../../../src/modules/interoperability/events/ccm_send_success';
 
-describe('Sidechain registration command', () => {
+describe('RegisterSidechainCommand', () => {
 	const interopMod = new MainchainInteroperabilityModule();
 	const chainID = Buffer.from([0, 0, 0, 0]);
 	const newChainID = utils.intToBuffer(2, 4);
@@ -117,7 +117,7 @@ describe('Sidechain registration command', () => {
 		status: 0,
 	};
 
-	let sidechainRegistrationCommand: SidechainRegistrationCommand;
+	let sidechainRegistrationCommand: RegisterSidechainCommand;
 	let stateStore: PrefixedStateReadWriter;
 	let nameSubstore: RegisteredNamesStore;
 	let chainAccountSubstore: ChainAccountStore;
@@ -130,7 +130,7 @@ describe('Sidechain registration command', () => {
 	let tokenMethod: TokenMethod;
 
 	beforeEach(async () => {
-		sidechainRegistrationCommand = new SidechainRegistrationCommand(
+		sidechainRegistrationCommand = new RegisterSidechainCommand(
 			interopMod.stores,
 			interopMod.events,
 			new Map(),

--- a/framework/test/unit/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.spec.ts
@@ -19,7 +19,7 @@ import {
 	CommandExecuteContext,
 	CommandVerifyContext,
 	VerifyStatus,
-	MainchainCCUpdateCommand,
+	SubmitMainchainCrossChainUpdateCommand,
 	MainchainInteroperabilityModule,
 	Transaction,
 } from '../../../../../../src';
@@ -72,7 +72,7 @@ import {
 import { MainchainInteroperabilityInternalMethod } from '../../../../../../src/modules/interoperability/mainchain/internal_method';
 import { CROSS_CHAIN_COMMAND_NAME_TRANSFER } from '../../../../../../src/modules/token/constants';
 
-describe('CrossChainUpdateCommand', () => {
+describe('SubmitMainchainCrossChainUpdateCommand', () => {
 	const interopMod = new MainchainInteroperabilityModule();
 
 	const chainID = Buffer.alloc(4, 0);
@@ -146,7 +146,7 @@ describe('CrossChainUpdateCommand', () => {
 	let partnerChannelAccount: ChannelData;
 	let verifyContext: CommandVerifyContext<CrossChainUpdateTransactionParams>;
 	let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
-	let mainchainCCUUpdateCommand: MainchainCCUpdateCommand;
+	let mainchainCCUUpdateCommand: SubmitMainchainCrossChainUpdateCommand;
 	let params: CrossChainUpdateTransactionParams;
 	let activeValidatorsUpdate: ActiveValidator[];
 	let sortedActiveValidatorsUpdate: ActiveValidator[];
@@ -155,7 +155,7 @@ describe('CrossChainUpdateCommand', () => {
 	let partnerValidatorStore: ChainValidatorsStore;
 
 	beforeEach(async () => {
-		mainchainCCUUpdateCommand = new MainchainCCUpdateCommand(
+		mainchainCCUUpdateCommand = new SubmitMainchainCrossChainUpdateCommand(
 			interopMod.stores,
 			interopMod.events,
 			new Map(),
@@ -434,7 +434,7 @@ describe('CrossChainUpdateCommand', () => {
 			params: Buffer.alloc(0),
 		};
 		let context: CrossChainMessageContext;
-		let command: MainchainCCUpdateCommand;
+		let command: SubmitMainchainCrossChainUpdateCommand;
 		let ccMethods: Map<string, BaseCCMethod>;
 		let ccCommands: Map<string, BaseCCCommand[]>;
 
@@ -456,7 +456,7 @@ describe('CrossChainUpdateCommand', () => {
 					public execute = jest.fn();
 				})(interopModule.stores, interopModule.events),
 			]);
-			command = new MainchainCCUpdateCommand(
+			command = new SubmitMainchainCrossChainUpdateCommand(
 				interopModule.stores,
 				interopModule.events,
 				ccMethods,

--- a/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
@@ -36,7 +36,7 @@ import {
 } from '../../../../../../src/modules/interoperability/stores/chain_account';
 import { TerminateSidechainForLivenessCommand } from '../../../../../../src/modules/interoperability';
 
-describe('Liveness termination command', () => {
+describe('TerminateSidechainForLivenessCommand', () => {
 	const interopMod = new MainchainInteroperabilityModule();
 
 	describe('verify', () => {

--- a/framework/test/unit/modules/interoperability/sidechain/commands/initialize_state_recovery.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/initialize_state_recovery.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../../src/modules/interoperability/constants';
 import { SidechainInteroperabilityInternalMethod } from '../../../../../../src/modules/interoperability/sidechain/internal_method';
 import { Mocked } from '../../../../../utils/types';
-import { StateRecoveryInitializationCommand } from '../../../../../../src/modules/interoperability/sidechain/commands/state_recovery_init';
+import { InitializeStateRecoveryCommand } from '../../../../../../src/modules/interoperability/sidechain/commands/initialize_state_recovery';
 import {
 	ChainAccount,
 	OwnChainAccount,
@@ -37,7 +37,7 @@ import { createStoreGetter } from '../../../../../../src/testing/utils';
 import { OwnChainAccountStore } from '../../../../../../src/modules/interoperability/stores/own_chain_account';
 import { getMainchainID } from '../../../../../../src/modules/interoperability/utils';
 
-describe('Sidechain StateRecoveryInitializationCommand', () => {
+describe('Sidechain InitializeStateRecoveryCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
 	type StoreMock = Mocked<SidechainInteroperabilityInternalMethod, 'createTerminatedStateAccount'>;
 	const chainAccountStoreMock = {
@@ -56,7 +56,7 @@ describe('Sidechain StateRecoveryInitializationCommand', () => {
 		set: jest.fn(),
 		has: jest.fn(),
 	};
-	let stateRecoveryInitCommand: StateRecoveryInitializationCommand;
+	let stateRecoveryInitCommand: InitializeStateRecoveryCommand;
 	let commandExecuteContext: CommandExecuteContext<StateRecoveryInitParams>;
 	let transaction: Transaction;
 	let transactionParams: StateRecoveryInitParams;
@@ -72,7 +72,7 @@ describe('Sidechain StateRecoveryInitializationCommand', () => {
 	let mainchainAccount: ChainAccount;
 
 	beforeEach(async () => {
-		stateRecoveryInitCommand = new StateRecoveryInitializationCommand(
+		stateRecoveryInitCommand = new InitializeStateRecoveryCommand(
 			interopMod.stores,
 			interopMod.events,
 			new Map(),

--- a/framework/test/unit/modules/interoperability/sidechain/commands/register_mainchain.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/register_mainchain.spec.ts
@@ -17,7 +17,7 @@ import * as crypto from '@liskhq/lisk-cryptography';
 import { Transaction } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { LiskValidationError } from '@liskhq/lisk-validator';
-import { MainchainRegistrationCommand } from '../../../../../../src/modules/interoperability/sidechain/commands/mainchain_registration';
+import { RegisterMainchainCommand } from '../../../../../../src/modules/interoperability/sidechain/commands/register_mainchain';
 import {
 	CCMStatusCode,
 	COMMAND_NAME_MAINCHAIN_REG,
@@ -72,7 +72,7 @@ jest.mock('@liskhq/lisk-cryptography', () => ({
 	...jest.requireActual('@liskhq/lisk-cryptography'),
 }));
 
-describe('Mainchain registration command', () => {
+describe('RegisterMainchainCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
 	interopMod['internalMethod'] = { addToOutbox: jest.fn() } as any;
 	const unsortedMainchainValidators: ActiveValidators[] = [];
@@ -101,14 +101,14 @@ describe('Mainchain registration command', () => {
 		params: encodedTransactionParams,
 		signatures: [publicKey],
 	});
-	let mainchainRegistrationCommand: MainchainRegistrationCommand;
+	let mainchainRegistrationCommand: RegisterMainchainCommand;
 	let verifyContext: CommandVerifyContext<MainchainRegistrationParams>;
 	let ownChainAccountSubstore: OwnChainAccountStore;
 	let stateStore: PrefixedStateReadWriter;
 	let validatorsMethod: ValidatorsMethod;
 
 	beforeEach(() => {
-		mainchainRegistrationCommand = new MainchainRegistrationCommand(
+		mainchainRegistrationCommand = new RegisterMainchainCommand(
 			interopMod.stores,
 			interopMod.events,
 			new Map(),

--- a/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
@@ -28,7 +28,7 @@ import {
 	ChannelData,
 	CrossChainUpdateTransactionParams,
 } from '../../../../../../src/modules/interoperability/types';
-import { SidechainCCUpdateCommand } from '../../../../../../src/modules/interoperability/sidechain/commands/cc_update';
+import { SubmitSidechainCrossChainUpdateCommand } from '../../../../../../src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update';
 import { Certificate } from '../../../../../../src/engine/consensus/certificate_generation/types';
 import { certificateSchema } from '../../../../../../src/engine/consensus/certificate_generation/schema';
 import * as interopUtils from '../../../../../../src/modules/interoperability/utils';
@@ -55,7 +55,7 @@ import { createStoreGetter } from '../../../../../../src/testing/utils';
 import { createTransactionContext } from '../../../../../../src/testing';
 import { CROSS_CHAIN_COMMAND_NAME_TRANSFER } from '../../../../../../src/modules/token/constants';
 
-describe('CrossChainUpdateCommand', () => {
+describe('SubmitSidechainCrossChainUpdateCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
 	const senderPublicKey = utils.getRandomBytes(32);
 	const messageFeeTokenID = Buffer.alloc(8, 0);
@@ -128,7 +128,7 @@ describe('CrossChainUpdateCommand', () => {
 	let partnerChannelAccount: ChannelData;
 	let verifyContext: CommandVerifyContext<CrossChainUpdateTransactionParams>;
 	let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
-	let sidechainCCUUpdateCommand: SidechainCCUpdateCommand;
+	let sidechainCCUUpdateCommand: SubmitSidechainCrossChainUpdateCommand;
 	let params: CrossChainUpdateTransactionParams;
 	let activeValidatorsUpdate: ActiveValidator[];
 	let sortedActiveValidatorsUpdate: ActiveValidator[];
@@ -137,7 +137,7 @@ describe('CrossChainUpdateCommand', () => {
 	let partnerValidatorStore: ChainValidatorsStore;
 
 	beforeEach(async () => {
-		sidechainCCUUpdateCommand = new SidechainCCUpdateCommand(
+		sidechainCCUUpdateCommand = new SubmitSidechainCrossChainUpdateCommand(
 			interopMod.stores,
 			interopMod.events,
 			new Map(),

--- a/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
@@ -23,7 +23,7 @@ import {
 	VerificationResult,
 	VerifyStatus,
 } from '../../../../../src';
-import { CrossChainTransferCommand } from '../../../../../src/modules/token/commands/cc_transfer';
+import { TransferCrossChainCommand } from '../../../../../src/modules/token/commands/transfer_cross_chain';
 import {
 	CCM_STATUS_OK,
 	CROSS_CHAIN_COMMAND_NAME_TRANSFER,
@@ -47,7 +47,7 @@ interface Params {
 }
 
 describe('CCTransfer command', () => {
-	let command: CrossChainTransferCommand;
+	let command: TransferCrossChainCommand;
 	const module = new TokenModule();
 	const method = new TokenMethod(module.stores, module.events, module.name);
 	const internalMethod = new InternalMethod(module.stores, module.events);
@@ -116,7 +116,7 @@ describe('CCTransfer command', () => {
 	};
 
 	beforeEach(() => {
-		command = new CrossChainTransferCommand(module.stores, module.events);
+		command = new TransferCrossChainCommand(module.stores, module.events);
 
 		interoperabilityMethod = {
 			getOwnChainAccount: jest.fn().mockResolvedValue({ id: Buffer.from([0, 0, 0, 1]) }),


### PR DESCRIPTION
### What was the problem?

This PR resolves #7935 

### How was it solved?

- Rename the command as described in the issue

### How was it tested?

```
./bin/run system:metadata | jq '.modules[] | .name as $moduleName | .commands[] | .name as $commandName | { module: $moduleName, command: $commandName }'
```

For sidechain, `examples/pos-mainchain/src/app/app.ts`, it needs to be updated as below to create application as sidechain
```
const { app } = Application.defaultApplication(config, false);
```