### PR TITLE
deductEscrowAmountWithTerminate function manually implements getOrDefault instead of calling the existing method 

### DIFF
--- a/framework/src/modules/token/stores/escrow.ts
+++ b/framework/src/modules/token/stores/escrow.ts
@@ -79,16 +79,8 @@ export class EscrowStore extends BaseStore<EscrowStoreData> {
 		tokenID: Buffer,
 		amount: bigint,
 	): Promise<void> {
-		let escrowData: EscrowStoreData;
 		const escrowKey = Buffer.concat([sendingChainID, tokenID]);
-		try {
-			escrowData = await this.get(context, escrowKey);
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
-			escrowData = { amount: BigInt(0) };
-		}
+		const escrowData = await this.getOrDefault(context, escrowKey);
 		if (escrowData.amount < amount) {
 			await interopMethod.terminateChain(context, sendingChainID);
 			return;


### PR DESCRIPTION
### What was the problem?

This PR resolves #8646

### How was it solved?
Relevant changes applied

### How was it tested?

Tests are passing
