### PR TITLE
Add disabled method functionality to RPC server

### DIFF
--- a/framework/src/engine/rpc/rpc_server.ts
+++ b/framework/src/engine/rpc/rpc_server.ts
@@ -232,10 +232,11 @@ export class RPCServer {
 		try {
 			const request = Request.fromJSONRPCRequest(requestObj);
 			if (this._isDisabledMethod(request.namespace, request.name)) {
-				const blacklistedErrorMessage = 'Requested method or namespace is disabled in node config.';
+				const disabledMethodErrorMessage =
+					'Requested method or namespace is disabled in node config.';
 				throw new JSONRPC.JSONRPCError(
-					blacklistedErrorMessage,
-					JSONRPC.errorResponse(request.id, JSONRPC.invalidRequest(blacklistedErrorMessage)),
+					disabledMethodErrorMessage,
+					JSONRPC.errorResponse(request.id, JSONRPC.invalidRequest(disabledMethodErrorMessage)),
 				);
 			}
 

--- a/framework/src/engine/rpc/rpc_server.ts
+++ b/framework/src/engine/rpc/rpc_server.ts
@@ -231,6 +231,14 @@ export class RPCServer {
 
 		try {
 			const request = Request.fromJSONRPCRequest(requestObj);
+			if (this._isDisabledMethod(request.namespace, request.name)) {
+				const blacklistedErrorMessage = 'Requested method or namespace is disabled in node config.';
+				throw new JSONRPC.JSONRPCError(
+					blacklistedErrorMessage,
+					JSONRPC.errorResponse(request.id, JSONRPC.invalidRequest(blacklistedErrorMessage)),
+				);
+			}
+
 			const handler = this._getHandler(request.namespace, request.name);
 
 			const context = {
@@ -304,5 +312,15 @@ export class RPCServer {
 			return undefined;
 		}
 		return existingMethod;
+	}
+
+	private _isDisabledMethod(namespace: string, method: string): boolean {
+		const { disabledMethods } = this._config;
+		if (!disabledMethods) {
+			return false;
+		}
+		return (
+			disabledMethods.includes(namespace) || disabledMethods.includes(`${namespace}_${method}`)
+		);
 	}
 }

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -51,6 +51,11 @@ export const applicationConfigSchema = {
 				},
 				host: { type: 'string' },
 				port: { type: 'number', minimum: 1024, maximum: 65535 },
+				disabledMethods: {
+					type: 'array',
+					items: { type: 'string' },
+					uniqueItems: true,
+				},
 			},
 		},
 		legacy: {

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -89,6 +89,7 @@ export interface RPCConfig {
 	modes: (typeof RPC_MODES.IPC | typeof RPC_MODES.WS | typeof RPC_MODES.HTTP)[];
 	port: number;
 	host: string;
+	disabledMethods?: string[];
 }
 
 export interface LegacyConfig {

--- a/framework/test/unit/engine/rpc/rpc_server.spec.ts
+++ b/framework/test/unit/engine/rpc/rpc_server.spec.ts
@@ -164,4 +164,49 @@ describe('RPC server', () => {
 			expect(rpcServer['_httpServer']?.stop).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe('_isDisabledMethod', () => {
+		it('should return true for a disabled method', () => {
+			rpcServer = new RPCServer(dataPath, {
+				modes: ['ipc'],
+				host: '0.0.0.0',
+				port: 7887,
+				disabledMethods: ['token_transfer'],
+			});
+
+			expect(rpcServer['_isDisabledMethod']('token', 'transfer')).toBeTrue();
+		});
+
+		it('should return true for method from a disabled namespace', () => {
+			rpcServer = new RPCServer(dataPath, {
+				modes: ['ipc'],
+				host: '0.0.0.0',
+				port: 7887,
+				disabledMethods: ['token'],
+			});
+
+			expect(rpcServer['_isDisabledMethod']('token', 'transfer')).toBeTrue();
+		});
+
+		it('should return false if a method is not disabled', () => {
+			rpcServer = new RPCServer(dataPath, {
+				modes: ['ipc'],
+				host: '0.0.0.0',
+				port: 7887,
+				disabledMethods: ['auth'],
+			});
+
+			expect(rpcServer['_isDisabledMethod']('token', 'transfer')).toBeFalse();
+		});
+
+		it('should return false when disabledMethods configuration is absent', () => {
+			rpcServer = new RPCServer(dataPath, {
+				modes: ['ipc'],
+				host: '0.0.0.0',
+				port: 7887,
+			});
+
+			expect(rpcServer['_isDisabledMethod']('token', 'transfer')).toBeFalse();
+		});
+	});
 });

--- a/framework/test/unit/engine/rpc/rpc_server.spec.ts
+++ b/framework/test/unit/engine/rpc/rpc_server.spec.ts
@@ -209,4 +209,29 @@ describe('RPC server', () => {
 			expect(rpcServer['_isDisabledMethod']('token', 'transfer')).toBeFalse();
 		});
 	});
+
+	describe('_handleRequest()', () => {
+		it('should throw for a disabled method', async () => {
+			rpcServer = new RPCServer(dataPath, {
+				modes: ['ipc'],
+				host: '0.0.0.0',
+				port: 7887,
+				disabledMethods: ['token_getBalance'],
+			});
+
+			const request = JSON.stringify({
+				id: 1,
+				jsonrpc: '2.0',
+				method: 'token_getBalance',
+				params: {
+					address: 'lske5sqed53fdcs4m9et28f2k7u9fk6hno9bauday',
+					tokenID: '0000000000000000',
+				},
+			});
+
+			await expect(rpcServer['_handleRequest'](request)).rejects.toThrow(
+				'Requested method or namespace is disabled in node config.',
+			);
+		});
+	});
 });

--- a/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
+++ b/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
@@ -276,6 +276,13 @@ exports[`schema/application_config_schema.js application config schema must matc
     },
     "rpc": {
       "properties": {
+        "disabledMethods": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+          "uniqueItems": true,
+        },
         "host": {
           "type": "string",
         },


### PR DESCRIPTION
### What was the problem?

This PR resolves #7989

### How was it solved?

* Added optional property `disabledMethods[]` to RPCConfig and updated schema
* Added private method `_isDisabledMethod()` to `RPCServer`
* Added disabled method check in `RPCServer._handleRequest()`

### How was it tested?

Added 4 unit tests
