### PR TITLE
Sign transactions with an undefined schema

### DIFF
--- a/elements/lisk-transactions/src/sign.ts
+++ b/elements/lisk-transactions/src/sign.ts
@@ -54,7 +54,11 @@ export const getSigningBytes = (
 	if (validationErrors) {
 		throw validationErrors;
 	}
-	if (typeof transactionObject.params !== 'object' || transactionObject.params === null) {
+	if (
+		typeof transactionObject.params !== 'object' ||
+		transactionObject.params === null ||
+		!paramsSchema
+	) {
 		const transactionBytes = codec.encode(baseTransactionSchema, {
 			...transactionObject,
 			params: Buffer.alloc(0),
@@ -94,7 +98,11 @@ export const getBytes = (
 	transactionObject: Record<string, unknown>,
 	paramsSchema?: object,
 ): Buffer => {
-	if (typeof transactionObject.params !== 'object' || transactionObject.params === null) {
+	if (
+		typeof transactionObject.params !== 'object' ||
+		transactionObject.params === null ||
+		!paramsSchema
+	) {
 		const transactionBytes = codec.encode(baseTransactionSchema, {
 			...transactionObject,
 			params: Buffer.alloc(0),

--- a/elements/lisk-transactions/test/sign.spec.ts
+++ b/elements/lisk-transactions/test/sign.spec.ts
@@ -237,6 +237,30 @@ describe('sign', () => {
 			expect(signedTransaction.signatures).toHaveLength(1);
 			return expect(signedTransaction).toMatchSnapshot();
 		});
+
+		it('should return a signed transaction for an undefined params schema', () => {
+			const signedTransaction = signTransaction(
+				{ ...validTransaction, params: undefined },
+				chainID,
+				privateKey,
+				undefined,
+			);
+
+			expect((signedTransaction.signatures as Array<Buffer>)[0].length).toBeGreaterThan(0);
+			expect(signedTransaction.signatures).toHaveLength(1);
+		});
+
+		it('should return a signed transaction for an empty params object', () => {
+			const signedTransaction = signTransaction(
+				{ ...validTransaction, params: {} },
+				chainID,
+				privateKey,
+				undefined,
+			);
+
+			expect((signedTransaction.signatures as Array<Buffer>)[0].length).toBeGreaterThan(0);
+			expect(signedTransaction.signatures).toHaveLength(1);
+		});
 	});
 
 	describe('signMultiSignatureTransaction', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8007

### How was it solved?

Updated the signTransaction function to handle empty param objects.

### How was it tested?

Added a unit test that ensures undefined schemas and empty param objects are signed.
