### PR TITLE
Add missing Auth module unit tests

### DIFF
--- a/framework/test/unit/modules/auth/register_multisignature.spec.ts
+++ b/framework/test/unit/modules/auth/register_multisignature.spec.ts
@@ -112,7 +112,7 @@ describe('Register Multisignature command', () => {
 			expect(result.status).toBe(VerifyStatus.OK);
 		});
 
-		it('should return status OK when the total number of keys between mandatory and optional is 64', async () => {
+		it('should return status OK when the total number of mandatory and optional keys is 64', async () => {
 			const mandatoryKeys = [...Array(20).keys()].map(() => utils.getRandomBytes(32));
 			const optionalKeys = [...Array(44).keys()].map(() => utils.getRandomBytes(32));
 

--- a/framework/test/unit/modules/auth/utils.spec.ts
+++ b/framework/test/unit/modules/auth/utils.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+
+import { utils, ed } from '@liskhq/lisk-cryptography';
+import { Transaction, TAG_TRANSACTION } from '@liskhq/lisk-chain';
+import { verifySignature } from '../../../../src/modules/auth/utils';
+
+describe('utils', () => {
+	describe('verifySignature', () => {
+		const chainID = Buffer.from('04000000', 'hex');
+
+		it('should verify a valid transaction signature', async () => {
+			const privateKey = await ed.getPrivateKeyFromPhraseAndPath('hello lisk', "m/44'/134'/0'");
+			const publicKey = ed.getPublicKeyFromPrivateKey(privateKey);
+
+			const transaction = new Transaction({
+				module: 'token',
+				command: 'transfer',
+				nonce: BigInt('0'),
+				fee: BigInt('100000000'),
+				senderPublicKey: publicKey,
+				params: utils.getRandomBytes(100),
+				signatures: [],
+			});
+
+			const transactionSigningBytes = transaction.getSigningBytes();
+			const signature = ed.signDataWithPrivateKey(
+				TAG_TRANSACTION,
+				chainID,
+				transactionSigningBytes,
+				privateKey,
+			);
+
+			transaction.signatures.push(signature);
+
+			expect(() =>
+				verifySignature(chainID, publicKey, signature, transactionSigningBytes, transaction.id),
+			).not.toThrow();
+		});
+	});
+});


### PR DESCRIPTION
### What was the problem?

This PR resolves #7826

### How was it solved?

Added all unit tests from the related issue, except for:

> Account registered with 4 optional keys. Number of signatures required 2. Transaction successful when optional signatures ordered and present. Test with different positions of keys.

Instead of creating a new 2-of-4 with 0 mandatory signer test case, I updated the existing 1-of-2 with 0 mandatory signer test case, to check for different positions of keys.

Bonus: added a test suite for `auth/utils` file with a test case for `verifySignature()` 😎

### How was it tested?

All tests pass 👌🏻 
