### PR TITLE
Validator is no longer reusing the used up hash onion

### DIFF
--- a/framework/src/modules/random/module.ts
+++ b/framework/src/modules/random/module.ts
@@ -235,7 +235,7 @@ export class RandomModule extends BaseModule {
 			);
 			return {
 				hash: utils.generateHashOnionSeed(),
-				count: 0,
+				count: usedHashOnion.count,
 			};
 		}
 

--- a/framework/test/unit/modules/random/module.spec.ts
+++ b/framework/test/unit/modules/random/module.spec.ts
@@ -196,11 +196,33 @@ describe('RandomModule', () => {
 
 				// each time it should provide unique values, that are different from the checkpoint hashes
 				expect(hashOnion.hashes).not.toContain(nextHashOnion.hash.toString('hex'));
-				expect(nextHashOnion.count).toBe(0);
+				expect(nextHashOnion.count).toBe(hashOnion.count);
 			}
 
 			// to confirm randomness, also check that each hash generated with the same input params is unique
 			expect(newHashOnions.size).toBe(newHashOnionsCount);
+		});
+
+		it('should not modify used hash count when the onion is used up', async () => {
+			// Arrange
+			const usedHashOnions: UsedHashOnion[] = [
+				{
+					count: hashOnion.count,
+					height: height - 100,
+				},
+			];
+
+			// Act
+			const nextHashOnion = await randomModule['_getNextHashOnion'](
+				usedHashOnions,
+				generatorAddress,
+				height,
+				testing.mocks.loggerMock,
+				inserAssetContext,
+			);
+
+			// Assert
+			expect(nextHashOnion.count).toEqual(hashOnion.count);
 		});
 	});
 
@@ -455,10 +477,6 @@ describe('RandomModule', () => {
 				usedHashOnions: [
 					{
 						count: maxCount,
-						height: 10,
-					},
-					{
-						count: 0,
 						height: 15,
 					},
 				],


### PR DESCRIPTION
### What was the problem?

This PR resolves #8299

### How was it solved?

When hash onion was used up, `RandomModule` method `_getNextHashOnion()` was previously returning a random hash [correct] with used hash count of 0 [incorrect]. Then hash onion count of 0 would be stored in `UsedHashOnionsStore`, which in the next block would trick the method to think that the previously used hash onion wasn't used at all, and it would start providing the hashes from the same onion again and again.

The implemented solution is to make `_getNextHashOnion()` method return the same hash onion count as it is stored in the `UsedHashOnionsStore`, instead of resetting it to 0.

### How was it tested?

* Added 1 test case which covers that scenario
* Ran a fresh new node, set a new hash onion, and waited for it to get used up
