### PR TITLE
Separate verification of outbox root into verify and execute steps

### DIFF
--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -104,7 +104,7 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 		}
 
 		if (!isInboxUpdateEmpty(params.inboxUpdate)) {
-			await this.internalMethod.verifyPartnerChainOutboxRoot(context, params);
+			this.internalMethod.verifyOutboxRootWitness(context, params);
 		}
 
 		return {

--- a/framework/test/unit/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.spec.ts
@@ -154,6 +154,7 @@ describe('SubmitMainchainCrossChainUpdateCommand', () => {
 		verifyCertificateSignature: jest.fn(),
 		verifyValidatorsUpdate: jest.fn(),
 		verifyPartnerChainOutboxRoot: jest.fn(),
+		verifyOutboxRootWitness: jest.fn(),
 		updateValidators: jest.fn(),
 		updateCertificate: jest.fn(),
 		updatePartnerChainOutboxRoot: jest.fn(),
@@ -543,7 +544,7 @@ describe('SubmitMainchainCrossChainUpdateCommand', () => {
 			).resolves.toEqual({ status: VerifyStatus.OK });
 
 			expect(
-				mainchainCCUUpdateCommand['internalMethod'].verifyPartnerChainOutboxRoot,
+				mainchainCCUUpdateCommand['internalMethod'].verifyOutboxRootWitness,
 			).toHaveBeenCalledTimes(1);
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8718 

### How was it solved?

- Separate verifyPartnerChainOutboxRoot into 2 parts (verifyOutboxRootWitness and verifyPartnerChainOutboxRoot)
- Update the usage to be in verify and execute

### How was it tested?

- Separate the tests for those 2 functions
