### PR TITLE
Remove ccu from crossChainMessageContext

### DIFF
--- a/framework/src/modules/interoperability/base_cross_chain_update_command.ts
+++ b/framework/src/modules/interoperability/base_cross_chain_update_command.ts
@@ -24,6 +24,7 @@ import { CcmSendSuccessEvent } from './events/ccm_send_success';
 import { ccmSchema, crossChainUpdateTransactionParams } from './schemas';
 import {
 	CCMsg,
+	CCUpdateParams,
 	CrossChainMessageContext,
 	CrossChainUpdateTransactionParams,
 	TokenMethod,
@@ -178,7 +179,7 @@ export abstract class BaseCrossChainUpdateCommand<
 	 * @see https://github.com/LiskHQ/lips/blob/main/proposals/lip-0049.md#apply
 	 */
 	protected async apply(context: CrossChainMessageContext): Promise<void> {
-		const { ccm, ccu, logger } = context;
+		const { ccm, logger } = context;
 		const { ccmID, encodedCCM } = getEncodedCCMAndID(ccm);
 		const valid = await this.verifyCCM(context, ccmID);
 		if (!valid) {
@@ -275,7 +276,11 @@ export abstract class BaseCrossChainUpdateCommand<
 				.get(ChainAccountStore)
 				.has(context, ccm.sendingChainID);
 
-			if (isSendingChainExist && !ccu.sendingChainID.equals(ccm.sendingChainID)) {
+			const ccuParams = codec.decode<CCUpdateParams>(
+				crossChainUpdateTransactionParams,
+				context.transaction.params,
+			);
+			if (isSendingChainExist && !ccuParams.sendingChainID.equals(ccm.sendingChainID)) {
 				throw new Error('Cannot receive forwarded messages for a direct channel.');
 			}
 			// Execute the cross-chain command.

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -187,9 +187,6 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 				...context,
 				ccm,
 				eventQueue: context.eventQueue.getChildQueue(ccmID),
-				ccu: {
-					sendingChainID: params.chainID,
-				},
 			};
 			// If the sending chain is the mainchain, recover the CCM.
 			// This function never raises an error.

--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -140,9 +140,6 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 					...context,
 					ccm,
 					eventQueue: context.eventQueue.getChildQueue(ccmID),
-					ccu: {
-						sendingChainID: params.sendingChainID,
-					},
 				};
 
 				// If the receiving chain is the mainchain, apply the CCM

--- a/framework/src/modules/interoperability/types.ts
+++ b/framework/src/modules/interoperability/types.ts
@@ -89,11 +89,9 @@ export interface ImmutableCrossChainMessageContext {
 	transaction: {
 		senderAddress: Buffer;
 		fee: bigint;
+		params: Buffer;
 	};
 	ccm: CCMsg;
-	ccu: {
-		sendingChainID: Buffer;
-	};
 }
 
 export interface CrossChainMessageContext extends ImmutableCrossChainMessageContext {

--- a/framework/test/unit/modules/interoperability/base_cc_commands/registration.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cc_commands/registration.spec.ts
@@ -116,16 +116,11 @@ describe('BaseCCRegistrationCommand', () => {
 		status: obj.status ?? CCMStatusCode.OK,
 	});
 
-	const createContext = (
-		ccm: CCMsg,
-		ccu?: { sendingChainID: Buffer },
-	): CrossChainMessageContext => {
+	const createContext = (ccm: CCMsg, sendingChainID?: Buffer): CrossChainMessageContext => {
 		return createCrossChainMessageContext({
 			ccm,
 			chainID: sidechainIDBuffer,
-			ccu: ccu ?? {
-				sendingChainID: ccm.sendingChainID,
-			},
+			sendingChainID: sendingChainID ?? ccm.sendingChainID,
 		});
 	};
 
@@ -158,9 +153,7 @@ describe('BaseCCRegistrationCommand', () => {
 		});
 
 		it('should fail if ccm.sendingChainID not equal to ccu.params.sendingChainID', async () => {
-			sampleExecuteContext = createContext(ccm, {
-				sendingChainID: Buffer.from([0, 0, 0, 8]),
-			});
+			sampleExecuteContext = createContext(ccm, Buffer.from([0, 0, 0, 8]));
 			await expect(ccRegistrationCommand.verify(sampleExecuteContext)).rejects.toThrow(
 				'Registration message must be sent from a direct channel.',
 			);

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -676,9 +676,6 @@ describe('MessageRecoveryCommand', () => {
 					...commandExecuteContext,
 					ccm,
 					eventQueue: commandExecuteContext.eventQueue.getChildQueue(utils.hash(crossChainMessage)),
-					ccu: {
-						sendingChainID: commandExecuteContext.params.chainID,
-					},
 				};
 
 				expect(command['_applyRecovery']).toHaveBeenCalledWith(ctx);
@@ -715,9 +712,6 @@ describe('MessageRecoveryCommand', () => {
 					...commandExecuteContext,
 					ccm,
 					eventQueue: commandExecuteContext.eventQueue.getChildQueue(utils.hash(crossChainMessage)),
-					ccu: {
-						sendingChainID: commandExecuteContext.params.chainID,
-					},
 				};
 
 				expect(command['_forwardRecovery']).toHaveBeenCalledWith(ctx);

--- a/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
@@ -14,7 +14,7 @@
 
 import { codec } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
-import { TokenModule, TokenMethod } from '../../../../../src';
+import { TokenModule, TokenMethod, ccuParamsSchema } from '../../../../../src';
 import { CrossChainTransferCommand } from '../../../../../src/modules/token/cc_commands/cc_transfer';
 import {
 	CCM_STATUS_OK,
@@ -60,6 +60,24 @@ describe('CrossChain Transfer Command', () => {
 	};
 	const defaultEscrowAmount = BigInt('100000000000');
 	const sendingChainID = Buffer.from([3, 0, 0, 0]);
+	const defaultEncodedCCUParams = codec.encode(ccuParamsSchema, {
+		activeValidatorsUpdate: {
+			blsKeysUpdate: [],
+			bftWeightsUpdate: [],
+			bftWeightsUpdateBitmap: Buffer.alloc(0),
+		},
+		certificate: Buffer.alloc(1),
+		certificateThreshold: BigInt(1),
+		inboxUpdate: {
+			crossChainMessages: [],
+			messageWitnessHashes: [],
+			outboxRootWitness: {
+				bitmap: Buffer.alloc(1),
+				siblingHashes: [],
+			},
+		},
+		sendingChainID: Buffer.from('04000001', 'hex'),
+	});
 
 	let command: CrossChainTransferCommand;
 	let method: TokenMethod;
@@ -151,6 +169,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -164,9 +183,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act & Assert
@@ -202,6 +218,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -215,9 +232,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: utils.getRandomBytes(32),
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act & Assert
@@ -253,6 +267,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -266,9 +281,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act & Assert
@@ -303,6 +315,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -316,9 +329,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Assert
@@ -354,6 +364,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -367,9 +378,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act & Assert
@@ -397,6 +405,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -410,9 +419,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act & Assert
@@ -448,6 +454,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -461,9 +468,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act & Assert
@@ -511,6 +515,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -524,9 +529,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act & Assert
@@ -563,6 +565,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -576,9 +579,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act
@@ -622,6 +622,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -635,9 +636,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act
@@ -685,6 +683,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -698,9 +697,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act
@@ -754,6 +750,7 @@ describe('CrossChain Transfer Command', () => {
 				transaction: {
 					senderAddress: defaultAddress,
 					fee: BigInt(0),
+					params: defaultEncodedCCUParams,
 				},
 				header: {
 					height: 0,
@@ -767,9 +764,6 @@ describe('CrossChain Transfer Command', () => {
 				getStore: (moduleID: Buffer, prefix: Buffer) => stateStore.getStore(moduleID, prefix),
 				logger: fakeLogger,
 				chainID: ownChainID,
-				ccu: {
-					sendingChainID,
-				},
 			};
 
 			// Act && Assert

--- a/framework/test/unit/modules/token/cc_method.spec.ts
+++ b/framework/test/unit/modules/token/cc_method.spec.ts
@@ -37,6 +37,7 @@ import { BeforeCCCExecutionEvent } from '../../../../src/modules/token/events/be
 import { BeforeCCMForwardingEvent } from '../../../../src/modules/token/events/before_ccm_forwarding';
 import { RecoverEvent } from '../../../../src/modules/token/events/recover';
 import { CROSS_CHAIN_COMMAND_REGISTRATION } from '../../../../src/modules/interoperability/constants';
+import { ccuParamsSchema } from '../../../../src';
 
 describe('TokenInteroperableMethod', () => {
 	const tokenModule = new TokenModule();
@@ -61,6 +62,24 @@ describe('TokenInteroperableMethod', () => {
 	const defaultTotalSupply = BigInt('100000000000000');
 	const defaultEscrowAmount = BigInt('100000000000');
 	const sendingChainID = Buffer.from([3, 0, 0, 0]);
+	const defaultEncodedCCUParams = codec.encode(ccuParamsSchema, {
+		activeValidatorsUpdate: {
+			blsKeysUpdate: [],
+			bftWeightsUpdate: [],
+			bftWeightsUpdateBitmap: Buffer.alloc(0),
+		},
+		certificate: Buffer.alloc(1),
+		certificateThreshold: BigInt(1),
+		inboxUpdate: {
+			crossChainMessages: [],
+			messageWitnessHashes: [],
+			outboxRootWitness: {
+				bitmap: Buffer.alloc(1),
+				siblingHashes: [],
+			},
+		},
+		sendingChainID: Buffer.from('04000001', 'hex'),
+	});
 
 	let tokenInteropMethod: TokenInteroperableMethod;
 	let stateStore: PrefixedStateReadWriter;
@@ -151,9 +170,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).resolves.toBeUndefined();
@@ -196,9 +213,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).rejects.toThrow('Insufficient balance in the sending chain for the message fee.');
@@ -236,9 +251,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).resolves.toBeUndefined();
@@ -288,9 +301,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).rejects.toThrow('Insufficient balance in the sending chain for the message fee.');
@@ -336,9 +347,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).resolves.toBeUndefined();
@@ -384,9 +393,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).resolves.toBeUndefined();
@@ -419,9 +426,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).rejects.toThrow('Insufficient escrow amount.');
@@ -457,9 +462,7 @@ describe('TokenInteroperableMethod', () => {
 					transaction: {
 						fee,
 						senderAddress: defaultAddress,
-					},
-					ccu: {
-						sendingChainID,
+						params: defaultEncodedCCUParams,
 					},
 				}),
 			).resolves.toBeUndefined();


### PR DESCRIPTION
### What was the problem?

This PR resolves #8223

### How was it solved?

- Include params in transaction property
- Interop ccms will decode ccu params by themselves

### How was it tested?
- Build `yarn build`
- Run all tests `npm t`
