### PR TITLE
Introduce unsignedCertificateSchema and update certificate generation mechanism

### DIFF
--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/active_validators_update.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/active_validators_update.ts
@@ -12,9 +12,13 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 /* eslint-disable no-bitwise */
-
-import { ActiveValidatorsUpdate } from 'lisk-sdk';
-import { ActiveValidator, Certificate, LastCertificate, utils } from 'lisk-sdk';
+import {
+	ActiveValidator,
+	Certificate,
+	LastCertificate,
+	utils,
+	ActiveValidatorsUpdate,
+} from 'lisk-sdk';
 import { ValidatorsData } from './types';
 
 // LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#computing-the-validators-update

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/certificate_generation.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/certificate_generation.ts
@@ -20,7 +20,7 @@ import {
 	chain,
 	ChainAccount,
 	ChainStatus,
-	computeCertificateFromBlockHeader,
+	computeUnsignedCertificateFromBlockHeader,
 	cryptography,
 	LastCertificate,
 	LIVENESS_LIMIT,
@@ -46,7 +46,7 @@ export const getCertificateFromAggregateCommit = (
 	}
 
 	return {
-		...computeCertificateFromBlockHeader(new chain.BlockHeader(blockHeader)),
+		...computeUnsignedCertificateFromBlockHeader(new chain.BlockHeader(blockHeader)),
 		aggregationBits: aggregateCommit.aggregationBits,
 		signature: aggregateCommit.certificateSignature,
 	};
@@ -210,8 +210,8 @@ export const validateCertificate = async (
 
 	const hasValidWeightedAggSig = cryptography.bls.verifyWeightedAggSig(
 		keysList,
-		certificate.aggregationBits as Buffer,
-		certificate.signature as Buffer,
+		certificate.aggregationBits,
+		certificate.signature,
 		MESSAGE_TAG_CERTIFICATE,
 		sendingChainID,
 		certificateBytes,

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/certificate_generation.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/certificate_generation.spec.ts
@@ -19,7 +19,7 @@ import {
 	ChainStatus,
 	LIVENESS_LIMIT,
 	chain,
-	computeCertificateFromBlockHeader,
+	computeUnsignedCertificateFromBlockHeader,
 	cryptography,
 	testing,
 	db,
@@ -132,11 +132,15 @@ describe('certificate generation', () => {
 			const firstBlockHeader = sampleBlockHeaders[0];
 			const { aggregateCommit } = firstBlockHeader;
 
-			const expectedCertificate = computeCertificateFromBlockHeader(
+			const unsignedCertificate = computeUnsignedCertificateFromBlockHeader(
 				new chain.BlockHeader(firstBlockHeader),
 			);
-			expectedCertificate.aggregationBits = aggregateCommit.aggregationBits;
-			expectedCertificate.signature = aggregateCommit.certificateSignature;
+			const expectedCertificate = {
+				...unsignedCertificate,
+				aggregationBits: aggregateCommit.aggregationBits,
+				signature: aggregateCommit.certificateSignature,
+			};
+
 			const computedCertificate = getCertificateFromAggregateCommit(aggregateCommit, [
 				firstBlockHeader,
 			]);
@@ -278,11 +282,15 @@ describe('certificate generation', () => {
 
 		it('should return a valid certificate passing chainOfTrust check', () => {
 			const secondBlockHeader = sampleBlockHeaders[1];
-			const expectedCertificate = computeCertificateFromBlockHeader(
+			const unsignedCertificate = computeUnsignedCertificateFromBlockHeader(
 				new chain.BlockHeader(secondBlockHeader),
 			);
-			expectedCertificate.aggregationBits = secondBlockHeader.aggregateCommit.aggregationBits;
-			expectedCertificate.signature = secondBlockHeader.aggregateCommit.certificateSignature;
+			const expectedCertificate = {
+				...unsignedCertificate,
+				aggregationBits: secondBlockHeader.aggregateCommit.aggregationBits,
+				signature: secondBlockHeader.aggregateCommit.certificateSignature,
+			};
+
 			expect(
 				getNextCertificateFromAggregateCommits(
 					sampleBlockHeaders,

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/inbox_update.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/inbox_update.spec.ts
@@ -45,6 +45,8 @@ describe('inboxUpdate', () => {
 			timestamp: sampleBlock.timestamp,
 			validatorsHash: sampleBlock.validatorsHash,
 			stateRoot: sampleBlock.stateRoot,
+			aggregationBits: Buffer.alloc(0),
+			signature: cryptography.utils.getRandomBytes(32),
 		};
 
 		const sampleLastCertificate: LastCertificate = {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/plugin.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/plugin.spec.ts
@@ -821,6 +821,8 @@ describe('ChainConnectorPlugin', () => {
 			stateRoot: Buffer.from('00'),
 			blockID: Buffer.from('00'),
 			timestamp: Date.now(),
+			aggregationBits: Buffer.alloc(0),
+			signature: cryptography.utils.getRandomBytes(32),
 		};
 		const certificateBytes = Buffer.from('ff');
 		// const newCertificateThreshold = BigInt(7);

--- a/framework/src/engine/consensus/certificate_generation/commit_pool.ts
+++ b/framework/src/engine/consensus/certificate_generation/commit_pool.ts
@@ -127,13 +127,14 @@ export class CommitPool {
 		}
 
 		// Validation Step 6
-		const certificate = computeUnsignedCertificateFromBlockHeader(blockHeaderAtCommitHeight);
+		const unsignedCertificate =
+			computeUnsignedCertificateFromBlockHeader(blockHeaderAtCommitHeight);
 		const { chainID } = this._chain;
 		const isSingleCertificateVerified = verifySingleCertificateSignature(
 			validator.blsKey,
 			commit.certificateSignature,
 			chainID,
-			certificate,
+			unsignedCertificate,
 		);
 
 		if (!isSingleCertificateVerified) {
@@ -155,7 +156,7 @@ export class CommitPool {
 		validatorInfo: ValidatorInfo,
 		chainID: Buffer,
 	): SingleCommit {
-		const commit = {
+		return {
 			blockID: blockHeader.id,
 			height: blockHeader.height,
 			validatorAddress: validatorInfo.address,
@@ -165,8 +166,6 @@ export class CommitPool {
 				computeUnsignedCertificateFromBlockHeader(blockHeader),
 			),
 		};
-
-		return commit;
 	}
 
 	public async verifyAggregateCommit(
@@ -280,13 +279,11 @@ export class CommitPool {
 			pubKeySignaturePairs,
 		);
 
-		const aggregateCommit = {
+		return {
 			height,
 			aggregationBits,
 			certificateSignature: aggregateSignature,
 		};
-
-		return aggregateCommit;
 	}
 
 	private async _selectAggregateCommit(methodContext: StateStore): Promise<AggregateCommit> {

--- a/framework/src/engine/consensus/certificate_generation/index.ts
+++ b/framework/src/engine/consensus/certificate_generation/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+export { Certificate, UnsignedCertificate } from './types';
+export { aggregateCommitSchema, certificateSchema, unsignedCertificateSchema } from './schema';
+export { computeUnsignedCertificateFromBlockHeader } from './utils';

--- a/framework/src/engine/consensus/certificate_generation/schema.ts
+++ b/framework/src/engine/consensus/certificate_generation/schema.ts
@@ -12,8 +12,11 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+/**
+ * @see https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#schema
+ */
 export const unsignedCertificateSchema = {
-	$id: '/consensus/certificate',
+	$id: '/consensus/unsignedCertificate',
 	type: 'object',
 	required: ['blockID', 'height', 'timestamp', 'stateRoot', 'validatorsHash'],
 	properties: {
@@ -40,39 +43,15 @@ export const unsignedCertificateSchema = {
 	},
 };
 
+/**
+ * @see https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#schema
+ */
 export const certificateSchema = {
 	$id: '/consensus/certificate',
 	type: 'object',
-	required: [
-		'blockID',
-		'height',
-		'timestamp',
-		'stateRoot',
-		'validatorsHash',
-		'aggregationBits',
-		'signature',
-	],
+	required: [...unsignedCertificateSchema.required, 'aggregationBits', 'signature'],
 	properties: {
-		blockID: {
-			dataType: 'bytes',
-			fieldNumber: 1,
-		},
-		height: {
-			dataType: 'uint32',
-			fieldNumber: 2,
-		},
-		timestamp: {
-			dataType: 'uint32',
-			fieldNumber: 3,
-		},
-		stateRoot: {
-			dataType: 'bytes',
-			fieldNumber: 4,
-		},
-		validatorsHash: {
-			dataType: 'bytes',
-			fieldNumber: 5,
-		},
+		...unsignedCertificateSchema.properties,
 		aggregationBits: {
 			dataType: 'bytes',
 			fieldNumber: 6,

--- a/framework/src/engine/consensus/certificate_generation/schema.ts
+++ b/framework/src/engine/consensus/certificate_generation/schema.ts
@@ -12,10 +12,46 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export const certificateSchema = {
+export const unsignedCertificateSchema = {
 	$id: '/consensus/certificate',
 	type: 'object',
 	required: ['blockID', 'height', 'timestamp', 'stateRoot', 'validatorsHash'],
+	properties: {
+		blockID: {
+			dataType: 'bytes',
+			fieldNumber: 1,
+		},
+		height: {
+			dataType: 'uint32',
+			fieldNumber: 2,
+		},
+		timestamp: {
+			dataType: 'uint32',
+			fieldNumber: 3,
+		},
+		stateRoot: {
+			dataType: 'bytes',
+			fieldNumber: 4,
+		},
+		validatorsHash: {
+			dataType: 'bytes',
+			fieldNumber: 5,
+		},
+	},
+};
+
+export const certificateSchema = {
+	$id: '/consensus/certificate',
+	type: 'object',
+	required: [
+		'blockID',
+		'height',
+		'timestamp',
+		'stateRoot',
+		'validatorsHash',
+		'aggregationBits',
+		'signature',
+	],
 	properties: {
 		blockID: {
 			dataType: 'bytes',

--- a/framework/src/engine/consensus/certificate_generation/types.ts
+++ b/framework/src/engine/consensus/certificate_generation/types.ts
@@ -18,14 +18,17 @@ import { BFTMethod } from '../../bft';
 import { Network } from '../../network';
 
 // aggregationBits and signatures are optional as these properties are removed when signing certificates
-export interface Certificate {
+export interface UnsignedCertificate {
 	readonly blockID: Buffer;
 	readonly height: number;
 	readonly timestamp: number;
 	readonly stateRoot: Buffer;
 	readonly validatorsHash: Buffer;
-	aggregationBits?: Buffer;
-	signature?: Buffer;
+}
+
+export interface Certificate extends UnsignedCertificate {
+	aggregationBits: Buffer;
+	signature: Buffer;
 }
 
 export interface SingleCommit {

--- a/framework/src/engine/consensus/certificate_generation/utils.ts
+++ b/framework/src/engine/consensus/certificate_generation/utils.ts
@@ -27,11 +27,11 @@ export const computeUnsignedCertificateFromBlockHeader = (
 	blockHeader: BlockHeader,
 ): UnsignedCertificate => {
 	if (!blockHeader.stateRoot) {
-		throw new Error("'stateRoot' is not defined.");
+		throw new Error('stateRoot is not defined.');
 	}
 
 	if (!blockHeader.validatorsHash) {
-		throw new Error("'validatorsHash' is not defined.");
+		throw new Error('validatorsHash is not defined.');
 	}
 
 	return {
@@ -108,9 +108,9 @@ export const getSortedWeightsAndValidatorKeys = (validators: Validator[]) => {
 	const weights = [];
 	const validatorKeys = [];
 
-	for (const validatorKeyWithWeight of validators) {
-		weights.push(validatorKeyWithWeight.bftWeight);
-		validatorKeys.push(validatorKeyWithWeight.blsKey);
+	for (const validator of validators) {
+		weights.push(validator.bftWeight);
+		validatorKeys.push(validator.blsKey);
 	}
 
 	return { weights, validatorKeys };

--- a/framework/src/engine/consensus/index.ts
+++ b/framework/src/engine/consensus/index.ts
@@ -21,3 +21,11 @@ export {
 } from './constants';
 export { BFTHeights } from '../bft/types';
 export { isEmptyConsensusUpdate } from './utils';
+export {
+	computeUnsignedCertificateFromBlockHeader,
+	aggregateCommitSchema,
+	certificateSchema,
+	unsignedCertificateSchema,
+	Certificate,
+	UnsignedCertificate,
+} from './certificate_generation';

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -137,7 +137,11 @@ export { TransactionExecutionResult, TransactionVerifyResult } from './abi/const
 export { AggregateCommit } from './engine/consensus/types';
 export { BFTHeights } from './engine/bft/types';
 export { BFTParameters } from './engine/bft/schemas';
-export { aggregateCommitSchema } from './engine/consensus/certificate_generation/schema';
-export { computeUnsignedCertificateFromBlockHeader } from './engine/consensus/certificate_generation/utils';
-export { Certificate } from './engine/consensus/certificate_generation/types';
-export { certificateSchema } from './engine/consensus/certificate_generation/schema';
+export {
+	computeUnsignedCertificateFromBlockHeader,
+	Certificate,
+	UnsignedCertificate,
+	aggregateCommitSchema,
+	certificateSchema,
+	unsignedCertificateSchema,
+} from './engine/consensus';

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -138,6 +138,6 @@ export { AggregateCommit } from './engine/consensus/types';
 export { BFTHeights } from './engine/bft/types';
 export { BFTParameters } from './engine/bft/schemas';
 export { aggregateCommitSchema } from './engine/consensus/certificate_generation/schema';
-export { computeUnsignedCertificateFromBlockHeader as computeCertificateFromBlockHeader } from './engine/consensus/certificate_generation/utils';
+export { computeUnsignedCertificateFromBlockHeader } from './engine/consensus/certificate_generation/utils';
 export { Certificate } from './engine/consensus/certificate_generation/types';
 export { certificateSchema } from './engine/consensus/certificate_generation/schema';

--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -138,6 +138,6 @@ export { AggregateCommit } from './engine/consensus/types';
 export { BFTHeights } from './engine/bft/types';
 export { BFTParameters } from './engine/bft/schemas';
 export { aggregateCommitSchema } from './engine/consensus/certificate_generation/schema';
-export { computeCertificateFromBlockHeader } from './engine/consensus/certificate_generation/utils';
+export { computeUnsignedCertificateFromBlockHeader as computeCertificateFromBlockHeader } from './engine/consensus/certificate_generation/utils';
 export { Certificate } from './engine/consensus/certificate_generation/types';
 export { certificateSchema } from './engine/consensus/certificate_generation/schema';

--- a/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
+++ b/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
@@ -407,8 +407,8 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 
 		const verifySignature = bls.verifyWeightedAggSig(
 			blsKeys,
-			certificate.aggregationBits as Buffer,
-			certificate.signature as Buffer,
+			certificate.aggregationBits,
+			certificate.signature,
 			MESSAGE_TAG_CERTIFICATE,
 			params.sendingChainID,
 			params.certificate,

--- a/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
@@ -31,12 +31,12 @@ import {
 	singleCommitsNetworkPacketSchema,
 } from '../../../../../src/engine/consensus/certificate_generation/schema';
 import {
-	Certificate,
 	SingleCommit,
+	UnsignedCertificate,
 } from '../../../../../src/engine/consensus/certificate_generation/types';
 import { createFakeBlockHeader } from '../../../../../src/testing';
 import {
-	computeCertificateFromBlockHeader,
+	computeUnsignedCertificateFromBlockHeader,
 	signCertificate,
 } from '../../../../../src/engine/consensus/certificate_generation/utils';
 import { AggregateCommit } from '../../../../../src/engine/consensus/types';
@@ -425,7 +425,7 @@ describe('CommitPool', () => {
 		let commit: SingleCommit;
 		let blockHeader: BlockHeader;
 		let blockHeaderOfFinalizedHeight: BlockHeader;
-		let certificate: Certificate;
+		let certificate: UnsignedCertificate;
 		let publicKey: Buffer;
 		let privateKey: Buffer;
 		let signature: Buffer;
@@ -455,7 +455,7 @@ describe('CommitPool', () => {
 				},
 			});
 
-			certificate = computeCertificateFromBlockHeader(blockHeader);
+			certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
 
 			privateKey = bls.generatePrivateKey(utils.getRandomBytes(32));
 			publicKey = bls.getPublicKeyFromPrivateKey(privateKey);
@@ -733,7 +733,7 @@ describe('CommitPool', () => {
 			blsPublicKey: utils.getRandomBytes(48),
 			blsSecretKey: utils.getRandomBytes(32),
 		};
-		const certificate = computeCertificateFromBlockHeader(blockHeader);
+		const certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
 		let expectedCommit: SingleCommit;
 
 		beforeEach(() => {
@@ -759,7 +759,7 @@ describe('CommitPool', () => {
 		let timestamp: number;
 		let stateStore: StateStore;
 		let aggregateCommit: AggregateCommit;
-		let certificate: Certificate;
+		let certificate: UnsignedCertificate;
 		let keysList: Buffer[];
 		let privateKeys: Buffer[];
 		let publicKeys: Buffer[];
@@ -1007,9 +1007,9 @@ describe('CommitPool', () => {
 			blsPublicKey: utils.getRandomBytes(48),
 			blsSecretKey: utils.getRandomBytes(32),
 		};
-		const certificate1 = computeCertificateFromBlockHeader(blockHeader1);
-		const certificate2 = computeCertificateFromBlockHeader(blockHeader2);
-		const certificate3 = computeCertificateFromBlockHeader(blockHeader3);
+		const certificate1 = computeUnsignedCertificateFromBlockHeader(blockHeader1);
+		const certificate2 = computeUnsignedCertificateFromBlockHeader(blockHeader2);
+		const certificate3 = computeUnsignedCertificateFromBlockHeader(blockHeader3);
 		const singleCommit1 = {
 			blockID: blockHeader1.id,
 			height: blockHeader1.height,
@@ -1158,8 +1158,8 @@ describe('CommitPool', () => {
 			blsPublicKey: utils.getRandomBytes(48),
 			blsSecretKey: utils.getRandomBytes(32),
 		};
-		const certificate1 = computeCertificateFromBlockHeader(blockHeader1);
-		const certificate2 = computeCertificateFromBlockHeader(blockHeader2);
+		const certificate1 = computeUnsignedCertificateFromBlockHeader(blockHeader1);
+		const certificate2 = computeUnsignedCertificateFromBlockHeader(blockHeader2);
 		const singleCommit1 = {
 			blockID: blockHeader1.id,
 			height: blockHeader1.height,

--- a/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
@@ -425,7 +425,7 @@ describe('CommitPool', () => {
 		let commit: SingleCommit;
 		let blockHeader: BlockHeader;
 		let blockHeaderOfFinalizedHeight: BlockHeader;
-		let certificate: UnsignedCertificate;
+		let unsignedCertificate: UnsignedCertificate;
 		let publicKey: Buffer;
 		let privateKey: Buffer;
 		let signature: Buffer;
@@ -455,11 +455,11 @@ describe('CommitPool', () => {
 				},
 			});
 
-			certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
+			unsignedCertificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
 
 			privateKey = bls.generatePrivateKey(utils.getRandomBytes(32));
 			publicKey = bls.getPublicKeyFromPrivateKey(privateKey);
-			signature = signCertificate(privateKey, chainID, certificate);
+			signature = signCertificate(privateKey, chainID, unsignedCertificate);
 
 			commit = {
 				blockID: blockHeader.id,
@@ -733,15 +733,20 @@ describe('CommitPool', () => {
 			blsPublicKey: utils.getRandomBytes(48),
 			blsSecretKey: utils.getRandomBytes(32),
 		};
-		const certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
+		let unsignedCertificate: UnsignedCertificate;
 		let expectedCommit: SingleCommit;
 
 		beforeEach(() => {
+			unsignedCertificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
 			expectedCommit = {
 				blockID: blockHeader.id,
 				height: blockHeader.height,
 				validatorAddress: validatorInfo.address,
-				certificateSignature: signCertificate(validatorInfo.blsSecretKey, chainID, certificate),
+				certificateSignature: signCertificate(
+					validatorInfo.blsSecretKey,
+					chainID,
+					unsignedCertificate,
+				),
 			};
 		});
 
@@ -759,7 +764,7 @@ describe('CommitPool', () => {
 		let timestamp: number;
 		let stateStore: StateStore;
 		let aggregateCommit: AggregateCommit;
-		let certificate: UnsignedCertificate;
+		let unsignedCertificate: UnsignedCertificate;
 		let keysList: Buffer[];
 		let privateKeys: Buffer[];
 		let publicKeys: Buffer[];
@@ -794,7 +799,7 @@ describe('CommitPool', () => {
 			weights = Array.from({ length: 103 }, _ => 1);
 			threshold = 33;
 
-			certificate = {
+			unsignedCertificate = {
 				blockID: blockHeader.id,
 				height: blockHeader.height,
 				stateRoot: blockHeader.stateRoot as Buffer,
@@ -802,7 +807,7 @@ describe('CommitPool', () => {
 				validatorsHash: blockHeader.validatorsHash as Buffer,
 			};
 
-			const encodedCertificate = codec.encode(certificateSchema, certificate);
+			const encodedCertificate = codec.encode(certificateSchema, unsignedCertificate);
 
 			signatures = privateKeys.map(privateKey =>
 				bls.signData(MESSAGE_TAG_CERTIFICATE, chainID, encodedCertificate, privateKey),
@@ -1158,19 +1163,27 @@ describe('CommitPool', () => {
 			blsPublicKey: utils.getRandomBytes(48),
 			blsSecretKey: utils.getRandomBytes(32),
 		};
-		const certificate1 = computeUnsignedCertificateFromBlockHeader(blockHeader1);
-		const certificate2 = computeUnsignedCertificateFromBlockHeader(blockHeader2);
+		const unsignedCertificate1 = computeUnsignedCertificateFromBlockHeader(blockHeader1);
+		const unsignedCertificate2 = computeUnsignedCertificateFromBlockHeader(blockHeader2);
 		const singleCommit1 = {
 			blockID: blockHeader1.id,
 			height: blockHeader1.height,
 			validatorAddress: validatorInfo1.address,
-			certificateSignature: signCertificate(validatorInfo1.blsSecretKey, chainID, certificate1),
+			certificateSignature: signCertificate(
+				validatorInfo1.blsSecretKey,
+				chainID,
+				unsignedCertificate1,
+			),
 		};
 		const singleCommit2 = {
 			blockID: blockHeader2.id,
 			height: blockHeader2.height,
 			validatorAddress: validatorInfo2.address,
-			certificateSignature: signCertificate(validatorInfo2.blsSecretKey, chainID, certificate2),
+			certificateSignature: signCertificate(
+				validatorInfo2.blsSecretKey,
+				chainID,
+				unsignedCertificate2,
+			),
 		};
 		let stateStore: StateStore;
 

--- a/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
@@ -1012,26 +1012,38 @@ describe('CommitPool', () => {
 			blsPublicKey: utils.getRandomBytes(48),
 			blsSecretKey: utils.getRandomBytes(32),
 		};
-		const certificate1 = computeUnsignedCertificateFromBlockHeader(blockHeader1);
-		const certificate2 = computeUnsignedCertificateFromBlockHeader(blockHeader2);
-		const certificate3 = computeUnsignedCertificateFromBlockHeader(blockHeader3);
+		const unsignedCertificate1 = computeUnsignedCertificateFromBlockHeader(blockHeader1);
+		const unsignedCertificate2 = computeUnsignedCertificateFromBlockHeader(blockHeader2);
+		const unsignedCertificate3 = computeUnsignedCertificateFromBlockHeader(blockHeader3);
 		const singleCommit1 = {
 			blockID: blockHeader1.id,
 			height: blockHeader1.height,
 			validatorAddress: validatorInfo1.address,
-			certificateSignature: signCertificate(validatorInfo1.blsSecretKey, chainID, certificate1),
+			certificateSignature: signCertificate(
+				validatorInfo1.blsSecretKey,
+				chainID,
+				unsignedCertificate1,
+			),
 		};
 		const singleCommit2 = {
 			blockID: blockHeader2.id,
 			height: blockHeader2.height,
 			validatorAddress: validatorInfo2.address,
-			certificateSignature: signCertificate(validatorInfo2.blsSecretKey, chainID, certificate2),
+			certificateSignature: signCertificate(
+				validatorInfo2.blsSecretKey,
+				chainID,
+				unsignedCertificate2,
+			),
 		};
 		const singleCommit3 = {
 			blockID: blockHeader3.id,
 			height: blockHeader3.height,
 			validatorAddress: validatorInfo3.address,
-			certificateSignature: signCertificate(validatorInfo3.blsSecretKey, chainID, certificate3),
+			certificateSignature: signCertificate(
+				validatorInfo3.blsSecretKey,
+				chainID,
+				unsignedCertificate3,
+			),
 		};
 		const singleCommits = [singleCommit1, singleCommit2, singleCommit3];
 		const validatorKeys = [

--- a/framework/test/unit/engine/consensus/certificate_generation/utils.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/utils.spec.ts
@@ -29,22 +29,22 @@ import {
 } from '../../../../../src/engine/consensus/certificate_generation/utils';
 import { createFakeBlockHeader } from '../../../../../src/testing';
 import { Validator } from '../../../../../src/engine/consensus/types';
+import { BLS_PUBLIC_KEY_LENGTH } from '../../../../../src/engine/bft/constants';
 
 describe('utils', () => {
 	const chainID = Buffer.alloc(0);
-	const BLS_PUBLIC_KEY_LENGTH = 48;
 	let unsignedCertificate: UnsignedCertificate;
 
 	describe('computeCertificateFromBlockHeader', () => {
 		let blockHeader: BlockHeader;
+		let certificate: UnsignedCertificate;
 
 		beforeEach(() => {
 			blockHeader = createFakeBlockHeader({});
+			certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
 		});
 
 		it('should return a certificate with proper parameters', () => {
-			const certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
-
 			expect(certificate.blockID).toBe(blockHeader.id);
 			expect(certificate.height).toBe(blockHeader.height);
 			expect(certificate.stateRoot).toBe(blockHeader.stateRoot);
@@ -56,7 +56,7 @@ describe('utils', () => {
 			(blockHeader as any).stateRoot = undefined;
 
 			expect(() => computeUnsignedCertificateFromBlockHeader(blockHeader)).toThrow(
-				"'stateRoot' is not defined.",
+				'stateRoot is not defined.',
 			);
 		});
 
@@ -64,7 +64,7 @@ describe('utils', () => {
 			(blockHeader as any).validatorsHash = undefined;
 
 			expect(() => computeUnsignedCertificateFromBlockHeader(blockHeader)).toThrow(
-				"'validatorsHash' is not defined.",
+				'validatorsHash is not defined.',
 			);
 		});
 	});
@@ -206,7 +206,7 @@ describe('utils', () => {
 			};
 		});
 
-		it('should return true for proper parameters', () => {
+		it('should return true for valid parameters', () => {
 			const isVerifiedSignature = verifyAggregateCertificateSignature(
 				validators,
 				threshold,

--- a/framework/test/unit/engine/consensus/network_endpoint.spec.ts
+++ b/framework/test/unit/engine/consensus/network_endpoint.spec.ts
@@ -18,7 +18,7 @@ import { codec } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
 import { SingleCommit } from '.../../../src/engine/consensus//certificate_generation/types';
 import {
-	computeCertificateFromBlockHeader,
+	computeUnsignedCertificateFromBlockHeader,
 	signCertificate,
 } from '.../../../src/engine/consensus//certificate_generation/utils';
 import { NetworkEndpoint } from '../../../../src/engine/consensus/network_endpoint';
@@ -234,7 +234,7 @@ describe('p2p endpoint', () => {
 	describe('handleEventSingleCommit', () => {
 		const chainID = Buffer.alloc(0);
 		const blockHeader = createFakeBlockHeader();
-		const certificate = computeCertificateFromBlockHeader(blockHeader);
+		const certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
 		const validatorInfo = {
 			address: utils.getRandomBytes(20),
 			blsPublicKey: utils.getRandomBytes(48),

--- a/framework/test/unit/engine/consensus/network_endpoint.spec.ts
+++ b/framework/test/unit/engine/consensus/network_endpoint.spec.ts
@@ -234,7 +234,7 @@ describe('p2p endpoint', () => {
 	describe('handleEventSingleCommit', () => {
 		const chainID = Buffer.alloc(0);
 		const blockHeader = createFakeBlockHeader();
-		const certificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
+		const unsignedCertificate = computeUnsignedCertificateFromBlockHeader(blockHeader);
 		const validatorInfo = {
 			address: utils.getRandomBytes(20),
 			blsPublicKey: utils.getRandomBytes(48),
@@ -249,7 +249,11 @@ describe('p2p endpoint', () => {
 					blockID: blockHeader.id,
 					height: blockHeader.height,
 					validatorAddress: validatorInfo.address,
-					certificateSignature: signCertificate(validatorInfo.blsSecretKey, chainID, certificate),
+					certificateSignature: signCertificate(
+						validatorInfo.blsSecretKey,
+						chainID,
+						unsignedCertificate,
+					),
 				},
 			};
 			encodedValidCommit = codec.encode(getSingleCommitEventSchema, validCommit);

--- a/framework/test/unit/modules/interoperability/internal_method.spec.ts
+++ b/framework/test/unit/modules/interoperability/internal_method.spec.ts
@@ -1105,8 +1105,8 @@ describe('Base interoperability internal method', () => {
 
 			expect(cryptography.bls.verifyWeightedAggSig).toHaveBeenCalledWith(
 				activeValidators.map(v => v.blsKey),
-				certificate.aggregationBits as Buffer,
-				certificate.signature as Buffer,
+				certificate.aggregationBits,
+				certificate.signature,
 				MESSAGE_TAG_CERTIFICATE,
 				txParams.sendingChainID,
 				txParams.certificate,


### PR DESCRIPTION
### What was the problem?

This PR resolves #8058 

### How was it solved?

- [🌱 Introduce unsignedCertificateSchema](https://github.com/LiskHQ/lisk-sdk/commit/eae934021746a309be47f8cbc155c1d76e4f26fb)
- Rename computeCertificateFromBlockHeader -> [computeUnsignedCertificateFromBlockHeader](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#creation)
- Update [signCertificate](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#execution) to take unsigned certificate
- Update [verifySingleCertificateSignature](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#execution-1) to take unsigned certificate
- Update [`verifyAggregateCertificateSignature`](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#execution-2) to sort `keyList` and `bftWeights`
- Update [`verifyAggregateCommit`](https://github.com/LiskHQ/lips/blob/main/proposals/lip-0061.md#block-processing) to remove sorting of `blsKeys` and make list of `bftWeights`
- No changes to `getNextCertificateFromAggregateCommits ` in `ChainConnectorPlugin`


### How was it tested?

<!--- Please describe how you tested your changes -->
