### PR TITLE
Missing unit tests for TokenMethod

### DIFF
--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -1151,8 +1151,10 @@ describe('token module', () => {
 
 	describe('supportAllTokens', () => {
 		it('should call support all token', async () => {
+			const supportAllSpy = jest.spyOn(tokenModule.stores.get(SupportedTokensStore), 'supportAll');
 			await expect(method.supportAllTokens(methodContext)).resolves.toBeUndefined();
 
+			expect(supportAllSpy).toHaveBeenCalledOnce();
 			expect(methodContext.eventQueue.getEvents()).toHaveLength(1);
 			expect(methodContext.eventQueue.getEvents()[0].toObject().name).toEqual(
 				new AllTokensSupportedEvent('token').name,
@@ -1162,9 +1164,13 @@ describe('token module', () => {
 
 	describe('removeAllTokensSupport', () => {
 		it('should call remove support all token', async () => {
-			await tokenModule.stores.get(SupportedTokensStore).supportAll(methodContext);
+			const supportedTokensStore = tokenModule.stores.get(SupportedTokensStore);
+
+			await supportedTokensStore.supportAll(methodContext);
+			const removeAllSpy = jest.spyOn(supportedTokensStore, 'removeAll');
 			await expect(method.removeAllTokensSupport(methodContext)).resolves.toBeUndefined();
 
+			expect(removeAllSpy).toHaveBeenCalledOnce();
 			expect(methodContext.eventQueue.getEvents()).toHaveLength(1);
 			expect(methodContext.eventQueue.getEvents()[0].toObject().name).toEqual(
 				new AllTokensSupportRemovedEvent('token').name,
@@ -1174,10 +1180,15 @@ describe('token module', () => {
 
 	describe('supportAllTokensFromChainID', () => {
 		it('should call support chain', async () => {
+			const supportChainSpy = jest.spyOn(
+				tokenModule.stores.get(SupportedTokensStore),
+				'supportChain',
+			);
 			await expect(
 				method.supportAllTokensFromChainID(methodContext, Buffer.from([1, 2, 3, 4])),
 			).resolves.toBeUndefined();
 
+			expect(supportChainSpy).toHaveBeenCalledOnce();
 			expect(methodContext.eventQueue.getEvents()).toHaveLength(1);
 			expect(methodContext.eventQueue.getEvents()[0].toObject().name).toEqual(
 				new AllTokensFromChainSupportedEvent('token').name,
@@ -1187,6 +1198,8 @@ describe('token module', () => {
 
 	describe('removeAllTokensSupportFromChainID', () => {
 		it('should call remove support from chain', async () => {
+			const supportedTokenStore = tokenModule.stores.get(SupportedTokensStore);
+			const removeSupportForChainSpy = jest.spyOn(supportedTokenStore, 'removeSupportForChain');
 			await tokenModule.stores
 				.get(SupportedTokensStore)
 				.supportChain(methodContext, Buffer.from([1, 2, 3, 4]));
@@ -1194,6 +1207,7 @@ describe('token module', () => {
 				method.removeAllTokensSupportFromChainID(methodContext, Buffer.from([1, 2, 3, 4])),
 			).resolves.toBeUndefined();
 
+			expect(removeSupportForChainSpy).toHaveBeenCalledOnce();
 			expect(methodContext.eventQueue.getEvents()).toHaveLength(1);
 			expect(methodContext.eventQueue.getEvents()[0].toObject().name).toEqual(
 				new AllTokensFromChainSupportRemovedEvent('token').name,
@@ -1203,10 +1217,15 @@ describe('token module', () => {
 
 	describe('supportTokenID', () => {
 		it('should call support token', async () => {
+			const supportTokenSpy = jest.spyOn(
+				tokenModule.stores.get(SupportedTokensStore),
+				'supportToken',
+			);
 			await expect(
 				method.supportTokenID(methodContext, Buffer.from([1, 2, 3, 4, 0, 0, 0, 0])),
 			).resolves.toBeUndefined();
 
+			expect(supportTokenSpy).toHaveBeenCalledOnce();
 			expect(methodContext.eventQueue.getEvents()).toHaveLength(1);
 			expect(methodContext.eventQueue.getEvents()[0].toObject().name).toEqual(
 				new TokenIDSupportedEvent('token').name,
@@ -1216,13 +1235,14 @@ describe('token module', () => {
 
 	describe('removeSupportTokenID', () => {
 		it('should call remove support for token', async () => {
-			await tokenModule.stores
-				.get(SupportedTokensStore)
-				.supportToken(methodContext, Buffer.from([1, 2, 3, 4, 0, 0, 0, 0]));
+			const supportedTokensStore = tokenModule.stores.get(SupportedTokensStore);
+			await supportedTokensStore.supportToken(methodContext, Buffer.from([1, 2, 3, 4, 0, 0, 0, 0]));
+			const removeSupportForTokenSpy = jest.spyOn(supportedTokensStore, 'removeSupportForToken');
 			await expect(
 				method.removeSupportTokenID(methodContext, Buffer.from([1, 2, 3, 4, 0, 0, 0, 0])),
 			).resolves.toBeUndefined();
 
+			expect(removeSupportForTokenSpy).toHaveBeenCalledOnce();
 			expect(methodContext.eventQueue.getEvents()).toHaveLength(1);
 			expect(methodContext.eventQueue.getEvents()[0].toObject().name).toEqual(
 				new TokenIDSupportRemovedEvent('token').name,

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -1241,4 +1241,14 @@ describe('token module', () => {
 			).resolves.toBeTrue();
 		});
 	});
+
+	describe('isTokenIDAvailable', () => {
+		it('should return true if provided tokenID exists in SupplyStore', async () => {
+			await expect(method.isTokenSupported(methodContext, defaultTokenID)).resolves.toBeTrue();
+		});
+
+		it('should return false if provided tokenID does not exist in SupplyStore', async () => {
+			await expect(method.isTokenSupported(methodContext, Buffer.alloc(8, 1))).resolves.toBeFalse();
+		});
+	});
 });

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -239,11 +239,6 @@ describe('token module', () => {
 		it('should reject if token is not native', async () => {
 			try {
 				await method.initializeToken(methodContext, Buffer.from([2, 0, 0, 0, 0, 0, 0, 0]));
-				checkEventResult(
-					methodContext.eventQueue,
-					InitializeTokenEvent,
-					TokenEventResult.TOKEN_ID_NOT_NATIVE,
-				);
 			} catch (e: any) {
 				expect(e.message).toBe('Only native token can be initialized.');
 				checkEventResult(

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -291,7 +291,7 @@ describe('token module', () => {
 			);
 		});
 
-		it('should reject if supply exceed max balance', async () => {
+		it('should reject if supply exceeds maximum range allowed', async () => {
 			await expect(
 				method.mint(
 					methodContext,


### PR DESCRIPTION
### What was the problem?

This PR resolves #7839

### How was it solved?

- Added unit tests for `isTokenIDAvailable`.
- Rephrased test case for supply exceeding maximum range allowed for `burn` method.
- Added tests to verify event emission for `initializeTokenMethod`.
- Added introspective matchers for calls to `SupportedTokensStore`.

### How was it tested?

Executed; `npm t token/method.spec.ts` on lisk-sdk\framework.
