### PR TITLE
Incorrect cleanup for validatorsHash

### DIFF
--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/active_validators_update.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/active_validators_update.ts
@@ -51,7 +51,7 @@ export const calculateActiveValidatorsUpdate = (
 		validatorDataAtCertificate.certificateThreshold ===
 		validatorDataAtLastCertificate.certificateThreshold
 	) {
-		certificateThreshold = BigInt(0);
+		certificateThreshold = validatorDataAtLastCertificate.certificateThreshold;
 	} else {
 		certificateThreshold = validatorDataAtCertificate.certificateThreshold;
 	}

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/chain_connector_plugin.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/chain_connector_plugin.ts
@@ -240,12 +240,6 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 						`No valid CCU can be generated for the height: ${newBlockHeader.height}`,
 					);
 				}
-				// If the CCU was sent successfully then update the last certified height and do the cleanup
-				chainAccountJSON = await this._receivingChainClient.invoke<ChainAccountJSON>(
-					'interoperability_getChainAccount',
-					{ chainID: this._ownChainID.toString('hex') },
-				);
-				this._lastCertificate = chainAccountDataJSONToObj(chainAccountJSON).lastCertificate;
 				await this._cleanup();
 			}
 		} catch (error) {
@@ -628,10 +622,18 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 	private async _deleteBlockHandler(data?: Record<string, unknown>) {
 		const { blockHeader: receivedBlock } = data as unknown as Data;
 
-		const newBlockHeader = chain.BlockHeader.fromJSON(receivedBlock).toObject();
+		const deletedBlockHeader = chain.BlockHeader.fromJSON(receivedBlock).toObject();
+
+		// Delete ccmEvents for the height of blockHeader
+		const crossChainMessages = await this._chainConnectorStore.getCrossChainMessages();
+		const indexForCCMEvents = crossChainMessages.findIndex(
+			ccm => ccm.height >= deletedBlockHeader.height,
+		);
+		crossChainMessages.splice(indexForCCMEvents, 1);
+		await this._chainConnectorStore.setCrossChainMessages(crossChainMessages);
 
 		const findIndexByHeight = (someData: { height: number }[]): number =>
-			someData.findIndex(datum => datum.height === newBlockHeader.height);
+			someData.findIndex(datum => datum.height === deletedBlockHeader.height);
 
 		const blockHeaders = await this._chainConnectorStore.getBlockHeaders();
 		const blockHeaderIndex = findIndexByHeight(blockHeaders);
@@ -640,21 +642,35 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 			await this._chainConnectorStore.setBlockHeaders(blockHeaders);
 		}
 
-		const aggregateCommits = await this._chainConnectorStore.getAggregateCommits();
-		const aggregateCommitIndex = findIndexByHeight(aggregateCommits);
-		if (aggregateCommitIndex !== -1) {
-			aggregateCommits.splice(aggregateCommitIndex, 1);
+		if (
+			!deletedBlockHeader.aggregateCommit.aggregationBits.equals(EMPTY_BYTES) ||
+			!deletedBlockHeader.aggregateCommit.certificateSignature.equals(EMPTY_BYTES)
+		) {
+			const aggregateCommits = await this._chainConnectorStore.getAggregateCommits();
+			const aggregateCommitIndex = aggregateCommits.findIndex(
+				commit => commit.height === deletedBlockHeader.aggregateCommit.height,
+			);
+			if (aggregateCommitIndex > -1) {
+				aggregateCommits.splice(aggregateCommitIndex, 1);
+			}
 			await this._chainConnectorStore.setAggregateCommits(aggregateCommits);
 		}
 
 		const validatorsHashPreimage = await this._chainConnectorStore.getValidatorsHashPreimage();
-		const validatorsHashPreimageIndex = validatorsHashPreimage.findIndex(v =>
-			v.validatorsHash.equals(newBlockHeader.validatorsHash),
-		);
-		if (validatorsHashPreimageIndex !== -1) {
-			validatorsHashPreimage.splice(validatorsHashPreimageIndex, 1);
-			await this._chainConnectorStore.setValidatorsHashPreimage(validatorsHashPreimage);
+		const activeValidatorsHashes = validatorsHashPreimage.map(b => b.validatorsHash);
+		for (const validatorHash of activeValidatorsHashes) {
+			const doesValidatorsHashExist = blockHeaders.some(b =>
+				validatorHash.equals(b.validatorsHash),
+			);
+			if (!doesValidatorsHashExist) {
+				const indexOfValidatorHash = validatorsHashPreimage.findIndex(vHash =>
+					vHash.validatorsHash.equals(validatorHash),
+				);
+				validatorsHashPreimage.splice(indexOfValidatorHash, 1);
+			}
 		}
+
+		await this._chainConnectorStore.setValidatorsHashPreimage(validatorsHashPreimage);
 	}
 
 	private async _cleanup() {
@@ -669,9 +685,10 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 		// Delete blockHeaders
 		const blockHeaders = await this._chainConnectorStore.getBlockHeaders();
 
-		await this._chainConnectorStore.setBlockHeaders(
-			blockHeaders.filter(blockHeader => blockHeader.height >= this._lastCertificate.height),
+		const updatedBlockHeaders = blockHeaders.filter(
+			blockHeader => blockHeader.height >= this._lastCertificate.height,
 		);
+		await this._chainConnectorStore.setBlockHeaders(updatedBlockHeaders);
 
 		// Delete aggregateCommits
 		const aggregateCommits = await this._chainConnectorStore.getAggregateCommits();
@@ -684,12 +701,20 @@ export class ChainConnectorPlugin extends BasePlugin<ChainConnectorPluginConfig>
 		// Delete validatorsHashPreimage
 		const validatorsHashPreimage = await this._chainConnectorStore.getValidatorsHashPreimage();
 
-		await this._chainConnectorStore.setValidatorsHashPreimage(
-			validatorsHashPreimage.filter(
-				validatorsData =>
-					validatorsData.certificateThreshold >= BigInt(this._lastCertificate.height),
-			),
-		);
+		const activeValidatorsHashes = validatorsHashPreimage.map(b => b.validatorsHash);
+		// Find validatorsHash that is not used in any blockHeaders and delete it
+		for (const validatorHash of activeValidatorsHashes) {
+			const doesValidatorsHashExist = updatedBlockHeaders.some(b =>
+				validatorHash.equals(b.validatorsHash),
+			);
+			if (!doesValidatorsHashExist) {
+				const indexOfValidatorHash = validatorsHashPreimage.findIndex(vHash =>
+					vHash.validatorsHash.equals(validatorHash),
+				);
+				validatorsHashPreimage.splice(indexOfValidatorHash, 1);
+			}
+		}
+		await this._chainConnectorStore.setValidatorsHashPreimage(validatorsHashPreimage);
 		// Delete CCUs
 		// When given -1 then there is no limit
 		if (this._ccuSaveLimit !== -1) {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8387 

### How was it solved?

- Incorrect cleanup for validatorsHash
- Incorrect cleanup for aggregateCommit
- Assign old certificateThreshold instead of zero when certificateThreshold is unchanged as compared to last Certificate

### How was it tested?

Run interops setup and run two sidechains along with mainchain nodes and observe CCUs
