### PR TITLE
Filter transaction pool by sender address

### DIFF
--- a/framework/src/engine/generator/endpoint.ts
+++ b/framework/src/engine/generator/endpoint.ts
@@ -37,7 +37,7 @@ import {
 	EstimateSafeStatusResponse,
 	GeneratedInfo,
 	GetStatusResponse,
-	HasKeysRequest,
+	Address,
 	hasKeysRequestSchema,
 	plainGeneratorKeysSchema,
 	SetKeysRequest,
@@ -309,7 +309,7 @@ export class Endpoint {
 	}
 
 	public async hasKeys(ctx: RequestContext): Promise<{ hasKey: boolean }> {
-		validator.validate<HasKeysRequest>(hasKeysRequestSchema, ctx.params);
+		validator.validate<Address>(hasKeysRequestSchema, ctx.params);
 		const generatorStore = new GeneratorStore(this._generatorDB);
 		const keysExist = await generatorKeysExist(
 			generatorStore,

--- a/framework/src/engine/generator/schemas.ts
+++ b/framework/src/engine/generator/schemas.ts
@@ -506,7 +506,7 @@ export const setKeysRequestSchema = {
 	],
 };
 
-export type HasKeysRequest = {
+export type Address = {
 	address: string;
 };
 
@@ -515,6 +515,17 @@ export const hasKeysRequestSchema = {
 	type: 'object',
 	// nosemgrep: schema_with_required_that_is_not_a_property
 	required: ['address'],
+	properties: {
+		address: {
+			type: 'string',
+			format: 'lisk32',
+		},
+	},
+};
+
+export const getTransactionsFromPoolRequestSchema = {
+	$id: '/generator/getTransactionsFromPool',
+	type: 'object',
 	properties: {
 		address: {
 			type: 'string',

--- a/framework/test/unit/engine/endpoint/txpool.spec.ts
+++ b/framework/test/unit/engine/endpoint/txpool.spec.ts
@@ -12,8 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { utils } from '@liskhq/lisk-cryptography';
-import { Chain, Transaction, Event } from '@liskhq/lisk-chain';
+import { utils, address as cryptoAddress } from '@liskhq/lisk-cryptography';
+import { Chain, Transaction, Event, TransactionAttrs } from '@liskhq/lisk-chain';
 import { TransactionPool } from '@liskhq/lisk-transaction-pool';
 import { LiskValidationError } from '@liskhq/lisk-validator';
 import { ABI, TransactionExecutionResult, TransactionVerifyResult } from '../../../../src/abi';
@@ -23,17 +23,20 @@ import { InvalidTransactionError } from '../../../../src/engine/generator/errors
 import { fakeLogger } from '../../../utils/mocks';
 import { TxpoolEndpoint } from '../../../../src/engine/endpoint/txpool';
 import { VerifyStatus } from '../../../../src';
+import { ED25519_PUBLIC_KEY_LENGTH } from '../../../../src/engine/bft/constants';
+
+const ED25519_SIGNATURE_LENGTH = 64;
 
 describe('txpool endpoint', () => {
 	const logger: Logger = fakeLogger;
 	const tx = new Transaction({
-		params: Buffer.alloc(20),
-		command: 'transfer',
-		fee: BigInt(100000),
 		module: 'token',
+		command: 'transfer',
+		params: Buffer.alloc(20),
+		fee: BigInt(100000),
 		nonce: BigInt(0),
-		senderPublicKey: Buffer.alloc(32),
-		signatures: [Buffer.alloc(64)],
+		senderPublicKey: Buffer.alloc(ED25519_PUBLIC_KEY_LENGTH),
+		signatures: [Buffer.alloc(ED25519_SIGNATURE_LENGTH)],
 	});
 	const chainID = Buffer.alloc(0);
 	const events = [
@@ -53,47 +56,58 @@ describe('txpool endpoint', () => {
 	let pool: TransactionPool;
 	let abi: ABI;
 	let chain: Chain;
-	let jsonMock: jest.Mock;
-	let transactionsFromPool;
+
+	const senderPublicKey = utils.getRandomBytes(ED25519_PUBLIC_KEY_LENGTH);
+	const senderLisk32Address = cryptoAddress.getLisk32AddressFromPublicKey(senderPublicKey);
+
+	const transactionAttributes: TransactionAttrs[] = [
+		{
+			module: 'module0',
+			command: 'command0',
+			senderPublicKey: utils.getRandomBytes(ED25519_PUBLIC_KEY_LENGTH),
+			nonce: BigInt(88),
+			fee: BigInt(23),
+			params: Buffer.from('params0'),
+			signatures: [utils.getRandomBytes(ED25519_SIGNATURE_LENGTH)],
+		},
+		{
+			module: 'module1',
+			command: 'command1',
+			senderPublicKey,
+			nonce: BigInt(12),
+			fee: BigInt(34),
+			params: Buffer.from('params1'),
+			signatures: [utils.getRandomBytes(ED25519_SIGNATURE_LENGTH)],
+		},
+		{
+			module: 'module2',
+			command: 'command2',
+			senderPublicKey: utils.getRandomBytes(ED25519_PUBLIC_KEY_LENGTH),
+			nonce: BigInt(12),
+			fee: BigInt(34),
+			params: Buffer.from('params2'),
+			signatures: [utils.getRandomBytes(ED25519_SIGNATURE_LENGTH)],
+		},
+	];
+
+	const transactionsFromPool = transactionAttributes.map(
+		transaction => new Transaction(transaction),
+	);
 
 	beforeEach(() => {
-		jsonMock = jest.fn();
-		transactionsFromPool = [
-			{
-				id: Buffer.from('id'),
-				module: 'module',
-				command: 'command',
-				senderPublicKey: Buffer.from('sender public key'),
-				nonce: BigInt(10),
-				fee: BigInt(2),
-				params: Buffer.from('params'),
-				signatures: [Buffer.from('signature1'), Buffer.from('signature2')],
-				toJSON: jsonMock,
-			},
-			{
-				id: Buffer.from('id'),
-				module: 'module',
-				command: 'command',
-				senderPublicKey: Buffer.from('sender public key'),
-				nonce: BigInt(10),
-				fee: BigInt(2),
-				params: Buffer.from('params'),
-				signatures: [Buffer.from('signature1'), Buffer.from('signature2')],
-				toJSON: jsonMock,
-			},
-		];
-		broadcaster = {
-			enqueueTransactionId: jest.fn(),
-		} as never;
+		broadcaster = { enqueueTransactionId: jest.fn() } as never;
+
 		pool = {
 			contains: jest.fn().mockReturnValue(false),
 			add: jest.fn().mockResolvedValue({}),
 			getAll: jest.fn().mockReturnValue(transactionsFromPool),
 		} as never;
+
 		abi = {
 			verifyTransaction: jest.fn().mockResolvedValue({ result: TransactionVerifyResult.OK }),
 			executeTransaction: jest.fn(),
 		} as never;
+
 		chain = {
 			lastBlock: {
 				header: {
@@ -105,6 +119,7 @@ describe('txpool endpoint', () => {
 				},
 			},
 		} as never;
+
 		endpoint = new TxpoolEndpoint({
 			abi,
 			broadcaster,
@@ -210,14 +225,36 @@ describe('txpool endpoint', () => {
 	});
 
 	describe('getTransactionsFromPool', () => {
-		it('should return transactions in the pool in JSON format', async () => {
-			await endpoint.getTransactionsFromPool({
+		it('should return all transactions in the pool in JSON format, when no address is provided', async () => {
+			const transactions = await endpoint.getTransactionsFromPool({
 				logger,
 				params: {},
 				chainID,
 			});
 
-			expect(jsonMock).toHaveBeenCalledTimes(transactionsFromPool.length);
+			expect(transactions).toHaveLength(transactionsFromPool.length);
+			expect(transactions[0].id).toBe(transactionsFromPool[0].id.toString('hex'));
+		});
+
+		it('should return only transactions sent from the provided address, when address is provided', async () => {
+			const transactions = await endpoint.getTransactionsFromPool({
+				logger,
+				params: { address: senderLisk32Address },
+				chainID,
+			});
+
+			expect(transactions).toHaveLength(1);
+			expect(transactions[0].id).toBe(transactionsFromPool[1].id.toString('hex'));
+		});
+
+		it('should return no transactions, when provided address does not correspond to any transaction in the pool', async () => {
+			const transactions = await endpoint.getTransactionsFromPool({
+				logger,
+				params: { address: 'lskw95gtvf3fpjm5y49hrc4fuhoy4n7dtp75adgx5' },
+				chainID,
+			});
+
+			expect(transactions).toHaveLength(0);
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8636 

### How was it solved?

* Endpoint `txpool_getTransactionsFromPool` now takes an optional `address` param, to filter results by address
* Added request schema validation for `txpool_getTransactionsFromPool`
* Improved existing test case to not rely on mocked functions, but check endpoint response instead
* Added 1 new test cases, when address exists in the transaction pool, and 1 when address does not exist
* BONUS: Improved the existing test case to create actual `Transaction` instances, instead of using something that attempts to look like a `Transaction` instance 😎
* BONUS: Introduced constants for public key and signature lengths to other test cases from the suite 😎

### How was it tested?

Updated existing test case and added 2 new ones.