### PR TITLE
Adds getMultiSigRegMsgTag endpoint to Auth module

### DIFF
--- a/framework/src/modules/auth/endpoint.ts
+++ b/framework/src/modules/auth/endpoint.ts
@@ -23,11 +23,13 @@ import {
 	VerifyEndpointResultJSON,
 	KeySignaturePair,
 	SortedMultisignatureGroup,
+	MultiSigRegMsgTag,
 } from './types';
 import { getTransactionFromParameter, verifyNonce, verifySignatures } from './utils';
 import { AuthAccountStore } from './stores/auth_account';
 import { NamedRegistry } from '../named_registry';
 import { multisigRegMsgSchema, sortMultisignatureGroupRequestSchema } from './schemas';
+import { MESSAGE_TAG_MULTISIG_REG } from './constants';
 
 export class AuthEndpoint extends BaseEndpoint {
 	public constructor(_moduleName: string, stores: NamedRegistry, offchainStores: NamedRegistry) {
@@ -129,5 +131,9 @@ export class AuthEndpoint extends BaseEndpoint {
 				.map(keySignaturePair => keySignaturePair.signature)
 				.concat(sortedOptional.map(keySignaturePair => keySignaturePair.signature)),
 		};
+	}
+
+	public getMultiSigRegMsgTag(): MultiSigRegMsgTag {
+		return { tag: MESSAGE_TAG_MULTISIG_REG };
 	}
 }

--- a/framework/src/modules/auth/module.ts
+++ b/framework/src/modules/auth/module.ts
@@ -35,6 +35,7 @@ import {
 	sortMultisignatureGroupRequestSchema,
 	transactionRequestSchema,
 	verifyResultSchema,
+	multiSigRegMsgTagSchema,
 } from './schemas';
 import { GenesisAuthStore } from './types';
 import { verifyNonce, verifySignatures } from './utils';
@@ -87,6 +88,10 @@ export class AuthModule extends BaseModule {
 					name: this.endpoint.sortMultisignatureGroup.name,
 					request: sortMultisignatureGroupRequestSchema,
 					response: sortMultisignatureGroupResponseSchema,
+				},
+				{
+					name: this.endpoint.getMultiSigRegMsgTag.name,
+					response: multiSigRegMsgTagSchema,
 				},
 			],
 			assets: [

--- a/framework/src/modules/auth/schemas.ts
+++ b/framework/src/modules/auth/schemas.ts
@@ -333,7 +333,6 @@ export const multiSigRegMsgTagSchema = {
 	properties: {
 		tag: {
 			type: 'string',
-			fieldNumber: 1,
 		},
 	},
 	required: ['tag'],

--- a/framework/src/modules/auth/schemas.ts
+++ b/framework/src/modules/auth/schemas.ts
@@ -326,3 +326,15 @@ export const sortMultisignatureGroupResponseSchema = {
 	},
 	required: ['mandatoryKeys', 'optionalKeys', 'signatures'],
 };
+
+export const multiSigRegMsgTagSchema = {
+	$id: '/auth/mutliSignatureRegistrationSignatureMessageTagResponse',
+	type: 'object',
+	properties: {
+		tag: {
+			type: 'string',
+			fieldNumber: 1,
+		},
+	},
+	required: ['tag'],
+};

--- a/framework/src/modules/auth/types.ts
+++ b/framework/src/modules/auth/types.ts
@@ -57,3 +57,7 @@ export interface GenesisAuthStore {
 		storeValue: AuthAccount;
 	}[];
 }
+
+export interface MultiSigRegMsgTag {
+	tag: string;
+}

--- a/framework/test/unit/modules/auth/endpoint.spec.ts
+++ b/framework/test/unit/modules/auth/endpoint.spec.ts
@@ -693,4 +693,12 @@ describe('AuthEndpoint', () => {
 			expect(() => authEndpoint.sortMultisignatureGroup(context)).toThrow(LiskValidationError);
 		});
 	});
+
+	describe('getMultiSigRegSigMessageTag', () => {
+		it('should return MultiSigRegMsgTag with tag set to MESSAGE_TAG_MULTISIG_REG', async () => {
+			const result = authEndpoint.getMultiSigRegMsgTag();
+
+			expect(result.tag).toEqual(MESSAGE_TAG_MULTISIG_REG);
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #8124

### How was it solved?

Add `multiSigRegMsgTag` endpoint to `auth` module to retrieve the constant `MESSAGE_TAG_MULTISIG_REG` required for creating signature(s) to post `registerMultisignature` transaction.

### How was it tested?
Implemented unit test.

Calling `./examples/pos-mainchain/bin/run endpoint:invoke auth_getMultiSigRegMsgTag`
