### PR TITLE
Add sidechain account validation in init state recovery verify hook

### DIFF
--- a/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
@@ -12,6 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { validator } from '@liskhq/lisk-validator';
 import { codec } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
 import { SparseMerkleTree } from '@liskhq/lisk-db';
@@ -64,6 +65,9 @@ export class InitializeStateRecoveryCommand extends BaseInteroperabilityCommand<
 			chainDataSchema,
 			sidechainAccount,
 		);
+
+		validator.validate(chainDataSchema, deserializedSidechainAccount);
+
 		const mainchainAccount = await this.stores.get(ChainAccountStore).get(context, mainchainID);
 		// The commands fails if the sidechain is not terminated and did not violate the liveness requirement.
 		if (


### PR DESCRIPTION
### What was the problem?

This PR resolves #8620 

### How was it solved?

Once side chain account is decoded, it is validated with chain data schema. 

### How was it tested?

Added relevant unit test
