### PR TITLE
Add is alive flag

### DIFF
--- a/elements/lisk-api-client/src/ipc_channel.ts
+++ b/elements/lisk-api-client/src/ipc_channel.ts
@@ -33,6 +33,8 @@ const getSocketsPath = (dataPath: string) => {
 };
 
 export class IPCChannel implements Channel {
+	public isAlive = false;
+
 	private readonly _events: EventEmitter;
 	private readonly _subSocket: Subscriber;
 	private readonly _rpcClient: Dealer;
@@ -90,6 +92,7 @@ export class IPCChannel implements Channel {
 
 				this._rpcClient.connect(this._rpcServerSocketPath);
 			});
+			this.isAlive = true;
 		} catch (error) {
 			this._subSocket.close();
 			this._rpcClient.close();
@@ -105,6 +108,7 @@ export class IPCChannel implements Channel {
 	public async disconnect(): Promise<void> {
 		this._subSocket.close();
 		this._rpcClient.close();
+		this.isAlive = false;
 	}
 
 	public async invoke<T = Record<string, unknown>>(


### PR DESCRIPTION
### What was the problem?

This PR resolves #8285 

### How was it solved?

add `isAlive` property to make it consistent with WS Channel

### How was it tested?
```
const { createIPCClient } = require('./dist-node');


(async () => {
	const client = await createIPCClient('~/.lisk/pos-mainchain');
	console.log(client._channel.isAlive)
})();
```
