### PR TITLE
Add missing unit tests for PoS module Stake command

### DIFF
--- a/framework/test/unit/modules/pos/commands/stake.spec.ts
+++ b/framework/test/unit/modules/pos/commands/stake.spec.ts
@@ -15,7 +15,7 @@
 import { Transaction } from '@liskhq/lisk-chain';
 import { codec } from '@liskhq/lisk-codec';
 import { address, utils } from '@liskhq/lisk-cryptography';
-import { validator } from '@liskhq/lisk-validator';
+import { validator as schemaValidator } from '@liskhq/lisk-validator';
 import { StakeCommand, VerifyStatus, PoSModule } from '../../../../../src';
 import {
 	MAX_NUMBER_PENDING_UNLOCKS,
@@ -83,18 +83,18 @@ describe('StakeCommand', () => {
 	const validator1StakeAmount = liskToBeddows(90);
 	const validator2StakeAmount = liskToBeddows(50);
 
-	let validatorInfo1: ValidatorAccount;
-	let validatorInfo2: ValidatorAccount;
-	let validatorInfo3: ValidatorAccount;
+	let defaultValidator: ValidatorAccount;
+	let validator1: ValidatorAccount;
+	let validator2: ValidatorAccount;
+	let validator3: ValidatorAccount;
 	let stakerStore: StakerStore;
 	let validatorStore: ValidatorStore;
 	let context: any;
 	let transaction: any;
 	let command: StakeCommand;
-	let transactionParams: Buffer;
 	let transactionParamsDecoded: any;
 	let stateStore: PrefixedStateReadWriter;
-	let lockFn: any;
+	let tokenLockMock: jest.Mock;
 	let tokenMethod: any;
 	let internalMethod: InternalMethod;
 	let mockAssignStakeRewards: jest.SpyInstance<
@@ -108,9 +108,9 @@ describe('StakeCommand', () => {
 	>;
 
 	beforeEach(async () => {
-		lockFn = jest.fn();
+		tokenLockMock = jest.fn();
 		tokenMethod = {
-			lock: lockFn,
+			lock: tokenLockMock,
 			unlock: jest.fn(),
 			getAvailableBalance: jest.fn(),
 			burn: jest.fn(),
@@ -136,56 +136,50 @@ describe('StakeCommand', () => {
 
 		stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 
-		validatorInfo1 = {
+		defaultValidator = {
 			consecutiveMissedBlocks: 0,
 			isBanned: false,
 			lastGeneratedHeight: 5,
+			name: 'defaultValidator',
+			reportMisbehaviorHeights: [],
+			selfStake: BigInt(0),
+			totalStake: BigInt(0),
+			commission: 0,
+			lastCommissionIncreaseHeight: 0,
+			sharingCoefficients: [{ tokenID: Buffer.alloc(8), coefficient: Buffer.alloc(24) }],
+		};
+
+		validator1 = {
+			...defaultValidator,
 			name: 'someValidator1',
-			reportMisbehaviorHeights: [],
-			selfStake: BigInt(0),
-			totalStake: BigInt(0),
-			commission: 0,
-			lastCommissionIncreaseHeight: 0,
-			sharingCoefficients: [{ tokenID: Buffer.alloc(8), coefficient: Buffer.alloc(24) }],
 		};
 
-		validatorInfo2 = {
-			consecutiveMissedBlocks: 0,
-			isBanned: false,
-			lastGeneratedHeight: 5,
+		validator2 = {
+			...defaultValidator,
 			name: 'someValidator2',
-			reportMisbehaviorHeights: [],
-			selfStake: BigInt(0),
-			totalStake: BigInt(0),
-			commission: 0,
-			lastCommissionIncreaseHeight: 0,
-			sharingCoefficients: [{ tokenID: Buffer.alloc(8), coefficient: Buffer.alloc(24) }],
 		};
 
-		validatorInfo3 = {
-			consecutiveMissedBlocks: 0,
-			isBanned: false,
-			lastGeneratedHeight: 5,
+		validator3 = {
+			...defaultValidator,
 			name: 'someValidator3',
-			reportMisbehaviorHeights: [],
-			selfStake: BigInt(0),
-			totalStake: BigInt(0),
-			commission: 0,
-			lastCommissionIncreaseHeight: 0,
-			sharingCoefficients: [{ tokenID: Buffer.alloc(8), coefficient: Buffer.alloc(24) }],
 		};
-
-		validatorStore = pos.stores.get(ValidatorStore);
-
-		await validatorStore.set(createStoreGetter(stateStore), validatorAddress1, validatorInfo1);
-		await validatorStore.set(createStoreGetter(stateStore), validatorAddress2, validatorInfo2);
 
 		stakerStore = pos.stores.get(StakerStore);
 		validatorStore = pos.stores.get(ValidatorStore);
 
-		await validatorStore.set(createStoreGetter(stateStore), validatorAddress1, validatorInfo1);
-		await validatorStore.set(createStoreGetter(stateStore), validatorAddress2, validatorInfo2);
-		await validatorStore.set(createStoreGetter(stateStore), validatorAddress3, validatorInfo3);
+		await validatorStore.set(createStoreGetter(stateStore), validatorAddress1, validator1);
+		await validatorStore.set(createStoreGetter(stateStore), validatorAddress2, validator2);
+		await validatorStore.set(createStoreGetter(stateStore), validatorAddress3, validator3);
+
+		transaction = new Transaction({
+			module: 'pos',
+			command: 'stake',
+			fee: BigInt(1500000),
+			nonce: BigInt(0),
+			params: Buffer.alloc(0),
+			senderPublicKey,
+			signatures: [],
+		});
 	});
 
 	describe('constructor', () => {
@@ -199,29 +193,13 @@ describe('StakeCommand', () => {
 	});
 
 	describe('verify', () => {
-		beforeEach(() => {
-			transaction = new Transaction({
-				module: 'pos',
-				command: 'stake',
-				fee: BigInt(1500000),
-				nonce: BigInt(0),
-				params: Buffer.alloc(0),
-				senderPublicKey: utils.getRandomBytes(32),
-				signatures: [],
-			});
-		});
-
 		describe('schema validation', () => {
 			describe('when transaction.params.stakes does not include any stake', () => {
 				beforeEach(() => {
 					transactionParamsDecoded = {
 						stakes: [],
 					};
-
-					transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-					transaction.params = transactionParams;
-
+					transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 					context = createTransactionContext({
 						transaction,
 						stateStore,
@@ -246,11 +224,7 @@ describe('StakeCommand', () => {
 								amount: liskToBeddows(0),
 							})),
 					};
-
-					transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-					transaction.params = transactionParams;
-
+					transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 					context = createTransactionContext({
 						transaction,
 						stateStore,
@@ -266,7 +240,7 @@ describe('StakeCommand', () => {
 			});
 
 			describe('when transaction.params.stakes includes amount which is less than int64 range', () => {
-				beforeEach(() => {
+				it('should return errors', () => {
 					transactionParamsDecoded = {
 						stakes: [
 							{
@@ -275,17 +249,15 @@ describe('StakeCommand', () => {
 							},
 						],
 					};
-				});
 
-				it('should return errors', () => {
-					expect(() => validator.validate(command.schema, transactionParamsDecoded)).toThrow(
+					expect(() => schemaValidator.validate(command.schema, transactionParamsDecoded)).toThrow(
 						'should pass "dataType" keyword validation',
 					);
 				});
 			});
 
 			describe('when transaction.params.stakes includes amount which is greater than int64 range', () => {
-				beforeEach(() => {
+				it('should return errors', () => {
 					transactionParamsDecoded = {
 						stakes: [
 							{
@@ -294,10 +266,8 @@ describe('StakeCommand', () => {
 							},
 						],
 					};
-				});
 
-				it('should return errors', () => {
-					expect(() => validator.validate(command.schema, transactionParamsDecoded)).toThrow(
+					expect(() => schemaValidator.validate(command.schema, transactionParamsDecoded)).toThrow(
 						'should pass "dataType" keyword validation',
 					);
 				});
@@ -306,81 +276,57 @@ describe('StakeCommand', () => {
 
 		describe('when transaction.params.stakes contains valid contents', () => {
 			it('should not throw errors with valid upstake case', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: utils.getRandomBytes(20), amount: liskToBeddows(20) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty('status', VerifyStatus.OK);
 			});
 
 			it('should not throw errors with valid downstake cast', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: utils.getRandomBytes(20), amount: liskToBeddows(-20) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty('status', VerifyStatus.OK);
 			});
 
 			it('should not throw errors with valid mixed stakes case', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: [
 						{ validatorAddress: utils.getRandomBytes(20), amount: liskToBeddows(20) },
 						{ validatorAddress: utils.getRandomBytes(20), amount: liskToBeddows(-20) },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty('status', VerifyStatus.OK);
 			});
 		});
 
 		describe('when transaction.params.stakes contains more than 10 positive stakes', () => {
 			it('should throw error', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: Array(11)
 						.fill(0)
 						.map(() => ({ validatorAddress: utils.getRandomBytes(20), amount: liskToBeddows(10) })),
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty(
 					'error.message',
 					'Upstake can only be casted up to 10.',
@@ -390,7 +336,6 @@ describe('StakeCommand', () => {
 
 		describe('when transaction.params.stakes contains more than 10 negative stakes', () => {
 			it('should throw error', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: Array(11)
 						.fill(0)
@@ -399,16 +344,11 @@ describe('StakeCommand', () => {
 							amount: liskToBeddows(-10),
 						})),
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty(
 					'error.message',
 					'Downstake can only be casted up to 10.',
@@ -418,23 +358,15 @@ describe('StakeCommand', () => {
 
 		describe('when transaction.params.stakes includes duplicate validators within positive amount', () => {
 			it('should throw error', async () => {
-				// Arrange
 				const validatorAddress = utils.getRandomBytes(20);
 				transactionParamsDecoded = {
-					stakes: Array(2)
-						.fill(0)
-						.map(() => ({ validatorAddress, amount: liskToBeddows(10) })),
+					stakes: Array(2).fill({ validatorAddress, amount: liskToBeddows(10) }),
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty(
 					'error.message',
 					'Validator address must be unique.',
@@ -444,7 +376,6 @@ describe('StakeCommand', () => {
 
 		describe('when transaction.params.stakes includes duplicate validators within positive and negative amount', () => {
 			it('should throw error', async () => {
-				// Arrange
 				const validatorAddress = utils.getRandomBytes(20);
 				transactionParamsDecoded = {
 					stakes: [
@@ -452,16 +383,11 @@ describe('StakeCommand', () => {
 						{ validatorAddress, amount: liskToBeddows(-10) },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty(
 					'error.message',
 					'Validator address must be unique.',
@@ -471,21 +397,15 @@ describe('StakeCommand', () => {
 
 		describe('when transaction.params.stakes includes zero amount', () => {
 			it('should throw error', async () => {
-				// Arrange
 				const validatorAddress = utils.getRandomBytes(20);
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress, amount: liskToBeddows(0) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty(
 					'error.message',
 					'Amount cannot be 0.',
@@ -495,21 +415,15 @@ describe('StakeCommand', () => {
 
 		describe('when transaction.params.stakes includes positive amount which is not multiple of 10 * 10^8', () => {
 			it('should throw an error', async () => {
-				// Arrange
 				const validatorAddress = utils.getRandomBytes(20);
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress, amount: BigInt(20) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty(
 					'error.message',
 					'Amount should be multiple of 10 * 10^8.',
@@ -519,21 +433,15 @@ describe('StakeCommand', () => {
 
 		describe('when transaction.params.stakes includes negative amount which is not multiple of 10 * 10^8', () => {
 			it('should throw error', async () => {
-				// Arrange
 				const validatorAddress = utils.getRandomBytes(20);
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress, amount: BigInt(-20) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 				}).createCommandVerifyContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.verify(context)).resolves.toHaveProperty(
 					'error.message',
 					'Amount should be multiple of 10 * 10^8.',
@@ -543,34 +451,17 @@ describe('StakeCommand', () => {
 	});
 
 	describe('execute', () => {
-		beforeEach(() => {
-			transaction = new Transaction({
-				module: 'pos',
-				command: 'stake',
-				fee: BigInt(1500000),
-				nonce: BigInt(0),
-				params: transactionParams,
-				senderPublicKey,
-				signatures: [],
-			});
-		});
 		describe('when transaction.params.stakes contain positive amount', () => {
 			it('should emit ValidatorStakedEvent with STAKE_SUCCESSFUL result', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: validatorAddress1, amount: liskToBeddows(10) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.execute(context)).resolves.toBeUndefined();
 
 				checkEventResult(
@@ -588,39 +479,28 @@ describe('StakeCommand', () => {
 			});
 
 			it('should throw error if stake amount is more than balance', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: utils.getRandomBytes(20), amount: liskToBeddows(100) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				lockFn.mockRejectedValue(new Error('Not enough balance to lock'));
+				tokenLockMock.mockRejectedValue(new Error('Not enough balance to lock'));
 
-				// Assert
 				await expect(command.execute(context)).rejects.toThrow();
 			});
 
 			it('should make account to have correct balance', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: [
 						{ validatorAddress: validatorAddress1, amount: validator1StakeAmount },
 						{ validatorAddress: validatorAddress2, amount: validator2StakeAmount },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -628,16 +508,15 @@ describe('StakeCommand', () => {
 
 				await command.execute(context);
 
-				// Assert
-				expect(lockFn).toHaveBeenCalledTimes(2);
-				expect(lockFn).toHaveBeenCalledWith(
+				expect(tokenLockMock).toHaveBeenCalledTimes(2);
+				expect(tokenLockMock).toHaveBeenCalledWith(
 					expect.anything(),
 					senderAddress,
 					MODULE_NAME_POS,
 					posTokenID,
 					validator1StakeAmount,
 				);
-				expect(lockFn).toHaveBeenCalledWith(
+				expect(tokenLockMock).toHaveBeenCalledWith(
 					expect.anything(),
 					senderAddress,
 					MODULE_NAME_POS,
@@ -647,20 +526,10 @@ describe('StakeCommand', () => {
 			});
 
 			it('should not change pendingUnlocks', async () => {
-				// Arrange
-				stakerStore = pos.stores.get(StakerStore);
-				validatorStore = pos.stores.get(ValidatorStore);
-
-				await validatorStore.set(createStoreGetter(stateStore), validatorAddress1, validatorInfo1);
-
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: validatorAddress1, amount: validator1StakeAmount }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -673,29 +542,17 @@ describe('StakeCommand', () => {
 					senderAddress,
 				);
 
-				// Assert
 				expect(pendingUnlocks).toHaveLength(0);
 			});
 
-			it('should order stakerData.sentStakes', async () => {
-				// Arrange
-				stakerStore = pos.stores.get(StakerStore);
-				validatorStore = pos.stores.get(ValidatorStore);
-
-				await validatorStore.set(createStoreGetter(stateStore), validatorAddress1, validatorInfo1);
-				await validatorStore.set(createStoreGetter(stateStore), validatorAddress2, validatorInfo2);
-
+			it('should order stakerData.stakes', async () => {
 				transactionParamsDecoded = {
 					stakes: [
 						{ validatorAddress: validatorAddress2, amount: validator2StakeAmount },
 						{ validatorAddress: validatorAddress1, amount: validator1StakeAmount },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -705,31 +562,20 @@ describe('StakeCommand', () => {
 
 				const { stakes } = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
 
-				const sentStakesCopy = stakes.slice(0);
-				sentStakesCopy.sort((a: any, b: any) => a.validatorAddress.compare(b.validatorAddress));
+				const stakesCopy = stakes.slice(0);
+				stakesCopy.sort((a: any, b: any) => a.validatorAddress.compare(b.validatorAddress));
 
-				// Assert
-				expect(stakes).toStrictEqual(sentStakesCopy);
+				expect(stakes).toStrictEqual(stakesCopy);
 			});
 
-			it('should make upstaked validator account to have correct totalStakeReceived', async () => {
-				// Arrange
-				validatorStore = pos.stores.get(ValidatorStore);
-
-				await validatorStore.set(createStoreGetter(stateStore), validatorAddress1, validatorInfo1);
-				await validatorStore.set(createStoreGetter(stateStore), validatorAddress2, validatorInfo2);
-
+			it('should correctly update validator totalStake when a staker is upstaking for the first time', async () => {
 				transactionParamsDecoded = {
 					stakes: [
 						{ validatorAddress: validatorAddress1, amount: validator1StakeAmount },
 						{ validatorAddress: validatorAddress2, amount: validator2StakeAmount },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -737,40 +583,29 @@ describe('StakeCommand', () => {
 
 				await command.execute(context);
 
-				const { totalStake: totalStakeReceived1 } = await validatorStore.get(
+				const { totalStake: totalStake1 } = await validatorStore.get(
 					createStoreGetter(stateStore),
 					validatorAddress1,
 				);
-				const { totalStake: totalStakeReceived2 } = await validatorStore.get(
+				const { totalStake: totalStake2 } = await validatorStore.get(
 					createStoreGetter(stateStore),
 					validatorAddress2,
 				);
 
-				// Assert
-				expect(totalStakeReceived1).toBe(validator1StakeAmount);
-				expect(totalStakeReceived2).toBe(validator2StakeAmount);
+				expect(totalStake1).toBe(validator1StakeAmount);
+				expect(totalStake2).toBe(validator2StakeAmount);
 			});
 
-			it('should update stake object when it exists before and create if it does not exist', async () => {
-				// Arrange
-				stakerStore = pos.stores.get(StakerStore);
-				validatorStore = pos.stores.get(ValidatorStore);
-
-				await validatorStore.set(createStoreGetter(stateStore), validatorAddress1, validatorInfo1);
+			it('should create a new entry in staker store, when a new staker upstakes', async () => {
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: validatorAddress1, amount: validator1StakeAmount }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(
 					stakerStore.get(createStoreGetter(stateStore), senderAddress),
 				).rejects.toThrow();
@@ -785,7 +620,7 @@ describe('StakeCommand', () => {
 			});
 		});
 
-		describe('when transaction.params.stakes contain negative amount which makes stakerStore.sentStakes to be 0 entries', () => {
+		describe('when transaction.params.stakes contain negative amount which decreases StakerData.stakes[x].amount to 0', () => {
 			beforeEach(async () => {
 				transactionParamsDecoded = {
 					stakes: [
@@ -793,11 +628,7 @@ describe('StakeCommand', () => {
 						{ validatorAddress: validatorAddress2, amount: validator2StakeAmount },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -814,11 +645,7 @@ describe('StakeCommand', () => {
 						{ validatorAddress: validatorAddress2, amount: validator2StakeAmount * BigInt(-1) },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -827,7 +654,7 @@ describe('StakeCommand', () => {
 					} as any,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				lockFn.mockClear();
+				tokenLockMock.mockClear();
 			});
 
 			it('should emit ValidatorStakedEvent with STAKE_SUCCESSFUL result', async () => {
@@ -850,25 +677,18 @@ describe('StakeCommand', () => {
 			});
 
 			it('should not change account balance', async () => {
-				// Act
 				await command.execute(context);
 
-				// Assert
-				expect(lockFn).toHaveBeenCalledTimes(0);
+				expect(tokenLockMock).toHaveBeenCalledTimes(0);
 			});
 
 			it('should remove stake which has zero amount', async () => {
-				// Arrange
 				transactionParamsDecoded = {
 					stakes: [
 						{ validatorAddress: validatorAddress1, amount: validator1StakeAmount * BigInt(-1) },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -878,23 +698,17 @@ describe('StakeCommand', () => {
 
 				const stakerData = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
 
-				// Assert
 				expect(stakerData.stakes).toHaveLength(1);
 				expect(stakerData.stakes[0].validatorAddress).not.toEqual(validatorAddress1);
 			});
 
 			it('should update stake which has non-zero amount', async () => {
-				// Arrange
 				const downStakeAmount = liskToBeddows(10);
 
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: validatorAddress1, amount: downStakeAmount * BigInt(-1) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -904,9 +718,8 @@ describe('StakeCommand', () => {
 
 				const stakerData = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
 
-				// Assert
 				expect(
-					stakerData.stakes.find((v: any) => v.validatorAddress.equals(validatorAddress1)),
+					stakerData.stakes.find(validator => validator.validatorAddress.equals(validatorAddress1)),
 				).toEqual({
 					validatorAddress: validatorAddress1,
 					amount: validator1StakeAmount - downStakeAmount,
@@ -915,12 +728,10 @@ describe('StakeCommand', () => {
 			});
 
 			it('should make account to have correct unlocking', async () => {
-				// Arrange
 				await command.execute(context);
 
 				const stakerData = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
 
-				// Assert
 				expect(stakerData.pendingUnlocks).toHaveLength(2);
 				expect(stakerData.pendingUnlocks).toEqual(
 					[
@@ -939,20 +750,17 @@ describe('StakeCommand', () => {
 			});
 
 			it('should order stakerData.pendingUnlocks', async () => {
-				// Arrange
 				await command.execute(context);
 
 				const stakerData = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
 
-				// Assert
 				expect(stakerData.pendingUnlocks).toHaveLength(2);
 				expect(stakerData.pendingUnlocks.map((d: any) => d.validatorAddress)).toEqual(
 					[validatorAddress1, validatorAddress2].sort((a, b) => a.compare(b)),
 				);
 			});
 
-			it('should make downstaked validator account to have correct totalStakeReceived', async () => {
-				// Arrange
+			it('should make downstaked validator account to have correct totalStake', async () => {
 				await command.execute(context);
 
 				const validatorData1 = await validatorStore.get(
@@ -964,29 +772,22 @@ describe('StakeCommand', () => {
 					validatorAddress2,
 				);
 
-				// Assert
 				expect(validatorData1.totalStake).toEqual(BigInt(0));
 				expect(validatorData2.totalStake).toEqual(BigInt(0));
 			});
 
 			it('should throw error and emit ValidatorStakedEvent with STAKE_FAILED_INVALID_UNSTAKE_PARAMETERS result when downstaked validator is not already upstaked', async () => {
-				// Arrange
 				const downStakeAmount = liskToBeddows(10);
 
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: validatorAddress3, amount: downStakeAmount * BigInt(-1) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				// Assert
 				await expect(command.execute(context)).rejects.toThrow(
 					'Cannot cast downstake to validator who is not upstaked.',
 				);
@@ -1016,11 +817,7 @@ describe('StakeCommand', () => {
 						{ validatorAddress: validatorAddress2, amount: validator2StakeAmount },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1037,11 +834,7 @@ describe('StakeCommand', () => {
 						{ validatorAddress: validatorAddress2, amount: negativeStakeValidator2 },
 					].sort((a, b) => -1 * a.validatorAddress.compare(b.validatorAddress)),
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1050,7 +843,7 @@ describe('StakeCommand', () => {
 					} as any,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				lockFn.mockClear();
+				tokenLockMock.mockClear();
 			});
 
 			it('should assign reward to staker for downstake and upstake for already staked validator', async () => {
@@ -1059,7 +852,7 @@ describe('StakeCommand', () => {
 				expect(mockAssignStakeRewards).toHaveBeenCalledTimes(2);
 			});
 
-			it('should assign sharingCoefficients of the validator to the corresponding sentStake of the staker for that validator', async () => {
+			it('should assign sharingCoefficients of the validator to the corresponding stake of the staker for that validator', async () => {
 				const sharingCoefficients = [
 					{
 						tokenID: Buffer.alloc(8),
@@ -1070,15 +863,6 @@ describe('StakeCommand', () => {
 						coefficient: Buffer.alloc(24, 1),
 					},
 				];
-
-				const validator1 = await validatorStore.get(
-					createStoreGetter(stateStore),
-					validatorAddress1,
-				);
-				const validator2 = await validatorStore.get(
-					createStoreGetter(stateStore),
-					validatorAddress2,
-				);
 
 				validator1.sharingCoefficients = sharingCoefficients;
 				validator2.sharingCoefficients = sharingCoefficients;
@@ -1091,11 +875,11 @@ describe('StakeCommand', () => {
 				const { stakes } = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
 
 				expect(
-					stakes.find(sentStake => sentStake.validatorAddress.equals(validatorAddress1))
+					stakes.find(stake => stake.validatorAddress.equals(validatorAddress1))
 						?.sharingCoefficients,
 				).toEqual(sharingCoefficients);
 				expect(
-					stakes.find(sentStake => sentStake.validatorAddress.equals(validatorAddress2))
+					stakes.find(stake => stake.validatorAddress.equals(validatorAddress2))
 						?.sharingCoefficients,
 				).toEqual(sharingCoefficients);
 			});
@@ -1104,11 +888,7 @@ describe('StakeCommand', () => {
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: validatorAddress3, amount: positiveStakeValidator1 }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1124,19 +904,18 @@ describe('StakeCommand', () => {
 				const validatorAddress = utils.getRandomBytes(20);
 				const selfStake = BigInt(2) + BigInt(defaultConfig.minWeightStandby);
 
-				const validatorInfo = {
-					...validatorInfo1,
+				const validator = {
+					...validator1,
 					selfStake,
 					totalStake: BigInt(1) + BigInt(100) * BigInt(defaultConfig.minWeightStandby),
 				};
 				const expectedWeight = BigInt(10) * selfStake;
-				await validatorStore.set(createStoreGetter(stateStore), validatorAddress, validatorInfo);
+				await validatorStore.set(createStoreGetter(stateStore), validatorAddress, validator);
+
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress, amount: positiveStakeValidator1 }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-				transaction.params = transactionParams;
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1159,9 +938,7 @@ describe('StakeCommand', () => {
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress, amount: BigInt(-2) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-				transaction.params = transactionParams;
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1181,12 +958,10 @@ describe('StakeCommand', () => {
 			});
 
 			it('should make staker to have correct balance', async () => {
-				// Arrange
 				await command.execute(context);
 
-				// Assert
-				expect(lockFn).toHaveBeenCalledTimes(1);
-				expect(lockFn).toHaveBeenCalledWith(
+				expect(tokenLockMock).toHaveBeenCalledTimes(1);
+				expect(tokenLockMock).toHaveBeenCalledWith(
 					expect.anything(),
 					senderAddress,
 					MODULE_NAME_POS,
@@ -1196,11 +971,9 @@ describe('StakeCommand', () => {
 			});
 
 			it('should make staker to have correct unlocking', async () => {
-				// Arrange
 				await command.execute(context);
 
 				const stakerData = await stakerStore.get(createStoreGetter(stateStore), senderAddress);
-				// Assert
 				expect(stakerData.pendingUnlocks).toHaveLength(1);
 				expect(stakerData.pendingUnlocks).toEqual([
 					{
@@ -1211,21 +984,20 @@ describe('StakeCommand', () => {
 				]);
 			});
 
-			it('should make upstaked validator account to have correct totalStakeReceived', async () => {
-				// Arrange
+			it('should make upstaked validator account to have correct totalStake', async () => {
 				await command.execute(context);
 
-				const validatorData1 = await validatorStore.get(
+				const updatedValidator1 = await validatorStore.get(
 					createStoreGetter(stateStore),
 					validatorAddress1,
 				);
 
-				// Assert
-				expect(validatorData1.totalStake).toEqual(validator1StakeAmount + positiveStakeValidator1);
+				expect(updatedValidator1.totalStake).toEqual(
+					validator1StakeAmount + positiveStakeValidator1,
+				);
 			});
 
-			it('should make downstaked validator account to have correct totalStakeReceived', async () => {
-				// Arrange
+			it('should make downstaked validator account to have correct totalStake', async () => {
 				await command.execute(context);
 
 				const validatorData2 = await validatorStore.get(
@@ -1233,7 +1005,6 @@ describe('StakeCommand', () => {
 					validatorAddress2,
 				);
 
-				// Assert
 				expect(validatorData2.totalStake).toEqual(validator2StakeAmount + negativeStakeValidator2);
 			});
 		});
@@ -1246,11 +1017,7 @@ describe('StakeCommand', () => {
 						{ validatorAddress: validatorAddress2, amount: validator2StakeAmount },
 					].sort((a, b) => -1 * a.validatorAddress.compare(b.validatorAddress)),
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1259,23 +1026,18 @@ describe('StakeCommand', () => {
 					} as any,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				lockFn.mockClear();
+				tokenLockMock.mockClear();
 			});
 
 			describe('when transaction.params.stakes contain validator address which is not registered', () => {
 				it('should throw error and emit ValidatorStakedEevnt with STAKE_FAILED_NON_REGISTERED_VALIDATOR failure', async () => {
-					// Arrange
 					const nonExistingValidatorAddress = utils.getRandomBytes(20);
 
 					transactionParamsDecoded = {
 						...transactionParamsDecoded,
 						stakes: [{ validatorAddress: nonExistingValidatorAddress, amount: liskToBeddows(76) }],
 					};
-
-					transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-					transaction.params = transactionParams;
-
+					transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 					context = createTransactionContext({
 						transaction,
 						stateStore,
@@ -1284,7 +1046,6 @@ describe('StakeCommand', () => {
 						} as any,
 					}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-					// Assert
 					await expect(command.execute(context)).rejects.toThrow(
 						'Invalid stake: no registered validator with the specified address',
 					);
@@ -1304,9 +1065,8 @@ describe('StakeCommand', () => {
 				});
 			});
 
-			describe('when transaction.params.stakes positive amount makes stakerData.sentStakes entries more than 10', () => {
+			describe('when transaction.params.stakes positive amount makes StakerData.stakes array contain more than 10 elements', () => {
 				it('should throw error and emit ValidatorStakedEvent with STAKE_FAILED_TOO_MANY_SENT_STAKES failure', async () => {
-					// Arrange
 					const stakes = [];
 
 					for (let i = 0; i < 12; i += 1) {
@@ -1337,17 +1097,12 @@ describe('StakeCommand', () => {
 					}
 
 					transactionParamsDecoded = { stakes };
-
-					transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-					transaction.params = transactionParams;
-
+					transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 					context = createTransactionContext({
 						transaction,
 						stateStore,
 					}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-					// Assert
 					await expect(command.execute(context)).rejects.toThrow('Sender can only stake upto 10.');
 
 					checkEventResult(
@@ -1365,9 +1120,8 @@ describe('StakeCommand', () => {
 				});
 			});
 
-			describe('when transaction.params.stakes negative amount decrease stakerData.sentStakes entries yet positive amount makes account exceeds more than 10', () => {
+			describe('when transaction.params.stakes negative amount decrease StakerData.stakes array entries, yet positive amount makes account exceeds more than 10', () => {
 				it('should throw error and emit ValidatorStakedEvent with STAKE_FAILED_TOO_MANY_SENT_STAKES failure', async () => {
-					// Arrange
 					const initialValidatorAmount = 8;
 					const stakerData = await stakerStore.getOrDefault(
 						createStoreGetter(stateStore),
@@ -1452,17 +1206,12 @@ describe('StakeCommand', () => {
 					// now we added 2 negative stakes and 3 new positive stakes
 					// which will make total positive stakes to grow over 10
 					transactionParamsDecoded = { stakes };
-
-					transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-					transaction.params = transactionParams;
-
+					transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 					context = createTransactionContext({
 						transaction,
 						stateStore,
 					}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-					// Assert
 					await expect(command.execute(context)).rejects.toThrow('Sender can only stake upto 10.');
 
 					checkEventResult(
@@ -1482,7 +1231,6 @@ describe('StakeCommand', () => {
 
 			describe('when transaction.params.stakes has negative amount and makes stakerData.pendingUnlocks more than 20 entries', () => {
 				it('should throw error and emit ValidatorStakedEvent with STAKE_FAILED_TOO_MANY_PENDING_UNLOCKS failure', async () => {
-					// Arrange
 					const initialValidatorAmountForUnlocks = 19;
 					const stakerData = await stakerStore.getOrDefault(
 						createStoreGetter(stateStore),
@@ -1569,17 +1317,12 @@ describe('StakeCommand', () => {
 					// now we added 2 negative stakes
 					// which will make total unlocking to grow over 20
 					transactionParamsDecoded = { stakes };
-
-					transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-					transaction.params = transactionParams;
-
+					transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 					context = createTransactionContext({
 						transaction,
 						stateStore,
 					}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-					// Assert
 					await expect(command.execute(context)).rejects.toThrow(
 						`Pending unlocks cannot exceed ${MAX_NUMBER_PENDING_UNLOCKS.toString()}.`,
 					);
@@ -1603,7 +1346,6 @@ describe('StakeCommand', () => {
 
 			describe('when transaction.params.stakes negative amount exceeds the previously staked amount', () => {
 				it('should throw error and emit ValidatorStakedEvent with STAKE_FAILED_INVALID_UNSTAKE_PARAMETERS', async () => {
-					// Arrange
 					const stakerData = await stakerStore.getOrDefault(
 						createStoreGetter(stateStore),
 						senderAddress,
@@ -1623,17 +1365,12 @@ describe('StakeCommand', () => {
 							},
 						],
 					};
-
-					transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-					transaction.params = transactionParams;
-
+					transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 					context = createTransactionContext({
 						transaction,
 						stateStore,
 					}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-					// Assert
 					await expect(command.execute(context)).rejects.toThrow(
 						'The unstake amount exceeds the staked amount for this validator.',
 					);
@@ -1664,7 +1401,7 @@ describe('StakeCommand', () => {
 				selfStake = BigInt(20);
 
 				const validatorInfo = {
-					...validatorInfo1,
+					...validator1,
 					totalStake,
 					selfStake,
 				};
@@ -1673,11 +1410,7 @@ describe('StakeCommand', () => {
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress: senderAddress, amount: senderStakeAmountPositive }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1686,11 +1419,10 @@ describe('StakeCommand', () => {
 					} as any,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				lockFn.mockClear();
+				tokenLockMock.mockClear();
 			});
 
-			it('should update stakes and totalStakeReceived', async () => {
-				// Act & Assign
+			it('should update stakes and totalStake', async () => {
 				await command.execute(context);
 
 				const validatorData = await validatorStore.get(
@@ -1701,10 +1433,10 @@ describe('StakeCommand', () => {
 					createStoreGetter(stateStore),
 					senderAddress,
 				);
-				// Assert
+
 				expect(validatorData.totalStake).toEqual(totalStake + senderStakeAmountPositive);
 				expect(stakerData.stakes).toHaveLength(1);
-				expect(lockFn).toHaveBeenCalledWith(
+				expect(tokenLockMock).toHaveBeenCalledWith(
 					expect.anything(),
 					senderAddress,
 					MODULE_NAME_POS,
@@ -1713,21 +1445,19 @@ describe('StakeCommand', () => {
 				);
 			});
 
-			it('should change validatorData.selfStake and totalStakeReceived with positive stake', async () => {
-				// Act & Assign
+			it('should change validatorData.selfStake and totalStake with positive stake', async () => {
 				await command.execute(context);
 
 				const validatorData = await validatorStore.get(
 					createStoreGetter(stateStore),
 					senderAddress,
 				);
-				// Assert
+
 				expect(validatorData.totalStake).toEqual(totalStake + senderStakeAmountPositive);
 				expect(validatorData.selfStake).toEqual(selfStake + senderStakeAmountPositive);
 			});
 
-			it('should change validatorData.selfStake, totalStakeReceived and unlocking with negative stake', async () => {
-				// Act & Assign
+			it('should change validatorData.selfStake, totalStake and unlocking with negative stake', async () => {
 				await command.execute(context);
 
 				transactionParamsDecoded = {
@@ -1735,11 +1465,7 @@ describe('StakeCommand', () => {
 						{ validatorAddress: senderAddress, amount: senderStakeAmountNegative * BigInt(-1) },
 					],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1759,7 +1485,6 @@ describe('StakeCommand', () => {
 					senderAddress,
 				);
 
-				// Assert
 				expect(validatorData.totalStake).toEqual(
 					totalStake + senderStakeAmountPositive - senderStakeAmountNegative,
 				);
@@ -1815,11 +1540,7 @@ describe('StakeCommand', () => {
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress, amount: senderStakeAmountPositive }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1828,34 +1549,28 @@ describe('StakeCommand', () => {
 					} as any,
 				}).createCommandExecuteContext<StakeTransactionParams>(command.schema);
 
-				lockFn.mockClear();
+				tokenLockMock.mockClear();
 			});
 
-			it('should not change validatorData.selfStake but should update totalStakeReceived with positive stake', async () => {
-				// Act & Assign
+			it('should not change validatorData.selfStake but should update totalStake with positive stake', async () => {
 				await command.execute(context);
 
 				const validatorData = await validatorStore.get(
 					createStoreGetter(stateStore),
 					validatorAddress,
 				);
-				// Assert
+
 				expect(validatorData.totalStake).toEqual(senderStakeAmountPositive + validatorSelfStake);
 				expect(validatorData.selfStake).toEqual(validatorSelfStake);
 			});
 
-			it('should not change validatorData.selfStake but should change totalStakeReceived and unlocking with negative stake', async () => {
-				// Act & Assign
+			it('should not change validatorData.selfStake but should change totalStake and unlocking with negative stake', async () => {
 				await command.execute(context);
 
 				transactionParamsDecoded = {
 					stakes: [{ validatorAddress, amount: senderStakeAmountNegative * BigInt(-1) }],
 				};
-
-				transactionParams = codec.encode(command.schema, transactionParamsDecoded);
-
-				transaction.params = transactionParams;
-
+				transaction.params = codec.encode(command.schema, transactionParamsDecoded);
 				context = createTransactionContext({
 					transaction,
 					stateStore,
@@ -1875,7 +1590,6 @@ describe('StakeCommand', () => {
 					senderAddress,
 				);
 
-				// Assert
 				expect(validatorData.totalStake).toEqual(
 					senderStakeAmountPositive - senderStakeAmountNegative + validatorSelfStake,
 				);


### PR DESCRIPTION
### What was the problem?

This PR resolves #7256

### How was it solved?

Cleaned up the existing tests.
Added 1 missing test case:
- should increase staker's `stakes.amount` and validator's `totalStake` when an existing staker further increases their stake

The remaining 4 scenarios from the original issue were already validated in the test suite.

**Scenario 2**
When valid upstake transaction >> Every upstake should increase that particular validator's totalStake
**Validated in**
should correctly update validator totalStake when a staker is upstaking for the first time
should increase staker's stakes.amount and validator's totalStake when an existing staker further increases their stake

**Scenario 3**
When valid downstake transaction >> Every downstake should decrease that particular validator's totalStake
**Validated in**
should make downstaked validator account to have correct totalStake

**Scenario 4**
When valid downstake transaction >> decrease the staker's stakes.amount for this validator
**Validated in**
should update stake which has non-zero amount

**Scenario 5**
When downstake makes staked amount reach zero >> It should remove the staked validator from staker's stakes array
**Validated in**
should remove stake which has zero amount

### How was it tested?

All tests passing 👌🏻 
