### PR TITLE
Missing escrow substore exists method

### DIFF
--- a/examples/interop/README.md
+++ b/examples/interop/README.md
@@ -61,7 +61,7 @@ Install and build `pos-mainchain-fast`
 
 Install and build `pos-sidechain-fast`
 
-- `cd pos-mainchain-fast`
+- `cd pos-sidechain-fast`
 - `yarn && yarn build`
 
 #### Run apps using pm2

--- a/framework/src/modules/interoperability/base_interoperability_module.ts
+++ b/framework/src/modules/interoperability/base_interoperability_module.ts
@@ -13,6 +13,7 @@
  */
 
 import { GenesisBlockExecuteContext } from '../../state_machine';
+import { TokenMethod } from '../token';
 import { BaseCCCommand } from './base_cc_command';
 import { BaseCCMethod } from './base_cc_method';
 import { BaseInteroperableModule } from './base_interoperable_module';
@@ -29,6 +30,7 @@ import { TerminatedStateStore } from './stores/terminated_state';
 export abstract class BaseInteroperabilityModule extends BaseInteroperableModule {
 	protected interoperableCCCommands = new Map<string, BaseCCCommand[]>();
 	protected interoperableCCMethods = new Map<string, BaseCCMethod>();
+	protected tokenMethod!: TokenMethod;
 
 	protected constructor() {
 		super();

--- a/framework/src/modules/interoperability/mainchain/module.ts
+++ b/framework/src/modules/interoperability/mainchain/module.ts
@@ -189,6 +189,7 @@ export class MainchainInteroperabilityModule extends BaseInteroperabilityModule 
 		this._sidechainRegistrationCommand.addDependencies(feeMethod, tokenMethod);
 		this._crossChainUpdateCommand.init(this.method, tokenMethod);
 		this.internalMethod.addDependencies(tokenMethod);
+		this.tokenMethod = tokenMethod;
 	}
 
 	public metadata(): ModuleMetadata {

--- a/framework/src/modules/interoperability/sidechain/module.ts
+++ b/framework/src/modules/interoperability/sidechain/module.ts
@@ -137,6 +137,7 @@ export class SidechainInteroperabilityModule extends BaseInteroperabilityModule 
 		this._validatorsMethod = validatorsMethod;
 		this._crossChainUpdateCommand.init(this.method, tokenMethod);
 		this.internalMethod.addDependencies(tokenMethod);
+		this.tokenMethod = tokenMethod;
 	}
 
 	public metadata(): ModuleMetadata {

--- a/framework/src/modules/token/method.ts
+++ b/framework/src/modules/token/method.ts
@@ -714,9 +714,8 @@ export class TokenMethod extends BaseMethod {
 		chainID: Buffer,
 		tokenID: Buffer,
 	) {
-		const escrowStore = this.stores.get(EscrowStore);
-		const escrowExist = await escrowStore.has(methodContext, escrowStore.getKey(chainID, tokenID));
-
-		return escrowExist;
+		return this.stores
+			.get(EscrowStore)
+			.has(methodContext, this.stores.get(EscrowStore).getKey(chainID, tokenID));
 	}
 }

--- a/framework/src/modules/token/method.ts
+++ b/framework/src/modules/token/method.ts
@@ -708,4 +708,15 @@ export class TokenMethod extends BaseMethod {
 			})),
 		};
 	}
+
+	public async escrowSubstoreExists(
+		methodContext: MethodContext,
+		chainID: Buffer,
+		tokenID: Buffer,
+	) {
+		const escrowStore = this.stores.get(EscrowStore);
+		const escrowExist = await escrowStore.has(methodContext, escrowStore.getKey(chainID, tokenID));
+
+		return escrowExist;
+	}
 }

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -1223,4 +1223,22 @@ describe('token module', () => {
 			});
 		});
 	});
+
+	describe('escrowSubstoreExists', () => {
+		const escrowChainID = defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH);
+
+		it('should return false if escrow subStore does not exist', async () => {
+			const escrowStore = tokenModule.stores.get(EscrowStore);
+			await escrowStore.del(methodContext, escrowStore.getKey(escrowChainID, defaultTokenID));
+			await expect(
+				method.escrowSubstoreExists(methodContext, escrowChainID, defaultTokenID),
+			).resolves.toBeFalse();
+		});
+
+		it('should return true if escrow subStore exists', async () => {
+			await expect(
+				method.escrowSubstoreExists(methodContext, escrowChainID, defaultTokenID),
+			).resolves.toBeTrue();
+		});
+	});
 });

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -1227,7 +1227,7 @@ describe('token module', () => {
 	describe('escrowSubstoreExists', () => {
 		const escrowChainID = defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH);
 
-		it('should return false if escrow subStore does not exist', async () => {
+		it('should return false if escrow subStore does not exist for the given chain id and token id', async () => {
 			const escrowStore = tokenModule.stores.get(EscrowStore);
 			await escrowStore.del(methodContext, escrowStore.getKey(escrowChainID, defaultTokenID));
 			await expect(
@@ -1235,7 +1235,7 @@ describe('token module', () => {
 			).resolves.toBeFalse();
 		});
 
-		it('should return true if escrow subStore exists', async () => {
+		it('should return true if escrow subStore exists for the given chain id and token id', async () => {
 			await expect(
 				method.escrowSubstoreExists(methodContext, escrowChainID, defaultTokenID),
 			).resolves.toBeTrue();


### PR DESCRIPTION
### What was the problem?

This PR resolves #8339

### How was it solved?

- [🌱 Add escrowSubstoreExists method](https://github.com/LiskHQ/lisk-sdk/commit/9842b84d267b52a428973264c7a2a0e78b89f7bb)

- [♻️ Add tokenMethod property on interoperability module](https://github.com/LiskHQ/lisk-sdk/commit/dc13a9dedd5091543e26afc58cfdfb0af3b7139f)

### How was it tested?

Run `npm run test:unit` under `framework`
