### PR TITLE
Ban peers after failed block verification

### DIFF
--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -661,11 +661,11 @@ export class Consensus {
 		const stateStore = new StateStore(this._db);
 
 		this._verifyTimestamp(block);
-		this._verifyAssetsHeight(block);
+		this._verifyBlockHeight(block);
 		this._verifyPreviousBlockID(block);
 		await this._verifyGeneratorAddress(stateStore, block);
 		await this._verifyBFTProperties(stateStore, block);
-		await this._verifyAssetsSignature(stateStore, block);
+		await this._verifyBlockSignature(stateStore, block);
 		await this._verifyAggregateCommit(stateStore, block);
 	}
 
@@ -706,7 +706,7 @@ export class Consensus {
 		}
 	}
 
-	private _verifyAssetsHeight(block: Block): void {
+	private _verifyBlockHeight(block: Block): void {
 		const { lastBlock } = this._chain;
 
 		if (block.header.height !== lastBlock.header.height + 1) {
@@ -772,7 +772,7 @@ export class Consensus {
 		}
 	}
 
-	private async _verifyAssetsSignature(stateStore: StateStore, block: Block): Promise<void> {
+	private async _verifyBlockSignature(stateStore: StateStore, block: Block): Promise<void> {
 		const bftParams = await this._bft.method.getBFTParameters(stateStore, block.header.height);
 		const generator = bftParams.validators.find(validator =>
 			validator.address.equals(block.header.generatorAddress),

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -526,11 +526,11 @@ export class Consensus {
 					throw new ApplyPenaltyError(error);
 				}
 
+				const previousLastBlock = objects.cloneDeep(lastBlock);
 				await this._deleteBlock(lastBlock);
 				try {
 					await this._executeValidated(block);
 				} catch (err) {
-					const previousLastBlock = objects.cloneDeep(lastBlock);
 					this._logger.error(
 						{
 							id: block.header.id,

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -762,14 +762,14 @@ describe('consensus', () => {
 					const invalidBlock = { ...block };
 					(invalidBlock.header as any).height = consensus['_chain'].lastBlock.header.height;
 
-					expect(() => consensus['_verifyAssetsHeight'](invalidBlock as any)).toThrow(
+					expect(() => consensus['_verifyBlockHeight'](invalidBlock as any)).toThrow(
 						`Invalid height ${
 							invalidBlock.header.height
 						} of the block with id: ${invalidBlock.header.id.toString('hex')}`,
 					);
 				});
 				it('should be success when block has [height===lastBlock.height+1]', () => {
-					expect(consensus['_verifyAssetsHeight'](block as any)).toBeUndefined();
+					expect(consensus['_verifyBlockHeight'](block as any)).toBeUndefined();
 				});
 			});
 
@@ -887,7 +887,7 @@ describe('consensus', () => {
 						} as never);
 
 					await expect(
-						consensus['_verifyAssetsSignature'](stateStore, block as any),
+						consensus['_verifyBlockSignature'](stateStore, block as any),
 					).rejects.toThrow(
 						`Invalid signature ${block.header.signature.toString(
 							'hex',
@@ -917,7 +917,7 @@ describe('consensus', () => {
 						} as never);
 
 					await expect(
-						consensus['_verifyAssetsSignature'](stateStore, validBlock as any),
+						consensus['_verifyBlockSignature'](stateStore, validBlock as any),
 					).resolves.toBeUndefined();
 				});
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8433

### How was it solved?

- Private methods `_execute()` and `_executeValidated()` now throw `ApplyPenaltyError` when block verification fails
- Removed redundant code comments
- Bonus: renamed `_verifyAssetsHeight()` and `_verifyAssetsSignature()` into `_verifyBlockHeight()` and `_verifyBlockSignature()` 😎 

### How was it tested?

Added 2 new unit tests which validate that `Consensus._execute()` and `Consensus._executeValidated()` throw `ApplyPenaltyError`

