### PR TITLE
Improve PoS Stake command verification

### DIFF
--- a/framework/test/unit/modules/pos/commands/stake.spec.ts
+++ b/framework/test/unit/modules/pos/commands/stake.spec.ts
@@ -1091,12 +1091,12 @@ describe('StakeCommand', () => {
 				const { stakes } = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
 
 				expect(
-					stakes.find(sentStake => sentStake.validatorAddress.equals(validatorAddress1))!
-						.sharingCoefficients,
+					stakes.find(sentStake => sentStake.validatorAddress.equals(validatorAddress1))
+						?.sharingCoefficients,
 				).toEqual(sharingCoefficients);
 				expect(
-					stakes.find(sentStake => sentStake.validatorAddress.equals(validatorAddress2))!
-						.sharingCoefficients,
+					stakes.find(sentStake => sentStake.validatorAddress.equals(validatorAddress2))
+						?.sharingCoefficients,
 				).toEqual(sharingCoefficients);
 			});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8070

### How was it solved?

* Verify method now throws as soon as it finds the first duplicated validator address
* Validator addresses are now stored in a set instead of in a map
* Renamed variable `originalUpstakeIndex` used both for upstake and downstake into more accurate `existingStakeIndex`
* Error messages now use variables instead of literals
* Bonus: simplified adding new stake and upstaking an existing stake 😎
* Bonus: replaced non-null assertion operator with optional chaining operator 🤓 

### How was it tested?

All tests OK 👌🏻 
