### PR TITLE
Receiving chain incorrectly checks for the owner of nft when sending chain is not own chain

### DIFF
--- a/framework/src/modules/nft/cc_commands/cc_transfer.ts
+++ b/framework/src/modules/nft/cc_commands/cc_transfer.ts
@@ -70,13 +70,16 @@ export class CrossChainTransferCommand extends BaseCCCommand {
 
 		const nftStore = this.stores.get(NFTStore);
 		const nftExists = await nftStore.has(getMethodContext(), nftID);
-		if (nftChainID.equals(ownChainID) && !nftExists) {
-			throw new Error('Non-existent entry in the NFT substore');
-		}
 
-		const owner = await this._method.getNFTOwner(getMethodContext(), nftID);
-		if (nftChainID.equals(ownChainID) && !owner.equals(sendingChainID)) {
-			throw new Error('NFT has not been properly escrowed');
+		if (nftChainID.equals(ownChainID)) {
+			if (!nftExists) {
+				throw new Error('Non-existent entry in the NFT substore');
+			}
+
+			const owner = await this._method.getNFTOwner(getMethodContext(), nftID);
+			if (!owner.equals(sendingChainID)) {
+				throw new Error('NFT has not been properly escrowed');
+			}
 		}
 
 		if (!nftChainID.equals(ownChainID) && nftExists) {

--- a/framework/src/modules/nft/cc_commands/cc_transfer.ts
+++ b/framework/src/modules/nft/cc_commands/cc_transfer.ts
@@ -72,10 +72,6 @@ export class CrossChainTransferCommand extends BaseCCCommand {
 		const nftExists = await nftStore.has(getMethodContext(), nftID);
 
 		if (nftChainID.equals(ownChainID)) {
-			if (!nftExists) {
-				throw new Error('Non-existent entry in the NFT substore');
-			}
-
 			const owner = await this._method.getNFTOwner(getMethodContext(), nftID);
 			if (!owner.equals(sendingChainID)) {
 				throw new Error('NFT has not been properly escrowed');

--- a/framework/test/unit/modules/nft/cc_comands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/nft/cc_comands/cc_transfer.spec.ts
@@ -291,9 +291,7 @@ describe('CrossChain Transfer Command', () => {
 		it('should throw if nft chain id equals own chain id but no entry exists in nft substore for the nft id', async () => {
 			await nftStore.del(methodContext, nftID);
 
-			await expect(command.verify(context)).rejects.toThrow(
-				'Non-existent entry in the NFT substore',
-			);
+			await expect(command.verify(context)).rejects.toThrow('NFT substore entry does not exist');
 		});
 
 		it('should throw if nft chain id equals own chain id but the owner of nft is different from the sending chain', async () => {

--- a/framework/test/unit/modules/nft/cc_comands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/nft/cc_comands/cc_transfer.spec.ts
@@ -280,7 +280,7 @@ describe('CrossChain Transfer Command', () => {
 				eventQueue,
 				getStore,
 				logger: fakeLogger,
-				chainID,
+				chainID: newConfig.ownChainID,
 			};
 
 			await expect(command.verify(context)).rejects.toThrow(
@@ -304,6 +304,32 @@ describe('CrossChain Transfer Command', () => {
 			});
 
 			await expect(command.verify(context)).rejects.toThrow('NFT has not been properly escrowed');
+		});
+
+		it('should not throw if nft chain id is not equal to own chain id and no entry exists in nft substore for the nft id', async () => {
+			const newConfig = {
+				ownChainID: utils.getRandomBytes(LENGTH_CHAIN_ID),
+				escrowAccountInitializationFee: BigInt(50000000),
+				userAccountInitializationFee: BigInt(50000000),
+			};
+			method.init(newConfig);
+			internalMethod.addDependencies(method, interopMethod);
+			internalMethod.init(newConfig);
+			context = {
+				ccm,
+				transaction: defaultTransaction,
+				header: defaultHeader,
+				stateStore,
+				contextStore,
+				getMethodContext,
+				eventQueue: new EventQueue(0),
+				getStore,
+				logger: fakeLogger,
+				chainID: newConfig.ownChainID,
+			};
+			await nftStore.del(methodContext, nftID);
+
+			await expect(command.verify(context)).resolves.toBeUndefined();
 		});
 
 		it('throw if nft chain id is not equal to own chain id and entry already exists in nft substore for the nft id', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8831 

### How was it solved?

Update verify logic of CrossChainTransferCommand in nft module

### How was it tested?

- Added a new test case
- Updated unit test
- Transfer nft b/w two different chains and observe the logs
