### PR TITLE
Rename the beforeExecuteBlock

### DIFF
--- a/framework/src/abi_handler/abi_handler.ts
+++ b/framework/src/abi_handler/abi_handler.ts
@@ -346,7 +346,7 @@ export class ABIHandler implements ABI {
 			eventQueue: new EventQueue(this._executionContext.header.height),
 			transactions: [],
 		});
-		await this._stateMachine.beforeExecuteBlock(context);
+		await this._stateMachine.beforeTransactionsExecute(context);
 
 		return {
 			events: context.eventQueue.getEvents().map(e => e.toObject()),

--- a/framework/src/state_machine/state_machine.ts
+++ b/framework/src/state_machine/state_machine.ts
@@ -240,7 +240,7 @@ export class StateMachine {
 		}
 	}
 
-	public async beforeExecuteBlock(ctx: BlockContext): Promise<void> {
+	public async beforeTransactionsExecute(ctx: BlockContext): Promise<void> {
 		const blockExecuteContext = ctx.getBlockExecuteContext();
 		for (const mod of this._modules) {
 			if (mod.beforeTransactionsExecute) {
@@ -263,7 +263,7 @@ export class StateMachine {
 	}
 
 	public async executeBlock(ctx: BlockContext): Promise<void> {
-		await this.beforeExecuteBlock(ctx);
+		await this.beforeTransactionsExecute(ctx);
 		for (const tx of ctx.transactions) {
 			const txContext = ctx.getTransactionContext(tx);
 			const verifyResult = await this.verifyTransaction(txContext);

--- a/framework/test/unit/abi_handler/abi_handler.spec.ts
+++ b/framework/test/unit/abi_handler/abi_handler.spec.ts
@@ -348,7 +348,7 @@ describe('abi handler', () => {
 		});
 
 		it('should execute beforeTransactionsExecute and resolve the response', async () => {
-			jest.spyOn(abiHandler['_stateMachine'], 'beforeExecuteBlock');
+			jest.spyOn(abiHandler['_stateMachine'], 'beforeTransactionsExecute');
 			const { contextID } = await abiHandler.initStateMachine({
 				header: createFakeBlockHeader().toObject(),
 			});
@@ -356,7 +356,7 @@ describe('abi handler', () => {
 				contextID,
 				assets: [{ data: utils.getRandomBytes(30), module: 'token' }],
 			});
-			expect(abiHandler['_stateMachine'].beforeExecuteBlock).toHaveBeenCalledTimes(1);
+			expect(abiHandler['_stateMachine'].beforeTransactionsExecute).toHaveBeenCalledTimes(1);
 
 			expect(resp.events).toBeArray();
 		});

--- a/framework/test/unit/modules/interoperability/method.spec.ts
+++ b/framework/test/unit/modules/interoperability/method.spec.ts
@@ -246,6 +246,7 @@ describe('Sample Method', () => {
 					ccm.receivingChainID,
 					ccm.fee,
 					ccm.params,
+					ccm.status,
 				),
 			).rejects.toThrow('Timestamp must be provided in mainchain context.');
 		});

--- a/framework/test/unit/state_machine/state_machine.spec.ts
+++ b/framework/test/unit/state_machine/state_machine.spec.ts
@@ -327,7 +327,7 @@ describe('state_machine', () => {
 				chainID,
 				transactions: [transaction],
 			});
-			await stateMachine.beforeExecuteBlock(ctx);
+			await stateMachine.beforeTransactionsExecute(ctx);
 			expect(mod.beforeTransactionsExecute).toHaveBeenCalledWith({
 				chainID,
 				logger,
@@ -354,7 +354,7 @@ describe('state_machine', () => {
 				chainID,
 				transactions: [transaction],
 			});
-			await stateMachine.beforeExecuteBlock(ctx);
+			await stateMachine.beforeTransactionsExecute(ctx);
 
 			const events = ctx.eventQueue.getEvents();
 			expect(events).toHaveLength(1);


### PR DESCRIPTION
### What was the problem?

This PR resolves #8641

### How was it solved?

- Rename the `beforeExecuteBlock` method to `beforeTransactionsExecute`

- Update all instances where `beforeExecuteBlock` is used.

### How was it tested?

Existing tests pass
