### PR TITLE
TransferCrossChainCommand amount calculation

### DIFF
--- a/framework/src/modules/token/commands/transfer_cross_chain.ts
+++ b/framework/src/modules/token/commands/transfer_cross_chain.ts
@@ -99,7 +99,7 @@ export class TransferCrossChainCommand extends BaseCommand {
 
 			balanceCheck.set(
 				messageFeeTokenID,
-				(balanceCheck.get(messageFeeTokenID) ?? BigInt(0)) + params.amount,
+				(balanceCheck.get(messageFeeTokenID) ?? BigInt(0)) + params.messageFee,
 			);
 
 			for (const [tokenID, amount] of balanceCheck.entries()) {

--- a/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
@@ -338,21 +338,21 @@ describe('CCTransfer command', () => {
 		it('should fail when sender balance is insufficient for messageFeeTokenID', async () => {
 			const userStore = module.stores.get(UserStore);
 			const amount = BigInt(50);
-			const senderBalance = BigInt(49);
+			const messageFee = BigInt(5);
+			const messageTokenBalance = BigInt(4);
 
 			const tokenID = Buffer.concat([defaultOwnChainID, Buffer.from([0, 0, 0, 0])]);
 			const messageFeeTokenID = Buffer.from([0, 0, 0, 0, 0, 0, 0, 1]);
-
 			const insufficientBalanceContext = createTransactionContextWithOverridingParams({
 				amount,
 				tokenID,
 				messageFeeTokenID,
+				messageFee,
 			});
 
 			jest
 				.spyOn(interoperabilityMethod, 'getMessageFeeTokenID')
 				.mockResolvedValue(messageFeeTokenID);
-
 			await userStore.save(
 				insufficientBalanceContext.createCommandExecuteContext<Params>(
 					crossChainTransferParamsSchema,
@@ -364,13 +364,95 @@ describe('CCTransfer command', () => {
 					lockedBalances: [],
 				},
 			);
-
 			await userStore.save(
 				insufficientBalanceContext.createCommandExecuteContext<Params>(
 					crossChainTransferParamsSchema,
 				),
 				insufficientBalanceContext.transaction.senderAddress,
 				messageFeeTokenID,
+				{
+					availableBalance: messageTokenBalance,
+					lockedBalances: [],
+				},
+			);
+
+			expectSchemaValidationError(
+				await command.verify(
+					insufficientBalanceContext.createCommandVerifyContext(crossChainTransferParamsSchema),
+				),
+				createInsufficientBalanceError(
+					insufficientBalanceContext.transaction.senderAddress,
+					messageTokenBalance,
+					messageFeeTokenID,
+					messageFee,
+				),
+			);
+		});
+
+		it('should fail when sender balance is insufficient for amount when params.tokenID and messageFeeTokenID are same', async () => {
+			const userStore = module.stores.get(UserStore);
+			const amount = BigInt(10);
+			const senderBalance = BigInt(9);
+			const messageFee = BigInt(0);
+
+			const tokenID = Buffer.concat([defaultOwnChainID, Buffer.from([0, 0, 0, 0])]);
+
+			const insufficientBalanceContext = createTransactionContextWithOverridingParams({
+				amount,
+				tokenID,
+				messageFeeTokenID: tokenID,
+				messageFee,
+			});
+
+			jest.spyOn(interoperabilityMethod, 'getMessageFeeTokenID').mockResolvedValue(tokenID);
+
+			await userStore.save(
+				insufficientBalanceContext.createCommandExecuteContext<Params>(
+					crossChainTransferParamsSchema,
+				),
+				insufficientBalanceContext.transaction.senderAddress,
+				tokenID,
+				{
+					availableBalance: senderBalance,
+					lockedBalances: [],
+				},
+			);
+			expectSchemaValidationError(
+				await command.verify(
+					insufficientBalanceContext.createCommandVerifyContext(crossChainTransferParamsSchema),
+				),
+				createInsufficientBalanceError(
+					insufficientBalanceContext.transaction.senderAddress,
+					senderBalance,
+					tokenID,
+					amount + messageFee,
+				),
+			);
+		});
+
+		it('should fail when sender balance is insufficient for messageFee when params.tokenID and messageFeeTokenID are same', async () => {
+			const userStore = module.stores.get(UserStore);
+			const amount = BigInt(10);
+			const senderBalance = BigInt(5);
+			const messageFee = BigInt(2);
+
+			const tokenID = Buffer.concat([defaultOwnChainID, Buffer.from([0, 0, 0, 0])]);
+
+			const insufficientBalanceContext = createTransactionContextWithOverridingParams({
+				amount,
+				tokenID,
+				messageFeeTokenID: tokenID,
+				messageFee,
+			});
+
+			jest.spyOn(interoperabilityMethod, 'getMessageFeeTokenID').mockResolvedValue(tokenID);
+
+			await userStore.save(
+				insufficientBalanceContext.createCommandExecuteContext<Params>(
+					crossChainTransferParamsSchema,
+				),
+				insufficientBalanceContext.transaction.senderAddress,
+				tokenID,
 				{
 					availableBalance: senderBalance,
 					lockedBalances: [],
@@ -384,8 +466,8 @@ describe('CCTransfer command', () => {
 				createInsufficientBalanceError(
 					insufficientBalanceContext.transaction.senderAddress,
 					senderBalance,
-					messageFeeTokenID,
-					amount,
+					tokenID,
+					amount + messageFee,
 				),
 			);
 		});
@@ -394,7 +476,6 @@ describe('CCTransfer command', () => {
 			const transactionContext = createTransactionContextWithOverridingParams({
 				receivingChainID: defaultOwnChainID,
 			});
-
 			expectSchemaValidationError(
 				await command.verify(
 					transactionContext.createCommandVerifyContext(crossChainTransferParamsSchema),

--- a/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
+++ b/framework/test/unit/modules/token/commands/transfer_cross_chain.spec.ts
@@ -389,51 +389,10 @@ describe('CCTransfer command', () => {
 			);
 		});
 
-		it('should fail when sender balance is insufficient for amount when params.tokenID and messageFeeTokenID are same', async () => {
+		it('should fail when sender balance is insufficient for (amount + messageFee) when params.tokenID and messageFeeTokenID are same', async () => {
 			const userStore = module.stores.get(UserStore);
-			const amount = BigInt(10);
 			const senderBalance = BigInt(9);
-			const messageFee = BigInt(0);
-
-			const tokenID = Buffer.concat([defaultOwnChainID, Buffer.from([0, 0, 0, 0])]);
-
-			const insufficientBalanceContext = createTransactionContextWithOverridingParams({
-				amount,
-				tokenID,
-				messageFeeTokenID: tokenID,
-				messageFee,
-			});
-
-			jest.spyOn(interoperabilityMethod, 'getMessageFeeTokenID').mockResolvedValue(tokenID);
-
-			await userStore.save(
-				insufficientBalanceContext.createCommandExecuteContext<Params>(
-					crossChainTransferParamsSchema,
-				),
-				insufficientBalanceContext.transaction.senderAddress,
-				tokenID,
-				{
-					availableBalance: senderBalance,
-					lockedBalances: [],
-				},
-			);
-			expectSchemaValidationError(
-				await command.verify(
-					insufficientBalanceContext.createCommandVerifyContext(crossChainTransferParamsSchema),
-				),
-				createInsufficientBalanceError(
-					insufficientBalanceContext.transaction.senderAddress,
-					senderBalance,
-					tokenID,
-					amount + messageFee,
-				),
-			);
-		});
-
-		it('should fail when sender balance is insufficient for messageFee when params.tokenID and messageFeeTokenID are same', async () => {
-			const userStore = module.stores.get(UserStore);
-			const amount = BigInt(10);
-			const senderBalance = BigInt(5);
+			const amount = BigInt(8);
 			const messageFee = BigInt(2);
 
 			const tokenID = Buffer.concat([defaultOwnChainID, Buffer.from([0, 0, 0, 0])]);
@@ -458,7 +417,6 @@ describe('CCTransfer command', () => {
 					lockedBalances: [],
 				},
 			);
-
 			expectSchemaValidationError(
 				await command.verify(
 					insufficientBalanceContext.createCommandVerifyContext(crossChainTransferParamsSchema),


### PR DESCRIPTION
### What was the problem?

This PR resolves #8457 

### How was it solved?

Updates `TransferCrossChainCommand.verify` to use message fee to compute total amount.

### How was it tested?

Implemented unit tests.
