### PR TITLE
Fix standby validator bft weight

### DIFF
--- a/framework/src/modules/pos/module.ts
+++ b/framework/src/modules/pos/module.ts
@@ -644,7 +644,7 @@ export class PoSModule extends BaseModule {
 		);
 		// select standby validators
 		let standbyValidators: ValidatorWeight[] = [];
-		if (nextRound > genesisData.initRounds + this._moduleConfig.numberActiveValidators) {
+		if (nextRound >= genesisData.initRounds + this._moduleConfig.numberActiveValidators) {
 			const candidates = snapshot.validatorWeightSnapshot.filter(
 				v => !activeValidatorMap.has(v.address),
 			);

--- a/framework/src/modules/pos/utils.ts
+++ b/framework/src/modules/pos/utils.ts
@@ -133,7 +133,10 @@ export const selectStandbyValidators = (
 	const numberOfCandidates = 1 + (randomSeed2 !== undefined ? 1 : 0);
 	// if validator weights is smaller than number selecting, select all
 	if (validatorWeights.length <= numberOfCandidates) {
-		return validatorWeights;
+		return validatorWeights.map(v => ({
+			address: v.address,
+			weight: BigInt(0),
+		}));
 	}
 	const result: ValidatorWeight[] = [];
 	const index = pickStandByValidator(validatorWeights, randomSeed1);


### PR DESCRIPTION
### What was the problem?

This PR resolves #8373 

### How was it solved?

Fix to return BFT weight `0`, when number of candidates is less than or equal to the input

### How was it tested?

- Added unit test
