### PR TITLE
Fixes PoS module's genesis block finalization for migration

### DIFF
--- a/framework/src/modules/pos/constants.ts
+++ b/framework/src/modules/pos/constants.ts
@@ -65,6 +65,7 @@ export const defaultConfig = {
 	maxBFTWeightCap: 500,
 	commissionIncreasePeriod: COMMISSION_INCREASE_PERIOD,
 	maxCommissionIncreaseRate: MAX_COMMISSION_INCREASE_RATE,
+	useInvalidBLSKey: false,
 };
 
 export const enum PoSEventResult {

--- a/framework/src/modules/pos/endpoint.ts
+++ b/framework/src/modules/pos/endpoint.ts
@@ -159,6 +159,7 @@ export class PoSEndpoint extends BaseEndpoint {
 			maxBFTWeightCap: this._moduleConfig.maxBFTWeightCap,
 			commissionIncreasePeriod: this._moduleConfig.commissionIncreasePeriod,
 			maxCommissionIncreaseRate: this._moduleConfig.maxCommissionIncreaseRate,
+			useInvalidBLSKey: this._moduleConfig.useInvalidBLSKey,
 		};
 	}
 

--- a/framework/src/modules/pos/schemas.ts
+++ b/framework/src/modules/pos/schemas.ts
@@ -193,6 +193,9 @@ export const configSchema = {
 			type: 'integer',
 			format: 'uint32',
 		},
+		useInvalidBLSKey: {
+			type: 'boolean',
+		},
 	},
 	required: [
 		'factorSelfStakes',
@@ -209,6 +212,7 @@ export const configSchema = {
 		'posTokenID',
 		'validatorRegistrationFee',
 		'maxBFTWeightCap',
+		'useInvalidBLSKey',
 	],
 };
 

--- a/framework/src/modules/pos/types.ts
+++ b/framework/src/modules/pos/types.ts
@@ -38,6 +38,7 @@ export interface ModuleConfig {
 	maxBFTWeightCap: number;
 	commissionIncreasePeriod: number;
 	maxCommissionIncreaseRate: number;
+	useInvalidBLSKey: boolean;
 }
 
 export type ModuleConfigJSON = JSONObject<ModuleConfig>;
@@ -62,6 +63,11 @@ export interface ValidatorsMethod {
 		blsKey: Buffer,
 		generatorKey: Buffer,
 		proofOfPossession: Buffer,
+	): Promise<boolean>;
+	registerValidatorWithoutBLSKey(
+		methodContext: MethodContext,
+		validatorAddress: Buffer,
+		generatorKey: Buffer,
 	): Promise<boolean>;
 	getValidatorKeys(methodContext: ImmutableMethodContext, address: Buffer): Promise<ValidatorKeys>;
 	getGeneratorsBetweenTimestamps(

--- a/framework/test/unit/modules/pos/commands/report_misbehavior.spec.ts
+++ b/framework/test/unit/modules/pos/commands/report_misbehavior.spec.ts
@@ -95,6 +95,7 @@ describe('ReportMisbehaviorCommand', () => {
 		mockValidatorsMethod = {
 			setValidatorGeneratorKey: jest.fn(),
 			registerValidatorKeys: jest.fn(),
+			registerValidatorWithoutBLSKey: jest.fn(),
 			getValidatorKeys: jest.fn().mockResolvedValue({ generatorKey: publicKey }),
 			getGeneratorsBetweenTimestamps: jest.fn(),
 			setValidatorsParams: jest.fn(),

--- a/framework/test/unit/modules/pos/commands/validator_registration.spec.ts
+++ b/framework/test/unit/modules/pos/commands/validator_registration.spec.ts
@@ -109,6 +109,7 @@ describe('Validator registration command', () => {
 		mockValidatorsMethod = {
 			setValidatorGeneratorKey: jest.fn(),
 			registerValidatorKeys: jest.fn().mockResolvedValue(true),
+			registerValidatorWithoutBLSKey: jest.fn().mockResolvedValue(true),
 			getValidatorKeys: jest.fn(),
 			getGeneratorsBetweenTimestamps: jest.fn(),
 			setValidatorsParams: jest.fn(),

--- a/framework/test/unit/modules/pos/method.spec.ts
+++ b/framework/test/unit/modules/pos/method.spec.ts
@@ -229,6 +229,7 @@ describe('PoSMethod', () => {
 			maxBFTWeightCap: 500,
 			commissionIncreasePeriod: COMMISSION_INCREASE_PERIOD,
 			maxCommissionIncreaseRate: MAX_COMMISSION_INCREASE_RATE,
+			useInvalidBLSKey: true,
 		};
 		let tokenMethod: any;
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8006 

### How was it solved?

Introduced a new flag for PoS module config, `useInvalidBLSKey` with default value set to false, when set, validators are registered without BLS key for main chain when finalising genesis state.
 
### How was it tested?

Implemented unit test.