### PR TITLE
Update message recovery

### DIFF
--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -90,27 +90,6 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 				};
 			}
 		}
-		// Check that the idxs are sorted in ascending order
-		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_returns_the_reference_to_the_same_array
-		// CAUTION! `sort` modifies original array
-		const sortedIdxs = [...idxs].sort((a, b) => a - b);
-		const isSame =
-			idxs.length === sortedIdxs.length &&
-			idxs.every((element, index) => element === sortedIdxs[index]);
-		if (!isSame) {
-			return {
-				status: VerifyStatus.FAIL,
-				error: new Error('Cross-chain message indexes are not sorted in ascending order.'),
-			};
-		}
-
-		// Check that the idxs are unique.
-		if (idxs.length !== new Set(idxs).size) {
-			return {
-				status: VerifyStatus.FAIL,
-				error: new Error('Cross-chain message indexes are not unique.'),
-			};
-		}
 
 		// Check that the CCMs are still pending. We can check only the first one,
 		// as the idxs are sorted in ascending order.

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -82,6 +82,14 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 			};
 		}
 
+		for (let i = 0; i < idxs.length - 1; i += 1) {
+			if (idxs[i] > idxs[i + 1]) {
+				return {
+					status: VerifyStatus.FAIL,
+					error: new Error('Cross-chain message indexes are not strictly increasing.'),
+				};
+			}
+		}
 		// Check that the idxs are sorted in ascending order
 		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_returns_the_reference_to_the_same_array
 		// CAUTION! `sort` modifies original array

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -255,44 +255,6 @@ describe('MessageRecoveryCommand', () => {
 			);
 		});
 
-		it('should return error if idxs are not sorted in ascending order', async () => {
-			transactionParams.idxs = [1, 0];
-			commandVerifyContext = createCommandVerifyContext(transaction, transactionParams);
-
-			await interopModule.stores
-				.get(TerminatedOutboxStore)
-				.set(createStoreGetter(commandVerifyContext.stateStore as any), chainID, {
-					outboxRoot,
-					outboxSize: terminatedChainOutboxSize,
-					partnerChainInboxSize: 1,
-				});
-
-			const result = await command.verify(commandVerifyContext);
-
-			expect(result.status).toBe(VerifyStatus.FAIL);
-			expect(result.error?.message).toInclude(
-				`Cross-chain message indexes are not sorted in ascending order.`,
-			);
-		});
-
-		it('should return error if idxs are not unique', async () => {
-			transactionParams.idxs = [1, 1];
-			commandVerifyContext = createCommandVerifyContext(transaction, transactionParams);
-
-			await interopModule.stores
-				.get(TerminatedOutboxStore)
-				.set(createStoreGetter(commandVerifyContext.stateStore as any), chainID, {
-					outboxRoot,
-					outboxSize: terminatedChainOutboxSize,
-					partnerChainInboxSize: 1,
-				});
-
-			const result = await command.verify(commandVerifyContext);
-
-			expect(result.status).toBe(VerifyStatus.FAIL);
-			expect(result.error?.message).toInclude('Cross-chain message indexes are not unique.');
-		});
-
 		it('should return error if cross-chain message is not pending', async () => {
 			transactionParams.idxs = [0];
 			ccms = [ccms[0]];

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -235,6 +235,26 @@ describe('MessageRecoveryCommand', () => {
 			);
 		});
 
+		it('should return error if cross chain messages indexes are not strictly increasing', async () => {
+			transactionParams.idxs = [2, 1];
+			commandVerifyContext = createCommandVerifyContext(transaction, transactionParams);
+
+			await interopModule.stores
+				.get(TerminatedOutboxStore)
+				.set(createStoreGetter(commandVerifyContext.stateStore as any), chainID, {
+					outboxRoot,
+					outboxSize: terminatedChainOutboxSize,
+					partnerChainInboxSize: 1,
+				});
+
+			const result = await command.verify(commandVerifyContext);
+
+			expect(result.status).toBe(VerifyStatus.FAIL);
+			expect(result.error?.message).toInclude(
+				'Cross-chain message indexes are not strictly increasing.',
+			);
+		});
+
 		it('should return error if idxs are not sorted in ascending order', async () => {
 			transactionParams.idxs = [1, 0];
 			commandVerifyContext = createCommandVerifyContext(transaction, transactionParams);


### PR DESCRIPTION
### What was the problem?

This PR resolves #8723 

### How was it solved?

- Introduce a new check "if cross chain messages indexes are not strictly increasing" in `verify`

### How was it tested?

`npm run test:unit interoperability`
