### PR TITLE
estimateSafeStatus no longer returns block heights from the future

### DIFF
--- a/framework/src/engine/bft/utils.ts
+++ b/framework/src/engine/bft/utils.ts
@@ -27,17 +27,15 @@ import { BFTHeader } from './types';
 export const areDistinctHeadersContradicting = (b1: BFTHeader, b2: BFTHeader): boolean => {
 	let earlierBlock = b1;
 	let laterBlock = b2;
-	const higherMaxHeightPreviouslyForged =
-		earlierBlock.maxHeightGenerated > laterBlock.maxHeightGenerated;
-	const sameMaxHeightPreviouslyForged =
-		earlierBlock.maxHeightGenerated === laterBlock.maxHeightGenerated;
+	const higherMaxHeightGenerated = earlierBlock.maxHeightGenerated > laterBlock.maxHeightGenerated;
+	const sameMaxHeightGenerated = earlierBlock.maxHeightGenerated === laterBlock.maxHeightGenerated;
 	const higherMaxHeightPrevoted = earlierBlock.maxHeightPrevoted > laterBlock.maxHeightPrevoted;
 	const sameMaxHeightPrevoted = earlierBlock.maxHeightPrevoted === laterBlock.maxHeightPrevoted;
 	const higherHeight = earlierBlock.height > laterBlock.height;
 	if (
-		higherMaxHeightPreviouslyForged ||
-		(sameMaxHeightPreviouslyForged && higherMaxHeightPrevoted) ||
-		(sameMaxHeightPreviouslyForged && sameMaxHeightPrevoted && higherHeight)
+		higherMaxHeightGenerated ||
+		(sameMaxHeightGenerated && higherMaxHeightPrevoted) ||
+		(sameMaxHeightGenerated && sameMaxHeightPrevoted && higherHeight)
 	) {
 		[earlierBlock, laterBlock] = [laterBlock, earlierBlock];
 	}
@@ -50,7 +48,7 @@ export const areDistinctHeadersContradicting = (b1: BFTHeader, b2: BFTHeader): b
 		earlierBlock.height >= laterBlock.height
 	) {
 		/* Violation of the fork choice rule as validator moved to different chain
-		 without strictly larger maxHeightPreviouslyForged or larger height as
+		 without strictly larger maxHeightGenerated or larger height as
 		 justification. This in particular happens, if a validator is double forging. */
 		return true;
 	}

--- a/framework/src/engine/engine.ts
+++ b/framework/src/engine/engine.ts
@@ -205,6 +205,7 @@ export class Engine {
 			blockchainDB: this._blockchainDB,
 			generatorDB: this._generatorDB,
 			logger: this._logger,
+			genesisBlockHeight: genesis.header.height,
 		});
 		await this._legacyChainHandler.init({
 			db: this._legacyDB,

--- a/framework/src/engine/generator/endpoint.ts
+++ b/framework/src/engine/generator/endpoint.ts
@@ -213,7 +213,7 @@ export class Endpoint {
 		const finalizedHeight = this._consensus.finalizedHeight();
 		// if there hasn't been a finalized block after genesis block yet, then heightOneMonthAgo could be
 		// higher than the current finalizedHeight, resulting in negative safe status estimate
-		if (!(finalizedHeight > this._genesisBlockHeight)) {
+		if (finalizedHeight === this._genesisBlockHeight) {
 			throw new Error('At least one block after the genesis block must be finalized.');
 		}
 

--- a/framework/src/engine/generator/generator.ts
+++ b/framework/src/engine/generator/generator.ts
@@ -87,6 +87,7 @@ interface GeneratorInitArgs {
 	generatorDB: Database;
 	blockchainDB: Database;
 	logger: Logger;
+	genesisBlockHeight: number;
 }
 
 const BLOCK_VERSION = 2;
@@ -112,6 +113,7 @@ export class Generator {
 	private _logger!: Logger;
 	private _generatorDB!: Database;
 	private _blockchainDB!: Database;
+	private _genesisBlockHeight!: number;
 
 	public constructor(args: GeneratorArgs) {
 		this._abi = args.abi;
@@ -163,12 +165,14 @@ export class Generator {
 		this._logger = args.logger;
 		this._generatorDB = args.generatorDB;
 		this._blockchainDB = args.blockchainDB;
+		this._genesisBlockHeight = args.genesisBlockHeight;
 
 		this._broadcaster.init({
 			logger: this._logger,
 		});
 		this._endpoint.init({
 			generatorDB: this._generatorDB,
+			genesisBlockHeight: this._genesisBlockHeight,
 		});
 		this._networkEndpoint.init({
 			logger: this._logger,

--- a/framework/test/unit/engine/generator/endpoint.spec.ts
+++ b/framework/test/unit/engine/generator/endpoint.spec.ts
@@ -98,6 +98,7 @@ describe('generator endpoint', () => {
 		db = new InMemoryDatabase() as never;
 		endpoint.init({
 			generatorDB: db,
+			genesisBlockHeight: 0,
 		});
 	});
 

--- a/framework/test/unit/engine/generator/generator.spec.ts
+++ b/framework/test/unit/engine/generator/generator.spec.ts
@@ -194,6 +194,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
+					genesisBlockHeight: 0,
 				});
 				expect(generator['_keypairs'].values()).toHaveLength(103);
 			});
@@ -209,6 +210,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
+					genesisBlockHeight: 0,
 				});
 				expect(generator['_handleFinalizedHeightChanged']).toHaveBeenCalledWith(200, 515);
 			});
@@ -221,6 +223,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
+					genesisBlockHeight: 0,
 				});
 
 				const store = new GeneratorStore(generator['_generatorDB']);
@@ -236,6 +239,7 @@ describe('generator', () => {
 						blockchainDB,
 						generatorDB,
 						logger,
+						genesisBlockHeight: 0,
 					}),
 				).rejects.toThrow('Lisk validator found 1 error');
 			});
@@ -245,6 +249,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
+					genesisBlockHeight: 0,
 				});
 
 				const store = new GeneratorStore(generator['_generatorDB']);
@@ -264,6 +269,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
+				genesisBlockHeight: 0,
 			});
 			jest.useFakeTimers();
 		});
@@ -295,6 +301,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
+				genesisBlockHeight: 0,
 			});
 			await generator.start();
 		});
@@ -323,6 +330,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
+				genesisBlockHeight: 0,
 			});
 			await generator.start();
 		});
@@ -341,6 +349,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
+				genesisBlockHeight: 0,
 			});
 			await generator.start();
 		});
@@ -368,6 +377,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
+				genesisBlockHeight: 0,
 			});
 		});
 
@@ -475,6 +485,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
+				genesisBlockHeight: 0,
 			});
 		});
 
@@ -650,6 +661,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
+				genesisBlockHeight: 0,
 			});
 			await generator.start();
 			jest.spyOn(generator['_consensus'], 'certifySingleCommit');


### PR DESCRIPTION
### What was the problem?

This PR resolves #8220

### How was it solved?

1. Genesis block height is no longer assumed to be 0 and hardcoded, but passed to the endpoint from engine.
1. If chain is less than 1 month old, `generator_estimateSafeStatus` endpoint will default past block to genesis block + 1, instead of genesis block.
2. Introduced variables `expectedBlocksCount` and `generatedBlocksCount` to make the calculation easier to understand.
3. BONUS: Aligned local variable names in `areDistinctHeadersContradicting()` function to new property names of `BFTHeader` class 😎 

### How was it tested?

1. If used **before** the first block after genesis is finalized, `generator_estimateSafeStatus` returns error 
1. If used **after** the first block after genesis is finalized, `generator_estimateSafeStatus` returns a reasonable block height, which is no longer in the future