### PR TITLE
Fix transaction:create to create command without params

### DIFF
--- a/commander/src/bootstrapping/commands/transaction/create.ts
+++ b/commander/src/bootstrapping/commands/transaction/create.ts
@@ -15,7 +15,7 @@
 /* eslint-disable no-param-reassign */
 import * as apiClient from '@liskhq/lisk-api-client';
 import { blockAssetSchema, eventSchema } from '@liskhq/lisk-chain';
-import { codec, Schema } from '@liskhq/lisk-codec';
+import { codec } from '@liskhq/lisk-codec';
 import * as cryptography from '@liskhq/lisk-cryptography';
 import * as transactions from '@liskhq/lisk-transactions';
 import { validator } from '@liskhq/lisk-validator';
@@ -75,7 +75,10 @@ interface Transaction {
 const getParamsObject = async (metadata: ModuleMetadataJSON[], flags: CreateFlags, args: Args) => {
 	let params: Record<string, unknown>;
 
-	const paramsSchema = getParamsSchema(metadata, args.module, args.command) as Schema;
+	const paramsSchema = getParamsSchema(metadata, args.module, args.command);
+	if (!paramsSchema) {
+		return {};
+	}
 
 	if (flags.file) {
 		params = JSON.parse(getFileParams(flags.file));
@@ -116,7 +119,7 @@ const validateAndSignTransaction = async (
 	noSignature: boolean,
 ) => {
 	const { params, ...transactionWithoutParams } = transaction;
-	const paramsSchema = getParamsSchema(metadata, transaction.module, transaction.command) as Schema;
+	const paramsSchema = getParamsSchema(metadata, transaction.module, transaction.command);
 
 	const txObject = codec.fromJSON(schema.transaction, { ...transactionWithoutParams, params: '' });
 	validator.validate(schema.transaction, txObject);

--- a/commander/test/bootstrapping/commands/transaction/create.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/create.spec.ts
@@ -99,6 +99,9 @@ describe('transaction:create command', () => {
 							name: 'stake',
 							params: posVoteParamsSchema,
 						},
+						{
+							name: 'unlock',
+						},
 					],
 				},
 			],
@@ -582,6 +585,19 @@ describe('transaction:create command', () => {
 				it('should return encoded transaction string in hex format with signature', async () => {
 					await CreateCommandExtended.run(
 						['pos', 'stake', '100000000', `--params=${unVoteParams}`, `--passphrase=${passphrase}`],
+						config,
+					);
+					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledTimes(1);
+					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledWith(undefined, {
+						transaction: mockEncodedTransaction.toString('hex'),
+					});
+				});
+			});
+
+			describe(`transaction:create pos unlock 100000000 --params=${voteParams} --passphrase=${passphrase}`, () => {
+				it('should return encoded transaction string in hex format with signature', async () => {
+					await CreateCommandExtended.run(
+						['pos', 'unlock', '100000000', `--passphrase=${passphrase}`],
 						config,
 					);
 					expect(CreateCommandExtended.prototype.printJSON).toHaveBeenCalledTimes(1);

--- a/commander/test/bootstrapping/commands/transaction/create.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/create.spec.ts
@@ -594,7 +594,7 @@ describe('transaction:create command', () => {
 				});
 			});
 
-			describe(`transaction:create pos unlock 100000000 --params=${voteParams} --passphrase=${passphrase}`, () => {
+			describe(`transaction:create pos unlock 100000000 --passphrase=${passphrase}`, () => {
 				it('should return encoded transaction string in hex format with signature', async () => {
 					await CreateCommandExtended.run(
 						['pos', 'unlock', '100000000', `--passphrase=${passphrase}`],


### PR DESCRIPTION
### What was the problem?

This PR resolves #8088 

### How was it solved?

- Fix the check to expect undefined schema

### How was it tested?

- Added unit test
- Run `./bin/run transaction:create pos unlock` command
