### PR TITLE
:bug: Fixes ModuleMetadata exports

### DIFF
--- a/framework/src/modules/base_module.ts
+++ b/framework/src/modules/base_module.ts
@@ -55,27 +55,7 @@ export interface ModuleMetadata {
 	}[];
 }
 
-export type RootModuleMetadata = ModuleMetadata & { name: string };
-export interface ModuleMetadataJSON {
-	name: string;
-	endpoints: {
-		name: string;
-		request?: Schema;
-		response: Schema;
-	}[];
-	events: {
-		name: string;
-		data?: Schema;
-	}[];
-	commands: {
-		name: string;
-		params?: Schema;
-	}[];
-	assets: {
-		version: number;
-		data: Schema;
-	}[];
-}
+export type ModuleMetadataJSON = ModuleMetadata & { name: string };
 
 export abstract class BaseModule {
 	public commands: BaseCommand[] = [];

--- a/framework/src/modules/index.ts
+++ b/framework/src/modules/index.ts
@@ -12,12 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export {
-	BaseModule,
-	RootModuleMetadata as ModuleMetadata,
-	ModuleMetadataJSON,
-	ModuleInitArgs,
-} from './base_module';
+export { BaseModule, ModuleMetadata, ModuleMetadataJSON, ModuleInitArgs } from './base_module';
 export { BaseCommand } from './base_command';
 export { BaseMethod } from './base_method';
 export { BaseEndpoint } from './base_endpoint';


### PR DESCRIPTION
### What was the problem?

This PR resolves #7878 

### How was it solved?

Removes `RootModuleMetadata` and exports `ModuleMetadata` from framework.

### How was it tested?

Passing build