### PR TITLE
Removes registration of ReportMisbehaviorPlugin from examples/pos-mainchain

### DIFF
--- a/examples/pos-mainchain/src/app/plugins.ts
+++ b/examples/pos-mainchain/src/app/plugins.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { ReportMisbehaviorPlugin } from '@liskhq/lisk-framework-report-misbehavior-plugin';
 import { Application } from 'lisk-sdk';
 
-export const registerPlugins = (_app: Application): void => {
-	_app.registerPlugin(new ReportMisbehaviorPlugin());
-};
+export const registerPlugins = (_app: Application): void => {};


### PR DESCRIPTION
### What was the problem?

This PR resolves #8878 

### How was it solved?

Removes registration of `ReportMisbehaviorPlugin` from `pos-mainchain`.

### How was it tested?
N/A.
