### PR TITLE
Fix q96 toBuffer and add PoS reward integration tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,7 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: build
     steps:
       - name: Checkout

--- a/elements/lisk-utils/src/math/q.ts
+++ b/elements/lisk-utils/src/math/q.ts
@@ -160,6 +160,9 @@ export class Q {
 
 	// _bigintToHex mitigates the problem where bigint.toString(16) does not prepend 0 at the beginning
 	private _bigintToHex(val: bigint): string {
+		if (val === BigInt(0)) {
+			return '';
+		}
 		const result = val.toString(16);
 		if (result.length % 2 === 0) {
 			return result;

--- a/elements/lisk-utils/src/math/q.ts
+++ b/elements/lisk-utils/src/math/q.ts
@@ -108,7 +108,7 @@ export class Q {
 	}
 
 	public toBuffer(): Buffer {
-		return Buffer.from(this._val.toString(16), 'hex');
+		return Buffer.from(this._bigintToHex(this._val), 'hex');
 	}
 
 	public eq(n: Q): boolean {
@@ -156,5 +156,14 @@ export class Q {
 			return result;
 		}
 		return result + ONE;
+	}
+
+	// _bigintToHex mitigates the problem where bigint.toString(16) does not prepend 0 at the beginning
+	private _bigintToHex(val: bigint): string {
+		const result = val.toString(16);
+		if (result.length % 2 === 0) {
+			return result;
+		}
+		return `0${result}`;
 	}
 }

--- a/elements/lisk-utils/test/math/q.spec.ts
+++ b/elements/lisk-utils/test/math/q.spec.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { q, q96 } from '../../src/math';
+import { Q, q, q96 } from '../../src/math';
 
 /**
  * For the test cases `binary` represents the calculation result in binary.
@@ -331,6 +331,20 @@ describe('Q', () => {
 			expect(muldivResult).not.toEqual(mulThenDivResult);
 			// muldiv should have closer value to fourNinths
 			expect(fourNinths.sub(muldivResult).lt(fourNinths.sub(mulThenDivResult))).toBeTrue();
+		});
+	});
+
+	describe('toBuffer', () => {
+		const cases = [
+			[{ original: BigInt('0') }],
+			[{ original: BigInt('100000000000') }],
+			[{ original: BigInt('396140812571321687967719751') }],
+		];
+
+		it.each(cases)('should result in expected value %o', val => {
+			expect(val.original).toBe(BigInt(`0x${val.original.toString(16)}`));
+			const qVal = new Q(val.original, 96);
+			expect(qVal).toEqual(q96(qVal.toBuffer()));
 		});
 	});
 });

--- a/framework/src/modules/pos/method.ts
+++ b/framework/src/modules/pos/method.ts
@@ -118,14 +118,16 @@ export class PoSMethod extends BaseMethod {
 
 		const oldSharingCoefficient = q96(validator.sharingCoefficients[index].coefficient);
 		const sharingCoefficientIncrease = rewardQ.muldiv(rewardFractionQ, totalStakesQ);
-		const sharedRewards = sharingCoefficientIncrease.mul(totalStakesQ.sub(selfStakeQ)).floor();
+		const sharedRewards = sharingCoefficientIncrease.mul(totalStakesQ.sub(selfStakeQ)).ceil();
+		// it should not lock more than the original reward. This might happen because of ceil above
+		const cappedSharedRewards = sharedRewards > reward ? reward : sharedRewards;
 
 		await this._tokenMethod.lock(
 			context,
 			generatorAddress,
 			this._moduleName,
 			tokenID,
-			sharedRewards,
+			cappedSharedRewards,
 		);
 
 		const newSharingCoefficient = oldSharingCoefficient.add(sharingCoefficientIncrease);

--- a/framework/src/modules/pos/types.ts
+++ b/framework/src/modules/pos/types.ts
@@ -164,17 +164,7 @@ export interface ValidatorAccount {
 	sharingCoefficients: StakeSharingCoefficient[];
 }
 
-export interface StakerDataJSON {
-	stakes: {
-		validatorAddress: string;
-		amount: string;
-	}[];
-	pendingUnlocks: {
-		validatorAddress: string;
-		amount: string;
-		unstakeHeight: number;
-	}[];
-}
+export type StakerDataJSON = JSONObject<StakerData>;
 
 export interface StakeObject {
 	validatorAddress: Buffer;

--- a/framework/src/testing/block_processing_env.ts
+++ b/framework/src/testing/block_processing_env.ts
@@ -234,7 +234,7 @@ export const getBlockProcessingEnv = async (
 	}));
 	await stateMachine.init(logger, appConfig.genesis, appConfig.modules);
 	const genesisBlock = await generateGenesisBlock(stateMachine, logger, {
-		timestamp: Math.floor(Date.now() / 1000) - 60 * 60,
+		timestamp: Math.floor(Date.now() / 1000) - 60 * 60 * 12,
 		assets: blockAssets,
 		chainID,
 	});
@@ -253,6 +253,7 @@ export const getBlockProcessingEnv = async (
 	const engine = new Engine(abiHandler, appConfig);
 	await engine['_init']();
 	engine['_logger'] = logger;
+	engine['_consensus']['_logger'] = logger;
 
 	await abiHandler.init({
 		chainID,

--- a/framework/src/testing/block_processing_env.ts
+++ b/framework/src/testing/block_processing_env.ts
@@ -17,10 +17,18 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import { Block, Chain, DataAccess, BlockHeader, Transaction, StateStore } from '@liskhq/lisk-chain';
+import {
+	Block,
+	Chain,
+	DataAccess,
+	BlockHeader,
+	Transaction,
+	StateStore,
+	standardEventDataSchema,
+} from '@liskhq/lisk-chain';
 import { Database, StateDB } from '@liskhq/lisk-db';
 import { objects } from '@liskhq/lisk-utils';
-import { codec } from '@liskhq/lisk-codec';
+import { codec, Schema } from '@liskhq/lisk-codec';
 import { BaseModule } from '../modules';
 import { channelMock } from './mocks';
 import {
@@ -30,7 +38,7 @@ import {
 	Keys,
 } from './fixtures';
 import { removeDB } from './utils';
-import { ApplicationConfig, EndpointHandler, GenesisConfig } from '../types';
+import { ApplicationConfig, EndpointHandler, EventJSON, GenesisConfig } from '../types';
 import { Consensus } from '../engine/consensus';
 import { MethodContext, StateMachine } from '../state_machine';
 import { Engine } from '../engine';
@@ -43,7 +51,6 @@ import { ValidatorsModule } from '../modules/validators';
 import { TokenModule } from '../modules/token';
 import { AuthModule } from '../modules/auth';
 import { FeeModule } from '../modules/fee';
-import { RewardModule } from '../modules/reward';
 import { RandomModule } from '../modules/random';
 import { PoSModule } from '../modules/pos';
 import { Generator } from '../engine/generator';
@@ -53,9 +60,11 @@ import { systemDirs } from '../system_dirs';
 import { PrefixedStateReadWriter } from '../state_machine/prefixed_state_read_writer';
 import { createLogger } from '../logger';
 import { MainchainInteroperabilityModule } from '../modules/interoperability';
+import { DynamicRewardModule } from '../modules/dynamic_rewards';
 
 type Options = {
 	genesis?: GenesisConfig;
+	modules?: Record<string, Record<string, unknown>>;
 	databasePath?: string;
 	passphrase?: string;
 };
@@ -66,6 +75,8 @@ interface BlockProcessingParams {
 	initValidators?: Buffer[];
 	logLevel?: string;
 }
+
+type DecodedEventJSON = EventJSON & { decodedData: Record<string, unknown> };
 
 export interface BlockProcessingEnv {
 	createBlock: (transactions?: Transaction[], timestamp?: number) => Promise<Block>;
@@ -79,8 +90,9 @@ export interface BlockProcessingEnv {
 	process: (block: Block) => Promise<void>;
 	processUntilHeight: (height: number) => Promise<void>;
 	getLastBlock: () => Block;
-	getNextValidatorKeys: (blockHeader: BlockHeader) => Promise<Keys>;
+	getNextValidatorKeys: (blockHeader: BlockHeader, distance?: number) => Promise<Keys>;
 	getDataAccess: () => DataAccess;
+	getEvents: (height: number, module?: string, name?: string) => Promise<DecodedEventJSON[]>;
 	getChainID: () => Buffer;
 	invoke: <T = void>(path: string, params?: Record<string, unknown>) => Promise<T>;
 	cleanup: (config: Options) => void;
@@ -111,11 +123,11 @@ const getAppConfig = (
 	return mergedConfig;
 };
 
-const getNextTimestamp = (engine: Engine, previousBlock: BlockHeader) => {
+const getNextTimestamp = (engine: Engine, previousBlock: BlockHeader, distance = 1) => {
 	const previousSlotNumber = engine['_consensus']['_bft'].method.getSlotNumber(
 		previousBlock.timestamp,
 	);
-	return engine['_consensus']['_bft'].method.getSlotTime(previousSlotNumber + 1);
+	return engine['_consensus']['_bft'].method.getSlotTime(previousSlotNumber + distance);
 };
 
 const createProcessableBlock = async (
@@ -163,6 +175,7 @@ export const getBlockProcessingEnv = async (
 					chainID: chainID.toString('hex'),
 			  }
 			: { chainID: chainID.toString('hex') },
+		params.options?.modules ?? {},
 	);
 
 	const systemDir = systemDirs(appConfig.system.dataPath);
@@ -175,7 +188,7 @@ export const getBlockProcessingEnv = async (
 	const authModule = new AuthModule();
 	const tokenModule = new TokenModule();
 	const feeModule = new FeeModule();
-	const rewardModule = new RewardModule();
+	const rewardModule = new DynamicRewardModule();
 	const randomModule = new RandomModule();
 	const posModule = new PoSModule();
 	const interopModule = new MainchainInteroperabilityModule();
@@ -194,7 +207,12 @@ export const getBlockProcessingEnv = async (
 	// resolve dependencies
 	tokenModule.addDependencies(interopModule.method, feeModule.method);
 	feeModule.addDependencies(tokenModule.method, interopModule.method);
-	rewardModule.addDependencies(tokenModule.method, randomModule.method);
+	rewardModule.addDependencies(
+		tokenModule.method,
+		randomModule.method,
+		validatorsModule.method,
+		posModule.method,
+	);
 	posModule.addDependencies(
 		randomModule.method,
 		validatorsModule.method,
@@ -270,17 +288,62 @@ export const getBlockProcessingEnv = async (
 			}
 		},
 		getLastBlock: () => engine['_chain'].lastBlock,
-		getNextValidatorKeys: async (previousBlockHeader: BlockHeader): Promise<Keys> => {
+		getNextValidatorKeys: async (previousBlockHeader: BlockHeader, distance = 1): Promise<Keys> => {
 			const stateStore = new StateStore(engine['_blockchainDB']);
-			const nextTimestamp = getNextTimestamp(engine, previousBlockHeader);
+			const nextTimestamp = getNextTimestamp(engine, previousBlockHeader, distance);
 			const validator = await engine['_consensus']['_bft'].method.getGeneratorAtTimestamp(
 				stateStore,
-				previousBlockHeader.height + 1,
+				previousBlockHeader.height + distance,
 				nextTimestamp,
 			);
 			const keys = getKeysFromDefaultConfig(validator.address);
 
 			return keys;
+		},
+		getEvents: async (
+			height: number,
+			module?: string,
+			name?: string,
+		): Promise<DecodedEventJSON[]> => {
+			const handler = engine['_rpcServer']['_getHandler']('chain', 'getEvents');
+			if (!handler) {
+				throw new Error('invalid');
+			}
+			const resp = (await handler({
+				logger,
+				chainID: engine['_chain'].chainID,
+				params: { height },
+			})) as EventJSON[];
+			const eventMetadata = stateMachine['_modules']
+				.map(m => ({ module: m.name, ...m.metadata().events } as Record<string, unknown>))
+				.flat();
+			const results: DecodedEventJSON[] = [];
+			for (const event of resp) {
+				if (module && event.module !== module) {
+					continue;
+				}
+				if (name && event.name !== name) {
+					continue;
+				}
+				if (event.name === 'commandExecutionResult') {
+					results.push({
+						...event,
+						decodedData: codec.decodeJSON(standardEventDataSchema, Buffer.from(event.data, 'hex')),
+					});
+					continue;
+				}
+				const metadata = eventMetadata.find(
+					e => e.module === event.module && e.name === event.name,
+				);
+
+				results.push({
+					...event,
+					decodedData: metadata
+						? codec.decodeJSON(metadata.schema as Schema, Buffer.from(event.data, 'hex'))
+						: {},
+				});
+			}
+			return results;
 		},
 		async invoke<T = void>(func: string, input: Record<string, unknown> = {}): Promise<T> {
 			const [namespace, method] = func.split('_');

--- a/framework/test/integration/node/processor/pos.spec.ts
+++ b/framework/test/integration/node/processor/pos.spec.ts
@@ -224,7 +224,12 @@ describe('PoS and reward', () => {
 			newBlock = await processEnv.createBlock([claimTx]);
 			await processEnv.process(newBlock);
 
-			expect(claimableRewards.rewards[0].reward).toEqual(lockedReward.reward);
+			expect(lockedReward.reward).toBe('500000000');
+			expect(claimableRewards.rewards[0].reward).toBe('499999999');
+
+			expect(Number(claimableRewards.rewards[0].reward)).toBeLessThanOrEqual(
+				Number(lockedReward.reward),
+			);
 		});
 
 		it('when validator generates a block with stake transaction without self stake, reward should be locked for sharing', async () => {
@@ -284,7 +289,9 @@ describe('PoS and reward', () => {
 				address: nextValidator.address,
 				tokenID: `${chainID.toString('hex')}00000000`,
 			});
-			expect(claimableRewards.rewards[0].reward).toEqual(lockedReward.reward);
+			expect(Number(claimableRewards.rewards[0].reward)).toBeLessThanOrEqual(
+				Number(lockedReward.reward),
+			);
 
 			const claimTx = createClaimRewardTransaction({
 				chainID,
@@ -449,10 +456,11 @@ describe('PoS and reward', () => {
 				address: nextValidator.address,
 				tokenID: `${chainID.toString('hex')}00000000`,
 			});
-			expect(claimableRewards.rewards[0].reward).toEqual(lockedReward.reward);
+			expect(Number(claimableRewards.rewards[0].reward)).toBeLessThanOrEqual(
+				Number(lockedReward.reward),
+			);
 			// Reward should be 5LSK * 0.5 (50% commission) * 0.5 (50% of whole stake)
-			expect(Number(lockedReward.reward)).toBeLessThanOrEqual(125000000);
-			expect(Number(lockedReward.reward)).toBeGreaterThanOrEqual(124999999);
+			expect(Number(lockedReward.reward)).toBe(125000000);
 		});
 
 		it('when validator generates a block and commission is 50, half of rewards should be given to generator and half should be locked for other stakers', async () => {

--- a/framework/test/integration/node/processor/pos.spec.ts
+++ b/framework/test/integration/node/processor/pos.spec.ts
@@ -16,14 +16,18 @@ import { Block } from '@liskhq/lisk-chain';
 import { address } from '@liskhq/lisk-cryptography';
 import { nodeUtils } from '../../../utils';
 import {
+	createChangeCommissionTransaction,
+	createClaimRewardTransaction,
 	createTransferTransaction,
 	createValidatorRegisterTransaction,
+	createValidatorStakeTransaction,
 } from '../../../utils/mocks/transaction';
 import * as testing from '../../../../src/testing';
 import { defaultConfig } from '../../../../src/modules/token/constants';
-import { EventJSON } from '../../../../src';
+import { ValidatorAccountJSON } from '../../../../src/modules/pos/stores/validator';
+import { StakerDataJSON } from '../../../../src/modules/pos/types';
 
-describe('Transaction order', () => {
+describe('PoS and reward', () => {
 	let processEnv: testing.BlockProcessingEnv;
 	let chainID: Buffer;
 	let newBlock: Block;
@@ -35,6 +39,15 @@ describe('Transaction order', () => {
 		processEnv = await testing.getBlockProcessingEnv({
 			options: {
 				databasePath,
+				modules: {
+					dynamicReward: {
+						offset: 1,
+					},
+					pos: {
+						commissionIncreasePeriod: 0,
+						maxCommissionIncreaseRate: 10000,
+					},
+				},
 			},
 		});
 		chainID = processEnv.getChainID();
@@ -75,9 +88,7 @@ describe('Transaction order', () => {
 			newBlock = await processEnv.createBlock([registrationTx]);
 			await processEnv.process(newBlock);
 
-			const events = await processEnv.invoke<EventJSON[]>('chain_getEvents', {
-				height: newBlock.header.height,
-			});
+			const events = await processEnv.getEvents(newBlock.header.height);
 			expect(events.find(e => e.name === 'generatorKeyRegistration')?.topics[0]).toEqual(
 				registrationTx.id.toString('hex'),
 			);
@@ -121,9 +132,7 @@ describe('Transaction order', () => {
 			newBlock = await processEnv.createBlock([registrationTx]);
 			await processEnv.process(newBlock);
 
-			const events = await processEnv.invoke<EventJSON[]>('chain_getEvents', {
-				height: newBlock.header.height,
-			});
+			const events = await processEnv.getEvents(newBlock.header.height);
 			expect(events.find(e => e.name === 'generatorKeyRegistration')?.topics[0]).toEqual(
 				registrationTx.id.toString('hex'),
 			);
@@ -136,6 +145,308 @@ describe('Transaction order', () => {
 				address: address.getLisk32AddressFromAddress(newAccount.address),
 			});
 			expect(newValidator.name).toBe('testvalidator2');
+		});
+	});
+
+	describe('reward', () => {
+		it('when validator generates a block without self stake and other account stakes, reward should be locked for sharing', async () => {
+			const authData = await processEnv.invoke<{ nonce: string }>('auth_getAuthAccount', {
+				address: genesis.address,
+			});
+			const newAccount = nodeUtils.createAccount();
+			const fundingTx = createTransferTransaction({
+				nonce: BigInt(authData.nonce),
+				recipientAddress: newAccount.address,
+				amount: BigInt('1000000000000'),
+				chainID,
+				privateKey: Buffer.from(genesis.privateKey, 'hex'),
+				fee: BigInt(200000) + BigInt(defaultConfig.userAccountInitializationFee), // minFee not to give fee for generator
+			});
+
+			newBlock = await processEnv.createBlock([fundingTx]);
+			await processEnv.process(newBlock);
+
+			const nextValidator = await processEnv.getNextValidatorKeys(newBlock.header, 2);
+			const stakeTx = createValidatorStakeTransaction({
+				chainID,
+				nonce: BigInt(0),
+				privateKey: newAccount.privateKey,
+				stakes: [
+					{
+						validatorAddress: address.getAddressFromLisk32Address(nextValidator.address),
+						amount: BigInt('100000000000'),
+					},
+				],
+			});
+			newBlock = await processEnv.createBlock([stakeTx]);
+			await processEnv.process(newBlock);
+
+			const [commandExecutionEvent] = await processEnv.getEvents(
+				newBlock.header.height,
+				undefined,
+				'commandExecutionResult',
+			);
+			expect(commandExecutionEvent).toHaveProperty('data', '0801');
+
+			newBlock = await processEnv.createBlock([]);
+			await processEnv.process(newBlock);
+
+			const validator = await processEnv.invoke<ValidatorAccountJSON>('pos_getValidator', {
+				address: nextValidator.address,
+			});
+			expect(validator.commission).toBe(0);
+			const staker = await processEnv.invoke<StakerDataJSON>('pos_getStaker', {
+				address: address.getLisk32AddressFromAddress(newAccount.address),
+			});
+			expect(staker.stakes[0].sharingCoefficients).toBeEmpty();
+			expect(validator.sharingCoefficients).not.toBeEmpty();
+
+			const claimableRewards = await processEnv.invoke<{ rewards: { reward: string }[] }>(
+				'pos_getClaimableRewards',
+				{ address: address.getLisk32AddressFromAddress(newAccount.address) },
+			);
+			const lockedReward = await processEnv.invoke<{ reward: string }>('pos_getLockedReward', {
+				address: nextValidator.address,
+				tokenID: `${chainID.toString('hex')}00000000`,
+			});
+
+			const claimTx = createClaimRewardTransaction({
+				chainID,
+				nonce: BigInt(1),
+				privateKey: newAccount.privateKey,
+			});
+			newBlock = await processEnv.createBlock([claimTx]);
+			await processEnv.process(newBlock);
+
+			expect(claimableRewards.rewards[0].reward).toEqual(lockedReward.reward);
+		});
+
+		it('when validator generates a block with stake transaction without self stake, reward should be locked for sharing', async () => {
+			const authData = await processEnv.invoke<{ nonce: string }>('auth_getAuthAccount', {
+				address: genesis.address,
+			});
+			const newAccount = nodeUtils.createAccount();
+			const fundingTx = createTransferTransaction({
+				nonce: BigInt(authData.nonce),
+				recipientAddress: newAccount.address,
+				amount: BigInt('1000000000000'),
+				chainID,
+				privateKey: Buffer.from(genesis.privateKey, 'hex'),
+				fee: BigInt(200000) + BigInt(defaultConfig.userAccountInitializationFee), // minFee not to give fee for generator
+			});
+
+			newBlock = await processEnv.createBlock([fundingTx]);
+			await processEnv.process(newBlock);
+
+			const nextValidator = await processEnv.getNextValidatorKeys(newBlock.header);
+			const stakeTx = createValidatorStakeTransaction({
+				chainID,
+				nonce: BigInt(0),
+				privateKey: newAccount.privateKey,
+				stakes: [
+					{
+						validatorAddress: address.getAddressFromLisk32Address(nextValidator.address),
+						amount: BigInt('100000000000'),
+					},
+				],
+			});
+			newBlock = await processEnv.createBlock([stakeTx]);
+			await processEnv.process(newBlock);
+
+			const [commandExecutionEvent] = await processEnv.getEvents(
+				newBlock.header.height,
+				undefined,
+				'commandExecutionResult',
+			);
+			expect(commandExecutionEvent.decodedData).toEqual({ success: true });
+
+			const validator = await processEnv.invoke<ValidatorAccountJSON>('pos_getValidator', {
+				address: nextValidator.address,
+			});
+			expect(validator.commission).toBe(0);
+			const staker = await processEnv.invoke<StakerDataJSON>('pos_getStaker', {
+				address: address.getLisk32AddressFromAddress(newAccount.address),
+			});
+			expect(staker.stakes[0].sharingCoefficients).toBeEmpty();
+			expect(validator.sharingCoefficients).not.toBeEmpty();
+
+			const claimableRewards = await processEnv.invoke<{ rewards: { reward: string }[] }>(
+				'pos_getClaimableRewards',
+				{ address: address.getLisk32AddressFromAddress(newAccount.address) },
+			);
+			const lockedReward = await processEnv.invoke<{ reward: string }>('pos_getLockedReward', {
+				address: nextValidator.address,
+				tokenID: `${chainID.toString('hex')}00000000`,
+			});
+			expect(claimableRewards.rewards[0].reward).toEqual(lockedReward.reward);
+
+			const claimTx = createClaimRewardTransaction({
+				chainID,
+				nonce: BigInt(1),
+				privateKey: newAccount.privateKey,
+			});
+			newBlock = await processEnv.createBlock([claimTx]);
+			await processEnv.process(newBlock);
+
+			const [afterEvents] = await processEnv.getEvents(
+				newBlock.header.height,
+				undefined,
+				'commandExecutionResult',
+			);
+			expect(afterEvents.decodedData).toEqual({ success: true });
+		});
+
+		it('when validator generates a block and commission is 100, all rewards should be given to generator without locking', async () => {
+			const authData = await processEnv.invoke<{ nonce: string }>('auth_getAuthAccount', {
+				address: genesis.address,
+			});
+			const newAccount = nodeUtils.createAccount();
+			const fundingTx = createTransferTransaction({
+				nonce: BigInt(authData.nonce),
+				recipientAddress: newAccount.address,
+				amount: BigInt('1000000000000'),
+				chainID,
+				privateKey: Buffer.from(genesis.privateKey, 'hex'),
+				fee: BigInt(200000) + BigInt(defaultConfig.userAccountInitializationFee), // minFee not to give fee for generator
+			});
+
+			newBlock = await processEnv.createBlock([fundingTx]);
+			await processEnv.process(newBlock);
+
+			const nextValidator = await processEnv.getNextValidatorKeys(newBlock.header, 2);
+			const stakeTx = createValidatorStakeTransaction({
+				chainID,
+				nonce: BigInt(0),
+				privateKey: newAccount.privateKey,
+				stakes: [
+					{
+						validatorAddress: address.getAddressFromLisk32Address(nextValidator.address),
+						amount: BigInt('100000000000'),
+					},
+				],
+			});
+			const changeCommissionTx = createChangeCommissionTransaction({
+				chainID,
+				nonce: BigInt(0),
+				privateKey: Buffer.from(nextValidator.privateKey, 'hex'),
+				newCommission: 10000,
+			});
+			newBlock = await processEnv.createBlock([stakeTx, changeCommissionTx]);
+			await processEnv.process(newBlock);
+
+			const [commandExecutionEvent] = await processEnv.getEvents(
+				newBlock.header.height,
+				undefined,
+				'commandExecutionResult',
+			);
+			expect(commandExecutionEvent.decodedData).toEqual({ success: true });
+
+			newBlock = await processEnv.createBlock([]);
+			await processEnv.process(newBlock);
+
+			const validator = await processEnv.invoke<ValidatorAccountJSON>('pos_getValidator', {
+				address: nextValidator.address,
+			});
+			expect(validator.commission).toBe(10000);
+			const staker = await processEnv.invoke<StakerDataJSON>('pos_getStaker', {
+				address: address.getLisk32AddressFromAddress(newAccount.address),
+			});
+			expect(staker.stakes[0].sharingCoefficients).toBeEmpty();
+			expect(validator.sharingCoefficients).not.toBeEmpty();
+
+			const claimableRewards = await processEnv.invoke<{ rewards: { reward: string }[] }>(
+				'pos_getClaimableRewards',
+				{ address: address.getLisk32AddressFromAddress(newAccount.address) },
+			);
+			const lockedReward = await processEnv.invoke<{ reward: string }>('pos_getLockedReward', {
+				address: nextValidator.address,
+				tokenID: `${chainID.toString('hex')}00000000`,
+			});
+			expect(lockedReward.reward).toBe('0');
+			expect(claimableRewards.rewards[0].reward).toEqual(lockedReward.reward);
+		});
+
+		it('when validator generates a block and commission is 50, half of rewards should be given to generator and half should be locked', async () => {
+			const authData = await processEnv.invoke<{ nonce: string }>('auth_getAuthAccount', {
+				address: genesis.address,
+			});
+			const newAccount = nodeUtils.createAccount();
+			const fundingTx = createTransferTransaction({
+				nonce: BigInt(authData.nonce),
+				recipientAddress: newAccount.address,
+				amount: BigInt('1000000000000'),
+				chainID,
+				privateKey: Buffer.from(genesis.privateKey, 'hex'),
+				fee: BigInt(200000) + BigInt(defaultConfig.userAccountInitializationFee), // minFee not to give fee for generator
+			});
+
+			newBlock = await processEnv.createBlock([fundingTx]);
+			await processEnv.process(newBlock);
+
+			const nextValidator = await processEnv.getNextValidatorKeys(newBlock.header, 2);
+			const stakeTx = createValidatorStakeTransaction({
+				chainID,
+				nonce: BigInt(0),
+				privateKey: newAccount.privateKey,
+				stakes: [
+					{
+						validatorAddress: address.getAddressFromLisk32Address(nextValidator.address),
+						amount: BigInt('100000000000'),
+					},
+				],
+			});
+			const selfStakeTx = createValidatorStakeTransaction({
+				chainID,
+				nonce: BigInt(0),
+				privateKey: Buffer.from(nextValidator.privateKey, 'hex'),
+				stakes: [
+					{
+						validatorAddress: address.getAddressFromLisk32Address(nextValidator.address),
+						amount: BigInt('100000000000'),
+					},
+				],
+			});
+			const changeCommissionTx = createChangeCommissionTransaction({
+				chainID,
+				nonce: BigInt(1),
+				privateKey: Buffer.from(nextValidator.privateKey, 'hex'),
+				newCommission: 5000,
+			});
+			newBlock = await processEnv.createBlock([stakeTx, selfStakeTx, changeCommissionTx]);
+			await processEnv.process(newBlock);
+
+			const [commandExecutionEvent] = await processEnv.getEvents(
+				newBlock.header.height,
+				undefined,
+				'commandExecutionResult',
+			);
+			expect(commandExecutionEvent.decodedData).toEqual({ success: true });
+
+			newBlock = await processEnv.createBlock([]);
+			await processEnv.process(newBlock);
+
+			const validator = await processEnv.invoke<ValidatorAccountJSON>('pos_getValidator', {
+				address: nextValidator.address,
+			});
+			expect(validator.commission).toBe(5000);
+			const staker = await processEnv.invoke<StakerDataJSON>('pos_getStaker', {
+				address: address.getLisk32AddressFromAddress(newAccount.address),
+			});
+			expect(staker.stakes[0].sharingCoefficients).toBeEmpty();
+			expect(validator.sharingCoefficients).not.toBeEmpty();
+
+			const claimableRewards = await processEnv.invoke<{ rewards: { reward: string }[] }>(
+				'pos_getClaimableRewards',
+				{ address: address.getLisk32AddressFromAddress(newAccount.address) },
+			);
+			const lockedReward = await processEnv.invoke<{ reward: string }>('pos_getLockedReward', {
+				address: nextValidator.address,
+				tokenID: `${chainID.toString('hex')}00000000`,
+			});
+			expect(claimableRewards.rewards[0].reward).toEqual(lockedReward.reward);
+			// Reward should be 5LSK * 0.5 (50% commission) * 0.5 (50% of whole stake)
+			expect(Number(lockedReward.reward)).toBeLessThanOrEqual(125000000);
+			expect(Number(lockedReward.reward)).toBeGreaterThanOrEqual(124999999);
 		});
 	});
 });

--- a/framework/test/utils/mocks/transaction.ts
+++ b/framework/test/utils/mocks/transaction.ts
@@ -28,6 +28,7 @@ import {
 	validatorRegistrationCommandParamsSchema,
 	reportMisbehaviorCommandParamsSchema,
 	stakeCommandParamsSchema,
+	changeCommissionCommandParamsSchema,
 } from '../../../src/modules/pos/schemas';
 import { TransferCommand } from '../../../src/modules/token/commands/transfer';
 import { transferParamsSchema } from '../../../src/modules/token/schemas';
@@ -121,6 +122,56 @@ export const createValidatorStakeTransaction = (input: {
 		senderPublicKey: publicKey,
 		fee: input.fee ?? BigInt('100000000'),
 		params: encodedAsset,
+		signatures: [],
+	});
+	tx.signatures.push(
+		ed.signData(TAG_TRANSACTION, input.chainID, tx.getSigningBytes(), input.privateKey),
+	);
+	return tx;
+};
+
+export const createChangeCommissionTransaction = (input: {
+	nonce: bigint;
+	chainID: Buffer;
+	privateKey: Buffer;
+	newCommission: number;
+	fee?: bigint;
+}): Transaction => {
+	const encodedAsset = codec.encode(changeCommissionCommandParamsSchema, {
+		newCommission: input.newCommission,
+	});
+	const publicKey = ed.getPublicKeyFromPrivateKey(input.privateKey);
+
+	const tx = new Transaction({
+		module: 'pos',
+		command: 'changeCommission',
+		nonce: input.nonce,
+		senderPublicKey: publicKey,
+		fee: input.fee ?? BigInt('100000000'),
+		params: encodedAsset,
+		signatures: [],
+	});
+	tx.signatures.push(
+		ed.signData(TAG_TRANSACTION, input.chainID, tx.getSigningBytes(), input.privateKey),
+	);
+	return tx;
+};
+
+export const createClaimRewardTransaction = (input: {
+	nonce: bigint;
+	chainID: Buffer;
+	privateKey: Buffer;
+	fee?: bigint;
+}): Transaction => {
+	const publicKey = ed.getPublicKeyFromPrivateKey(input.privateKey);
+
+	const tx = new Transaction({
+		module: 'pos',
+		command: 'claimRewards',
+		nonce: input.nonce,
+		senderPublicKey: publicKey,
+		fee: input.fee ?? BigInt('100000000'),
+		params: Buffer.alloc(0),
 		signatures: [],
 	});
 	tx.signatures.push(


### PR DESCRIPTION
### What was the problem?

This PR resolves #8118 

### How was it solved?

- Fix Q `toBuffer` to pad `0` when it's odd length
- Add PoS reward integration tests

### How was it tested?

- Added reward integration tests
