### PR TITLE
Update apply() and crossChainCommands based on LIP49

### DIFF
--- a/framework/src/modules/interoperability/base_cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/base_cc_commands/channel_terminated.ts
@@ -34,15 +34,15 @@ export abstract class BaseCCChannelTerminatedCommand<
 		}
 
 		const terminatedStateSubstore = this.stores.get(TerminatedStateStore);
-		const terminatedStateAccountExists = await terminatedStateSubstore.has(
-			context,
-			context.ccm.sendingChainID,
-		);
+		const {
+			ccm: { sendingChainID },
+		} = context;
+		const terminatedStateAccountExists = await terminatedStateSubstore.has(context, sendingChainID);
 
 		if (terminatedStateAccountExists) {
 			return;
 		}
 
-		await this.internalMethods.createTerminatedStateAccount(context, context.ccm.sendingChainID);
+		await this.internalMethods.createTerminatedStateAccount(context, sendingChainID);
 	}
 }

--- a/framework/src/modules/interoperability/base_cc_commands/channel_terminated.ts
+++ b/framework/src/modules/interoperability/base_cc_commands/channel_terminated.ts
@@ -16,6 +16,7 @@ import { BaseInteroperabilityCCCommand } from '../base_interoperability_cc_comma
 import { CROSS_CHAIN_COMMAND_NAME_CHANNEL_TERMINATED } from '../constants';
 import { CCCommandExecuteContext } from '../types';
 import { BaseInteroperabilityInternalMethod } from '../base_interoperability_internal_methods';
+import { TerminatedStateStore } from '../stores/terminated_state';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#channel-terminated-message-1
 export abstract class BaseCCChannelTerminatedCommand<
@@ -31,8 +32,17 @@ export abstract class BaseCCChannelTerminatedCommand<
 				`CCM to execute cross chain command '${CROSS_CHAIN_COMMAND_NAME_CHANNEL_TERMINATED}' is missing.`,
 			);
 		}
-		if (await this.internalMethods.isLive(context, context.ccm.sendingChainID, Date.now())) {
-			await this.internalMethods.createTerminatedStateAccount(context, context.ccm.sendingChainID);
+
+		const terminatedStateSubstore = this.stores.get(TerminatedStateStore);
+		const terminatedStateAccountExists = await terminatedStateSubstore.has(
+			context,
+			context.ccm.sendingChainID,
+		);
+
+		if (terminatedStateAccountExists) {
+			return;
 		}
+
+		await this.internalMethods.createTerminatedStateAccount(context, context.ccm.sendingChainID);
 	}
 }

--- a/framework/src/modules/interoperability/base_cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/base_cc_commands/registration.ts
@@ -42,9 +42,6 @@ export abstract class BaseCCRegistrationCommand<
 		if (!ccm) {
 			throw new Error('CCM to execute registration cross chain command is missing.');
 		}
-		if (!ccu) {
-			throw new Error('CCU to execute registration cross chain command is missing.');
-		}
 		const ccmRegistrationParams = codec.decode<CCMRegistrationParams>(
 			registrationCCMParamsSchema,
 			ccm.params,

--- a/framework/src/modules/interoperability/base_cc_commands/registration.ts
+++ b/framework/src/modules/interoperability/base_cc_commands/registration.ts
@@ -37,6 +37,10 @@ export abstract class BaseCCRegistrationCommand<
 		return CROSS_CHAIN_COMMAND_NAME_REGISTRATION;
 	}
 
+	/**
+	 *
+	 * @see https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#verification
+	 */
 	public async verify(ctx: ImmutableCrossChainMessageContext): Promise<void> {
 		const { ccm, ccu } = ctx;
 		if (!ccm) {
@@ -56,7 +60,9 @@ export abstract class BaseCCRegistrationCommand<
 			throw new Error('Registration message must be sent from a direct channel.');
 		}
 		if (chainAccount.status !== ChainStatus.REGISTERED) {
-			throw new Error("Registration message must be sent from a chain with status 'registered'.");
+			throw new Error(
+				`Registration message must be sent from a chain with status ${ChainStatus.REGISTERED}.`,
+			);
 		}
 
 		const channel = await this.stores.get(ChannelDataStore).get(ctx, ccm.sendingChainID);

--- a/framework/src/modules/interoperability/base_cross_chain_update_command.ts
+++ b/framework/src/modules/interoperability/base_cross_chain_update_command.ts
@@ -174,9 +174,6 @@ export abstract class BaseCrossChainUpdateCommand<
 		if (!valid) {
 			return;
 		}
-		if (!ccu) {
-			throw new Error('CCU to apply cross chain command is missing.');
-		}
 		const commands = this.ccCommands.get(ccm.module);
 		if (!commands) {
 			await this.bounce(

--- a/framework/src/modules/interoperability/events/ccm_processed.ts
+++ b/framework/src/modules/interoperability/events/ccm_processed.ts
@@ -53,9 +53,9 @@ export const enum CCMProcessedCode {
 }
 
 export interface CcmProcessedEventData {
+	ccm: CCMsg;
 	result: CCMProcessedResult;
 	code: CCMProcessedCode;
-	ccm: CCMsg;
 }
 
 export const ccmProcessedEventSchema = {

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -154,7 +154,7 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 				ccm,
 				eventQueue: context.eventQueue.getChildQueue(ccmID),
 				ccu: {
-					sendingChainID: context.params.chainID,
+					sendingChainID: params.chainID,
 				},
 			};
 			// If the sending chain is the mainchain, recover the CCM.

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -153,6 +153,9 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 				...context,
 				ccm,
 				eventQueue: context.eventQueue.getChildQueue(ccmID),
+				ccu: {
+					sendingChainID: context.params.chainID,
+				},
 			};
 			// If the sending chain is the mainchain, recover the CCM.
 			// This function never raises an error.

--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -110,6 +110,9 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 					...context,
 					ccm,
 					eventQueue: context.eventQueue.getChildQueue(ccmID),
+					ccu: {
+						sendingChainID: params.sendingChainID,
+					},
 				};
 
 				if (ccm.receivingChainID.equals(getMainchainID(context.chainID))) {

--- a/framework/src/modules/interoperability/schemas.ts
+++ b/framework/src/modules/interoperability/schemas.ts
@@ -373,17 +373,25 @@ export const messageRecoveryInitializationParamsSchema = {
 export const registrationCCMParamsSchema = {
 	$id: '/modules/interoperability/ccCommand/registration',
 	type: 'object',
-	required: ['name', 'messageFeeTokenID'],
+	required: ['name', 'chainID', 'messageFeeTokenID'],
 	properties: {
 		name: {
 			dataType: 'string',
+			minLength: MIN_CHAIN_NAME_LENGTH,
+			maxLength: MAX_CHAIN_NAME_LENGTH,
 			fieldNumber: 1,
+		},
+		chainID: {
+			dataType: 'bytes',
+			fieldNumber: 2,
+			minLength: CHAIN_ID_LENGTH,
+			maxLength: CHAIN_ID_LENGTH,
 		},
 		messageFeeTokenID: {
 			dataType: 'bytes',
 			minLength: TOKEN_ID_LENGTH,
 			maxLength: TOKEN_ID_LENGTH,
-			fieldNumber: 2,
+			fieldNumber: 3,
 		},
 	},
 };

--- a/framework/src/modules/interoperability/sidechain/commands/register_mainchain.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/register_mainchain.ts
@@ -243,6 +243,7 @@ export class RegisterMainchainCommand extends BaseInteroperabilityCommand<Sidech
 
 		const encodedParams = codec.encode(registrationCCMParamsSchema, {
 			name: CHAIN_NAME_MAINCHAIN,
+			chainID: mainchainID,
 			messageFeeTokenID: mainchainTokenID,
 		});
 

--- a/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
@@ -83,6 +83,9 @@ export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdate
 				const ccmContext = {
 					...context,
 					ccm,
+					ccu: {
+						sendingChainID: params.sendingChainID,
+					},
 				};
 
 				await this.apply(ccmContext);

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -91,6 +91,7 @@ export interface ImmutableCrossChainMessageContext {
 		fee: bigint;
 	};
 	ccm: CCMsg;
+	ccu?: CrossChainUpdateTransactionParams;
 }
 
 export interface CrossChainMessageContext extends ImmutableCrossChainMessageContext {
@@ -387,6 +388,7 @@ export interface GenesisInteroperability {
 
 export interface CCMRegistrationParams {
 	name: string;
+	chainID: Buffer;
 	messageFeeTokenID: Buffer;
 }
 export interface TokenMethod {

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -91,7 +91,9 @@ export interface ImmutableCrossChainMessageContext {
 		fee: bigint;
 	};
 	ccm: CCMsg;
-	ccu?: CrossChainUpdateTransactionParams;
+	ccu: {
+		sendingChainID: Buffer;
+	};
 }
 
 export interface CrossChainMessageContext extends ImmutableCrossChainMessageContext {

--- a/framework/src/testing/create_contexts.ts
+++ b/framework/src/testing/create_contexts.ts
@@ -237,6 +237,7 @@ export const createCrossChainMessageContext = (params: {
 	stateStore?: IStateStore;
 	contextStore?: Map<string, unknown>;
 	eventQueue?: EventQueue;
+	ccu?: { sendingChainID: Buffer };
 }): CrossChainMessageContext => {
 	const stateStore =
 		params.stateStore ?? new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
@@ -268,6 +269,9 @@ export const createCrossChainMessageContext = (params: {
 		transaction: params.transaction ?? {
 			senderAddress: utils.getRandomBytes(20),
 			fee: BigInt(100000000),
+		},
+		ccu: params.ccu ?? {
+			sendingChainID: Buffer.from([0, 0, 0, 4]),
 		},
 	};
 };

--- a/framework/test/unit/modules/interoperability/base_cc_commands/channel_terminated.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cc_commands/channel_terminated.spec.ts
@@ -111,7 +111,7 @@ describe('BaseCCChannelTerminatedCommand', () => {
 			expect(createTerminatedStateAccountMock).toHaveBeenCalledTimes(0);
 		});
 
-		it('should call createTerminatedStateAccount if terminatedStateAccount do not exists', async () => {
+		it('should call createTerminatedStateAccount if terminatedStateAccount does not exist', async () => {
 			await ccChannelTerminatedCommand.execute(sampleExecuteContext);
 			expect(createTerminatedStateAccountMock).toHaveBeenCalledWith(
 				sampleExecuteContext,

--- a/framework/test/unit/modules/interoperability/base_cc_commands/registration.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cc_commands/registration.spec.ts
@@ -147,7 +147,7 @@ describe('BaseCCRegistrationCommand', () => {
 	});
 
 	describe('verify', () => {
-		it('should fail if chainAccount does not exist', async () => {
+		it('should fail if partner chainAccount does not exist', async () => {
 			chainAccountStoreMock.get.mockResolvedValue(undefined);
 			await expect(ccRegistrationCommand.verify(sampleExecuteContext)).rejects.toThrow(
 				'Registration message must be sent from a registered chain.',
@@ -169,7 +169,7 @@ describe('BaseCCRegistrationCommand', () => {
 				status: ChainStatus.TERMINATED,
 			});
 			await expect(ccRegistrationCommand.verify(sampleExecuteContext)).rejects.toThrow(
-				"Registration message must be sent from a chain with status 'registered'.",
+				`Registration message must be sent from a chain with status ${ChainStatus.REGISTERED}.`,
 			);
 		});
 
@@ -184,7 +184,7 @@ describe('BaseCCRegistrationCommand', () => {
 			);
 		});
 
-		it('should fail if ccm.status !== OK', async () => {
+		it('should fail if ccm.status !== CCMStatusCode.OK', async () => {
 			sampleExecuteContext = createContext(
 				buildCCM({
 					status: CCMStatusCode.FAILED_CCM,

--- a/framework/test/unit/modules/interoperability/base_cc_commands/registration.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cc_commands/registration.spec.ts
@@ -153,6 +153,7 @@ describe('BaseCCRegistrationCommand', () => {
 				'Registration message must be sent from a registered chain.',
 			);
 		});
+
 		it('should fail if ccm.sendingChainID not equal to ccu.params.sendingChainID', async () => {
 			sampleExecuteContext = createContext(ccm, {
 				sendingChainID: Buffer.from([0, 0, 0, 8]),
@@ -161,6 +162,7 @@ describe('BaseCCRegistrationCommand', () => {
 				'Registration message must be sent from a direct channel.',
 			);
 		});
+
 		it('should fail if chainAccount.status not equal to ChainStatus.REGISTERED', async () => {
 			chainAccountStoreMock.get.mockResolvedValue({
 				...fakeChainAccount,
@@ -170,6 +172,7 @@ describe('BaseCCRegistrationCommand', () => {
 				"Registration message must be sent from a chain with status 'registered'.",
 			);
 		});
+
 		it('should fail if channel.inbox.size !== 0', async () => {
 			channelStoreMock.get.mockResolvedValue({
 				inbox: {

--- a/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
@@ -905,7 +905,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 				context.ccm.receivingChainID,
 				{
 					ccm: context.ccm,
-					code: CCMProcessedCode.INVALID_CCM_VALIDATION_EXCEPTION,
+					code: CCMProcessedCode.INVALID_CCM_VERIFY_CCM_EXCEPTION,
 					result: CCMProcessedResult.DISCARDED,
 				},
 			);
@@ -950,7 +950,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 			expect(context.stateStore.restoreSnapshot).toHaveBeenCalledWith(10);
 		});
 
-		it('should raise exception(and hence bounce) when chainAccount(ccm.sendingChainID) exists and ccu.params.sendingChainID != ccm.sendingChainID', async () => {
+		it('should raise exception(and hence bounce) when chainAccount(ccm.sendingChainID) exists and ccu.params.sendingChainID !== ccm.sendingChainID', async () => {
 			const chainAccountStore = command['stores'].get(ChainAccountStore);
 			jest.spyOn(chainAccountStore, 'has').mockResolvedValue(true);
 			(

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -616,6 +616,9 @@ describe('Mainchain InitializeMessageRecoveryCommand', () => {
 					...commandExecuteContext,
 					ccm,
 					eventQueue: commandExecuteContext.eventQueue.getChildQueue(utils.hash(crossChainMessage)),
+					ccu: {
+						sendingChainID: commandExecuteContext.params.chainID,
+					},
 				};
 
 				expect(command['_applyRecovery']).toHaveBeenCalledWith(ctx);
@@ -652,6 +655,9 @@ describe('Mainchain InitializeMessageRecoveryCommand', () => {
 					...commandExecuteContext,
 					ccm,
 					eventQueue: commandExecuteContext.eventQueue.getChildQueue(utils.hash(crossChainMessage)),
+					ccu: {
+						sendingChainID: commandExecuteContext.params.chainID,
+					},
 				};
 
 				expect(command['_forwardRecovery']).toHaveBeenCalledWith(ctx);

--- a/framework/test/unit/modules/interoperability/sidechain/commands/register_mainchain.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/register_mainchain.spec.ts
@@ -500,6 +500,7 @@ describe('RegisterMainchainCommand', () => {
 			// Arrange
 			const encodedParams = codec.encode(registrationCCMParamsSchema, {
 				name: CHAIN_NAME_MAINCHAIN,
+				chainID: mainchainID,
 				messageFeeTokenID: mainchainTokenID,
 			});
 			const ccm = {
@@ -542,6 +543,7 @@ describe('RegisterMainchainCommand', () => {
 		it(`should emit ${EVENT_NAME_CCM_SEND_SUCCESS} event`, async () => {
 			const encodedParams = codec.encode(registrationCCMParamsSchema, {
 				name: CHAIN_NAME_MAINCHAIN,
+				chainID: mainchainID,
 				messageFeeTokenID: mainchainTokenID,
 			});
 			const ownChainAccount = {

--- a/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
@@ -165,6 +165,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act & Assert
@@ -213,6 +216,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act & Assert
@@ -261,6 +267,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act & Assert
@@ -308,6 +317,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Assert
@@ -356,6 +368,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act & Assert
@@ -396,6 +411,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act & Assert
@@ -444,6 +462,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act & Assert
@@ -504,6 +525,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act & Assert
@@ -553,6 +577,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act
@@ -609,6 +636,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act
@@ -669,6 +699,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act
@@ -735,6 +768,9 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
+				ccu: {
+					sendingChainID,
+				},
 			};
 
 			// Act && Assert

--- a/framework/test/unit/modules/token/cc_method.spec.ts
+++ b/framework/test/unit/modules/token/cc_method.spec.ts
@@ -153,6 +153,9 @@ describe('TokenInteroperableMethod', () => {
 						fee,
 						senderAddress: defaultAddress,
 					},
+					ccu: {
+						sendingChainID,
+					},
 				}),
 			).resolves.toBeUndefined();
 			const { availableBalance } = await userStore.get(
@@ -195,6 +198,9 @@ describe('TokenInteroperableMethod', () => {
 						fee,
 						senderAddress: defaultAddress,
 					},
+					ccu: {
+						sendingChainID,
+					},
 				}),
 			).rejects.toThrow('Insufficient balance in the sending chain for the message fee.');
 			checkEventResult(
@@ -231,6 +237,9 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
+					},
+					ccu: {
+						sendingChainID,
 					},
 				}),
 			).resolves.toBeUndefined();
@@ -281,6 +290,9 @@ describe('TokenInteroperableMethod', () => {
 						fee,
 						senderAddress: defaultAddress,
 					},
+					ccu: {
+						sendingChainID,
+					},
 				}),
 			).rejects.toThrow('Insufficient balance in the sending chain for the message fee.');
 			checkEventResult(
@@ -325,6 +337,9 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
+					},
+					ccu: {
+						sendingChainID,
 					},
 				}),
 			).resolves.toBeUndefined();
@@ -377,6 +392,9 @@ describe('TokenInteroperableMethod', () => {
 						fee,
 						senderAddress: defaultAddress,
 					},
+					ccu: {
+						sendingChainID,
+					},
 				}),
 			).rejects.toThrow('Insufficient balance in the sending chain for the transfer.');
 			checkEventResult(
@@ -421,6 +439,9 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
+					},
+					ccu: {
+						sendingChainID,
 					},
 				}),
 			).resolves.toBeUndefined();
@@ -471,6 +492,9 @@ describe('TokenInteroperableMethod', () => {
 						fee,
 						senderAddress: defaultAddress,
 					},
+					ccu: {
+						sendingChainID,
+					},
 				}),
 			).resolves.toBeUndefined();
 		});
@@ -502,6 +526,9 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
+					},
+					ccu: {
+						sendingChainID,
 					},
 				}),
 			).rejects.toThrow('Insufficient escrow amount.');
@@ -537,6 +564,9 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
+					},
+					ccu: {
+						sendingChainID,
 					},
 				}),
 			).resolves.toBeUndefined();


### PR DESCRIPTION
### What was the problem?

This PR resolves #8011

### How was it solved?
Added check to `apply`
Removed `isLive` from `Channel Terminated Message`
Added `chainID` from `registrationCCMParamsSchema`
Updated `verify` and `execute` of `Registration Message`

### How was it tested?
Unit testes updated accordingly