### PR TITLE
Update to allow empty schema

### DIFF
--- a/elements/lisk-codec/test/decode.spec.ts
+++ b/elements/lisk-codec/test/decode.spec.ts
@@ -34,6 +34,24 @@ import { testCases as transactionTestCases } from '../fixtures/transaction_decod
 import { generateKey } from '../src/utils';
 
 describe('decode', () => {
+	describe('empty', () => {
+		const emptySchema = {
+			$id: '/lisk/empty',
+			type: 'object',
+			properties: {},
+		};
+
+		it('should decode empty schema to empty object', () => {
+			expect(codec.decode(emptySchema, Buffer.alloc(0))).toEqual({});
+		});
+
+		it('should throw if input is not empty bytes', () => {
+			expect(() => codec.decode(emptySchema, Buffer.from([1, 2, 3]))).toThrow(
+				'Invalid terminate index',
+			);
+		});
+	});
+
 	describe('account', () => {
 		it.each(buildTestCases(accountTestCases))('%s', ({ input, output }) => {
 			const object = getAccountFromJSON(output.object);

--- a/elements/lisk-codec/test/encode.spec.ts
+++ b/elements/lisk-codec/test/encode.spec.ts
@@ -31,6 +31,22 @@ import { testCases as stringTestCases } from '../fixtures/string_encodings.json'
 import { testCases as transactionTestCases } from '../fixtures/transaction_encodings.json';
 
 describe('encode', () => {
+	describe('empty', () => {
+		const emptySchema = {
+			$id: '/lisk/empty',
+			type: 'object',
+			properties: {},
+		};
+
+		it('should encode empty schema to empty bytes', () => {
+			expect(codec.encode(emptySchema, {})).toEqual(Buffer.alloc(0));
+		});
+
+		it('should encode empty schema to empty bytes when additional properties exist', () => {
+			expect(codec.encode(emptySchema, { additional: 'property' })).toEqual(Buffer.alloc(0));
+		});
+	});
+
 	describe('account', () => {
 		it.each(buildTestCases(accountTestCases))('%s', ({ input, output }) => {
 			const message = getAccountFromJSON(input.object);

--- a/elements/lisk-validator/src/lisk_meta_schema.ts
+++ b/elements/lisk-validator/src/lisk_meta_schema.ts
@@ -56,7 +56,6 @@ export const liskMetaSchema = {
 					},
 				],
 			},
-			minProperties: 1,
 		},
 		required: {
 			type: 'array',

--- a/elements/lisk-validator/test/lisk_validator.spec.ts
+++ b/elements/lisk-validator/test/lisk_validator.spec.ts
@@ -44,8 +44,7 @@ describe('validator', () => {
 				properties: {},
 			};
 
-			const msg =
-				'Lisk validator found 2 error[s]:\nmust be equal to constant\nmust NOT have fewer than 1 items';
+			const msg = 'Lisk validator found 1 error[s]:\nmust be equal to constant';
 			expect(() => validator.validateSchema(invalidSchema)).toThrow(msg);
 		});
 
@@ -109,12 +108,11 @@ describe('validator', () => {
 			expect(() => validator.validateSchema(invalidSchema)).toThrow(msg);
 		});
 
-		it('should return error when "properties" are empty object', () => {
+		it('should not return error when "properties" are empty object', () => {
 			const invalidSchema = cloneDeep(validSchema);
 			delete invalidSchema.properties.myProp;
 
-			const msg = 'Lisk validator found 1 error[s]:\nmust NOT have fewer than 1 items';
-			expect(() => validator.validateSchema(invalidSchema)).toThrow(msg);
+			expect(() => validator.validateSchema(invalidSchema)).not.toThrow();
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #8174 

### How was it solved?

- Update schema validation to allow empty schema

### How was it tested?

- Add tests to check the empty schema behaviors
