### PR TITLE
Fix transaction execution when pool has more than full block

### DIFF
--- a/framework/src/engine/generator/strategies.ts
+++ b/framework/src/engine/generator/strategies.ts
@@ -69,6 +69,14 @@ export class HighFeeGenerationStrategy {
 			if (!lowestNonceHighestFeeTrx) {
 				throw new Error('lowest nonce tx must exist');
 			}
+			// If transaction byte size can't fit in max transactions length
+			// then discard all transactions from that account as
+			// other transactions will be higher nonce
+			const trsByteSize = lowestNonceHighestFeeTrx.getBytes().length;
+			if (blockTransactionsSize + trsByteSize > this._constants.maxTransactionsSize) {
+				// End up filling the block
+				break;
+			}
 			const senderId = address.getAddressFromPublicKey(lowestNonceHighestFeeTrx.senderPublicKey);
 			// Try to process transaction
 			try {
@@ -98,15 +106,6 @@ export class HighFeeGenerationStrategy {
 				// from that account as other transactions will be higher nonce
 				transactionsBySender.delete(senderId);
 				continue;
-			}
-
-			// If transaction byte size can't fit in max transactions length
-			// then discard all transactions from that account as
-			// other transactions will be higher nonce
-			const trsByteSize = lowestNonceHighestFeeTrx.getBytes().length;
-			if (blockTransactionsSize + trsByteSize > this._constants.maxTransactionsSize) {
-				// End up filling the block
-				break;
 			}
 
 			// Select transaction as ready for forging

--- a/framework/test/unit/engine/generator/strategies.spec.ts
+++ b/framework/test/unit/engine/generator/strategies.spec.ts
@@ -185,7 +185,7 @@ describe('strategies', () => {
 				);
 			});
 
-			it('should not execute transaction if maximum size after maximum size is reached', async () => {
+			it('should not execute transaction if the transaction byte size exceeds max transaction byte size allowed for the block', async () => {
 				// Arrange
 				mockTxPool.getProcessableTransactions.mockReturnValue(
 					buildProcessableTxMock(maxTransactionsSizeCase.input.transactions, abi),

--- a/framework/test/unit/engine/generator/strategies.spec.ts
+++ b/framework/test/unit/engine/generator/strategies.spec.ts
@@ -185,6 +185,25 @@ describe('strategies', () => {
 				);
 			});
 
+			it('should not execute transaction if maximum size after maximum size is reached', async () => {
+				// Arrange
+				mockTxPool.getProcessableTransactions.mockReturnValue(
+					buildProcessableTxMock(maxTransactionsSizeCase.input.transactions, abi),
+				);
+				(strategy['_constants'] as any).maxTransactionsSize = BigInt(
+					maxTransactionsSizeCase.input.maxTransactionsSize,
+				);
+
+				// Act
+				const result = await strategy.getTransactionsForBlock(contextID, header, new BlockAssets());
+
+				// Assert
+				expect(result.transactions.map((tx: any) => tx.id.toString())).toEqual(
+					maxTransactionsSizeCase.output.map(tx => tx.id),
+				);
+				expect(abi.executeTransaction).toHaveBeenCalledTimes(maxTransactionsSizeCase.output.length);
+			});
+
 			it('should not include subsequent transactions from same sender if one failed', async () => {
 				// Arrange
 				mockTxPool.getProcessableTransactions.mockReturnValue(


### PR DESCRIPTION
### What was the problem?

This PR resolves #8148 

### How was it solved?

- Fix order of the transaction size check while generating a block
- the transaction was discarded if the size of the block reached, but state and event were still included

### How was it tested?

- Updated unit tests
- Tried script in the issue
