### PR TITLE
Fix generator not to sign if BLS key is not registered

### DIFF
--- a/framework/src/engine/generator/endpoint.ts
+++ b/framework/src/engine/generator/endpoint.ts
@@ -188,6 +188,7 @@ export class Endpoint {
 
 		// Enable validator to forge by adding keypairs corresponding to address
 		this._keypairs.set(address, {
+			blsPublicKey: decryptedKeys.blsKey,
 			blsSecretKey: decryptedKeys.blsPrivateKey,
 			privateKey: decryptedKeys.generatorPrivateKey,
 			publicKey: decryptedKeys.generatorKey,

--- a/framework/src/engine/generator/types.ts
+++ b/framework/src/engine/generator/types.ts
@@ -23,6 +23,7 @@ import { JSONObject } from '../../types';
 export interface Keypair {
 	publicKey: Buffer;
 	privateKey: Buffer;
+	blsPublicKey: Buffer;
 	blsSecretKey: Buffer;
 }
 

--- a/framework/test/unit/engine/generator/endpoint.spec.ts
+++ b/framework/test/unit/engine/generator/endpoint.spec.ts
@@ -187,6 +187,7 @@ describe('generator endpoint', () => {
 			endpoint['_keypairs'].set(defaultEncryptedKeys.address, {
 				publicKey: Buffer.alloc(0),
 				privateKey: Buffer.alloc(0),
+				blsPublicKey: Buffer.alloc(0),
 				blsSecretKey: Buffer.alloc(0),
 			});
 			await expect(
@@ -556,6 +557,7 @@ describe('generator endpoint', () => {
 
 		it('should delete in-memory keypairs when new keys are set', async () => {
 			endpoint['_keypairs'].set(defaultEncryptedKeys.address, {
+				blsPublicKey: Buffer.alloc(0),
 				blsSecretKey: Buffer.alloc(0),
 				privateKey: Buffer.alloc(0),
 				publicKey: Buffer.alloc(0),


### PR DESCRIPTION
### What was the problem?

This PR resolves #8108 

### How was it solved?

- Add check before signing single commit if BLS key is registered

### How was it tested?

Run the updated code with lisk-core and run more than 150 blocks