### PR TITLE
Don't generate while syncing

### DIFF
--- a/framework/src/engine/generator/generator.ts
+++ b/framework/src/engine/generator/generator.ts
@@ -443,6 +443,10 @@ export class Generator {
 	}
 
 	private async _generateLoop(): Promise<void> {
+		if (this._consensus.syncing()) {
+			return;
+		}
+
 		const stateStore = new StateStore(this._blockchainDB);
 
 		const MS_IN_A_SEC = 1000;

--- a/framework/src/engine/generator/types.ts
+++ b/framework/src/engine/generator/types.ts
@@ -39,6 +39,7 @@ export interface GeneratorStore {
 
 export interface Consensus {
 	execute: (block: Block) => Promise<void>;
+	syncing(): boolean;
 	isSynced: (height: number, maxHeightPrevoted: number) => boolean;
 	finalizedHeight: () => number;
 	getAggregateCommit: (stateStore: StateStore) => Promise<AggregateCommit>;

--- a/framework/test/unit/engine/generator/generator.spec.ts
+++ b/framework/test/unit/engine/generator/generator.spec.ts
@@ -88,6 +88,7 @@ describe('generator', () => {
 		consensusEvent = new EventEmitter();
 		consensus = {
 			execute: jest.fn(),
+			syncing: jest.fn().mockReturnValue(false),
 			getAggregateCommit: jest.fn(),
 			certifySingleCommit: jest.fn(),
 			getConsensusParams: jest.fn().mockResolvedValue({
@@ -379,6 +380,22 @@ describe('generator', () => {
 				logger,
 				genesisHeight: 0,
 			});
+		});
+
+		it('should verify if node is syncing', async () => {
+			await generator['_generateLoop']();
+
+			expect(consensus.syncing).toHaveBeenCalledOnce();
+		});
+
+		it('should not generate if node is syncing', async () => {
+			consensus.syncing = jest.fn().mockReturnValue(true);
+
+			await generator['_generateLoop']();
+
+			expect(consensus.syncing).toHaveBeenCalledOnce();
+
+			expect(bft.method.getGeneratorAtTimestamp).not.toHaveBeenCalled();
 		});
 
 		it('should not generate if current block slot is same as last block slot', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8460 

### How was it solved?

Added `this._consensus.syncing()` check to terminate execution in `Generator._generateLoop`.

### How was it tested?

Implemented unit tests.
