### PR TITLE
PoS module now derives round length from the number of configured validators

### DIFF
--- a/framework/src/modules/pos/constants.ts
+++ b/framework/src/modules/pos/constants.ts
@@ -58,7 +58,6 @@ export const defaultConfig = {
 	failSafeMissedBlocks: 50,
 	failSafeInactiveWindow: 260000,
 	punishmentWindow: PUNISHMENT_PERIOD,
-	roundLength: 103,
 	minWeightStandby: '100000000000',
 	numberActiveValidators: 101,
 	numberStandbyValidators: 2,

--- a/framework/src/modules/pos/constants.ts
+++ b/framework/src/modules/pos/constants.ts
@@ -25,7 +25,6 @@ export const MAX_LENGTH_NAME = 20;
 export const BASE_STAKE_AMOUNT = BigInt(10) * BigInt(10) ** BigInt(8);
 export const MAX_NUMBER_SENT_STAKES = 10;
 export const MAX_NUMBER_PENDING_UNLOCKS = 20;
-export const TOKEN_ID_POS = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
 export const VALIDATOR_REGISTRATION_FEE = BigInt(10) * BigInt(10) ** BigInt(8);
 export const MAX_PUNISHABLE_BLOCK_HEIGHT_DIFFERENCE = 260000;
 export const REPORT_MISBEHAVIOR_LIMIT_BANNED = 5;

--- a/framework/src/modules/pos/module.ts
+++ b/framework/src/modules/pos/module.ts
@@ -265,6 +265,7 @@ export class PoSModule extends BaseModule {
 			{},
 			{
 				...defaultConfig,
+				roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 				posTokenID: defaultPoSTokenID,
 			},
 			moduleConfig,

--- a/framework/src/modules/pos/module.ts
+++ b/framework/src/modules/pos/module.ts
@@ -260,13 +260,11 @@ export class PoSModule extends BaseModule {
 	// eslint-disable-next-line @typescript-eslint/require-await
 	public async init(args: ModuleInitArgs) {
 		const { moduleConfig } = args;
-		const defaultPoSTokenID = `${args.genesisConfig.chainID}${Buffer.alloc(4).toString('hex')}`;
 		const config = objects.mergeDeep(
 			{},
 			{
 				...defaultConfig,
-				roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
-				posTokenID: defaultPoSTokenID,
+				posTokenID: `${args.genesisConfig.chainID}${Buffer.alloc(4).toString('hex')}`,
 			},
 			moduleConfig,
 		) as ModuleConfigJSON;

--- a/framework/src/modules/pos/schemas.ts
+++ b/framework/src/modules/pos/schemas.ts
@@ -158,10 +158,6 @@ export const configSchema = {
 			type: 'integer',
 			format: 'uint32',
 		},
-		roundLength: {
-			type: 'integer',
-			format: 'uint32',
-		},
 		minWeightStandby: {
 			type: 'string',
 			format: 'uint64',
@@ -208,7 +204,6 @@ export const configSchema = {
 		'failSafeMissedBlocks',
 		'failSafeInactiveWindow',
 		'punishmentWindow',
-		'roundLength',
 		'minWeightStandby',
 		'numberActiveValidators',
 		'numberStandbyValidators',

--- a/framework/src/modules/pos/utils.ts
+++ b/framework/src/modules/pos/utils.ts
@@ -253,8 +253,11 @@ export const getPunishmentPeriod = (
 };
 
 export function getModuleConfig(config: ModuleConfigJSON): ModuleConfig {
+	const roundLength = config.numberActiveValidators + config.numberStandbyValidators;
+
 	return {
 		...config,
+		roundLength,
 		minWeightStandby: BigInt(config.minWeightStandby),
 		posTokenID: Buffer.from(config.posTokenID, 'hex'),
 		validatorRegistrationFee: BigInt(config.validatorRegistrationFee),

--- a/framework/test/unit/modules/pos/commands/report_misbehavior.spec.ts
+++ b/framework/test/unit/modules/pos/commands/report_misbehavior.spec.ts
@@ -83,6 +83,7 @@ describe('ReportMisbehaviorCommand', () => {
 	beforeEach(async () => {
 		pos.stores.get(EligibleValidatorsStore).init({
 			...defaultConfig,
+			roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 			minWeightStandby: BigInt(defaultConfig.minWeightStandby),
 			posTokenID: Buffer.alloc(8),
 			validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),

--- a/framework/test/unit/modules/pos/commands/report_misbehavior.spec.ts
+++ b/framework/test/unit/modules/pos/commands/report_misbehavior.spec.ts
@@ -24,11 +24,13 @@ import {
 	LOCKING_PERIOD_SELF_STAKING,
 	MODULE_NAME_POS,
 	REPORTING_PUNISHMENT_REWARD,
+	TOKEN_ID_LENGTH,
 } from '../../../../../src/modules/pos/constants';
 import {
 	TokenMethod,
 	ValidatorsMethod,
 	PomTransactionParams,
+	ModuleConfigJSON,
 } from '../../../../../src/modules/pos/types';
 import { DEFAULT_LOCAL_ID } from '../../../../utils/mocks/transaction';
 import * as bftUtil from '../../../../../src/engine/bft/utils';
@@ -39,7 +41,7 @@ import { createStoreGetter } from '../../../../../src/testing/utils';
 import { EligibleValidatorsStore } from '../../../../../src/modules/pos/stores/eligible_validators';
 import { StakerStore } from '../../../../../src/modules/pos/stores/staker';
 import { liskToBeddows } from '../../../../utils/assets';
-import { getValidatorWeight } from '../../../../../src/modules/pos/utils';
+import { getModuleConfig, getValidatorWeight } from '../../../../../src/modules/pos/utils';
 
 describe('ReportMisbehaviorCommand', () => {
 	const pos = new PoSModule();
@@ -79,15 +81,13 @@ describe('ReportMisbehaviorCommand', () => {
 		lastCommissionIncreaseHeight: 0,
 		sharingCoefficients: [{ tokenID: Buffer.alloc(8), coefficient: Buffer.alloc(24) }],
 	};
+	const config = getModuleConfig({
+		...defaultConfig,
+		posTokenID: '00'.repeat(TOKEN_ID_LENGTH),
+	} as ModuleConfigJSON);
 
 	beforeEach(async () => {
-		pos.stores.get(EligibleValidatorsStore).init({
-			...defaultConfig,
-			roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
-			minWeightStandby: BigInt(defaultConfig.minWeightStandby),
-			posTokenID: Buffer.alloc(8),
-			validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),
-		});
+		pos.stores.get(EligibleValidatorsStore).init(config);
 		pomCommand = new ReportMisbehaviorCommand(pos.stores, pos.events);
 		mockTokenMethod = {
 			lock: jest.fn(),

--- a/framework/test/unit/modules/pos/commands/unlock.spec.ts
+++ b/framework/test/unit/modules/pos/commands/unlock.spec.ts
@@ -23,8 +23,14 @@ import {
 	PUNISHMENT_WINDOW_STAKING,
 	LOCKING_PERIOD_SELF_STAKING,
 	LOCKING_PERIOD_STAKING,
+	TOKEN_ID_LENGTH,
 } from '../../../../../src/modules/pos/constants';
-import { TokenMethod, UnlockingObject, StakerData } from '../../../../../src/modules/pos/types';
+import {
+	TokenMethod,
+	UnlockingObject,
+	StakerData,
+	ModuleConfigJSON,
+} from '../../../../../src/modules/pos/types';
 import { liskToBeddows } from '../../../../utils/assets';
 import { PrefixedStateReadWriter } from '../../../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../../../src/testing';
@@ -32,6 +38,7 @@ import { ValidatorStore } from '../../../../../src/modules/pos/stores/validator'
 import { StakerStore } from '../../../../../src/modules/pos/stores/staker';
 import { createStoreGetter } from '../../../../../src/testing/utils';
 import { GenesisDataStore } from '../../../../../src/modules/pos/stores/genesis';
+import { getModuleConfig } from '../../../../../src/modules/pos/utils';
 
 describe('UnlockCommand', () => {
 	const pos = new PoSModule();
@@ -95,6 +102,10 @@ describe('UnlockCommand', () => {
 		'e48feb88db5b5cf5ad71d93cdcd1d879b6d5ed187a36b0002cc34e0ef9883255',
 		'hex',
 	);
+	const config = getModuleConfig({
+		...defaultConfig,
+		posTokenID: '00'.repeat(TOKEN_ID_LENGTH),
+	} as ModuleConfigJSON);
 
 	beforeEach(() => {
 		unlockCommand = new UnlockCommand(pos.stores, pos.events);
@@ -109,10 +120,7 @@ describe('UnlockCommand', () => {
 		unlockCommand.addDependencies({
 			tokenMethod: mockTokenMethod,
 		});
-		unlockCommand.init({
-			roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
-			posTokenID: Buffer.alloc(8),
-		});
+		unlockCommand.init(config);
 		stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 		validatorSubstore = pos.stores.get(ValidatorStore);
 		stakerSubstore = pos.stores.get(StakerStore);

--- a/framework/test/unit/modules/pos/commands/unlock.spec.ts
+++ b/framework/test/unit/modules/pos/commands/unlock.spec.ts
@@ -110,7 +110,7 @@ describe('UnlockCommand', () => {
 			tokenMethod: mockTokenMethod,
 		});
 		unlockCommand.init({
-			roundLength: defaultConfig.roundLength,
+			roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 			posTokenID: Buffer.alloc(8),
 		});
 		stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());

--- a/framework/test/unit/modules/pos/endpoint.spec.ts
+++ b/framework/test/unit/modules/pos/endpoint.spec.ts
@@ -119,6 +119,7 @@ describe('PosModuleEndpoint', () => {
 
 	const config: ModuleConfig = {
 		...defaultConfig,
+		roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 		minWeightStandby: BigInt(defaultConfig.minWeightStandby),
 		posTokenID: Buffer.from('1000000000000002', 'hex'),
 		validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),
@@ -305,6 +306,7 @@ describe('PosModuleEndpoint', () => {
 
 			expect(constants).toStrictEqual({
 				...defaultConfig,
+				roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 				posTokenID: config.posTokenID.toString('hex'),
 			});
 		});

--- a/framework/test/unit/modules/pos/endpoint.spec.ts
+++ b/framework/test/unit/modules/pos/endpoint.spec.ts
@@ -26,7 +26,7 @@ import { PoSEndpoint } from '../../../../src/modules/pos/endpoint';
 import { InMemoryPrefixedStateDB } from '../../../../src/testing/in_memory_prefixed_state';
 import { PrefixedStateReadWriter } from '../../../../src/state_machine/prefixed_state_read_writer';
 import {
-	ModuleConfig,
+	ModuleConfigJSON,
 	StakerData,
 	StakeSharingCoefficient,
 } from '../../../../src/modules/pos/types';
@@ -40,7 +40,7 @@ import {
 } from '../../../../src/testing';
 import { GenesisDataStore } from '../../../../src/modules/pos/stores/genesis';
 import { EligibleValidatorsStore } from '../../../../src/modules/pos/stores/eligible_validators';
-import { calculateStakeRewards } from '../../../../src/modules/pos/utils';
+import { calculateStakeRewards, getModuleConfig } from '../../../../src/modules/pos/utils';
 
 const { q96 } = math;
 
@@ -117,13 +117,10 @@ describe('PosModuleEndpoint', () => {
 		sharingCoefficients: [validatorSharingCoefficient1, validatorSharingCoefficient2],
 	};
 
-	const config: ModuleConfig = {
+	const config = getModuleConfig({
 		...defaultConfig,
-		roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
-		minWeightStandby: BigInt(defaultConfig.minWeightStandby),
-		posTokenID: Buffer.from('1000000000000002', 'hex'),
-		validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),
-	};
+		posTokenID: '1000000000000002',
+	} as ModuleConfigJSON);
 
 	beforeEach(() => {
 		posEndpoint = new PoSEndpoint(pos.stores, pos.offchainStores);

--- a/framework/test/unit/modules/pos/module.spec.ts
+++ b/framework/test/unit/modules/pos/module.spec.ts
@@ -35,7 +35,7 @@ import {
 	createTransientMethodContext,
 } from '../../../../src/testing';
 import { genesisStoreSchema } from '../../../../src/modules/pos/schemas';
-import { GenesisData, ValidatorsMethod } from '../../../../src/modules/pos/types';
+import { GenesisData, ModuleConfigJSON, ValidatorsMethod } from '../../../../src/modules/pos/types';
 import { GenesisBlockExecuteContext, Validator } from '../../../../src/state_machine/types';
 import { invalidAssets, validAsset } from './genesis_block_test_data';
 import { InMemoryPrefixedStateDB } from '../../../../src/testing/in_memory_prefixed_state';
@@ -48,13 +48,18 @@ import { GenesisDataStore } from '../../../../src/modules/pos/stores/genesis';
 import { SnapshotStore } from '../../../../src/modules/pos/stores/snapshot';
 import { createStoreGetter } from '../../../../src/testing/utils';
 import {
+	CHAIN_ID_LENGTH,
 	COMMISSION_INCREASE_PERIOD,
 	MAX_COMMISSION_INCREASE_RATE,
 	TOKEN_ID_LENGTH,
 	WEIGHT_SCALE_FACTOR,
 } from '../../../../src/modules/pos/constants';
 import { EligibleValidatorsStore } from '../../../../src/modules/pos/stores/eligible_validators';
-import { getValidatorWeight, ValidatorWeight } from '../../../../src/modules/pos/utils';
+import {
+	getModuleConfig,
+	getValidatorWeight,
+	ValidatorWeight,
+} from '../../../../src/modules/pos/utils';
 
 describe('PoS module', () => {
 	const EMPTY_KEY = Buffer.alloc(0);
@@ -99,23 +104,23 @@ describe('PoS module', () => {
 		it('should initialize config with default value when module config is empty', async () => {
 			await expect(
 				pos.init({
-					genesisConfig: { chainID: '00000000' } as any,
+					genesisConfig: { chainID: '00'.repeat(CHAIN_ID_LENGTH) } as any,
 					moduleConfig: {},
 				}),
 			).resolves.toBeUndefined();
 
-			expect(pos['_moduleConfig']).toEqual({
+			const expectedConfig = getModuleConfig({
 				...defaultConfig,
-				minWeightStandby: BigInt(defaultConfig.minWeightStandby),
-				posTokenID: Buffer.alloc(TOKEN_ID_LENGTH),
-				validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),
-			});
+				posTokenID: '00'.repeat(TOKEN_ID_LENGTH),
+			} as ModuleConfigJSON);
+
+			expect(pos['_moduleConfig']).toEqual(expectedConfig);
 		});
 
 		it('should initialize config with given value', async () => {
 			await expect(
 				pos.init({
-					genesisConfig: { chainID: '00000000' } as any,
+					genesisConfig: { chainID: '00'.repeat(CHAIN_ID_LENGTH) } as any,
 					moduleConfig: { ...defaultConfig, maxLengthName: 50 },
 				}),
 			).toResolve();

--- a/framework/test/unit/modules/pos/stores/eligible_validators_store.spec.ts
+++ b/framework/test/unit/modules/pos/stores/eligible_validators_store.spec.ts
@@ -61,6 +61,7 @@ describe('EligibleValidatorsStore', () => {
 		eligibleValidatorsStore = new EligibleValidatorsStore('pos', 6);
 		eligibleValidatorsStore.init({
 			...defaultConfig,
+			roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 			minWeightStandby: BigInt(defaultConfig.minWeightStandby),
 			posTokenID: Buffer.alloc(TOKEN_ID_LENGTH),
 			validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),

--- a/framework/test/unit/modules/pos/stores/eligible_validators_store.spec.ts
+++ b/framework/test/unit/modules/pos/stores/eligible_validators_store.spec.ts
@@ -14,11 +14,13 @@
 
 import { utils } from '@liskhq/lisk-cryptography';
 import { StoreGetter } from '../../../../../src/modules/base_store';
-import { defaultConfig, TOKEN_ID_LENGTH } from '../../../../../src/modules/pos/constants';
+import { TOKEN_ID_LENGTH, defaultConfig } from '../../../../../src/modules/pos/constants';
 import { EligibleValidatorsStore } from '../../../../../src/modules/pos/stores/eligible_validators';
 import { PrefixedStateReadWriter } from '../../../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../../../src/testing/in_memory_prefixed_state';
 import { createStoreGetter } from '../../../../../src/testing/utils';
+import { getModuleConfig } from '../../../../../src/modules/pos/utils';
+import { ModuleConfigJSON } from '../../../../../src/modules/pos/types';
 
 describe('EligibleValidatorsStore', () => {
 	let stateStore: PrefixedStateReadWriter;
@@ -54,18 +56,16 @@ describe('EligibleValidatorsStore', () => {
 		totalStake: BigInt(250000000000),
 		sharingCoefficients: [],
 	};
+	const config = getModuleConfig({
+		...defaultConfig,
+		posTokenID: '00'.repeat(TOKEN_ID_LENGTH),
+	} as ModuleConfigJSON);
 
 	beforeEach(async () => {
 		stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 		context = createStoreGetter(stateStore);
 		eligibleValidatorsStore = new EligibleValidatorsStore('pos', 6);
-		eligibleValidatorsStore.init({
-			...defaultConfig,
-			roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
-			minWeightStandby: BigInt(defaultConfig.minWeightStandby),
-			posTokenID: Buffer.alloc(TOKEN_ID_LENGTH),
-			validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),
-		});
+		eligibleValidatorsStore.init(config);
 		for (const eligibleValidator of eligibleValidators) {
 			const key = eligibleValidatorsStore.getKey(
 				eligibleValidator.address,

--- a/framework/test/unit/modules/pos/utils.spec.ts
+++ b/framework/test/unit/modules/pos/utils.spec.ts
@@ -14,7 +14,11 @@
 import { address as cryptoAddress } from '@liskhq/lisk-cryptography';
 import { math } from '@liskhq/lisk-utils';
 import { defaultConfig, TOKEN_ID_LENGTH } from '../../../../src/modules/pos/constants';
-import { ModuleConfig, StakeSharingCoefficient } from '../../../../src/modules/pos/types';
+import {
+	ModuleConfig,
+	ModuleConfigJSON,
+	StakeSharingCoefficient,
+} from '../../../../src/modules/pos/types';
 import {
 	calculateStakeRewards,
 	getModuleConfig,
@@ -53,7 +57,7 @@ describe('utils', () => {
 	});
 
 	describe('getModuleConfig', () => {
-		it('converts ModuleConfigJSON to ModuleConfg', () => {
+		it('converts ModuleConfigJSON to ModuleConfig', () => {
 			const expected: ModuleConfig = {
 				...defaultConfig,
 				roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
@@ -64,9 +68,8 @@ describe('utils', () => {
 
 			const actual: ModuleConfig = getModuleConfig({
 				...defaultConfig,
-				roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
-				posTokenID: '0000000000000000',
-			});
+				posTokenID: '00'.repeat(TOKEN_ID_LENGTH),
+			} as ModuleConfigJSON);
 
 			expect(actual).toStrictEqual(expected);
 		});

--- a/framework/test/unit/modules/pos/utils.spec.ts
+++ b/framework/test/unit/modules/pos/utils.spec.ts
@@ -56,6 +56,7 @@ describe('utils', () => {
 		it('converts ModuleConfigJSON to ModuleConfg', () => {
 			const expected: ModuleConfig = {
 				...defaultConfig,
+				roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 				minWeightStandby: BigInt(defaultConfig.minWeightStandby),
 				posTokenID: Buffer.alloc(TOKEN_ID_LENGTH),
 				validatorRegistrationFee: BigInt(defaultConfig.validatorRegistrationFee),
@@ -63,6 +64,7 @@ describe('utils', () => {
 
 			const actual: ModuleConfig = getModuleConfig({
 				...defaultConfig,
+				roundLength: defaultConfig.numberActiveValidators + defaultConfig.numberStandbyValidators,
 				posTokenID: '0000000000000000',
 			});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8562 

### How was it solved?

- Removed `roundLength` from `defaultConfig`
- PoS module calculates `roundLength` using `getModuleConfig()` util function and stores it in config object as before

### How was it tested?

All existing tests are passing 👌🏻 
