### PR TITLE
Call fee endpoint init function and load config

### DIFF
--- a/framework/src/modules/fee/module.ts
+++ b/framework/src/modules/fee/module.ts
@@ -89,6 +89,7 @@ export class FeeModule extends BaseInteroperableModule {
 			feeTokenID: Buffer.from(config.feeTokenID, 'hex'),
 		};
 		this.method.init(moduleConfig);
+		this.endpoint.init(moduleConfig);
 
 		this._tokenID = moduleConfig.feeTokenID;
 		this._minFeePerByte = moduleConfig.minFeePerByte;

--- a/framework/test/unit/modules/fee/module.spec.ts
+++ b/framework/test/unit/modules/fee/module.spec.ts
@@ -64,6 +64,17 @@ describe('FeeModule', () => {
 		it('should set the minFeePerByte property', () => {
 			expect(feeModule['_minFeePerByte']).toBe(1000);
 		});
+
+		it('should call method and endpoint init', async () => {
+			feeModule = new FeeModule();
+			// Spy on init functions
+			jest.spyOn(feeModule.endpoint, 'init');
+			jest.spyOn(feeModule.method, 'init');
+			await feeModule.init({ genesisConfig, moduleConfig });
+
+			expect(feeModule.endpoint.init).toHaveBeenCalled();
+			expect(feeModule.method.init).toHaveBeenCalled();
+		});
 	});
 
 	describe('verifyTransaction', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8109 

### How was it solved?

[🐛 Call fee endpoint init function and load config](https://github.com/LiskHQ/lisk-sdk/commit/1b8f2e6bb583c0dc95872e53be398ff574170cd2)

### How was it tested?

Run `examples/pos-mainchain` and call `fee_getMinFeePerByte` endpoint to see if it returns config successfully
