### PR TITLE
Fix Commander incorrectly parsing no input at array prompt

### DIFF
--- a/commander/src/utils/reader.ts
+++ b/commander/src/utils/reader.ts
@@ -221,8 +221,7 @@ const castValue = (
 		return JSON.parse(val);
 	}
 	if (schemaType === 'array') {
-		if (val === '') return [];
-		return val.split(',');
+		return val !== '' ? val.split(',') : [];
 	}
 	if (schemaType === 'uint64' || schemaType === 'sint64') {
 		return BigInt(val);

--- a/commander/src/utils/reader.ts
+++ b/commander/src/utils/reader.ts
@@ -221,6 +221,7 @@ const castValue = (
 		return JSON.parse(val);
 	}
 	if (schemaType === 'array') {
+		if (val === '') return [];
 		return val.split(',');
 	}
 	if (schemaType === 'uint64' || schemaType === 'sint64') {

--- a/commander/test/bootstrapping/commands/transaction/prompt.spec.ts
+++ b/commander/test/bootstrapping/commands/transaction/prompt.spec.ts
@@ -47,8 +47,8 @@ describe('prompt', () => {
 			const transformedAsset = transformAsset(registerMultisignatureParamsSchema, {
 				numberOfSignatures: '4',
 				mandatoryKeys: 'a,b',
-				optionalKeys: 'c,d',
-				signatures: '',
+				optionalKeys: '',
+				signatures: 'c,d',
 			});
 			expect(questions).toEqual([
 				{
@@ -75,8 +75,8 @@ describe('prompt', () => {
 			expect(transformedAsset).toEqual({
 				numberOfSignatures: 4,
 				mandatoryKeys: ['a', 'b'],
-				optionalKeys: ['c', 'd'],
-				signatures: [''],
+				optionalKeys: [],
+				signatures: ['c', 'd'],
 			});
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8517

When an empty string would be received for a param where array is expected, Commander would cast it into an array with an empty string `['']` instead of into an empty array `[]`.

### How was it solved?

- Added logic to `castValue()` to correctly parse empty array input
- Modified `/auth/command/regMultisig` schema to remove `mandatoryKeys` and `optionalKeys` as required properties

### How was it tested?

The scenario from the related issue now successfully creates a transaction.
