### PR TITLE
⬆️ Bump semver from 7.3.8 to 7.5.2 (#8639)

### DIFF
--- a/commander/package.json
+++ b/commander/package.json
@@ -124,7 +124,7 @@
 		"lisk-framework": "^0.10.0-beta.4",
 		"listr": "0.14.3",
 		"progress": "2.0.3",
-		"semver": "7.3.8",
+		"semver": "7.5.2",
 		"strip-ansi": "6.0.1",
 		"tar": "6.1.12",
 		"ts-morph": "17.0.1",

--- a/elements/lisk-p2p/package.json
+++ b/elements/lisk-p2p/package.json
@@ -45,7 +45,7 @@
 		"@liskhq/lisk-cryptography": "^4.0.0-beta.2",
 		"@liskhq/lisk-validator": "^0.7.0-beta.2",
 		"lodash.shuffle": "4.2.0",
-		"semver": "7.3.8",
+		"semver": "7.5.2",
 		"socketcluster-client": "14.3.1",
 		"socketcluster-server": "14.6.0"
 	},

--- a/elements/lisk-validator/package.json
+++ b/elements/lisk-validator/package.json
@@ -40,7 +40,7 @@
 		"ajv": "8.1.0",
 		"ajv-formats": "2.1.1",
 		"debug": "4.3.4",
-		"semver": "7.3.8",
+		"semver": "7.5.2",
 		"validator": "13.7.0"
 	},
 	"devDependencies": {

--- a/framework-plugins/lisk-framework-dashboard-plugin/package.json
+++ b/framework-plugins/lisk-framework-dashboard-plugin/package.json
@@ -89,7 +89,7 @@
 		"parcel": "2.8.0",
 		"prettier": "2.8.0",
 		"regenerator-runtime": "0.13.9",
-		"semver": "7.3.8",
+		"semver": "7.5.2",
 		"source-map-support": "0.5.21",
 		"ts-jest": "29.0.3",
 		"ts-node": "10.9.1",

--- a/framework-plugins/lisk-framework-faucet-plugin/package.json
+++ b/framework-plugins/lisk-framework-faucet-plugin/package.json
@@ -92,7 +92,7 @@
 		"parcel": "2.8.0",
 		"prettier": "2.8.0",
 		"regenerator-runtime": "0.13.9",
-		"semver": "7.3.8",
+		"semver": "7.5.2",
 		"source-map-support": "0.5.21",
 		"ts-jest": "29.0.3",
 		"ts-node": "10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11225,15 +11225,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.4.4, lru-cache@^7.5.1:
+lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
   integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
-
-lru-cache@^7.7.1:
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.0.tgz#21be64954a4680e303a09e9468f880b98a0b3c7f"
-  integrity sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==
 
 lunr@^2.3.9:
   version "2.3.9"
@@ -14174,17 +14169,17 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.3.4, semver@7.x, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2:
+semver@7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.3.8, semver@^7.0.0, semver@^7.3.8:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+semver@7.5.2, semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
+  integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -14192,20 +14187,6 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.1.1, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.3.7:
-  version "7.3.7"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
-  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
-  dependencies:
-    lru-cache "^6.0.0"
 
 send@0.18.0:
   version "0.18.0"


### PR DESCRIPTION
:arrow_up: Bump semver from 7.3.8 to 7.5.2

Bumps [semver](https://github.com/npm/node-semver) from 7.3.8 to 7.5.2.
- [Release notes](https://github.com/npm/node-semver/releases)
- [Changelog](https://github.com/npm/node-semver/blob/main/CHANGELOG.md)
- [Commits](https://github.com/npm/node-semver/compare/v7.3.8...v7.5.2)

---
updated-dependencies:
- dependency-name: semver dependency-type: direct:production ...

### What was the problem?

This PR resolves #INSERT_ISSUE_NUMBER

### How was it solved?

<!--- Please describe your technical implementation -->

### How was it tested?

<!--- Please describe how you tested your changes -->
