### PR TITLE
Add missing unit tests for the Validator Registration Command

### DIFF
--- a/framework/test/unit/modules/pos/commands/register_validator.spec.ts
+++ b/framework/test/unit/modules/pos/commands/register_validator.spec.ts
@@ -30,11 +30,7 @@ import { ValidatorStore } from '../../../../../src/modules/pos/stores/validator'
 import { NameStore } from '../../../../../src/modules/pos/stores/name';
 import { PoSModule } from '../../../../../src';
 import { createStoreGetter } from '../../../../../src/testing/utils';
-import {
-	COMMISSION,
-	MAX_LENGTH_NAME,
-	VALIDATOR_REGISTRATION_FEE,
-} from '../../../../../src/modules/pos/constants';
+import { COMMISSION, VALIDATOR_REGISTRATION_FEE } from '../../../../../src/modules/pos/constants';
 import { ValidatorRegisteredEvent } from '../../../../../src/modules/pos/events/validator_registered';
 
 describe('Validator registration command', () => {
@@ -317,37 +313,6 @@ describe('Validator registration command', () => {
 						...transaction.toObject(),
 						fee: validatorRegistrationCommand['_validatorRegistrationFee'] - BigInt(1),
 					}),
-					chainID,
-				})
-				.createCommandVerifyContext<ValidatorRegistrationParams>(
-					validatorRegistrationCommandParamsSchema,
-				);
-
-			const result = await validatorRegistrationCommand.verify(context);
-
-			expect(result.status).toBe(VerifyStatus.FAIL);
-			expect(result.error?.message).toInclude('Insufficient transaction fee.');
-		});
-
-		it('should throw error if name is longer than MAX_LENGTH_NAME characters long', async () => {
-			const invalidParams = codec.encode(validatorRegistrationCommandParamsSchema, {
-				...transactionParams,
-				name: 'a'.repeat(MAX_LENGTH_NAME + 1),
-			});
-
-			const invalidTransaction = new Transaction({
-				module: 'pos',
-				command: 'registerValidator',
-				senderPublicKey: publicKey,
-				nonce: BigInt(0),
-				fee: BigInt(100000000),
-				params: invalidParams,
-				signatures: [publicKey],
-			});
-
-			const context = testing
-				.createTransactionContext({
-					transaction: invalidTransaction,
 					chainID,
 				})
 				.createCommandVerifyContext<ValidatorRegistrationParams>(

--- a/framework/test/unit/modules/pos/commands/register_validator.spec.ts
+++ b/framework/test/unit/modules/pos/commands/register_validator.spec.ts
@@ -30,7 +30,11 @@ import { ValidatorStore } from '../../../../../src/modules/pos/stores/validator'
 import { NameStore } from '../../../../../src/modules/pos/stores/name';
 import { PoSModule } from '../../../../../src';
 import { createStoreGetter } from '../../../../../src/testing/utils';
-import { COMMISSION, VALIDATOR_REGISTRATION_FEE } from '../../../../../src/modules/pos/constants';
+import {
+	COMMISSION,
+	MAX_LENGTH_NAME,
+	VALIDATOR_REGISTRATION_FEE,
+} from '../../../../../src/modules/pos/constants';
 import { ValidatorRegisteredEvent } from '../../../../../src/modules/pos/events/validator_registered';
 
 describe('Validator registration command', () => {
@@ -323,6 +327,68 @@ describe('Validator registration command', () => {
 
 			expect(result.status).toBe(VerifyStatus.FAIL);
 			expect(result.error?.message).toInclude('Insufficient transaction fee.');
+		});
+
+		it('should throw error if name is longer than MAX_LENGTH_NAME characters long', async () => {
+			const invalidParams = codec.encode(validatorRegistrationCommandParamsSchema, {
+				...transactionParams,
+				name: 'a'.repeat(MAX_LENGTH_NAME + 1),
+			});
+
+			const invalidTransaction = new Transaction({
+				module: 'pos',
+				command: 'registerValidator',
+				senderPublicKey: publicKey,
+				nonce: BigInt(0),
+				fee: BigInt(100000000),
+				params: invalidParams,
+				signatures: [publicKey],
+			});
+
+			const context = testing
+				.createTransactionContext({
+					transaction: invalidTransaction,
+					chainID,
+				})
+				.createCommandVerifyContext<ValidatorRegistrationParams>(
+					validatorRegistrationCommandParamsSchema,
+				);
+
+			const result = await validatorRegistrationCommand.verify(context);
+
+			expect(result.status).toBe(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude('Insufficient transaction fee.');
+		});
+
+		it('should throw error if name is empty', async () => {
+			const invalidParams = codec.encode(validatorRegistrationCommandParamsSchema, {
+				...transactionParams,
+				name: '',
+			});
+
+			const invalidTransaction = new Transaction({
+				module: 'pos',
+				command: 'registerValidator',
+				senderPublicKey: publicKey,
+				nonce: BigInt(0),
+				fee: BigInt(100000000),
+				params: invalidParams,
+				signatures: [publicKey],
+			});
+
+			const context = testing
+				.createTransactionContext({
+					transaction: invalidTransaction,
+					chainID,
+				})
+				.createCommandVerifyContext<ValidatorRegistrationParams>(
+					validatorRegistrationCommandParamsSchema,
+				);
+
+			const result = await validatorRegistrationCommand.verify(context);
+
+			expect(result.status).toBe(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude("'name' is in an unsupported format: ");
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #7873

### How was it solved?

Added missing unit tests

### How was it tested?

Added unit tests and all are passing ✅
`npm t register_validator`
