### PR TITLE
Update message recovery indices check logic

### DIFF
--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -92,10 +92,10 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 			}
 		}
 
-		// Encoded indices equal to zero are also not valid here as they represent non-existing
-		// entries. It's sufficient to check only the first one due the ascending order.
+		// Ensure that there are at least two bits, i.e. the value must be larger than 1.
+		// It's sufficient to check only the first one due the ascending order.
 		// See https://github.com/LiskHQ/lips/blob/main/proposals/lip-0031.md#proof-serialization.
-		if (idxs[0] === 0) {
+		if (idxs[0] <= 1) {
 			return {
 				status: VerifyStatus.FAIL,
 				error: new Error('Cross-chain message does not have a valid index.'),

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -264,7 +264,7 @@ describe('MessageRecoveryCommand', () => {
 			);
 		});
 
-		it('should return error if idxs = [0]', async () => {
+		it('should return error if idxs[0] <= 1', async () => {
 			transactionParams.idxs = [0];
 			ccms = [ccms[0]];
 			ccmsEncoded = ccms.map(ccm => codec.encode(ccmSchema, ccm));


### PR DESCRIPTION
### What was the problem?

This PR resolves #8859 

### How was it solved?

Updated indices check to `idx[0] <= 1`

### How was it tested?

Updated relevant test
