### PR TITLE
Defines lisk property on REPLServer context for console command

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -108,6 +108,7 @@
 	"dependencies": {
 		"@liskhq/lisk-api-client": "^6.0.0-alpha.11",
 		"@liskhq/lisk-chain": "^0.4.0-alpha.11",
+		"@liskhq/lisk-client": "6.0.0-alpha.11",
 		"@liskhq/lisk-codec": "^0.3.0-alpha.7",
 		"@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
 		"@liskhq/lisk-db": "0.3.2",

--- a/commander/src/bootstrapping/commands/console.ts
+++ b/commander/src/bootstrapping/commands/console.ts
@@ -16,6 +16,7 @@
 import { REPLServer, start } from 'repl';
 import { Command, Flags as flagParser } from '@oclif/core';
 import * as apiClient from '@liskhq/lisk-api-client';
+import * as lisk from '@liskhq/lisk-client';
 
 interface ConsoleFlags {
 	readonly 'api-ipc'?: string;
@@ -63,6 +64,10 @@ export class ConsoleCommand extends Command {
 	}
 
 	async initREPLContext(replServer: REPLServer, flags: ConsoleFlags): Promise<void> {
+		Object.defineProperty(replServer.context, 'lisk', {
+			enumerable: true,
+			value: lisk,
+		});
 		if (flags['api-ipc']) {
 			const ipcClient = await apiClient.createIPCClient(flags['api-ipc']);
 			Object.defineProperty(replServer.context, 'client', {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8000

### How was it solved?

Defined elements property set to the exports of `@liskhq/lisk-client` on `REPLServer.context` for console command.
 
### How was it tested?
Implemented unit tests.

Execute `console` command; `./examples/pos-mainchain/bin/run console` and access `lisk.{desired module}`.
An example would be to execute `lisk.cryptography.utils.hash(Buffer.from('space force'))`