### PR TITLE
Name length check is missing from the validator registration command

### DIFF
--- a/framework/src/modules/pos/schemas.ts
+++ b/framework/src/modules/pos/schemas.ts
@@ -19,6 +19,7 @@ import {
 	BLS_PUBLIC_KEY_LENGTH,
 	BLS_POP_LENGTH,
 	ED25519_PUBLIC_KEY_LENGTH,
+	MAX_LENGTH_NAME,
 } from './constants';
 
 export const validatorRegistrationCommandParamsSchema = {
@@ -29,6 +30,8 @@ export const validatorRegistrationCommandParamsSchema = {
 		name: {
 			dataType: 'string',
 			fieldNumber: 1,
+			minLength: 1,
+			maxLength: MAX_LENGTH_NAME,
 		},
 		blsKey: {
 			dataType: 'bytes',

--- a/framework/test/unit/modules/pos/commands/validator_registration.spec.ts
+++ b/framework/test/unit/modules/pos/commands/validator_registration.spec.ts
@@ -169,6 +169,66 @@ describe('Validator registration command', () => {
 			expect(result.error?.message).toInclude("'name' is in an unsupported format");
 		});
 
+		it('should return error if name is longer than MAX_LENGTH_NAME characters long', async () => {
+			const invalidParams = codec.encode(validatorRegistrationCommandParamsSchema, {
+				...transactionParams,
+				name: 'esdfgvhbjnkljdseasexdcrfgvhbjkhbgvfcdxszasdfghjkhnbgvfcdsxsdfcgvhb',
+			});
+			const invalidTransaction = new Transaction({
+				module: 'pos',
+				command: 'registerValidator',
+				senderPublicKey: publicKey,
+				nonce: BigInt(0),
+				fee: BigInt(100000000),
+				params: invalidParams,
+				signatures: [publicKey],
+			});
+			const context = testing
+				.createTransactionContext({
+					transaction: invalidTransaction,
+					chainID,
+				})
+				.createCommandVerifyContext<ValidatorRegistrationParams>(
+					validatorRegistrationCommandParamsSchema,
+				);
+			const result = await validatorRegistrationCommand.verify(context);
+
+			expect(result.status).toBe(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude(
+				"Lisk validator found 1 error[s]:\nProperty '.name' must NOT have more than 20 characters",
+			);
+		});
+
+		it('should return error if name is less than 1 character long', async () => {
+			const invalidParams = codec.encode(validatorRegistrationCommandParamsSchema, {
+				...transactionParams,
+				name: '',
+			});
+			const invalidTransaction = new Transaction({
+				module: 'pos',
+				command: 'registerValidator',
+				senderPublicKey: publicKey,
+				nonce: BigInt(0),
+				fee: BigInt(100000000),
+				params: invalidParams,
+				signatures: [publicKey],
+			});
+			const context = testing
+				.createTransactionContext({
+					transaction: invalidTransaction,
+					chainID,
+				})
+				.createCommandVerifyContext<ValidatorRegistrationParams>(
+					validatorRegistrationCommandParamsSchema,
+				);
+			const result = await validatorRegistrationCommand.verify(context);
+
+			expect(result.status).toBe(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude(
+				"Lisk validator found 1 error[s]:\nProperty '.name' must NOT have fewer than 1 characters",
+			);
+		});
+
 		it('should return error if generatorKey is invalid', async () => {
 			const invalidParams = codec.encode(validatorRegistrationCommandParamsSchema, {
 				...transactionParams,


### PR DESCRIPTION
### What was the problem?

This PR resolves #8407 

### How was it solved?

Updated schema to include min and max limits for name length

### How was it tested?

Added unit tests
