### PR TITLE
Fixes NFTEndpoint.getNFT for  escrowed NFTs

### DIFF
--- a/framework/src/modules/nft/endpoint.ts
+++ b/framework/src/modules/nft/endpoint.ts
@@ -111,6 +111,12 @@ export class NFTEndpoint extends BaseEndpoint {
 
 		const userStore = this.stores.get(UserStore);
 		const nftData = await nftStore.get(context.getImmutableMethodContext(), nftID);
+		const owner = nftData.owner.toString('hex');
+		const attributesArray = nftData.attributesArray.map(attribute => ({
+			module: attribute.module,
+			attributes: attribute.attributes.toString('hex'),
+		}));
+
 		if (nftData.owner.length === LENGTH_ADDRESS) {
 			const userData = await userStore.get(
 				context.getImmutableMethodContext(),
@@ -118,21 +124,15 @@ export class NFTEndpoint extends BaseEndpoint {
 			);
 
 			return {
-				owner: nftData.owner.toString('hex'),
-				attributesArray: nftData.attributesArray.map(attribute => ({
-					module: attribute.module,
-					attributes: attribute.attributes.toString('hex'),
-				})),
+				owner,
+				attributesArray,
 				lockingModule: userData.lockingModule,
 			};
 		}
 
 		return {
-			owner: nftData.owner.toString('hex'),
-			attributesArray: nftData.attributesArray.map(attribute => ({
-				module: attribute.module,
-				attributes: attribute.attributes.toString('hex'),
-			})),
+			owner,
+			attributesArray,
 		};
 	}
 

--- a/framework/src/modules/nft/endpoint.ts
+++ b/framework/src/modules/nft/endpoint.ts
@@ -26,7 +26,7 @@ import {
 	isNFTSupportedRequestSchema,
 } from './schemas';
 import { NFTStore } from './stores/nft';
-import { LENGTH_NFT_ID } from './constants';
+import { LENGTH_ADDRESS, LENGTH_NFT_ID } from './constants';
 import { UserStore } from './stores/user';
 import { NFT } from './types';
 import { SupportedNFTsStore } from './stores/supported_nfts';
@@ -111,10 +111,21 @@ export class NFTEndpoint extends BaseEndpoint {
 
 		const userStore = this.stores.get(UserStore);
 		const nftData = await nftStore.get(context.getImmutableMethodContext(), nftID);
-		const userData = await userStore.get(
-			context.getImmutableMethodContext(),
-			userStore.getKey(nftData.owner, nftID),
-		);
+		if (nftData.owner.length === LENGTH_ADDRESS) {
+			const userData = await userStore.get(
+				context.getImmutableMethodContext(),
+				userStore.getKey(nftData.owner, nftID),
+			);
+
+			return {
+				owner: nftData.owner.toString('hex'),
+				attributesArray: nftData.attributesArray.map(attribute => ({
+					module: attribute.module,
+					attributes: attribute.attributes.toString('hex'),
+				})),
+				lockingModule: userData.lockingModule,
+			};
+		}
 
 		return {
 			owner: nftData.owner.toString('hex'),
@@ -122,7 +133,6 @@ export class NFTEndpoint extends BaseEndpoint {
 				module: attribute.module,
 				attributes: attribute.attributes.toString('hex'),
 			})),
-			lockingModule: userData.lockingModule,
 		};
 	}
 

--- a/framework/src/modules/nft/module.ts
+++ b/framework/src/modules/nft/module.ts
@@ -142,6 +142,7 @@ export class NFTModule extends BaseInteroperableModule {
 		);
 		this._internalMethod.addDependencies(this.method, this._interoperabilityMethod);
 		this.crossChainMethod.addDependencies(interoperabilityMethod);
+		this.endpoint.addDependencies(this.method);
 	}
 
 	public metadata(): ModuleMetadata {

--- a/framework/src/modules/nft/types.ts
+++ b/framework/src/modules/nft/types.ts
@@ -61,7 +61,7 @@ export interface NFTAttributes {
 export interface NFT {
 	owner: string;
 	attributesArray: NFTAttributes[];
-	lockingModule: string;
+	lockingModule?: string;
 }
 
 export interface GenesisNFTStore {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8714 

### How was it solved?

Modifies `NFT` type to have a nullable `lockingModule` field and updates `NFTEndpoint.getNFT` to return NFT details for escrowed NFT.

Calls `NFTEndpoint.addDependencies` from `NFTModule.addDependencies`.

### How was it tested?

Implemented unit tests.
