### PR TITLE
Update cerificate heightcheck to account for invalid BLS key

### DIFF
--- a/framework/src/engine/consensus/certificate_generation/commit_pool.ts
+++ b/framework/src/engine/consensus/certificate_generation/commit_pool.ts
@@ -211,7 +211,7 @@ export class CommitPool {
 			return false;
 		}
 
-		// The heights of aggregate commits must be at least MIN_CERTIFY_HEIGHT.
+		// The heights of aggregate commits must be greater than or equal to MIN_CERTIFY_HEIGHT.
 		if (aggregateCommit.height < this._minCertifyHeight) {
 			return false;
 		}

--- a/framework/src/engine/consensus/certificate_generation/types.ts
+++ b/framework/src/engine/consensus/certificate_generation/types.ts
@@ -41,6 +41,7 @@ export interface SingleCommit {
 export interface CommitPoolConfig {
 	readonly network: Network;
 	readonly blockTime: number;
+	readonly minCertifyHeight: number;
 	readonly bftMethod: BFTMethod;
 	readonly chain: Chain;
 	readonly db: Database;

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -147,6 +147,7 @@ export class Consensus {
 		this._commitPool = new CommitPool({
 			db: this._db,
 			blockTime: this._genesisConfig.blockTime,
+			minCertifyHeight: this._genesisConfig.minimumCertifyHeight,
 			bftMethod: this._bft.method,
 			chain: this._chain,
 			network: this._network,

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -255,6 +255,11 @@ export const applicationConfigSchema = {
 					maximum: 30 * 1024, // Kilo Bytes
 					description: 'Maximum number of transactions allowed per block',
 				},
+				minimumCertifyHeight: {
+					type: 'integer',
+					minimum: 0,
+					description: 'Minimum block height which can be certified',
+				},
 			},
 			additionalProperties: false,
 		},
@@ -321,6 +326,7 @@ export const applicationConfigSchema = {
 			blockTime: 10,
 			bftBatchSize: 103,
 			maxTransactionsSize: 15 * 1024, // Kilo Bytes
+			minimumCertifyHeight: 0,
 		},
 		generator: {
 			keys: {},

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -257,7 +257,7 @@ export const applicationConfigSchema = {
 				},
 				minimumCertifyHeight: {
 					type: 'integer',
-					minimum: 0,
+					minimum: 1,
 					description: 'Minimum block height which can be certified',
 				},
 			},

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -326,7 +326,7 @@ export const applicationConfigSchema = {
 			blockTime: 10,
 			bftBatchSize: 103,
 			maxTransactionsSize: 15 * 1024, // Kilo Bytes
-			minimumCertifyHeight: 0,
+			minimumCertifyHeight: 1,
 		},
 		generator: {
 			keys: {},

--- a/framework/src/testing/fixtures/config.ts
+++ b/framework/src/testing/fixtures/config.ts
@@ -27,6 +27,7 @@ export const defaultConfig: ApplicationConfig = {
 	genesis: {
 		block: {},
 		bftBatchSize: 103,
+		minimumCertifyHeight: 0,
 		blockTime: 10,
 		chainID: '10000000',
 		maxTransactionsSize: 15 * 1024, // Kilo Bytes

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -64,6 +64,7 @@ export interface GenesisConfig {
 	maxTransactionsSize: number;
 	blockTime: number;
 	bftBatchSize: number;
+	minimumCertifyHeight: number;
 }
 
 export interface TransactionPoolConfig {

--- a/framework/test/unit/__snapshots__/application.spec.ts.snap
+++ b/framework/test/unit/__snapshots__/application.spec.ts.snap
@@ -13,7 +13,7 @@ exports[`Application #constructor should set internal variables 1`] = `
     "blockTime": 10,
     "chainID": "10000000",
     "maxTransactionsSize": 15360,
-    "minimumCertifyHeight": 0,
+    "minimumCertifyHeight": 1,
   },
   "legacy": {
     "brackets": [],

--- a/framework/test/unit/__snapshots__/application.spec.ts.snap
+++ b/framework/test/unit/__snapshots__/application.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`Application #constructor should set internal variables 1`] = `
     "blockTime": 10,
     "chainID": "10000000",
     "maxTransactionsSize": 15360,
+    "minimumCertifyHeight": 0,
   },
   "legacy": {
     "brackets": [],

--- a/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
@@ -1427,7 +1427,7 @@ describe('CommitPool', () => {
 
 		it('should certify the singleCommit2 even when heightNextBFTParameters is lower than minCerfifyHeight', async () => {
 			// Arrange
-			bftMethod.getNextHeightBFTParameters.mockResolvedValue(heightNextBFTParameters - 1);
+			bftMethod.getNextHeightBFTParameters.mockResolvedValue(heightNextBFTParameters - 2);
 			(commitPool['_minCertifyHeight'] as any) = heightNextBFTParameters - 1;
 
 			// Act

--- a/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
@@ -1411,9 +1411,37 @@ describe('CommitPool', () => {
 			});
 		});
 
-		it('should certify the minCertifyHeight even when heightNextBFTParameters is lower', async () => {
+		it('should certify the singleCommit1 when nextBFTParameter is lower and minCertifyHeight is the same as singleCommit1', async () => {
 			// Arrange
 			bftMethod.getNextHeightBFTParameters.mockResolvedValue(309);
+			(commitPool['_minCertifyHeight'] as any) = singleCommit1.height;
+
+			// Act
+			await commitPool['_selectAggregateCommit'](stateStore);
+
+			// Assert
+			expect(commitPool['aggregateSingleCommits']).toHaveBeenCalledWith(stateStore, [
+				singleCommit1,
+			]);
+		});
+
+		it('should certify the singleCommit2 even when heightNextBFTParameters is lower than minCerfifyHeight', async () => {
+			// Arrange
+			bftMethod.getNextHeightBFTParameters.mockResolvedValue(heightNextBFTParameters - 1);
+			(commitPool['_minCertifyHeight'] as any) = heightNextBFTParameters - 1;
+
+			// Act
+			await commitPool['_selectAggregateCommit'](stateStore);
+
+			// Assert
+			expect(commitPool['aggregateSingleCommits']).toHaveBeenCalledWith(stateStore, [
+				singleCommit2,
+			]);
+		});
+
+		it('should certify the singleCommit2 even when heightNextBFTParameters is equal to minCerfifyHeight', async () => {
+			// Arrange
+			bftMethod.getNextHeightBFTParameters.mockResolvedValue(heightNextBFTParameters - 1);
 			(commitPool['_minCertifyHeight'] as any) = heightNextBFTParameters - 1;
 
 			// Act

--- a/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/commit_pool.spec.ts
@@ -924,8 +924,16 @@ describe('CommitPool', () => {
 			expect(isCommitVerified).toBeTrue();
 		});
 
-		it('should return true when heightNextBFTParameters is low, but minCertifyHeight is set', async () => {
+		it('should return false when aggregate commit height is lower than minCertifyHeight', async () => {
 			(commitPool['_minCertifyHeight'] as any) = height + 1;
+
+			const isCommitVerified = await commitPool.verifyAggregateCommit(stateStore, aggregateCommit);
+
+			expect(isCommitVerified).toBeFalse();
+		});
+
+		it('should return true when heightNextBFTParameters is low, but minCertifyHeight is set', async () => {
+			(commitPool['_minCertifyHeight'] as any) = height;
 			bftMethod.getBFTHeights.mockReturnValue({
 				maxHeightCertified: 0,
 				maxHeightPrecommitted,
@@ -1406,7 +1414,7 @@ describe('CommitPool', () => {
 		it('should certify the minCertifyHeight even when heightNextBFTParameters is lower', async () => {
 			// Arrange
 			bftMethod.getNextHeightBFTParameters.mockResolvedValue(309);
-			(commitPool['_minCertifyHeight'] as any) = heightNextBFTParameters;
+			(commitPool['_minCertifyHeight'] as any) = heightNextBFTParameters - 1;
 
 			// Act
 			await commitPool['_selectAggregateCommit'](stateStore);

--- a/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
+++ b/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`schema/application_config_schema.js application config schema must matc
       },
       "blockTime": 10,
       "maxTransactionsSize": 15360,
+      "minimumCertifyHeight": 0,
     },
     "legacy": {
       "brackets": [],
@@ -122,6 +123,11 @@ exports[`schema/application_config_schema.js application config schema must matc
           "description": "Maximum number of transactions allowed per block",
           "maximum": 30720,
           "minimum": 10240,
+          "type": "integer",
+        },
+        "minimumCertifyHeight": {
+          "description": "Minimum block height which can be certified",
+          "minimum": 0,
           "type": "integer",
         },
       },

--- a/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
+++ b/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`schema/application_config_schema.js application config schema must matc
       },
       "blockTime": 10,
       "maxTransactionsSize": 15360,
-      "minimumCertifyHeight": 0,
+      "minimumCertifyHeight": 1,
     },
     "legacy": {
       "brackets": [],

--- a/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
+++ b/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
@@ -127,7 +127,7 @@ exports[`schema/application_config_schema.js application config schema must matc
         },
         "minimumCertifyHeight": {
           "description": "Minimum block height which can be certified",
-          "minimum": 0,
+          "minimum": 1,
           "type": "integer",
         },
       },


### PR DESCRIPTION
### What was the problem?

This PR resolves #8381 

### How was it solved?

- Update config to include `minCertifyHeight`. This value should be minimal height key to be considered for the certification
- Update commit pool to take the height in the check

### How was it tested?

- Add unit test
- Link with core devnet and check if block will be certified after init rounds. (validator needs to be registered in the init round)
