### PR TITLE
Use context.params.chainID instead

### DIFF
--- a/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
+++ b/framework/src/modules/interoperability/sidechain/cc_commands/sidechain_terminated.ts
@@ -50,29 +50,24 @@ export class SidechainCCSidechainTerminatedCommand extends BaseInteroperabilityC
 	public async execute(
 		context: CCCommandExecuteContext<CCMSidechainTerminatedParams>,
 	): Promise<void> {
+		const { chainID, stateRoot } = context.params;
+
 		const terminatedStateSubstore = this.stores.get(TerminatedStateStore);
-		const terminatedStateAccountExists = await terminatedStateSubstore.has(
-			context,
-			context.chainID,
-		);
+		const terminatedStateAccountExists = await terminatedStateSubstore.has(context, chainID);
 
 		if (terminatedStateAccountExists) {
-			const terminatedStateAccount = await terminatedStateSubstore.get(context, context.chainID);
+			const terminatedStateAccount = await terminatedStateSubstore.get(context, chainID);
 			if (terminatedStateAccount.initialized) {
 				return;
 			}
 
-			await terminatedStateSubstore.set(context, context.chainID, {
-				stateRoot: context.params.stateRoot,
+			await terminatedStateSubstore.set(context, chainID, {
+				stateRoot,
 				mainchainStateRoot: EMPTY_HASH,
 				initialized: true,
 			});
 		} else {
-			await this.internalMethods.createTerminatedStateAccount(
-				context,
-				context.params.chainID,
-				context.params.stateRoot,
-			);
+			await this.internalMethods.createTerminatedStateAccount(context, chainID, stateRoot);
 		}
 	}
 }

--- a/framework/test/unit/modules/interoperability/sidechain/cc_commands/sidechain_terminated.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/cc_commands/sidechain_terminated.spec.ts
@@ -128,11 +128,20 @@ describe('SidechainCCSidechainTerminatedCommand', () => {
 	});
 
 	describe('execute', () => {
-		it('should update terminatedStateAccount exists and initialized', async () => {
+		const expectedTerminatedStateAccount = {
+			stateRoot: ccmSidechainTerminatedParams.stateRoot,
+			mainchainStateRoot: EMPTY_HASH,
+			initialized: true,
+		};
+
+		it('should do nothing when terminatedStateAccount exists and initialized', async () => {
 			await terminatedStateSubstore.set(
 				createStoreGetter(stateStore),
-				chainID,
-				storedTerminatedState,
+				ccmSidechainTerminatedParams.chainID,
+				{
+					...storedTerminatedState,
+					initialized: false,
+				},
 			);
 
 			await expect(
@@ -145,16 +154,24 @@ describe('SidechainCCSidechainTerminatedCommand', () => {
 			expect(
 				ccSidechainTerminatedCommand['internalMethods'].createTerminatedStateAccount,
 			).toHaveBeenCalledTimes(0);
+
 			await expect(
-				terminatedStateSubstore.get(createStoreGetter(stateStore), chainID),
-			).resolves.toStrictEqual(storedTerminatedState);
+				terminatedStateSubstore.get(
+					createStoreGetter(stateStore),
+					ccmSidechainTerminatedParams.chainID,
+				),
+			).resolves.toStrictEqual(expectedTerminatedStateAccount);
 		});
 
-		it('should do nothing when terminatedStateAccount exists and not initialized', async () => {
-			await terminatedStateSubstore.set(createStoreGetter(stateStore), chainID, {
-				...storedTerminatedState,
-				initialized: false,
-			});
+		it('should update when terminatedStateAccount exists and not initialized', async () => {
+			await terminatedStateSubstore.set(
+				createStoreGetter(stateStore),
+				ccmSidechainTerminatedParams.chainID,
+				{
+					...storedTerminatedState,
+					initialized: false,
+				},
+			);
 
 			await expect(
 				ccSidechainTerminatedCommand.execute({
@@ -166,13 +183,13 @@ describe('SidechainCCSidechainTerminatedCommand', () => {
 			expect(
 				ccSidechainTerminatedCommand['internalMethods'].createTerminatedStateAccount,
 			).toHaveBeenCalledTimes(0);
+
 			await expect(
-				terminatedStateSubstore.get(createStoreGetter(stateStore), chainID),
-			).resolves.toStrictEqual({
-				stateRoot: ccmSidechainTerminatedParams.stateRoot,
-				mainchainStateRoot: EMPTY_HASH,
-				initialized: true,
-			});
+				terminatedStateSubstore.get(
+					createStoreGetter(stateStore),
+					ccmSidechainTerminatedParams.chainID,
+				),
+			).resolves.toStrictEqual(expectedTerminatedStateAccount);
 		});
 
 		it('should create terminatedStateAccount when terminatedStateAccount does not exist', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8509

### How was it solved?
correct `chainID` used

### How was it tested?
Tests rearranged as per code execution
