### PR TITLE
API Client assigns correct transaction nonce when it is provided in string format

### DIFF
--- a/elements/lisk-api-client/src/transaction.ts
+++ b/elements/lisk-api-client/src/transaction.ts
@@ -100,9 +100,9 @@ export class Transaction {
 		if (!registeredCommand) {
 			throw new Error(`Command corresponding to name ${txInput.command} not registered.`);
 		}
-		if (typeof txInput.nonce !== 'bigint' && txInput.nonce !== 'string') {
-			txInput.nonce = BigInt(authAccount.nonce);
-		}
+
+		txInput.nonce ??= BigInt(authAccount.nonce);
+
 		if (txInput.nonce < BigInt(0)) {
 			throw new Error('Nonce must be greater or equal to zero');
 		}

--- a/elements/lisk-api-client/test/unit/transaction.spec.ts
+++ b/elements/lisk-api-client/test/unit/transaction.spec.ts
@@ -199,6 +199,16 @@ describe('transaction', () => {
 				});
 			});
 
+			describe('when transaction nonce is not provided', () => {
+				it('should default to account nonce', async () => {
+					const returnedTx = await transaction.create(
+						{ ...validTransaction, nonce: undefined },
+						privateKey1,
+					);
+					expect(returnedTx.nonce).toBe('1');
+				});
+			});
+
 			describe('when called without sender public key in input', () => {
 				it('should return created tx', async () => {
 					const returnedTx = await transaction.create(


### PR DESCRIPTION
### What was the problem?

This PR resolves #8132

### How was it solved?

Instead of adding missing `typeof` operator in front of `txInput.nonce !== 'string'` statement, I replaced that whole verbose conditional [whose only purpose seem to be to detect if nonce value is undefined], with a more elegant nullish coalescing assignment operator [??=].

### How was it tested?

Added 1 unit test.
