### PR TITLE
Fix init command to use updated schema

### DIFF
--- a/commander/src/utils/genesis_creation.ts
+++ b/commander/src/utils/genesis_creation.ts
@@ -119,7 +119,7 @@ export const generateGenesisBlockDefaultPoSAssets = (input: GenesisBlockDefaultA
 					generatorKey: v.plain.generatorKey,
 					lastGeneratedHeight: 0,
 					isBanned: false,
-					pomHeights: [],
+					reportMisbehaviorHeights: [],
 					consecutiveMissedBlocks: 0,
 					commission: 0,
 					lastCommissionIncreaseHeight: 0,


### PR DESCRIPTION
### What was the problem?

This PR resolves #8060 

### How was it solved?

Fix init command to use updated schema

### How was it tested?

add
```
this.spawnCommandSync('yarn', ['link', 'lisk-sdk']);
this.spawnCommandSync('yarn', ['link', 'lisk-commander']);
```
to `commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts:L94` and run
```
./bin/run init ~/Desktop/temp --registry https://npm.lisk.com 
```
