### PR TITLE
Improve `bitwiseXOR()` and `getRandomSeed()` functions

### DIFF
--- a/framework/src/modules/random/utils.ts
+++ b/framework/src/modules/random/utils.ts
@@ -101,14 +101,16 @@ export const bitwiseXOR = (bufferArray: Buffer[]): Buffer => {
 		return bufferArray[0];
 	}
 
-	const bufferSizes = new Set(bufferArray.map(buffer => buffer.length));
-	if (bufferSizes.size > 1) {
-		throw new Error('All input for XOR should be same size');
+	const size = bufferArray[0].length;
+	for (let i = 1; i < bufferArray.length; i += 1) {
+		if (bufferArray[i].length !== size) {
+			throw new Error('All input for XOR should be same size');
+		}
 	}
-	const outputSize = [...bufferSizes][0];
-	const result = Buffer.alloc(outputSize, 0);
 
-	for (let i = 0; i < outputSize; i += 1) {
+	const result = Buffer.alloc(size);
+
+	for (let i = 0; i < size; i += 1) {
 		// eslint-disable-next-line no-bitwise
 		result[i] = bufferArray.map(b => b[i]).reduce((a, b) => a ^ b, 0);
 	}

--- a/framework/src/modules/random/utils.ts
+++ b/framework/src/modules/random/utils.ts
@@ -92,7 +92,7 @@ export const getRandomSeed = (
 
 export const bitwiseXOR = (bufferArray: Buffer[]): Buffer => {
 	if (bufferArray.length === 0) {
-		throw new Error('No inputs to XOR');
+		throw new Error('bitwiseXOR requires at least one buffer for the input.');
 	}
 
 	if (bufferArray.length === 1) {

--- a/framework/src/modules/random/utils.ts
+++ b/framework/src/modules/random/utils.ts
@@ -91,6 +91,10 @@ export const getRandomSeed = (
 };
 
 export const bitwiseXOR = (bufferArray: Buffer[]): Buffer => {
+	if (bufferArray.length === 0) {
+		throw new Error('No inputs to XOR');
+	}
+
 	if (bufferArray.length === 1) {
 		return bufferArray[0];
 	}

--- a/framework/src/modules/random/utils.ts
+++ b/framework/src/modules/random/utils.ts
@@ -70,7 +70,7 @@ export const getRandomSeed = (
 		throw new Error('Height or number of seeds cannot be negative.');
 	}
 
-    const initRandomBuffer = utils.intToBuffer(height + numberOfSeeds, 4);
+	const initRandomBuffer = utils.intToBuffer(height + numberOfSeeds, 4);
 	const currentSeeds = [utils.hash(initRandomBuffer).slice(0, 16)];
 	let isInFuture = true;
 

--- a/framework/src/modules/random/utils.ts
+++ b/framework/src/modules/random/utils.ts
@@ -69,16 +69,16 @@ export const getRandomSeed = (
 	if (height < 0 || numberOfSeeds < 0) {
 		throw new Error('Height or number of seeds cannot be negative.');
 	}
-	const initRandomBuffer = utils.intToBuffer(height + numberOfSeeds, 4);
-	let randomSeed = utils.hash(initRandomBuffer).slice(0, SEED_LENGTH);
 
+    const initRandomBuffer = utils.intToBuffer(height + numberOfSeeds, 4);
+	const currentSeeds = [utils.hash(initRandomBuffer).slice(0, 16)];
 	let isInFuture = true;
-	const currentSeeds = [];
+
 	for (const validatorReveal of validatorsReveal) {
 		if (validatorReveal.height >= height) {
 			isInFuture = false;
-			if (validatorReveal.height < height + numberOfSeeds) {
-				currentSeeds.push(validatorReveal);
+			if (validatorReveal.height < height + numberOfSeeds && validatorReveal.valid) {
+				currentSeeds.push(validatorReveal.seedReveal);
 			}
 		}
 	}
@@ -87,13 +87,7 @@ export const getRandomSeed = (
 		throw new Error('Height is in the future.');
 	}
 
-	for (const seedObject of currentSeeds) {
-		if (seedObject.valid) {
-			randomSeed = bitwiseXOR([randomSeed, seedObject.seedReveal]);
-		}
-	}
-
-	return randomSeed;
+	return bitwiseXOR(currentSeeds);
 };
 
 export const bitwiseXOR = (bufferArray: Buffer[]): Buffer => {

--- a/framework/test/unit/modules/random/method.spec.ts
+++ b/framework/test/unit/modules/random/method.spec.ts
@@ -320,10 +320,7 @@ describe('RandomModuleMethod', () => {
 				Buffer.from(genesisValidators.validators[0].hashOnion.hashes[2], 'hex'),
 			];
 			// Do XOR of randomSeed with hashes of seed reveal with height >= randomStoreValidator.height >= height + numberOfSeeds
-			const xorExpected = bitwiseXOR([
-				bitwiseXOR([randomSeed, hashesExpected[0]]),
-				hashesExpected[1],
-			]);
+			const xorExpected = bitwiseXOR([randomSeed, ...hashesExpected]);
 
 			expect(xorExpected).toHaveLength(16);
 			await expect(randomMethod.getRandomBytes(context, height, numberOfSeeds)).resolves.toEqual(
@@ -343,10 +340,7 @@ describe('RandomModuleMethod', () => {
 				Buffer.from(genesisValidators.validators[1].hashOnion.hashes[1], 'hex'),
 			];
 			// Do XOR of randomSeed with hashes of seed reveal with height >= randomStoreValidator.height >= height + numberOfSeeds
-			const xorExpected = bitwiseXOR([
-				bitwiseXOR([bitwiseXOR([randomSeed, hashesExpected[0]]), hashesExpected[1]]),
-				hashesExpected[2],
-			]);
+			const xorExpected = bitwiseXOR([randomSeed, ...hashesExpected]);
 
 			await expect(randomMethod.getRandomBytes(context, height, numberOfSeeds)).resolves.toEqual(
 				xorExpected,
@@ -385,7 +379,7 @@ describe('RandomModuleMethod', () => {
 				Buffer.from(genesisValidators.validators[0].hashOnion.hashes[1], 'hex'),
 			];
 			// Do XOR of randomSeed with hashes of seed reveal with height >= randomStoreValidator.height >= height + numberOfSeeds
-			const xorExpected = bitwiseXOR([randomSeed, hashesExpected[0]]);
+			const xorExpected = bitwiseXOR([randomSeed, ...hashesExpected]);
 
 			await expect(randomMethod.getRandomBytes(context, height, numberOfSeeds)).resolves.toEqual(
 				xorExpected,

--- a/framework/test/unit/modules/random/utils.spec.ts
+++ b/framework/test/unit/modules/random/utils.spec.ts
@@ -18,7 +18,9 @@ import { bitwiseXORFixtures } from './bitwise_xor_fixtures';
 describe('Random module utils', () => {
 	describe('bitwiseXOR', () => {
 		it('should throw if an empty array is provided as an argument', () => {
-			expect(() => bitwiseXOR([])).toThrow('No inputs to XOR');
+			expect(() => bitwiseXOR([])).toThrow(
+				'bitwiseXOR requires at least one buffer for the input.',
+			);
 		});
 
 		it('should return the first element if there are no other elements', () => {

--- a/framework/test/unit/modules/random/utils.spec.ts
+++ b/framework/test/unit/modules/random/utils.spec.ts
@@ -17,6 +17,10 @@ import { bitwiseXORFixtures } from './bitwise_xor_fixtures';
 
 describe('Random module utils', () => {
 	describe('bitwiseXOR', () => {
+		it('should throw if an empty array is provided as an argument', () => {
+			expect(() => bitwiseXOR([])).toThrow('No inputs to XOR');
+		});
+
 		it('should return the first element if there are no other elements', () => {
 			const buffer = Buffer.from([0, 1, 1, 1]);
 			const input = [buffer];


### PR DESCRIPTION
### What was the problem?

This PR resolves #8571

### How was it solved?

- `bitwiseXOR()` now throws as soon as it finds the first element of different length, so it does not have to loop through the rest of the array.
- `getRandomSeed()` now uses one loop to populate seeds in `currentSeeds` that satisfy both the height and the validity criteria.
- tests no longer invoke `bitwiseXOR()` recursively with only 2 seeds as arguments, but provide full array of seeds all at once.

### How was it tested?

The existing unit tests pass 👌🏻 
