### PR TITLE
Method isNFTSupported incorrectly checks if the nft already exists

### DIFF
--- a/framework/src/modules/nft/cc_commands/cc_transfer.ts
+++ b/framework/src/modules/nft/cc_commands/cc_transfer.ts
@@ -70,13 +70,16 @@ export class CrossChainTransferCommand extends BaseCCCommand {
 
 		const nftStore = this.stores.get(NFTStore);
 		const nftExists = await nftStore.has(getMethodContext(), nftID);
-		if (nftChainID.equals(ownChainID) && !nftExists) {
-			throw new Error('Non-existent entry in the NFT substore');
-		}
 
-		const owner = await this._method.getNFTOwner(getMethodContext(), nftID);
-		if (nftChainID.equals(ownChainID) && !owner.equals(sendingChainID)) {
-			throw new Error('NFT has not been properly escrowed');
+		if (nftChainID.equals(ownChainID)) {
+			if (!nftExists) {
+				throw new Error('Non-existent entry in the NFT substore');
+			}
+
+			const owner = await this._method.getNFTOwner(getMethodContext(), nftID);
+			if (!owner.equals(sendingChainID)) {
+				throw new Error('NFT has not been properly escrowed');
+			}
 		}
 
 		if (!nftChainID.equals(ownChainID) && nftExists) {

--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -200,12 +200,6 @@ export class NFTMethod extends BaseMethod {
 		methodContext: ImmutableMethodContext,
 		nftID: Buffer,
 	): Promise<boolean> {
-		const nftStore = this.stores.get(NFTStore);
-		const nftExists = await nftStore.has(methodContext, nftID);
-		if (!nftExists) {
-			throw new Error('NFT substore entry does not exist');
-		}
-
 		const nftChainID = this.getChainID(nftID);
 		if (nftChainID.equals(this._config.ownChainID)) {
 			return true;

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -380,20 +380,6 @@ describe('NFTMethod', () => {
 	});
 
 	describe('isNFTSupported', () => {
-		beforeEach(async () => {
-			await nftStore.save(methodContext, nftID, {
-				owner: utils.getRandomBytes(LENGTH_CHAIN_ID),
-				attributesArray: [],
-			});
-		});
-
-		it('should throw if entry does not exist in the nft substore for the nft id', async () => {
-			await nftStore.del(methodContext, nftID);
-			await expect(method.isNFTSupported(methodContext, nftID)).rejects.toThrow(
-				'NFT substore entry does not exist',
-			);
-		});
-
 		it('should return true if nft chain id equals own chain id', async () => {
 			const isSupported = await method.isNFTSupported(methodContext, existingNativeNFT.nftID);
 			expect(isSupported).toBe(true);


### PR DESCRIPTION
### What was the problem?

This PR resolves #8832 

### How was it solved?

Remove the invalid check

### How was it tested?

Updated unit test
