### PR TITLE
Fix BFT removal height and certificate range

### DIFF
--- a/framework/src/engine/bft/module.ts
+++ b/framework/src/engine/bft/module.ts
@@ -62,6 +62,7 @@ export class BFTModule {
 	public async beforeTransactionsExecute(
 		stateStore: StateStore,
 		header: BlockHeader,
+		maxRemovalHeight: number,
 	): Promise<void> {
 		const votesStore = stateStore.getStore(MODULE_STORE_PREFIX_BFT, STORE_PREFIX_BFT_VOTES);
 		const paramsStore = stateStore.getStore(MODULE_STORE_PREFIX_BFT, STORE_PREFIX_BFT_PARAMETERS);
@@ -80,7 +81,7 @@ export class BFTModule {
 		await votesStore.setWithSchema(EMPTY_KEY, bftVotes, bftVotesSchema);
 		const minHeightBFTParametersRequired = Math.min(
 			bftVotes.blockBFTInfos[bftVotes.blockBFTInfos.length - 1].height,
-			bftVotes.maxHeightCertified + 1,
+			maxRemovalHeight,
 		);
 		await deleteBFTParameters(paramsStore, minHeightBFTParametersRequired);
 	}

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -377,6 +377,13 @@ export class Consensus {
 		);
 	}
 
+	public async getMaxRemovalHeight(): Promise<number> {
+		const finalizedBlockHeader = await this._chain.dataAccess.getBlockHeaderByHeight(
+			this._chain.finalizedHeight,
+		);
+		return finalizedBlockHeader.aggregateCommit.height;
+	}
+
 	private async _execute(block: Block, peerID: string): Promise<void> {
 		if (this._stop) {
 			return;
@@ -930,7 +937,8 @@ export class Consensus {
 		block: Block,
 	): Promise<Event[]> {
 		try {
-			await this._bft.beforeTransactionsExecute(stateStore, block.header);
+			const maxRemovalHeight = await this.getMaxRemovalHeight();
+			await this._bft.beforeTransactionsExecute(stateStore, block.header, maxRemovalHeight);
 
 			const events = [];
 			const beforeResult = await this._abi.beforeTransactionsExecute({

--- a/framework/src/engine/generator/types.ts
+++ b/framework/src/engine/generator/types.ts
@@ -43,6 +43,7 @@ export interface Consensus {
 	finalizedHeight: () => number;
 	getAggregateCommit: (stateStore: StateStore) => Promise<AggregateCommit>;
 	certifySingleCommit: (blockHeader: BlockHeader, validatorInfo: ValidatorInfo) => void;
+	getMaxRemovalHeight: () => Promise<number>;
 	readonly events: EventEmitter;
 }
 

--- a/framework/test/unit/engine/bft/bft_processing.spec.ts
+++ b/framework/test/unit/engine/bft/bft_processing.spec.ts
@@ -153,7 +153,7 @@ describe('BFT processing', () => {
 						bftVotesSchema,
 					);
 
-					await bftModule.beforeTransactionsExecute(stateStore, header);
+					await bftModule.beforeTransactionsExecute(stateStore, header, 0);
 
 					const votesStore = stateStore.getStore(MODULE_STORE_PREFIX_BFT, STORE_PREFIX_BFT_VOTES);
 					const result = await votesStore.getWithSchema<BFTVotes>(EMPTY_KEY, bftVotesSchema);

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -71,6 +71,9 @@ describe('consensus', () => {
 			validateBlock: jest.fn(),
 			validateTransaction: jest.fn(),
 			removeBlock: jest.fn(),
+			dataAccess: {
+				getBlockHeaderByHeight: jest.fn().mockResolvedValue(lastBlock.header),
+			},
 		} as unknown as Chain;
 		network = {
 			registerEndpoint: jest.fn(),

--- a/framework/test/unit/engine/generator/generator.spec.ts
+++ b/framework/test/unit/engine/generator/generator.spec.ts
@@ -95,6 +95,7 @@ describe('generator', () => {
 				implyMaxPrevote: true,
 				maxHeightCertified: 0,
 			}),
+			getMaxRemovalHeight: jest.fn().mockResolvedValue(0),
 			events: consensusEvent,
 		} as never;
 		network = {
@@ -197,18 +198,19 @@ describe('generator', () => {
 				expect(generator['_keypairs'].values()).toHaveLength(103);
 			});
 
-			it('should handle finalized height change between maxHeightCertified + 1 and max height precommitted', async () => {
+			it('should handle finalized height change between maxRemovalHeight and max height precommitted', async () => {
 				jest.spyOn(generator, '_handleFinalizedHeightChanged' as any).mockReturnValue([] as never);
 				jest
 					.spyOn(generator['_bft'].method, 'getBFTHeights')
 					.mockResolvedValue({ maxHeightPrecommitted: 515, maxHeightCertified: 313 } as never);
+				jest.spyOn(generator['_consensus'], 'getMaxRemovalHeight').mockResolvedValue(200);
 
 				await generator.init({
 					blockchainDB,
 					generatorDB,
 					logger,
 				});
-				expect(generator['_handleFinalizedHeightChanged']).toHaveBeenCalledWith(313, 515);
+				expect(generator['_handleFinalizedHeightChanged']).toHaveBeenCalledWith(200, 515);
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8139 

### How was it solved?

- Revert some change from https://github.com/LiskHQ/lisk-sdk/pull/8095
- Update `await this._bft.beforeTransactionsExecute` to take removal height

### How was it tested?

- Update unit tests
- Check exmaple apps, wait for height where certification starts and restart in several different heights