### PR TITLE
SupportedTokensStore#supportToken to only support unsupported tokens

### DIFF
--- a/framework/src/modules/token/stores/supported_tokens.ts
+++ b/framework/src/modules/token/stores/supported_tokens.ts
@@ -154,10 +154,12 @@ export class SupportedTokensStore extends BaseStore<SupportedTokensStoreData> {
 				throw error;
 			}
 		}
-		supported.supportedTokenIDs.push(tokenID);
-		supported.supportedTokenIDs.sort((a, b) => a.compare(b));
-		await this.del(context, ALL_SUPPORTED_TOKENS_KEY);
-		await this.set(context, chainID, supported);
+		if (supported.supportedTokenIDs.findIndex(id => id.equals(tokenID)) === -1) {
+			supported.supportedTokenIDs.push(tokenID);
+			supported.supportedTokenIDs.sort((a, b) => a.compare(b));
+			await this.del(context, ALL_SUPPORTED_TOKENS_KEY);
+			await this.set(context, chainID, supported);
+		}
 	}
 
 	public async removeSupportForToken(context: StoreGetter, tokenID: Buffer): Promise<void> {

--- a/framework/test/unit/modules/token/stores/supported_tokens.spec.ts
+++ b/framework/test/unit/modules/token/stores/supported_tokens.spec.ts
@@ -233,6 +233,21 @@ describe('SupportedTokensStore', () => {
 			expect(supportedTokens.supportedTokenIDs).toHaveLength(2);
 			expect(supportedTokens.supportedTokenIDs[0]).toEqual(tokenID);
 		});
+
+		it('should not update store for the chain if provided token is already supported', async () => {
+			const tokenID = Buffer.from([2, 0, 0, 0, 1, 0, 0, 1]);
+			const supportedTokensState = {
+				supportedTokenIDs: [tokenID],
+			};
+
+			await store.set(context, Buffer.from([2, 0, 0, 0]), supportedTokensState);
+
+			await store.supportToken(context, tokenID);
+
+			const updatedSupportedTokens = await store.get(context, Buffer.from([2, 0, 0, 0]));
+
+			expect(updatedSupportedTokens).toEqual(supportedTokensState);
+		});
 	});
 
 	describe('removeSupportForToken', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8436 

### How was it solved?

Adds check to only support unsupported token for a chain.

### How was it tested?

Implemented unit test.
