### PR TITLE
Accept chainID as string as params for getChainAccount

### DIFF
--- a/framework/src/modules/interoperability/constants.ts
+++ b/framework/src/modules/interoperability/constants.ts
@@ -44,6 +44,7 @@ export const MAX_MODULE_NAME_LENGTH = 32;
 export const MIN_CROSS_CHAIN_COMMAND_NAME_LENGTH = 1;
 export const MAX_CROSS_CHAIN_COMMAND_NAME_LENGTH = 32;
 export const CHAIN_ID_LENGTH = 4;
+export const CHAIN_ID_STRING_LENGTH = 2 * CHAIN_ID_LENGTH;
 export const SUBSTORE_PREFIX_LENGTH = 2;
 
 // Value is in beddows

--- a/framework/src/modules/interoperability/schemas.ts
+++ b/framework/src/modules/interoperability/schemas.ts
@@ -26,6 +26,7 @@ import {
 	HASH_LENGTH,
 	NUMBER_ACTIVE_VALIDATORS_MAINCHAIN,
 	SUBSTORE_PREFIX_LENGTH,
+	CHAIN_ID_STRING_LENGTH,
 } from './constants';
 import { chainDataJSONSchema, chainDataSchema } from './stores/chain_account';
 import { chainValidatorsSchema } from './stores/chain_validators';
@@ -564,10 +565,10 @@ export const getChainAccountRequestSchema = {
 	required: ['chainID'],
 	properties: {
 		chainID: {
-			dataType: 'bytes',
-			fieldNumber: 1,
-			minLength: CHAIN_ID_LENGTH,
-			maxLength: CHAIN_ID_LENGTH,
+			type: 'string',
+			format: 'hex',
+			minLength: CHAIN_ID_STRING_LENGTH,
+			maxLength: CHAIN_ID_STRING_LENGTH,
 		},
 	},
 };

--- a/framework/test/unit/modules/interoperability/endpoint.spec.ts
+++ b/framework/test/unit/modules/interoperability/endpoint.spec.ts
@@ -191,7 +191,7 @@ describe('Test interoperability endpoint', () => {
 			getImmutableMethodContext: jest.fn(),
 			getOffchainStore: jest.fn(),
 			chainID: utils.intToBuffer(1, 4),
-			params: { chainID: utils.intToBuffer(1, 4) },
+			params: { chainID: '00000001' },
 			logger: {} as any,
 			header: { aggregateCommit: { height: 10 }, height: 12, timestamp: Date.now() },
 		};
@@ -219,16 +219,14 @@ describe('Test interoperability endpoint', () => {
 			chainAccountResult = await testInteroperabilityEndpoint.getChainAccount(moduleContext);
 		});
 
-		it('should reject if chainID is not in bytes format', async () => {
+		it('should reject if chainID is not in hex string format', async () => {
 			await expect(
 				testInteroperabilityEndpoint.getChainAccount({
 					...moduleContext,
-					params: { chainID: '00000001' },
+					params: { chainID: 'zy000001' },
 				}),
 			).rejects.toThrow(
-				'Lisk validator found 2 error[s]:\n' +
-					'Property \'.chainID\' should pass "dataType" keyword validation\n' +
-					"Property '.chainID' must NOT have more than 4 characters",
+				'Lisk validator found 1 error[s]:\nProperty \'.chainID\' must match format "hex"',
 			);
 		});
 
@@ -236,9 +234,11 @@ describe('Test interoperability endpoint', () => {
 			await expect(
 				testInteroperabilityEndpoint.getChainAccount({
 					...moduleContext,
-					params: { chainID: utils.intToBuffer(1, 5) },
+					params: { chainID: '0400000001' },
 				}),
-			).rejects.toThrow("Property '.chainID' maxLength exceeded");
+			).rejects.toThrow(
+				"Lisk validator found 1 error[s]:\nProperty '.chainID' must NOT have more than 8 characters",
+			);
 		});
 
 		it('should call getChainAccount', () => {

--- a/framework/test/unit/modules/interoperability/mainchain/endpoint.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/endpoint.spec.ts
@@ -138,7 +138,7 @@ describe('MainchainInteroperabilityEndpoint', () => {
 		it('should return false when chainID equals mainchainID', async () => {
 			context = createTransientModuleEndpointContext({
 				params: {
-					chainID: Buffer.from('00000000', 'hex'),
+					chainID: '00000000',
 				},
 			});
 			const isAvailable = await endpoint.isChainIDAvailable(context);
@@ -148,7 +148,7 @@ describe('MainchainInteroperabilityEndpoint', () => {
 		it('should return false when chainID is not on the mainchain network', async () => {
 			context = createTransientModuleEndpointContext({
 				params: {
-					chainID: Buffer.from('11111111', 'hex'),
+					chainID: '11111111',
 				},
 			});
 			const isAvailable = await endpoint.isChainIDAvailable(context);
@@ -158,7 +158,7 @@ describe('MainchainInteroperabilityEndpoint', () => {
 		it('should return false when the chainID exists', async () => {
 			context = createTransientModuleEndpointContext({
 				params: {
-					chainID: Buffer.from('00000001', 'hex'),
+					chainID: '00000001',
 				},
 			});
 			chainAccountStore.has.mockResolvedValue(true);


### PR DESCRIPTION
### What was the problem?

This PR resolves #8657 

### How was it solved?

- Updated request schema to accept `chainID` as string [🐛 Accept chainID as string as params for getChainAccount](https://github.com/LiskHQ/lisk-sdk/commit/e25249270b59d9088b6bb986460bb1f587e62549)

### How was it tested?

Call `interoperability_getChainAccount` with a valid and invalid values of `chainID` 
