### PR TITLE
Check key sorting using the existing util function

### DIFF
--- a/elements/lisk-utils/src/objects/buffer_array.ts
+++ b/elements/lisk-utils/src/objects/buffer_array.ts
@@ -29,7 +29,7 @@ export const bufferArrayEqual = (arr1: Buffer[], arr2: Buffer[]): boolean =>
 export const bufferArraySubtract = (arr1: Buffer[], arr2: Buffer[]): Buffer[] =>
 	arr1.filter(a => !bufferArrayIncludes(arr2, a));
 
-export const bufferArrayOrderByLex = (arr1: Buffer[]): boolean => {
+export const isBufferArrayOrdered = (arr1: Buffer[]): boolean => {
 	const sortedArray = [...arr1];
 	sortedArray.sort((a, b) => a.compare(b));
 

--- a/elements/lisk-utils/test/objects/buffer_array.spec.ts
+++ b/elements/lisk-utils/test/objects/buffer_array.spec.ts
@@ -132,16 +132,16 @@ describe('buffer arrays', () => {
 		});
 	});
 
-	describe('bufferArrayOrderByLex', () => {
+	describe('isBufferArrayOrdered', () => {
 		it('should not mutate the original array', () => {
 			const original = [Buffer.from('val2'), Buffer.from('target'), Buffer.from('val1')];
-			bufferArray.bufferArrayOrderByLex(original);
+			bufferArray.isBufferArrayOrdered(original);
 			expect(original[0]).toEqual(Buffer.from('val2'));
 		});
 
 		it('should return true if ordered lexicographically', () => {
 			expect(
-				bufferArray.bufferArrayOrderByLex([
+				bufferArray.isBufferArrayOrdered([
 					Buffer.from('target'),
 					Buffer.from('val1'),
 					Buffer.from('val1'),
@@ -152,13 +152,17 @@ describe('buffer arrays', () => {
 
 		it('should return false if ordered lexicographically', () => {
 			expect(
-				bufferArray.bufferArrayOrderByLex([
+				bufferArray.isBufferArrayOrdered([
 					Buffer.from('val1'),
 					Buffer.from('target'),
 					Buffer.from('val1'),
 					Buffer.from('val2'),
 				]),
 			).toBeFalse();
+		});
+
+		it('should return true if provided array is empty', () => {
+			expect(bufferArray.isBufferArrayOrdered([])).toBeTrue();
 		});
 	});
 
@@ -193,6 +197,10 @@ describe('buffer arrays', () => {
 					Buffer.from('target'),
 				]),
 			).toBeTrue();
+		});
+
+		it('should return true if provided array is empty', () => {
+			expect(bufferArray.bufferArrayUniqueItems([])).toBeTrue();
 		});
 	});
 });

--- a/framework/src/modules/auth/commands/register_multisignature.ts
+++ b/framework/src/modules/auth/commands/register_multisignature.ts
@@ -103,24 +103,18 @@ export class RegisterMultisignatureCommand extends BaseCommand {
 			};
 		}
 
-		const sortedMandatoryKeys = [...mandatoryKeys].sort((a, b) => a.compare(b));
-		for (let i = 0; i < sortedMandatoryKeys.length; i += 1) {
-			if (!mandatoryKeys[i].equals(sortedMandatoryKeys[i])) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error('Mandatory keys should be sorted lexicographically.'),
-				};
-			}
+		if (!objectUtils.isBufferArrayOrdered(mandatoryKeys)) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error('Mandatory keys should be sorted lexicographically.'),
+			};
 		}
 
-		const sortedOptionalKeys = [...optionalKeys].sort((a, b) => a.compare(b));
-		for (let i = 0; i < sortedOptionalKeys.length; i += 1) {
-			if (!optionalKeys[i].equals(sortedOptionalKeys[i])) {
-				return {
-					status: VerifyStatus.FAIL,
-					error: new Error('Optional keys should be sorted lexicographically.'),
-				};
-			}
+		if (!objectUtils.isBufferArrayOrdered(optionalKeys)) {
+			return {
+				status: VerifyStatus.FAIL,
+				error: new Error('Optional keys should be sorted lexicographically.'),
+			};
 		}
 
 		return {

--- a/framework/src/modules/auth/module.ts
+++ b/framework/src/modules/auth/module.ts
@@ -121,27 +121,25 @@ export class AuthModule extends BaseModule {
 			validator.validate(authAccountSchema, storeValue);
 
 			const { mandatoryKeys, optionalKeys, numberOfSignatures } = storeValue;
-			if (mandatoryKeys.length > 0) {
-				if (!objectUtils.bufferArrayOrderByLex(mandatoryKeys)) {
-					throw new Error(
-						'Invalid store value for auth module. MandatoryKeys are not sorted lexicographically.',
-					);
-				}
-				if (!objectUtils.bufferArrayUniqueItems(mandatoryKeys)) {
-					throw new Error('Invalid store value for auth module. MandatoryKeys are not unique.');
-				}
+
+			if (!objectUtils.isBufferArrayOrdered(mandatoryKeys)) {
+				throw new Error(
+					'Invalid store value for auth module. MandatoryKeys are not sorted lexicographically.',
+				);
+			}
+			if (!objectUtils.bufferArrayUniqueItems(mandatoryKeys)) {
+				throw new Error('Invalid store value for auth module. MandatoryKeys are not unique.');
 			}
 
-			if (optionalKeys.length > 0) {
-				if (!objectUtils.bufferArrayOrderByLex(optionalKeys)) {
-					throw new Error(
-						'Invalid store value for auth module. OptionalKeys are not sorted lexicographically.',
-					);
-				}
-				if (!objectUtils.bufferArrayUniqueItems(optionalKeys)) {
-					throw new Error('Invalid store value for auth module. OptionalKeys are not unique.');
-				}
+			if (!objectUtils.isBufferArrayOrdered(optionalKeys)) {
+				throw new Error(
+					'Invalid store value for auth module. OptionalKeys are not sorted lexicographically.',
+				);
 			}
+			if (!objectUtils.bufferArrayUniqueItems(optionalKeys)) {
+				throw new Error('Invalid store value for auth module. OptionalKeys are not unique.');
+			}
+
 			if (mandatoryKeys.length + optionalKeys.length > MAX_NUMBER_OF_SIGNATURES) {
 				throw new Error(
 					`The count of Mandatory and Optional keys should be maximum ${MAX_NUMBER_OF_SIGNATURES}.`,

--- a/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
+++ b/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
@@ -307,7 +307,7 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 			throw new Error('Certificate must be non-empty if validators have been updated.');
 		}
 		const { bftWeightsUpdate, bftWeightsUpdateBitmap, blsKeysUpdate } = ccu.activeValidatorsUpdate;
-		if (!objects.bufferArrayOrderByLex(blsKeysUpdate)) {
+		if (!objects.isBufferArrayOrdered(blsKeysUpdate)) {
 			throw new Error('Keys are not sorted lexicographic order.');
 		}
 		const { activeValidators } = await this.stores

--- a/framework/src/modules/pos/module.ts
+++ b/framework/src/modules/pos/module.ts
@@ -351,7 +351,7 @@ export class PoSModule extends BaseModule {
 			if (!objectUtils.bufferArrayUniqueItems(staker.stakes.map(v => v.validatorAddress))) {
 				throw new Error('Sent stake validator address is not unique.');
 			}
-			if (!objectUtils.bufferArrayOrderByLex(staker.stakes.map(v => v.validatorAddress))) {
+			if (!objectUtils.isBufferArrayOrdered(staker.stakes.map(v => v.validatorAddress))) {
 				throw new Error('Sent stake validator address is not lexicographically ordered.');
 			}
 			for (const stakes of staker.stakes) {

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -391,7 +391,7 @@ export class TokenModule extends BaseInteroperableModule {
 					}
 					if (
 						!objects.bufferArrayUniqueItems(supportedTokenIDsData.supportedTokenIDs) ||
-						!objects.bufferArrayOrderByLex(supportedTokenIDsData.supportedTokenIDs)
+						!objects.isBufferArrayOrdered(supportedTokenIDsData.supportedTokenIDs)
 					) {
 						throw new Error(
 							'supportedTokensSubstore tokenIDs must be unique and sorted by lexicographically.',


### PR DESCRIPTION
### What was the problem?

This PR resolves #8644

### How was it solved?

* Renamed `bufferArrayOrderByLex()` which returns Boolean into `isBufferArrayOrdered()`, to make it semantically correct and prevent confusion
* `RegisterMultisignatureCommand.verify()` now checks if the array is sorted using `isBufferArrayOrdered()` instead of implementing its own logic
* Removed unnecessary logic which checked if array is not empty, before checking if it is sorted
* Added unit tests for `isBufferArrayOrdered()` and `bufferArrayUniqueItems()` that check if the functions return `true` when provided array is empty

### How was it tested?

All existing and new tests passing 👌🏻 