### PR TITLE
Handle dry run in non-strict mode with insufficient transaction fee

### DIFF
--- a/framework/test/unit/modules/fee/module.spec.ts
+++ b/framework/test/unit/modules/fee/module.spec.ts
@@ -194,6 +194,16 @@ describe('FeeModule', () => {
 				defaultTransaction.fee,
 			);
 		});
+
+		it('should throw if provided fee is lower than the min fee', async () => {
+			const transaction = new Transaction({ ...defaultTransaction, fee: BigInt(1) });
+			const context = createTransactionContext({ transaction });
+			const transactionExecuteContext = context.createTransactionExecuteContext();
+
+			await expect(feeModule.beforeCommandExecute(transactionExecuteContext)).rejects.toThrow(
+				'Insufficient transaction fee',
+			);
+		});
 	});
 
 	describe('afterCommandExecute', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8779

### How was it solved?

Added a check in `beforeCommandExecute()` identical to the one in `verifyTransaction()`, which throws when the provided fee is insufficient.

### How was it tested?

- Added a unit test.
- Invoked a manual dry run, and it resolved transaction as invalid, with no events.
