### PR TITLE
Use correct nonce to choose first ccm and improve certificate creation

### DIFF
--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/constants.ts
@@ -27,6 +27,8 @@ export const BLS_PUBLIC_KEY_LENGTH = 48;
 export const HASH_LENGTH = 32;
 export const CCM_PROCESSED = 'ccmProcessed';
 export const CHAIN_ID_LENGTH = 4;
+export const DEFAULT_REGISTRATION_HEIGHT = 1;
+export const DEFAULT_LAST_CCM_SENT_NONCE = BigInt(-1);
 
 export const DB_KEY_CROSS_CHAIN_MESSAGES = Buffer.from([1]);
 export const DB_KEY_BLOCK_HEADERS = Buffer.from([2]);

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/inbox_update.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/inbox_update.ts
@@ -56,7 +56,7 @@ export const calculateMessageWitnesses = (
 			if (ccm.nonce > lastSentCCMInfo.nonce) {
 				const ccmBytes = codec.encode(ccmSchema, ccm);
 				totalSize += ccmBytes.length;
-				if (totalSize <= maxCCUSize) {
+				if (totalSize < maxCCUSize) {
 					includedSerializedCCMs.push(ccmBytes);
 					lastCCMWithHeight = { ...ccm, height: ccmsFromEvents.height };
 				}

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/schemas.ts
@@ -13,7 +13,7 @@
  */
 
 import { chain, aggregateCommitSchema, ccmSchema } from 'lisk-sdk';
-import { CCU_FREQUENCY, CCU_TOTAL_CCM_SIZE } from './constants';
+import { CCU_FREQUENCY, CCU_TOTAL_CCM_SIZE, DEFAULT_REGISTRATION_HEIGHT } from './constants';
 
 const pluginSchemaIDPrefix = '/lisk/plugins/chainConnector';
 
@@ -57,12 +57,18 @@ export const configSchema = {
 			minimum: 1,
 			maximum: CCU_TOTAL_CCM_SIZE,
 		},
+		registrationHeight: {
+			type: 'integer',
+			description: 'Height at the time of registration on the receiving chain.',
+			minimum: 1,
+		},
 	},
 	required: ['ccuFee', 'encryptedPrivateKey', 'password'],
 	default: {
 		ccuFrequency: CCU_FREQUENCY,
 		isSaveCCU: false,
 		maxCCUSize: CCU_TOTAL_CCM_SIZE,
+		registrationHeight: DEFAULT_REGISTRATION_HEIGHT,
 	},
 };
 

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/types.ts
@@ -27,6 +27,7 @@ export interface ChainConnectorPluginConfig {
 	password: string;
 	isSaveCCU: boolean;
 	maxCCUSize: number;
+	registrationHeight: number;
 }
 
 export type SentCCUs = Transaction[];

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/plugin.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/plugin.spec.ts
@@ -200,6 +200,7 @@ describe('ChainConnectorPlugin', () => {
 			password: defaultPassword,
 			maxCCUSize: CCU_TOTAL_CCM_SIZE,
 			isSaveCCU: false,
+			registrationHeight: 1,
 		};
 
 		sendingChainAPIClientMock = getApiClientMock() as any;

--- a/framework/src/abi/abi.ts
+++ b/framework/src/abi/abi.ts
@@ -245,14 +245,29 @@ export interface Proof {
 	queries: QueryProof[];
 }
 
+export interface ProofJSON {
+	siblingHashes: string[];
+	queries: QueryProofJSON[];
+}
+
 export interface QueryProof {
 	key: Buffer;
 	value: Buffer;
 	bitmap: Buffer;
 }
 
+export interface QueryProofJSON {
+	key: string;
+	value: string;
+	bitmap: string;
+}
+
 export interface ProveResponse {
 	proof: Proof;
+}
+
+export interface ProveResponseJSON {
+	proof: ProofJSON;
 }
 
 export interface IPCRequest {

--- a/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
+++ b/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
@@ -624,14 +624,16 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 			}
 			return;
 		}
+		const ownChainAccount = await this.stores.get(OwnChainAccountStore).get(context, EMPTY_BYTES);
+
 		const outboxRootStore = this.stores.get(OutboxRootStore);
-		const outboxKey = Buffer.concat([outboxRootStore.key, utils.hash(params.sendingChainID)]);
+		const outboxKey = Buffer.concat([outboxRootStore.key, utils.hash(ownChainAccount.chainID)]);
 		const proof = {
 			siblingHashes: outboxRootWitness.siblingHashes,
 			queries: [
 				{
 					key: outboxKey,
-					value: codec.encode(outboxRootSchema, { root: newInboxRoot }),
+					value: utils.hash(codec.encode(outboxRootSchema, { root: newInboxRoot })),
 					bitmap: outboxRootWitness.bitmap,
 				},
 			],

--- a/framework/src/modules/interoperability/mainchain/module.ts
+++ b/framework/src/modules/interoperability/mainchain/module.ts
@@ -52,6 +52,8 @@ import { InitializeMessageRecoveryCommand } from './commands/initialize_message_
 import { FeeMethod } from '../types';
 import { MainchainCCChannelTerminatedCommand, MainchainCCRegistrationCommand } from './cc_commands';
 import { RecoverStateCommand } from './commands/recover_state';
+import { CcmSentFailedEvent } from '../events/ccm_send_fail';
+import { InvalidRegistrationSignatureEvent } from '../events/invalid_registration_signature';
 
 export class MainchainInteroperabilityModule extends BaseInteroperabilityModule {
 	public crossChainMethod = new MainchainCCMethod(this.stores, this.events);
@@ -144,6 +146,11 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 		this.events.register(ChainAccountUpdatedEvent, new ChainAccountUpdatedEvent(this.name));
 		this.events.register(CcmProcessedEvent, new CcmProcessedEvent(this.name));
 		this.events.register(CcmSendSuccessEvent, new CcmSendSuccessEvent(this.name));
+		this.events.register(CcmSentFailedEvent, new CcmSentFailedEvent(this.name));
+		this.events.register(
+			InvalidRegistrationSignatureEvent,
+			new InvalidRegistrationSignatureEvent(this.name),
+		);
 		this.events.register(TerminatedStateCreatedEvent, new TerminatedStateCreatedEvent(this.name));
 		this.events.register(TerminatedOutboxCreatedEvent, new TerminatedOutboxCreatedEvent(this.name));
 	}

--- a/framework/src/modules/interoperability/sidechain/module.ts
+++ b/framework/src/modules/interoperability/sidechain/module.ts
@@ -44,6 +44,7 @@ import { SubmitSidechainCrossChainUpdateCommand } from './commands';
 import { InitializeStateRecoveryCommand } from './commands/initialize_state_recovery';
 import { RecoverStateCommand } from './commands/recover_state';
 import { SidechainCCChannelTerminatedCommand, SidechainCCRegistrationCommand } from './cc_commands';
+import { CcmSentFailedEvent } from '../events/ccm_send_fail';
 
 export class SidechainInteroperabilityModule extends BaseInteroperabilityModule {
 	public crossChainMethod: BaseCCMethod = new SidechainCCMethod(this.stores, this.events);
@@ -125,6 +126,7 @@ export class SidechainInteroperabilityModule extends BaseInteroperabilityModule 
 			InvalidRegistrationSignatureEvent,
 			new InvalidRegistrationSignatureEvent(this.name),
 		);
+		this.events.register(CcmSentFailedEvent, new CcmSentFailedEvent(this.name));
 	}
 
 	public addDependencies(validatorsMethod: ValidatorsMethod, tokenMethod: TokenMethod) {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8200 #8199 #8210 #8218 #8219

### How was it solved?

- Use `BigInt(-1)` as the initial lastSentCCM
- Improve certificate creation for the first certificate
- Take registrationHeight from the config that can be set by the user to identify the height from where we can start creating certificate and sending CCU

### How was it tested?

`npm t`
