### PR TITLE
Fix missing default key in genesis asset

### DIFF
--- a/commander/src/utils/genesis_creation.ts
+++ b/commander/src/utils/genesis_creation.ts
@@ -16,6 +16,8 @@
 import { Schema } from '@liskhq/lisk-codec';
 import { address } from '@liskhq/lisk-cryptography';
 import {
+	genesisInteroperabilitySchema,
+	MODULE_NAME_INTEROPERABILITY,
 	posGenesisStoreSchema,
 	PoSModule,
 	tokenGenesisStoreSchema,
@@ -132,6 +134,17 @@ export const generateGenesisBlockDefaultPoSAssets = (input: GenesisBlockDefaultA
 				},
 			} as Record<string, unknown>,
 			schema: posGenesisStoreSchema,
+		},
+		{
+			module: MODULE_NAME_INTEROPERABILITY,
+			data: {
+				ownChainName: '',
+				ownChainNonce: 0,
+				chainInfos: [],
+				terminatedStateAccounts: [],
+				terminatedOutboxAccounts: [],
+			},
+			schema: genesisInteroperabilitySchema,
 		},
 	];
 

--- a/commander/test/utils/genesis_creation.spec.ts
+++ b/commander/test/utils/genesis_creation.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * LiskHQ/lisk-commander
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+import { Application } from 'lisk-framework';
+import { codec } from '@liskhq/lisk-codec';
+import { generateGenesisBlockDefaultPoSAssets } from '../../src/utils/genesis_creation';
+
+describe('genesis creation', () => {
+	describe('generateGenesisBlockDefaultPoSAssets', () => {
+		const chainID = Buffer.from([2, 0, 0, 0]);
+		it('should create processable genesis block', async () => {
+			const { genesisAssets } = generateGenesisBlockDefaultPoSAssets({
+				chainID: chainID.toString('hex'),
+				keysList: [],
+				numberOfValidators: 101,
+				tokenDistribution: BigInt('100000000000000'),
+			});
+
+			const { app } = Application.defaultApplication({
+				genesis: {
+					chainID: chainID.toString('hex'),
+				},
+			});
+
+			const genesisBlock = await app.generateGenesisBlock({
+				assets: genesisAssets.map(a => ({
+					module: a.module,
+					data: codec.fromJSON(a.schema, a.data),
+					schema: a.schema,
+				})),
+				chainID,
+			});
+			expect(genesisBlock.assets.toJSON().map(a => a.module)).toEqual([
+				'interoperability',
+				'pos',
+				'token',
+			]);
+			expect(
+				genesisBlock.assets
+					.toJSON()
+					.map(a => a.data)
+					.every(d => typeof d === 'string'),
+			).toBe(true);
+		});
+	});
+});

--- a/commander/test/utils/genesis_creation.spec.ts
+++ b/commander/test/utils/genesis_creation.spec.ts
@@ -43,17 +43,9 @@ describe('genesis creation', () => {
 				})),
 				chainID,
 			});
-			expect(genesisBlock.assets.toJSON().map(a => a.module)).toEqual([
-				'interoperability',
-				'pos',
-				'token',
-			]);
-			expect(
-				genesisBlock.assets
-					.toJSON()
-					.map(a => a.data)
-					.every(d => typeof d === 'string'),
-			).toBe(true);
+			const assetsJSON = genesisBlock.assets.toJSON();
+			expect(assetsJSON.map(a => a.module)).toEqual(['interoperability', 'pos', 'token']);
+			expect(assetsJSON.map(a => a.data).every(d => typeof d === 'string')).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #8399 

### How was it solved?

- Add missing `interoperability` default asset to the default genesis asset for `init` command

### How was it tested?
- Added unit test

```
this.spawnCommandSync('yarn', ['link', 'lisk-commander']);
```
to `commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts:L94` and run
```
./bin/run init ~/Desktop/temp
```
