### PR TITLE
Register ccCommands of interoperability module as well

### DIFF
--- a/framework/src/modules/interoperability/base_interoperability_module.ts
+++ b/framework/src/modules/interoperability/base_interoperability_module.ts
@@ -67,6 +67,7 @@ export abstract class BaseInteroperabilityModule extends BaseInteroperableModule
 	}
 
 	public registerInteroperableModule(module: BaseInteroperableModule): void {
+		this.interoperableCCCommands.set(this.name, this.crossChainCommand);
 		this.interoperableCCMethods.set(module.name, module.crossChainMethod);
 		this.interoperableCCCommands.set(module.name, module.crossChainCommand);
 	}


### PR DESCRIPTION
### What was the problem?

This PR resolves #8366

### How was it solved?

[🐛 Register ccCommands of interoperability module as well](https://github.com/LiskHQ/lisk-sdk/commit/0bc86694062eb743fc55ec06c12e2011e575ebbc)

### How was it tested?

Send a valid CCM to another chain and see if its accepted. Chain registration and enabling chain connector plugin can be one way to send a CCM to perform this test.
