### PR TITLE
Add filter for mainchain to collect ccms for specific sidechain

### DIFF
--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/chain_connector_plugin.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/chain_connector_plugin.ts
@@ -557,7 +557,9 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 		};
 		const crossChainMessages = await this._chainConnectorStore.getCrossChainMessages();
 		crossChainMessages.push({
-			ccms: ccmsFromEvents,
+			ccms: this._isReceivingChainMainchain
+				? ccmsFromEvents
+				: ccmsFromEvents.filter(ccm => ccm.receivingChainID.equals(this._receivingChainID)),
 			height: newBlockHeader.height,
 			inclusionProof: outboxRootWitness,
 		});

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/utils/sampleCCM.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/utils/sampleCCM.ts
@@ -20,7 +20,7 @@ export const getSampleCCM = (nonce = 1, ccmSizeInBytes?: number): CCMsg => {
 		module: MODULE_NAME_INTEROPERABILITY,
 		crossChainCommand: CROSS_CHAIN_COMMAND_NAME_TRANSFER,
 		sendingChainID: Buffer.from([0, 0, 0, 3]),
-		receivingChainID: Buffer.from([0, 0, 0, 2]),
+		receivingChainID: Buffer.from('04000000', 'hex'),
 		fee: BigInt(nonce),
 		status: 0,
 		params: Buffer.alloc(ccmSizeInBytes ?? 10),


### PR DESCRIPTION
### What was the problem?

This PR resolves #8347 

### How was it solved?

[🐛 Add filter for mainchain to collect ccms for specific sidechain](https://github.com/LiskHQ/lisk-sdk/commit/0f60c5c44d461b6de0a13c516064fc6b4c4c0404)

### How was it tested?

Run interop examples setup and see if all the CCUs are sent from mainchain->sidechain1 and sidechain1,2->mainchain
