### PR TITLE
Lisk-db: the update and new methods are ambiguous

### DIFF
--- a/framework/src/engine/endpoint/chain.ts
+++ b/framework/src/engine/endpoint/chain.ts
@@ -36,6 +36,7 @@ import { areHeadersContradictingRequestSchema, BFTVotes, bftVotesSchema } from '
 import { areDistinctHeadersContradicting } from '../bft/utils';
 import { getBFTParameters } from '../bft/bft_params';
 import { BFTMethod } from '../bft';
+import { EMPTY_HASH } from '../consensus/constants';
 
 interface EndpointArgs {
 	chain: Chain;
@@ -212,7 +213,7 @@ export class ChainEndpoint {
 				data.push(pair);
 			}
 		}
-		const root = await eventSMT.update(Buffer.alloc(0), data);
+		const root = await eventSMT.update(EMPTY_HASH, data);
 		const proof = await eventSMT.prove(root, queryBytes);
 		return {
 			queries: proof.queries.map(q => ({

--- a/framework/src/genesis_block.ts
+++ b/framework/src/genesis_block.ts
@@ -113,7 +113,7 @@ export const generateGenesisBlock = async (
 			data.push(pair);
 		}
 	}
-	header.eventRoot = await eventSMT.update(Buffer.alloc(0), data);
+	header.eventRoot = await eventSMT.update(EMPTY_HASH, data);
 	header.validatorsHash = computeValidatorsHash(
 		blockCtx.nextValidators.validators,
 		blockCtx.nextValidators.certificateThreshold,


### PR DESCRIPTION
### What was the problem?

This PR resolves #8850

### How was it solved?

- Updated usage in `chain.ts` and `genesis_block.ts` to use empty hash.

### How was it tested?

All tests are passing
