### PR TITLE
Fix fast chain switching to include genesis block

### DIFF
--- a/framework/src/engine/consensus/synchronizer/fast_chain_switching_mechanism.ts
+++ b/framework/src/engine/consensus/synchronizer/fast_chain_switching_mechanism.ts
@@ -268,7 +268,7 @@ export class FastChainSwitchingMechanism extends BaseSynchronizer {
 	}
 
 	private _computeLastTwoRoundsHeights(numberOfValidators: number): number[] {
-		return new Array(Math.min(numberOfValidators * 2, this._chain.lastBlock.header.height))
+		return new Array(Math.min(numberOfValidators * 2, this._chain.lastBlock.header.height + 1))
 			.fill(0)
 			.map((_, index) => this._chain.lastBlock.header.height - index);
 	}

--- a/framework/test/unit/engine/consensus/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
+++ b/framework/test/unit/engine/consensus/synchronizer/fast_chain_switching_mechanism/fast_chain_switching_mechanism.spec.ts
@@ -259,7 +259,7 @@ describe('fast_chain_switching_mechanism', () => {
 				.mockResolvedValue(lastBlock as never);
 
 			when(chainModule.dataAccess.getBlockHeadersWithHeights)
-				.calledWith([2, 1])
+				.calledWith([2, 1, 0])
 				.mockResolvedValue([genesisBlock.header, lastBlock.header] as never);
 
 			// Simulate finalized height stored in ConsensusState table is 0
@@ -503,7 +503,7 @@ describe('fast_chain_switching_mechanism', () => {
 					.calledWith()
 					.mockResolvedValue(lastBlock as never);
 				when(chainModule.dataAccess.getBlockHeadersWithHeights)
-					.calledWith([2, 1])
+					.calledWith([2, 1, 0])
 					.mockResolvedValue([genesisBlock.header, lastBlock.header] as never);
 
 				when(chainModule.dataAccess.getBlockHeadersByHeightBetween)
@@ -511,7 +511,7 @@ describe('fast_chain_switching_mechanism', () => {
 					.mockResolvedValue([lastBlock] as never);
 
 				const heightList = new Array(
-					Math.min(numberOfValidators * 2, chainModule.lastBlock.header.height),
+					Math.min(numberOfValidators * 2, (chainModule.lastBlock.header.height as number) + 1),
 				)
 					.fill(0)
 					.map((_, index) => chainModule.lastBlock.header.height - index);
@@ -579,7 +579,7 @@ describe('fast_chain_switching_mechanism', () => {
 				});
 
 				when(chainModule.dataAccess.getBlockHeadersWithHeights)
-					.calledWith([2, 1])
+					.calledWith([2, 1, 0])
 					.mockResolvedValue(storageReturnValue as never);
 				const blockIds = codec.encode(getHighestCommonBlockRequestSchema, {
 					ids: storageReturnValue.map(blocks => blocks.id),
@@ -646,7 +646,7 @@ describe('fast_chain_switching_mechanism', () => {
 					.mockResolvedValue(requestedBlocks);
 
 				when(chainModule.dataAccess.getBlockHeadersWithHeights)
-					.calledWith([2, 1])
+					.calledWith([2, 1, 0])
 					.mockResolvedValue(storageReturnValue as never);
 				const blockIds = codec.encode(getHighestCommonBlockRequestSchema, {
 					ids: storageReturnValue.map(blocks => blocks.id),
@@ -814,7 +814,7 @@ describe('fast_chain_switching_mechanism', () => {
 						chainModule._lastBlock = genesisBlock;
 					});
 				when(chainModule.dataAccess.getBlockHeadersWithHeights)
-					.calledWith([2, 1])
+					.calledWith([2, 1, 0])
 					.mockResolvedValue(storageReturnValue as never);
 				when(chainModule.dataAccess.getBlockByID)
 					.calledWith(highestCommonBlock.id)
@@ -924,7 +924,7 @@ describe('fast_chain_switching_mechanism', () => {
 					.mockResolvedValue(highestCommonBlock as never);
 
 				when(chainModule.dataAccess.getBlockHeadersWithHeights)
-					.calledWith([2, 1])
+					.calledWith([2, 1, 0])
 					.mockResolvedValue(storageReturnValue as never);
 				when(chainModule.dataAccess.getBlockByID)
 					.calledWith(highestCommonBlock.id)


### PR DESCRIPTION
### What was the problem?

This PR resolves #8188

### How was it solved?

- Fix to include genesis block for checking common block in case height is less than 2 * # of validators

### How was it tested?

- Sync 2 nodes before 209 blocks in example app
- Update unit tests
