### PR TITLE
Fix the blsSign function to be constant time

### DIFF
--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -13,6 +13,8 @@
  *
  */
 
+import { timingSafeEqual } from 'crypto';
+
 import {
 	aggregateSignatures,
 	aggregateVerify,
@@ -60,7 +62,7 @@ export const blsAggregate = (signatures: Buffer[]): Buffer | false => {
 export const blsSign = (sk: Buffer, message: Buffer): Buffer => {
 	// In case of zero private key, it should return particular output regardless of message.
 	// elements/lisk-cryptography/test/protocol_specs/bls_specs/sign/zero_private_key.yml
-	if (sk.equals(Buffer.alloc(32))) {
+	if (timingSafeEqual(sk, Buffer.alloc(32))) {
 		return Buffer.concat([Buffer.from([192]), Buffer.alloc(95)]);
 	}
 

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -86,6 +86,15 @@ describe('bls_lib', () => {
 				});
 			},
 		);
+
+		it('returns expected signature when secret key is zero', () => {
+			const sk = Buffer.alloc(32);
+			const message = Buffer.from('Hello, World!');
+
+			const signature = blsSign(sk, message);
+
+			expect(signature).toEqual(Buffer.concat([Buffer.from([192]), Buffer.alloc(95)]));
+		});
 	});
 
 	describe('blsVerify', () => {

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -86,15 +86,6 @@ describe('bls_lib', () => {
 				});
 			},
 		);
-
-		it('returns expected signature when secret key is zero', () => {
-			const sk = Buffer.alloc(32);
-			const message = Buffer.from('Hello, World!');
-
-			const signature = blsSign(sk, message);
-
-			expect(signature).toEqual(Buffer.concat([Buffer.from([192]), Buffer.alloc(95)]));
-		});
 	});
 
 	describe('blsVerify', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8449

### How was it solved?

Replaced the `equals()` function with the `crypto.timingSafeEqual()` function to compare buffers in constant time.

### How was it tested?

Added unit tests
