### PR TITLE
Use blockHeader timestamp

### DIFF
--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -140,7 +140,11 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 			}
 
 			// The sending chain must be live.
-			const isLive = await this.internalMethod.isLive(context, ccm.sendingChainID, Date.now());
+			const isLive = await this.internalMethod.isLive(
+				context,
+				ccm.sendingChainID,
+				context.header.timestamp,
+			);
 			if (!isLive) {
 				return {
 					status: VerifyStatus.FAIL,


### PR DESCRIPTION
### What was the problem?

This PR resolves #8349 

### How was it solved?

[🐛 Use blockHeader timestamp](https://github.com/LiskHQ/lisk-sdk/commit/82f18166ca92b518902222818e34a73f02fba202)

### How was it tested?

Run `npm run test:unit interoperability` under `framework`
