### PR TITLE
Check that the sk is not a multiple of group order and is 32 bytes long

### DIFF
--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -65,12 +65,22 @@ export const isNotMultipleOfGroupOrder = (sk: Buffer): boolean => {
 		'hex',
 	);
 
-	return !(timingSafeEqual(sk, groupOrder) || timingSafeEqual(sk, groupOrderDouble));
+	if (timingSafeEqual(sk, groupOrder)) {
+		return false;
+	}
+
+	if (timingSafeEqual(sk, groupOrderDouble)) {
+		return false;
+	}
+
+	return true;
 };
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.4
 export const blsSkToPk = (sk: Buffer): Buffer => {
-	isNotMultipleOfGroupOrder(sk);
+	if (!isNotMultipleOfGroupOrder(sk)) {
+		throw new Error('Secret key is not valid.');
+	}
 
 	const secretKey = SecretKey.fromBytes(sk);
 
@@ -88,7 +98,9 @@ export const blsAggregate = (signatures: Buffer[]): Buffer | false => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.6
 export const blsSign = (sk: Buffer, message: Buffer): Buffer => {
-	isNotMultipleOfGroupOrder(sk);
+	if (!isNotMultipleOfGroupOrder(sk)) {
+		throw new Error('Secret key is not valid.');
+	}
 
 	const secretKey = SecretKey.fromBytes(sk);
 
@@ -149,7 +161,9 @@ export const blsPopProve = (sk: Buffer): Buffer => {
 	const message = blsSkToPk(sk);
 	const sig = new blst.P2();
 
-	isNotMultipleOfGroupOrder(sk);
+	if (!isNotMultipleOfGroupOrder(sk)) {
+		throw new Error('Secret key is not valid.');
+	}
 
 	const secretKey = SecretKey.fromBytes(sk);
 

--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -51,7 +51,7 @@ export const blsKeyGen = (ikm: Buffer): Buffer => Buffer.from(SecretKey.fromKeyg
  * @param {Buffer} sk - The parameter `sk` is a Buffer that represents a secret key.
  * @returns a boolean value.
  */
-export const isNotMultipleOfGroupOrder = (sk: Buffer): boolean => {
+export const isMultipleOfGroupOrder = (sk: Buffer): boolean => {
 	/// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#section-4.2.1
 	// r: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001;
 	const groupOrder = Buffer.from(
@@ -78,7 +78,7 @@ export const isNotMultipleOfGroupOrder = (sk: Buffer): boolean => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.4
 export const blsSkToPk = (sk: Buffer): Buffer => {
-	if (!isNotMultipleOfGroupOrder(sk)) {
+	if (!isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
 
@@ -98,7 +98,7 @@ export const blsAggregate = (signatures: Buffer[]): Buffer | false => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.6
 export const blsSign = (sk: Buffer, message: Buffer): Buffer => {
-	if (!isNotMultipleOfGroupOrder(sk)) {
+	if (!isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
 
@@ -161,7 +161,7 @@ export const blsPopProve = (sk: Buffer): Buffer => {
 	const message = blsSkToPk(sk);
 	const sig = new blst.P2();
 
-	if (!isNotMultipleOfGroupOrder(sk)) {
+	if (!isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
 

--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -45,7 +45,8 @@ export const blsKeyValidate = (pk: Buffer): boolean => {
 export const blsKeyGen = (ikm: Buffer): Buffer => Buffer.from(SecretKey.fromKeygen(ikm).toBytes());
 
 /**
- * The function checks if a given buffer `sk` is not a multiple of the group order and 32 bytes long.
+ * The function checks if a given buffer `sk` is not a multiple of the group order that fits into 32 bytes,
+ * except for zero. The only multiples of the group order `r` that fit into 32 bytes are `0`, `r` and `2*r`.
  *
  * @param {Buffer} sk - The parameter `sk` is a Buffer that represents a secret key.
  * @returns a boolean value.

--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -44,27 +44,27 @@ export const blsKeyValidate = (pk: Buffer): boolean => {
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.3
 export const blsKeyGen = (ikm: Buffer): Buffer => Buffer.from(SecretKey.fromKeygen(ikm).toBytes());
 
+// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#section-4.2.1
+// r: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001;
+const groupOrder = Buffer.from(
+	'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+	'hex',
+);
+
+// 2 * r (group order)
+const groupOrderDouble = Buffer.from(
+	'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+	'hex',
+);
+
 /**
- * The function checks if a given buffer `sk` is not a multiple of the group order that fits into 32 bytes,
- * except for zero. The only multiples of the group order `r` that fit into 32 bytes are `0`, `r` and `2*r`.
+ * The function checks if a given buffer `sk` is not a multiple of the group order that fits into 32 bytes except for zero.
+ * The only multiples of the group order `r` that fit into 32 bytes are `0`, `r` and `2*r`.
  *
  * @param {Buffer} sk - The parameter `sk` is a Buffer that represents a secret key.
  * @returns a boolean value.
  */
 export const isMultipleOfGroupOrder = (sk: Buffer): boolean => {
-	/// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#section-4.2.1
-	// r: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001;
-	const groupOrder = Buffer.from(
-		'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
-		'hex',
-	);
-
-	// 2 * r (group order)
-	const groupOrderDouble = Buffer.from(
-		'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
-		'hex',
-	);
-
 	if (timingSafeEqual(sk, groupOrder)) {
 		return false;
 	}

--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -27,6 +27,7 @@ import {
 
 // eslint-disable-next-line camelcase, import/no-extraneous-dependencies
 import { blst, BLST_ERROR, P1_Affine, P2_Affine } from '@chainsafe/blst/dist/bindings';
+import { timingSafeEqual } from 'crypto';
 
 const DST_POP = 'BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_';
 
@@ -43,28 +44,34 @@ export const blsKeyValidate = (pk: Buffer): boolean => {
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.3
 export const blsKeyGen = (ikm: Buffer): Buffer => Buffer.from(SecretKey.fromKeygen(ikm).toBytes());
 
-// check that the secret key generated is non-zero modulo the group order.
-export const isSecretKeyNonZeroModOrder = (secretKey: SecretKey): boolean => {
-	// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#section-4.2.1
-	const groupOrder = '0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001';
+/**
+ * The function checks if a given buffer `sk` is not a multiple of the group order and 32 bytes long.
+ *
+ * @param {Buffer} sk - The parameter `sk` is a Buffer that represents a secret key.
+ * @returns a boolean value.
+ */
+export const isNotMultipleOfGroupOrder = (sk: Buffer): boolean => {
+	/// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#section-4.2.1
+	// r: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001;
+	const groupOrder = Buffer.from(
+		'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+		'hex',
+	);
 
-	const skBigInt = BigInt(`0x${Buffer.from(secretKey.toBytes()).toString('hex')}`);
+	// 2 * r (group order)
+	const groupOrderDouble = Buffer.from(
+		'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+		'hex',
+	);
 
-	// check if secret key is non-zero modulo the order of the elliptic curve.
-	if (skBigInt % BigInt(groupOrder) === BigInt(0)) {
-		return false;
-	}
-
-	return true;
+	return !(timingSafeEqual(sk, groupOrder) || timingSafeEqual(sk, groupOrderDouble));
 };
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.4
 export const blsSkToPk = (sk: Buffer): Buffer => {
-	const secretKey = SecretKey.fromBytes(sk);
+	isNotMultipleOfGroupOrder(sk);
 
-	if (!isSecretKeyNonZeroModOrder(secretKey)) {
-		throw new Error('Secret key is not valid.');
-	}
+	const secretKey = SecretKey.fromBytes(sk);
 
 	return Buffer.from(secretKey.toPublicKey().toBytes());
 };
@@ -80,11 +87,9 @@ export const blsAggregate = (signatures: Buffer[]): Buffer | false => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.6
 export const blsSign = (sk: Buffer, message: Buffer): Buffer => {
-	const secretKey = SecretKey.fromBytes(sk);
+	isNotMultipleOfGroupOrder(sk);
 
-	if (!isSecretKeyNonZeroModOrder(secretKey)) {
-		throw new Error('Secret key is not valid.');
-	}
+	const secretKey = SecretKey.fromBytes(sk);
 
 	return Buffer.from(secretKey.sign(message).toBytes());
 };
@@ -143,11 +148,9 @@ export const blsPopProve = (sk: Buffer): Buffer => {
 	const message = blsSkToPk(sk);
 	const sig = new blst.P2();
 
-	const secretKey = SecretKey.fromBytes(sk);
+	isNotMultipleOfGroupOrder(sk);
 
-	if (!isSecretKeyNonZeroModOrder(secretKey)) {
-		throw new Error('Secret key is not valid.');
-	}
+	const secretKey = SecretKey.fromBytes(sk);
 
 	return Buffer.from(
 		new Signature(sig.hash_to(message, DST_POP).sign_with(secretKey.value)).toBytes(),

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -84,7 +84,7 @@ describe('bls_lib', () => {
 			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
-		it('should return true when the buffer is not a multiple of the group order and not 32 bytes long', () => {
+		it('should return true when the buffer is not a multiple of the group order that is 32 bytes long', () => {
 			const sk = Buffer.from(
 				'0000000000000000000000000000000000000000000000000000000000000001',
 				'hex',
@@ -100,7 +100,7 @@ describe('bls_lib', () => {
 			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
-		it('should return false when the buffer is a multiple of the group order and 32 bytes long', () => {
+		it('should return false when the buffer is equal to the group order', () => {
 			const sk = Buffer.from(
 				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
 				'hex',
@@ -116,7 +116,7 @@ describe('bls_lib', () => {
 			expect(isNotMultipleOfGroupOrder(sk)).toBe(false);
 		});
 
-		it('should return false if sk is equal to groupOrderDouble', () => {
+		it('should return false if sk is equal to 2 times the group order', () => {
 			const sk = Buffer.from(
 				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
 				'hex',

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { isNotMultipleOfGroupOrder } from '../../src/bls_lib/lib';
+import { isMultipleOfGroupOrder } from '../../src/bls_lib/lib';
 import {
 	blsAggregate,
 	blsAggregateVerify,
@@ -59,13 +59,13 @@ interface EthFastAggrVerifySpec {
 }
 
 describe('bls_lib', () => {
-	describe('isNotMultipleOfGroupOrder', () => {
+	describe('isMultipleOfGroupOrder', () => {
 		it('should return true if sk is not equal to groupOrder or groupOrderDouble', () => {
 			const sk = Buffer.from(
 				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000003',
 				'hex',
 			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
+			expect(isMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
 		it('should return true when the buffer is not a multiple of the group order that is 32 bytes long', () => {
@@ -73,7 +73,7 @@ describe('bls_lib', () => {
 				'0000000000000000000000000000000000000000000000000000000000000001',
 				'hex',
 			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
+			expect(isMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
 		it('should return false when the buffer is equal to the group order', () => {
@@ -81,7 +81,7 @@ describe('bls_lib', () => {
 				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
 				'hex',
 			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(false);
+			expect(isMultipleOfGroupOrder(sk)).toBe(false);
 		});
 
 		it('should return false if sk is equal to 2 times the group order', () => {
@@ -89,7 +89,7 @@ describe('bls_lib', () => {
 				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
 				'hex',
 			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(false);
+			expect(isMultipleOfGroupOrder(sk)).toBe(false);
 		});
 	});
 

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -68,22 +68,6 @@ describe('bls_lib', () => {
 			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
-		it('should return true if sk is 3*groupOrder', () => {
-			const sk = Buffer.from(
-				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
-				'hex',
-			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
-		});
-
-		it('should return true when the buffer is not a multiple of the group order and 32 bytes long', () => {
-			const sk = Buffer.from(
-				'0000000000000000000000000000000000000000000000000000000000000000',
-				'hex',
-			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
-		});
-
 		it('should return true when the buffer is not a multiple of the group order that is 32 bytes long', () => {
 			const sk = Buffer.from(
 				'0000000000000000000000000000000000000000000000000000000000000001',
@@ -92,23 +76,7 @@ describe('bls_lib', () => {
 			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
-		it('should return true when the buffer is a multiple of the group order but not 32 bytes long', () => {
-			const sk = Buffer.from(
-				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000002',
-				'hex',
-			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(true);
-		});
-
 		it('should return false when the buffer is equal to the group order', () => {
-			const sk = Buffer.from(
-				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
-				'hex',
-			);
-			expect(isNotMultipleOfGroupOrder(sk)).toBe(false);
-		});
-
-		it('should return false if sk is equal to groupOrder', () => {
 			const sk = Buffer.from(
 				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
 				'hex',
@@ -160,6 +128,30 @@ describe('bls_lib', () => {
 				blsSkToPk(sk);
 			}).toThrow();
 		});
+
+		it('should throw error when sk is equal to the group order', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+				'hex',
+			);
+			expect(() => blsSkToPk(sk)).toThrow('Secret key is not valid.');
+		});
+
+		it('should throw error if sk is equal to 2 times the group order', () => {
+			const sk = Buffer.from(
+				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+				'hex',
+			);
+			expect(() => blsSkToPk(sk)).toThrow('Secret key is not valid.');
+		});
+
+		it('should pass if sk is equal to 3 times the group order', () => {
+			const sk = Buffer.from(
+				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'hex',
+			);
+			expect(() => blsSkToPk(sk)).not.toThrow();
+		});
 	});
 
 	describe('blsSign', () => {
@@ -189,6 +181,30 @@ describe('bls_lib', () => {
 			expect(() => {
 				blsSign(sk, Buffer.alloc(32, 1));
 			}).toThrow();
+		});
+
+		it('should throw error when sk is equal to the group order', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+				'hex',
+			);
+			expect(() => blsSign(sk, Buffer.alloc(32, 1))).toThrow('Secret key is not valid.');
+		});
+
+		it('should throw error if sk is equal to 2 times the group order', () => {
+			const sk = Buffer.from(
+				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+				'hex',
+			);
+			expect(() => blsSign(sk, Buffer.alloc(32, 1))).toThrow('Secret key is not valid.');
+		});
+
+		it('should pass if sk is equal to 3 times the group order', () => {
+			const sk = Buffer.from(
+				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'hex',
+			);
+			expect(() => blsSign(sk, Buffer.alloc(32, 1))).not.toThrow();
 		});
 	});
 
@@ -300,6 +316,30 @@ describe('bls_lib', () => {
 			expect(() => {
 				blsPopProve(sk);
 			}).toThrow();
+		});
+
+		it('should throw error when sk is equal to the group order', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+				'hex',
+			);
+			expect(() => blsPopProve(sk)).toThrow('Secret key is not valid.');
+		});
+
+		it('should throw error if sk is equal to 2 times the group order', () => {
+			const sk = Buffer.from(
+				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+				'hex',
+			);
+			expect(() => blsPopProve(sk)).toThrow('Secret key is not valid.');
+		});
+
+		it('should pass if sk is equal to 3 times the group order', () => {
+			const sk = Buffer.from(
+				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'hex',
+			);
+			expect(() => blsPopProve(sk)).not.toThrow();
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8449

### How was it solved?

Added the `isNotMultipleOfGroupOrder` function.

### How was it tested?

Added and updated unit tests
