### PR TITLE
Expose genesis height from system_getNodeInfo endpoint

### DIFF
--- a/framework/src/engine/endpoint/system.ts
+++ b/framework/src/engine/endpoint/system.ts
@@ -32,6 +32,7 @@ interface EndpointArgs {
 	consensus: Consensus;
 	generator: Generator;
 	config: EngineConfig;
+	genesisHeight: number;
 }
 
 export class SystemEndpoint {
@@ -41,6 +42,7 @@ export class SystemEndpoint {
 	private readonly _consensus: Consensus;
 	private readonly _generator: Generator;
 	private readonly _config: EngineConfig;
+	private readonly _genesisHeight: number;
 
 	public constructor(args: EndpointArgs) {
 		this._abi = args.abi;
@@ -48,6 +50,7 @@ export class SystemEndpoint {
 		this._consensus = args.consensus;
 		this._generator = args.generator;
 		this._config = args.config;
+		this._genesisHeight = args.genesisHeight;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
@@ -61,6 +64,7 @@ export class SystemEndpoint {
 			finalizedHeight: this._consensus.finalizedHeight(),
 			syncing: this._consensus.syncing(),
 			unconfirmedTransactions: this._generator.getPooledTransactions().length,
+			genesisHeight: this._genesisHeight,
 			genesis: {
 				...this._config.genesis,
 			},

--- a/framework/src/engine/engine.ts
+++ b/framework/src/engine/engine.ts
@@ -205,7 +205,7 @@ export class Engine {
 			blockchainDB: this._blockchainDB,
 			generatorDB: this._generatorDB,
 			logger: this._logger,
-			genesisBlockHeight: genesis.header.height,
+			genesisHeight: genesis.header.height,
 		});
 		await this._legacyChainHandler.init({
 			db: this._legacyDB,

--- a/framework/src/engine/engine.ts
+++ b/framework/src/engine/engine.ts
@@ -241,6 +241,7 @@ export class Engine {
 			consensus: this._consensus,
 			generator: this._generator,
 			config: this._config,
+			genesisHeight: genesis.header.height,
 		});
 		const txpoolEndpoint = new TxpoolEndpoint({
 			abi: this._abi,

--- a/framework/src/engine/generator/endpoint.ts
+++ b/framework/src/engine/generator/endpoint.ts
@@ -64,7 +64,7 @@ interface EndpointArgs {
 
 interface EndpointInit {
 	generatorDB: Database;
-	genesisBlockHeight: number;
+	genesisHeight: number;
 }
 
 export class Endpoint {
@@ -76,7 +76,7 @@ export class Endpoint {
 	private readonly _blockTime: number;
 
 	private _generatorDB!: Database;
-	private _genesisBlockHeight!: number;
+	private _genesisHeight!: number;
 
 	public constructor(args: EndpointArgs) {
 		this._keypairs = args.keypair;
@@ -88,7 +88,7 @@ export class Endpoint {
 
 	public init(args: EndpointInit) {
 		this._generatorDB = args.generatorDB;
-		this._genesisBlockHeight = args.genesisBlockHeight;
+		this._genesisHeight = args.genesisHeight;
 	}
 
 	public async getStatus(_ctx: RequestContext): Promise<GetStatusResponse> {
@@ -213,7 +213,7 @@ export class Endpoint {
 		const finalizedHeight = this._consensus.finalizedHeight();
 		// if there hasn't been a finalized block after genesis block yet, then heightOneMonthAgo could be
 		// higher than the current finalizedHeight, resulting in negative safe status estimate
-		if (finalizedHeight === this._genesisBlockHeight) {
+		if (finalizedHeight === this._genesisHeight) {
 			throw new Error('At least one block after the genesis block must be finalized.');
 		}
 
@@ -228,7 +228,7 @@ export class Endpoint {
 		// in missed blocks calculation below, due to the hardcoded timestamp of the genesis block in the example app
 		const heightOneMonthAgo = Math.max(
 			finalizedHeight - numberOfBlocksPerMonth,
-			this._genesisBlockHeight + 1,
+			this._genesisHeight + 1,
 		);
 		const blockHeaderLastMonth = await this._chain.dataAccess.getBlockHeaderByHeight(
 			heightOneMonthAgo,

--- a/framework/src/engine/generator/generator.ts
+++ b/framework/src/engine/generator/generator.ts
@@ -87,7 +87,7 @@ interface GeneratorInitArgs {
 	generatorDB: Database;
 	blockchainDB: Database;
 	logger: Logger;
-	genesisBlockHeight: number;
+	genesisHeight: number;
 }
 
 const BLOCK_VERSION = 2;
@@ -113,7 +113,7 @@ export class Generator {
 	private _logger!: Logger;
 	private _generatorDB!: Database;
 	private _blockchainDB!: Database;
-	private _genesisBlockHeight!: number;
+	private _genesisHeight!: number;
 
 	public constructor(args: GeneratorArgs) {
 		this._abi = args.abi;
@@ -168,14 +168,14 @@ export class Generator {
 		this._logger = args.logger;
 		this._generatorDB = args.generatorDB;
 		this._blockchainDB = args.blockchainDB;
-		this._genesisBlockHeight = args.genesisBlockHeight;
+		this._genesisHeight = args.genesisHeight;
 
 		this._broadcaster.init({
 			logger: this._logger,
 		});
 		this._endpoint.init({
 			generatorDB: this._generatorDB,
-			genesisBlockHeight: this._genesisBlockHeight,
+			genesisHeight: this._genesisHeight,
 		});
 		this._networkEndpoint.init({
 			logger: this._logger,

--- a/framework/test/unit/engine/endpoint/system.spec.ts
+++ b/framework/test/unit/engine/endpoint/system.spec.ts
@@ -14,13 +14,13 @@
 
 import { Block, BlockAssets } from '@liskhq/lisk-chain';
 import { utils } from '@liskhq/lisk-cryptography';
-import { TokenModule } from '../../../../src';
 import { SystemEndpoint } from '../../../../src/engine/endpoint/system';
 import { createFakeBlockHeader } from '../../../../src/testing';
 import { nodeOptions } from '../../../fixtures';
 
 describe('system endpoint', () => {
 	let endpoint: SystemEndpoint;
+	const genesisHeight = 1234;
 
 	beforeEach(() => {
 		endpoint = new SystemEndpoint({
@@ -62,7 +62,7 @@ describe('system endpoint', () => {
 					...nodeOptions.genesis,
 				},
 			},
-			registeredModules: [new TokenModule()],
+			genesisHeight,
 		} as never);
 	});
 
@@ -76,6 +76,7 @@ describe('system endpoint', () => {
 				finalizedHeight: expect.any(Number),
 				syncing: true,
 				unconfirmedTransactions: 0,
+				genesisHeight,
 				genesis: expect.any(Object),
 				network: expect.any(Object),
 			});

--- a/framework/test/unit/engine/generator/endpoint.spec.ts
+++ b/framework/test/unit/engine/generator/endpoint.spec.ts
@@ -98,7 +98,7 @@ describe('generator endpoint', () => {
 		db = new InMemoryDatabase() as never;
 		endpoint.init({
 			generatorDB: db,
-			genesisBlockHeight: 0,
+			genesisHeight: 0,
 		});
 	});
 

--- a/framework/test/unit/engine/generator/generator.spec.ts
+++ b/framework/test/unit/engine/generator/generator.spec.ts
@@ -194,7 +194,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
-					genesisBlockHeight: 0,
+					genesisHeight: 0,
 				});
 				expect(generator['_keypairs'].values()).toHaveLength(103);
 			});
@@ -210,7 +210,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
-					genesisBlockHeight: 0,
+					genesisHeight: 0,
 				});
 				expect(generator['_handleFinalizedHeightChanged']).toHaveBeenCalledWith(200, 515);
 			});
@@ -223,7 +223,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
-					genesisBlockHeight: 0,
+					genesisHeight: 0,
 				});
 
 				const store = new GeneratorStore(generator['_generatorDB']);
@@ -239,7 +239,7 @@ describe('generator', () => {
 						blockchainDB,
 						generatorDB,
 						logger,
-						genesisBlockHeight: 0,
+						genesisHeight: 0,
 					}),
 				).rejects.toThrow('Lisk validator found 1 error');
 			});
@@ -249,7 +249,7 @@ describe('generator', () => {
 					blockchainDB,
 					generatorDB,
 					logger,
-					genesisBlockHeight: 0,
+					genesisHeight: 0,
 				});
 
 				const store = new GeneratorStore(generator['_generatorDB']);
@@ -269,7 +269,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
-				genesisBlockHeight: 0,
+				genesisHeight: 0,
 			});
 			jest.useFakeTimers();
 		});
@@ -301,7 +301,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
-				genesisBlockHeight: 0,
+				genesisHeight: 0,
 			});
 			await generator.start();
 		});
@@ -330,7 +330,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
-				genesisBlockHeight: 0,
+				genesisHeight: 0,
 			});
 			await generator.start();
 		});
@@ -349,7 +349,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
-				genesisBlockHeight: 0,
+				genesisHeight: 0,
 			});
 			await generator.start();
 		});
@@ -377,7 +377,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
-				genesisBlockHeight: 0,
+				genesisHeight: 0,
 			});
 		});
 
@@ -485,7 +485,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
-				genesisBlockHeight: 0,
+				genesisHeight: 0,
 			});
 		});
 
@@ -661,7 +661,7 @@ describe('generator', () => {
 				blockchainDB,
 				generatorDB,
 				logger,
-				genesisBlockHeight: 0,
+				genesisHeight: 0,
 			});
 			await generator.start();
 			jest.spyOn(generator['_consensus'], 'certifySingleCommit');


### PR DESCRIPTION
### What was the problem?

This PR resolves #8289

### How was it solved?

* Passed genesis height from engine to system endpoint
* Added `genesisHeight` property to response of `system_getNodeInfo`
* BONUS: renamed `genesisBlockHeight` in `Engine` and `Generator` into `genesisHeight` 😎 

### How was it tested?

Invoked `system_getNodeInfo` endpoint. It contained correct `genesisHeight` property.
