### PR TITLE
Add missing param timestamp to internal method

### DIFF
--- a/framework/src/modules/nft/commands/transfer_cross_chain.ts
+++ b/framework/src/modules/nft/commands/transfer_cross_chain.ts
@@ -134,6 +134,7 @@ export class TransferCrossChainCommand extends BaseCommand {
 			params.messageFee,
 			params.data,
 			params.includeAttributes,
+			context.header.timestamp,
 		);
 	}
 }

--- a/framework/src/modules/nft/internal_method.ts
+++ b/framework/src/modules/nft/internal_method.ts
@@ -116,6 +116,7 @@ export class InternalMethod extends BaseMethod {
 		messageFee: bigint,
 		data: string,
 		includeAttributes: boolean,
+		timestamp?: number,
 	): Promise<void> {
 		const chainID = this._method.getChainID(nftID);
 		const nftStore = this.stores.get(NFTStore);
@@ -172,6 +173,7 @@ export class InternalMethod extends BaseMethod {
 				attributesArray,
 				data,
 			}),
+			timestamp,
 		);
 	}
 

--- a/framework/test/unit/modules/nft/internal_method.spec.ts
+++ b/framework/test/unit/modules/nft/internal_method.spec.ts
@@ -205,6 +205,7 @@ describe('InternalMethod', () => {
 		let receivingChainID: Buffer;
 		const messageFee = BigInt(1000);
 		const data = '';
+		const timestamp = Math.floor(Date.now() / 1000);
 
 		beforeEach(() => {
 			receivingChainID = utils.getRandomBytes(LENGTH_CHAIN_ID);
@@ -254,6 +255,7 @@ describe('InternalMethod', () => {
 						messageFee,
 						data,
 						includeAttributes,
+						timestamp,
 					),
 				).resolves.toBeUndefined();
 
@@ -294,6 +296,7 @@ describe('InternalMethod', () => {
 					receivingChainID,
 					messageFee,
 					ccmParameters,
+					timestamp,
 				);
 			});
 
@@ -330,6 +333,7 @@ describe('InternalMethod', () => {
 						messageFee,
 						data,
 						includeAttributes,
+						timestamp,
 					),
 				).resolves.toBeUndefined();
 
@@ -362,6 +366,7 @@ describe('InternalMethod', () => {
 					receivingChainID,
 					messageFee,
 					ccmParameters,
+					timestamp,
 				);
 			});
 		});
@@ -407,6 +412,7 @@ describe('InternalMethod', () => {
 						messageFee,
 						data,
 						includeAttributes,
+						timestamp,
 					),
 				).resolves.toBeUndefined();
 
@@ -447,6 +453,7 @@ describe('InternalMethod', () => {
 					receivingChainID,
 					messageFee,
 					ccmParameters,
+					timestamp,
 				);
 			});
 
@@ -490,6 +497,7 @@ describe('InternalMethod', () => {
 						messageFee,
 						data,
 						includeAttributes,
+						timestamp,
 					),
 				).resolves.toBeUndefined();
 
@@ -522,6 +530,7 @@ describe('InternalMethod', () => {
 					receivingChainID,
 					messageFee,
 					ccmParameters,
+					timestamp,
 				);
 			});
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8791

### How was it solved?

Added timestamp as optional param to internal function and updated usage in other places

### How was it tested?

- Updated unit tests
