### PR TITLE
Add backup.height to getNodeInfo

### DIFF
--- a/framework/src/node/node.ts
+++ b/framework/src/node/node.ts
@@ -513,6 +513,9 @@ export class Node {
 					...this._options.genesisConfig,
 				},
 				registeredModules: this.getRegisteredModules(),
+				backup: {
+					height: this._options.backup.height,
+				},
 				network: {
 					port: this._options.network.port,
 					hostIp: this._options.network.hostIp,

--- a/framework/test/functional/actions/application.spec.ts
+++ b/framework/test/functional/actions/application.spec.ts
@@ -43,6 +43,9 @@ describe('Application related actions', () => {
 					networkIdentifier: expect.any(String),
 					networkVersion: expect.any(String),
 					lastBlockID: expect.any(String),
+					backup: {
+						height: expect.any(Number),
+					},
 					finalizedHeight: expect.any(Number),
 					unconfirmedTransactions: expect.any(Number),
 				}),


### PR DESCRIPTION
### What was the problem?

This PR resolves #8790 

### How was it solved?

- Add backup.height to the getNodeInfo endpoint(action)

### How was it tested?

- Add functional test to check the endpoint(action)
