### PR TITLE
NFTMethod.create uses integer as the index segment of NFT ID

### DIFF
--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -310,14 +310,10 @@ export class NFTMethod extends BaseMethod {
 		}
 
 		const index = await this.getNextAvailableIndex(methodContext, collectionID);
-		const indexBytes = Buffer.from(index.toString());
+		const indexBytes = Buffer.alloc(LENGTH_NFT_ID - LENGTH_CHAIN_ID - LENGTH_COLLECTION_ID);
+		indexBytes.writeBigInt64BE(BigInt(index));
 
-		const nftID = Buffer.concat([
-			this._config.ownChainID,
-			collectionID,
-			Buffer.alloc(LENGTH_NFT_ID - LENGTH_CHAIN_ID - LENGTH_COLLECTION_ID - indexBytes.length, 0),
-			indexBytes,
-		]);
+		const nftID = Buffer.concat([this._config.ownChainID, collectionID, indexBytes]);
 		this._feeMethod.payFee(methodContext, BigInt(FEE_CREATE_NFT));
 
 		const nftStore = this.stores.get(NFTStore);

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -574,13 +574,10 @@ describe('NFTMethod', () => {
 		});
 
 		it('should set data to stores with correct key and emit successfull create event when there is no entry in the nft substore', async () => {
-			const index = Buffer.from('0');
-			const expectedKey = Buffer.concat([
-				config.ownChainID,
-				collectionID,
-				Buffer.alloc(LENGTH_NFT_ID - LENGTH_CHAIN_ID - LENGTH_COLLECTION_ID - index.length, 0),
-				index,
-			]);
+			const indexBytes = Buffer.alloc(LENGTH_NFT_ID - LENGTH_CHAIN_ID - LENGTH_COLLECTION_ID);
+			indexBytes.writeBigInt64BE(BigInt(0));
+
+			const expectedKey = Buffer.concat([config.ownChainID, collectionID, indexBytes]);
 
 			await method.create(methodContext, address, collectionID, attributesArray3);
 			const nftStoreData = await nftStore.get(methodContext, expectedKey);
@@ -600,7 +597,9 @@ describe('NFTMethod', () => {
 		});
 
 		it('should set data to stores with correct key and emit successfull create event when there is some entry in the nft substore', async () => {
-			const index = Buffer.from('2');
+			const indexBytes = Buffer.alloc(LENGTH_NFT_ID - LENGTH_CHAIN_ID - LENGTH_COLLECTION_ID);
+			indexBytes.writeBigInt64BE(BigInt(2));
+
 			await nftStore.save(methodContext, nftID, {
 				owner: utils.getRandomBytes(LENGTH_CHAIN_ID),
 				attributesArray: attributesArray1,
@@ -610,12 +609,7 @@ describe('NFTMethod', () => {
 				owner: utils.getRandomBytes(LENGTH_CHAIN_ID),
 				attributesArray: attributesArray2,
 			});
-			const expectedKey = Buffer.concat([
-				config.ownChainID,
-				collectionID,
-				Buffer.alloc(LENGTH_NFT_ID - LENGTH_CHAIN_ID - LENGTH_COLLECTION_ID - index.length, 0),
-				index,
-			]);
+			const expectedKey = Buffer.concat([config.ownChainID, collectionID, indexBytes]);
 
 			await method.create(methodContext, address, collectionID, attributesArray3);
 			const nftStoreData = await nftStore.get(methodContext, expectedKey);


### PR DESCRIPTION
### What was the problem?

This PR resolves #8724 

### How was it solved?

Updates `NFTMethod.create` to use the index received from `getNextAvailableIndex` directly without converting it into string.

### How was it tested?

Updated unit tests.
