### PR TITLE
Fix state initialization to include property validation

### DIFF
--- a/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
@@ -15,6 +15,7 @@
 import { codec } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
 import { SparseMerkleTree } from '@liskhq/lisk-db';
+import { validator } from '@liskhq/lisk-validator';
 import {
 	CommandExecuteContext,
 	CommandVerifyContext,
@@ -38,9 +39,11 @@ export class InitializeStateRecoveryCommand extends BaseInteroperabilityCommand<
 	public async verify(
 		context: CommandVerifyContext<StateRecoveryInitParams>,
 	): Promise<VerificationResult> {
-		const {
-			params: { chainID, sidechainAccount, bitmap, siblingHashes },
-		} = context;
+		const { params } = context;
+		validator.validate<StateRecoveryInitParams>(this.schema, params);
+
+		const { chainID, bitmap, siblingHashes, sidechainAccount } = params;
+
 		const ownChainAccount = await this.stores.get(OwnChainAccountStore).get(context, EMPTY_BYTES);
 
 		const mainchainID = getMainchainID(ownChainAccount.chainID);

--- a/framework/test/unit/modules/interoperability/sidechain/commands/initialize_state_recovery.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/initialize_state_recovery.spec.ts
@@ -178,6 +178,50 @@ describe('Sidechain InitializeStateRecoveryCommand', () => {
 			);
 		});
 
+		it('should reject when chain id has invalid length', async () => {
+			await expect(
+				stateRecoveryInitCommand.verify(
+					createTransactionContext({
+						transaction: new Transaction({
+							module: MODULE_NAME_INTEROPERABILITY,
+							command: COMMAND_NAME_STATE_RECOVERY_INIT,
+							fee: BigInt(100000000),
+							nonce: BigInt(0),
+							params: codec.encode(stateRecoveryInitParamsSchema, {
+								...transactionParams,
+								chainID: Buffer.alloc(20, 255),
+							}),
+							senderPublicKey: utils.getRandomBytes(32),
+							signatures: [],
+						}),
+						stateStore,
+					}).createCommandVerifyContext(stateRecoveryInitParamsSchema),
+				),
+			).rejects.toThrow("Property '.chainID' maxLength exceeded");
+		});
+
+		it('should reject when sibglingHashes contains bytes with invalid length', async () => {
+			await expect(
+				stateRecoveryInitCommand.verify(
+					createTransactionContext({
+						transaction: new Transaction({
+							module: MODULE_NAME_INTEROPERABILITY,
+							command: COMMAND_NAME_STATE_RECOVERY_INIT,
+							fee: BigInt(100000000),
+							nonce: BigInt(0),
+							params: codec.encode(stateRecoveryInitParamsSchema, {
+								...transactionParams,
+								siblingHashes: [Buffer.alloc(100, 255)],
+							}),
+							senderPublicKey: utils.getRandomBytes(32),
+							signatures: [],
+						}),
+						stateStore,
+					}).createCommandVerifyContext(stateRecoveryInitParamsSchema),
+				),
+			).rejects.toThrow("Property '.siblingHashes.0' maxLength exceeded");
+		});
+
 		it('should return status OK for valid params', async () => {
 			const result = await stateRecoveryInitCommand.verify(commandVerifyContext);
 			expect(result.status).toBe(VerifyStatus.OK);


### PR DESCRIPTION
### What was the problem?

This PR resolves #7969 

### How was it solved?

- Add validation to initializeStateRecovery command

### How was it tested?

- Added unit tests
