### PR TITLE
Token method not registered interoperability 

### DIFF
--- a/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
+++ b/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
@@ -60,14 +60,7 @@ import { verifyAggregateCertificateSignature } from '../../engine/consensus/cert
 
 export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMethod {
 	protected readonly interoperableModuleMethods = new Map<string, BaseCCMethod>();
-	protected _tokenMethod!: TokenMethod & {
-		payMessageFee: (
-			context: MethodContext,
-			payFromAddress: Buffer,
-			fee: bigint,
-			receivingChainID: Buffer,
-		) => Promise<void>;
-	};
+	protected _tokenMethod!: TokenMethod;
 
 	public constructor(
 		stores: NamedRegistry,
@@ -78,17 +71,7 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 		this.interoperableModuleMethods = interoperableModuleMethods;
 	}
 
-	public addDependencies(
-		tokenMethod: TokenMethod & {
-			// TODO: Remove this after token module update
-			payMessageFee: (
-				context: MethodContext,
-				payFromAddress: Buffer,
-				fee: bigint,
-				receivingChainID: Buffer,
-			) => Promise<void>;
-		},
-	) {
+	public addDependencies(tokenMethod: TokenMethod) {
 		this._tokenMethod = tokenMethod;
 	}
 
@@ -513,7 +496,7 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 		if (fee > 0) {
 			try {
 				// eslint-disable-next-line no-lonely-if
-				await this._tokenMethod.payMessageFee(context, sendingAddress, fee, ccm.receivingChainID);
+				await this._tokenMethod.payMessageFee(context, sendingAddress, ccm.receivingChainID, fee);
 			} catch (error) {
 				this.events.get(CcmSentFailedEvent).log(
 					context,

--- a/framework/src/modules/interoperability/mainchain/module.ts
+++ b/framework/src/modules/interoperability/mainchain/module.ts
@@ -160,6 +160,7 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 	public addDependencies(tokenMethod: TokenMethod, feeMethod: FeeMethod) {
 		this._sidechainRegistrationCommand.addDependencies(feeMethod);
 		this._crossChainUpdateCommand.init(this.method, tokenMethod);
+		this.internalMethod.addDependencies(tokenMethod);
 	}
 
 	public metadata(): ModuleMetadata {

--- a/framework/src/modules/interoperability/sidechain/module.ts
+++ b/framework/src/modules/interoperability/sidechain/module.ts
@@ -38,13 +38,14 @@ import { CcmProcessedEvent } from '../events/ccm_processed';
 import { InvalidRegistrationSignatureEvent } from '../events/invalid_registration_signature';
 import { CcmSendSuccessEvent } from '../events/ccm_send_success';
 import { BaseCCMethod } from '../base_cc_method';
-import { TokenMethod, ValidatorsMethod } from '../types';
+import { ValidatorsMethod } from '../types';
 import { SidechainInteroperabilityInternalMethod } from './internal_method';
 import { SubmitSidechainCrossChainUpdateCommand } from './commands';
 import { InitializeStateRecoveryCommand } from './commands/initialize_state_recovery';
 import { RecoverStateCommand } from './commands/recover_state';
 import { SidechainCCChannelTerminatedCommand, SidechainCCRegistrationCommand } from './cc_commands';
 import { CcmSentFailedEvent } from '../events/ccm_send_fail';
+import { TokenMethod } from '../../token';
 
 export class SidechainInteroperabilityModule extends BaseInteroperabilityModule {
 	public crossChainMethod: BaseCCMethod = new SidechainCCMethod(this.stores, this.events);
@@ -132,6 +133,7 @@ export class SidechainInteroperabilityModule extends BaseInteroperabilityModule 
 	public addDependencies(validatorsMethod: ValidatorsMethod, tokenMethod: TokenMethod) {
 		this._validatorsMethod = validatorsMethod;
 		this._crossChainUpdateCommand.init(this.method, tokenMethod);
+		this.internalMethod.addDependencies(tokenMethod);
 	}
 
 	public metadata(): ModuleMetadata {

--- a/framework/src/modules/token/commands/transfer_cross_chain.ts
+++ b/framework/src/modules/token/commands/transfer_cross_chain.ts
@@ -24,7 +24,11 @@ import {
 	VerifyStatus,
 } from '../../../state_machine';
 import { TokenMethod } from '../method';
-import { crossChainTransferParamsSchema } from '../schemas';
+import {
+	CCTransferMessageParams,
+	crossChainTransferMessageParams,
+	crossChainTransferParamsSchema,
+} from '../schemas';
 import { InteroperabilityMethod } from '../types';
 import { CCM_STATUS_OK, CROSS_CHAIN_COMMAND_NAME_TRANSFER } from '../constants';
 import { splitTokenID } from '../utils';
@@ -172,6 +176,14 @@ export class TransferCrossChainCommand extends BaseCommand {
 			recipientAddress: params.recipientAddress,
 		});
 
+		const transferCCM: CCTransferMessageParams = {
+			amount: params.amount,
+			data: params.data,
+			recipientAddress: params.recipientAddress,
+			senderAddress,
+			tokenID: params.tokenID,
+		};
+
 		await this._interoperabilityMethod.send(
 			context.getMethodContext(),
 			senderAddress,
@@ -180,7 +192,7 @@ export class TransferCrossChainCommand extends BaseCommand {
 			params.receivingChainID,
 			params.messageFee,
 			CCM_STATUS_OK,
-			codec.encode(this.schema, params),
+			codec.encode(crossChainTransferMessageParams, transferCCM),
 		);
 	}
 }

--- a/framework/src/modules/token/schemas.ts
+++ b/framework/src/modules/token/schemas.ts
@@ -223,8 +223,6 @@ export interface CCTransferMessageParams {
 	senderAddress: Buffer;
 	recipientAddress: Buffer;
 	data: string;
-	messageFee: bigint;
-	escrowInitialzationFee: bigint;
 }
 
 export const crossChainTransferMessageParams = {

--- a/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
@@ -28,7 +28,11 @@ import {
 	CCM_STATUS_OK,
 	CROSS_CHAIN_COMMAND_NAME_TRANSFER,
 } from '../../../../../src/modules/token/constants';
-import { crossChainTransferParamsSchema } from '../../../../../src/modules/token/schemas';
+import {
+	CCTransferMessageParams,
+	crossChainTransferMessageParams,
+	crossChainTransferParamsSchema,
+} from '../../../../../src/modules/token/schemas';
 import { EventQueue } from '../../../../../src/state_machine';
 import { EscrowStore } from '../../../../../src/modules/token/stores/escrow';
 import { UserStore } from '../../../../../src/modules/token/stores/user';
@@ -468,11 +472,13 @@ describe('CCTransfer command', () => {
 					validParams.receivingChainID,
 					validParams.messageFee,
 					CCM_STATUS_OK,
-					codec.encode(crossChainTransferParamsSchema, {
-						...validParams,
-						amount,
+					codec.encode(crossChainTransferMessageParams, {
 						tokenID: commonTokenID,
-					}),
+						amount,
+						senderAddress: context.transaction.senderAddress,
+						recipientAddress: validParams.recipientAddress,
+						data: validParams.data,
+					} as CCTransferMessageParams),
 				);
 			});
 		});
@@ -526,11 +532,13 @@ describe('CCTransfer command', () => {
 				validParams.receivingChainID,
 				validParams.messageFee,
 				CCM_STATUS_OK,
-				codec.encode(crossChainTransferParamsSchema, {
-					...validParams,
-					amount,
+				codec.encode(crossChainTransferMessageParams, {
 					tokenID: commonTokenID,
-				}),
+					amount,
+					senderAddress: context.transaction.senderAddress,
+					recipientAddress: validParams.recipientAddress,
+					data: validParams.data,
+				} as CCTransferMessageParams),
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8260 #8261

### How was it solved?

[♻️](https://github.com/LiskHQ/lisk-sdk/commit/0843c9f2ed755f76396e5cb5c57ce06bc8ae11f8) [Add token method dependency to interop internal methods -](https://github.com/LiskHQ/lisk-sdk/commit/0843c9f2ed755f76396e5cb5c57ce06bc8ae11f8) [Closes](https://github.com/LiskHQ/lisk-sdk/commit/0843c9f2ed755f76396e5cb5c57ce06bc8ae11f8) https://github.com/LiskHQ/lisk-sdk/issues/8260

[🐛](https://github.com/LiskHQ/lisk-sdk/commit/0d8a8f68a7ecad3e5886db70945e0eff140429b6) [Wrong CCTransferMessageParams encoding -](https://github.com/LiskHQ/lisk-sdk/commit/0d8a8f68a7ecad3e5886db70945e0eff140429b6) [Closes](https://github.com/LiskHQ/lisk-sdk/commit/0d8a8f68a7ecad3e5886db70945e0eff140429b6) https://github.com/LiskHQ/lisk-sdk/issues/8261

### How was it tested?

- Run `npm t`
- Run a node and try to send a transferCrossChain transaction
