### PR TITLE
Use chainID from genesisConfig and fix ccm selection

### DIFF
--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/endpoint.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/endpoint.spec.ts
@@ -27,7 +27,8 @@ import * as chainConnectorDB from '../../src/db';
 import { CCMsFromEvents, CCMsFromEventsJSON, LastSentCCMWithHeightJSON } from '../../src/types';
 import { ccmsFromEventsToJSON, getMainchainID } from '../../src/utils';
 
-describe('getSentCCUs', () => {
+describe('endpoints', () => {
+	const ownChainID = Buffer.from('10000000', 'hex');
 	const appConfigForPlugin: ApplicationConfigForPlugin = {
 		system: {
 			keepEventsForHeights: -1,
@@ -52,7 +53,9 @@ describe('getSentCCUs', () => {
 			minEntranceFeePriority: '0',
 			minReplacementFeeDifference: '10',
 		},
-		genesis: {} as GenesisConfig,
+		genesis: {
+			chainID: ownChainID.toString('hex'),
+		} as GenesisConfig,
 		generator: {
 			keys: {
 				fromFile: '',
@@ -114,7 +117,6 @@ describe('getSentCCUs', () => {
 	const defaultPassword = '123';
 	const defaultCCUFee = '100000000';
 
-	const ownChainID = Buffer.from('10000000', 'hex');
 	let chainConnectorPlugin: ChainConnectorPlugin;
 
 	beforeEach(async () => {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/inbox_update.spec.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/test/unit/inbox_update.spec.ts
@@ -12,44 +12,17 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import {
-	CCMsg,
-	Certificate,
-	testing,
-	cryptography,
-	BlockHeader,
-	tree,
-	ChannelData,
-} from 'lisk-sdk';
+import { CCMsg, tree } from 'lisk-sdk';
 import { CCU_TOTAL_CCM_SIZE } from '../../src/constants';
 import { CCMsFromEvents } from '../../src/types';
 import { calculateMessageWitnesses } from '../../src/inbox_update';
 import { getSampleCCM } from '../utils/sampleCCM';
 
 describe('inboxUpdate', () => {
-	let sampleBlock: BlockHeader;
-	let sampleCertificate: Certificate;
-
 	let sampleCCMs: CCMsg[];
 	let sampleCCMsFromEvents: CCMsFromEvents[];
 
 	beforeEach(() => {
-		sampleBlock = testing.createFakeBlockHeader({
-			stateRoot: cryptography.utils.getRandomBytes(32),
-			validatorsHash: cryptography.utils.getRandomBytes(32),
-			height: 100,
-		}) as BlockHeader & { validatorsHash: Buffer; stateRoot: Buffer };
-
-		sampleCertificate = {
-			blockID: sampleBlock.id,
-			height: sampleBlock.height,
-			timestamp: sampleBlock.timestamp,
-			validatorsHash: sampleBlock.validatorsHash as Buffer,
-			stateRoot: sampleBlock.stateRoot as Buffer,
-			aggregationBits: Buffer.alloc(0),
-			signature: cryptography.utils.getRandomBytes(32),
-		};
-
 		sampleCCMs = new Array(4).fill(0).map((_, index) => getSampleCCM(index + 1));
 
 		sampleCCMsFromEvents = [
@@ -73,27 +46,16 @@ describe('inboxUpdate', () => {
 	});
 
 	describe('calculateMessageWitnesses', () => {
-		const channelData: ChannelData = {
-			inbox: {
-				size: 2,
-				appendPath: [],
-				root: Buffer.alloc(1),
-			},
-			outbox: {
-				size: 2,
-				appendPath: [],
-				root: Buffer.alloc(1),
-			},
-			messageFeeTokenID: Buffer.from('04000001', 'hex'),
-			partnerChainOutboxRoot: Buffer.alloc(2),
-			minReturnFeePerByte: BigInt(0),
-		};
 		it('should return one inboxUpdate when all the ccms can be included', () => {
 			jest.spyOn(tree.regularMerkleTree, 'calculateRightWitness').mockReturnValue([]);
 			const messageWitnessHashesForCCMs = calculateMessageWitnesses(
-				channelData,
+				0,
+				1,
+				{
+					height: 1,
+					nonce: BigInt(0),
+				},
 				sampleCCMsFromEvents,
-				{ height: 1, nonce: BigInt(0) },
 				CCU_TOTAL_CCM_SIZE,
 			);
 
@@ -119,9 +81,13 @@ describe('inboxUpdate', () => {
 			];
 
 			const messageWitnessHashesForCCMs = calculateMessageWitnesses(
-				channelData,
+				0,
+				1,
+				{
+					height: 1,
+					nonce: BigInt(0),
+				},
 				ccmListWithBigSize,
-				{ height: 1, nonce: BigInt(0) },
 				CCU_TOTAL_CCM_SIZE,
 			);
 
@@ -136,9 +102,13 @@ describe('inboxUpdate', () => {
 				.mockReturnValue([Buffer.alloc(1)]);
 			const { crossChainMessages, lastCCMToBeSent, messageWitnessHashes } =
 				calculateMessageWitnesses(
-					channelData,
+					0,
+					1,
+					{
+						height: 1,
+						nonce: BigInt(0),
+					},
 					[],
-					{ height: sampleCertificate.height + 1, nonce: BigInt(2) },
 					CCU_TOTAL_CCM_SIZE,
 				);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8356 #8357

### How was it solved?

[🐛 Use chainID from genesisConfig and fix ccm selection](https://github.com/LiskHQ/lisk-sdk/commit/647d7b85f2936025f635a7a61c410c4308dd77bb)

### How was it tested?

`npm t`
