### PR TITLE
Update to allow invalid key in the setBFTParameters

### DIFF
--- a/framework/src/engine/bft/method.ts
+++ b/framework/src/engine/bft/method.ts
@@ -22,6 +22,7 @@ import {
 } from './utils';
 import { getBFTParameters } from './bft_params';
 import {
+	BLS_PUBLIC_KEY_LENGTH,
 	EMPTY_KEY,
 	MAX_UINT32,
 	MODULE_STORE_PREFIX_BFT,
@@ -165,10 +166,20 @@ export class BFTMethod {
 			);
 		}
 
-		if (!objects.bufferArrayUniqueItems(validators.map(validator => validator.address))) {
+		const validatorAddresses = [];
+		const validatorValidBLSKeys = [];
+		for (const validator of validators) {
+			validatorAddresses.push(validator.address);
+			if (!validator.blsKey.equals(Buffer.alloc(BLS_PUBLIC_KEY_LENGTH, 0))) {
+				validatorValidBLSKeys.push(validator.blsKey);
+			}
+		}
+
+		if (!objects.bufferArrayUniqueItems(validatorAddresses)) {
 			throw new Error('Provided validator addresses are not unique.');
 		}
-		if (!objects.bufferArrayUniqueItems(validators.map(validator => validator.blsKey))) {
+
+		if (!objects.bufferArrayUniqueItems(validatorValidBLSKeys)) {
 			throw new Error('Provided validator BLS keys are not unique.');
 		}
 

--- a/framework/test/unit/engine/bft/method.spec.ts
+++ b/framework/test/unit/engine/bft/method.spec.ts
@@ -742,6 +742,21 @@ describe('BFT Method', () => {
 			).rejects.toThrow('Provided validator BLS keys are not unique.');
 		});
 
+		it('should not throw when validator BLS keys are not unique only with invalid keys', async () => {
+			const validators = new Array(bftMethod['_batchSize']).fill(0).map(() => ({
+				address: utils.getRandomBytes(20),
+				bftWeight: BigInt(1),
+				blsKey: utils.getRandomBytes(48),
+				generatorKey: utils.getRandomBytes(32),
+			}));
+			validators[7].blsKey = Buffer.alloc(48, 0);
+			validators[13].blsKey = Buffer.alloc(48, 0);
+
+			await expect(
+				bftMethod.setBFTParameters(stateStore, BigInt(68), BigInt(68), validators),
+			).not.toReject();
+		});
+
 		it('should throw when bft weight is negative', async () => {
 			await expect(
 				bftMethod.setBFTParameters(


### PR DESCRIPTION
### What was the problem?

This PR resolves #8291 

### How was it solved?

- Update `setBFTParameters` to allow invalid bls key duplications

### How was it tested?

- Add test to check the new condition
