### PR TITLE
Fix BLS test fixtures

### DIFF
--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -27,6 +27,7 @@ import {
 
 // eslint-disable-next-line camelcase, import/no-extraneous-dependencies
 import { blst, BLST_ERROR, P1_Affine, P2_Affine } from '@chainsafe/blst/dist/bindings';
+import { timingSafeEqual } from 'crypto';
 
 const DST_POP = 'BLS_POP_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_';
 
@@ -43,15 +44,32 @@ export const blsKeyValidate = (pk: Buffer): boolean => {
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.3
 export const blsKeyGen = (ikm: Buffer): Buffer => Buffer.from(SecretKey.fromKeygen(ikm).toBytes());
 
-// check that the secret key generated is non-zero modulo the group order.
-export const isSecretKeyNonZeroModOrder = (secretKey: SecretKey): boolean => {
-	// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#section-4.2.1
-	const groupOrder = '0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001';
+// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-pairing-friendly-curves-10#section-4.2.1
+// r: 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001;
+const groupOrder = Buffer.from(
+	'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+	'hex',
+);
 
-	const skBigInt = BigInt(`0x${Buffer.from(secretKey.toBytes()).toString('hex')}`);
+// 2 * r (group order)
+const groupOrderDouble = Buffer.from(
+	'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+	'hex',
+);
 
-	// check if secret key is non-zero modulo the order of the elliptic curve.
-	if (skBigInt % BigInt(groupOrder) === BigInt(0)) {
+/**
+ * The function checks if a given buffer `sk` is not a multiple of the group order that fits into 32 bytes except for zero.
+ * The only multiples of the group order `r` that fit into 32 bytes are `0`, `r` and `2*r`.
+ *
+ * @param {Buffer} sk - The parameter `sk` is a Buffer that represents a secret key.
+ * @returns a boolean value.
+ */
+export const isMultipleOfGroupOrder = (sk: Buffer): boolean => {
+	if (timingSafeEqual(sk, groupOrder)) {
+		return false;
+	}
+
+	if (timingSafeEqual(sk, groupOrderDouble)) {
 		return false;
 	}
 
@@ -60,11 +78,11 @@ export const isSecretKeyNonZeroModOrder = (secretKey: SecretKey): boolean => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.4
 export const blsSkToPk = (sk: Buffer): Buffer => {
-	const secretKey = SecretKey.fromBytes(sk);
-
-	if (!isSecretKeyNonZeroModOrder(secretKey)) {
+	if (!isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
+
+	const secretKey = SecretKey.fromBytes(sk);
 
 	return Buffer.from(secretKey.toPublicKey().toBytes());
 };
@@ -80,11 +98,11 @@ export const blsAggregate = (signatures: Buffer[]): Buffer | false => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.6
 export const blsSign = (sk: Buffer, message: Buffer): Buffer => {
-	const secretKey = SecretKey.fromBytes(sk);
-
-	if (!isSecretKeyNonZeroModOrder(secretKey)) {
+	if (!isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
+
+	const secretKey = SecretKey.fromBytes(sk);
 
 	return Buffer.from(secretKey.sign(message).toBytes());
 };
@@ -143,11 +161,11 @@ export const blsPopProve = (sk: Buffer): Buffer => {
 	const message = blsSkToPk(sk);
 	const sig = new blst.P2();
 
-	const secretKey = SecretKey.fromBytes(sk);
-
-	if (!isSecretKeyNonZeroModOrder(secretKey)) {
+	if (!isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
+
+	const secretKey = SecretKey.fromBytes(sk);
 
 	return Buffer.from(
 		new Signature(sig.hash_to(message, DST_POP).sign_with(secretKey.value)).toBytes(),

--- a/elements/lisk-cryptography/src/bls_lib/lib.ts
+++ b/elements/lisk-cryptography/src/bls_lib/lib.ts
@@ -65,20 +65,15 @@ const groupOrderDouble = Buffer.from(
  * @returns a boolean value.
  */
 export const isMultipleOfGroupOrder = (sk: Buffer): boolean => {
-	if (timingSafeEqual(sk, groupOrder)) {
-		return false;
-	}
+	const equalToGroupOrder = timingSafeEqual(sk, groupOrder);
+	const equalToDoubleGroupOrder = timingSafeEqual(sk, groupOrderDouble);
 
-	if (timingSafeEqual(sk, groupOrderDouble)) {
-		return false;
-	}
-
-	return true;
+	return equalToGroupOrder || equalToDoubleGroupOrder;
 };
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.4
 export const blsSkToPk = (sk: Buffer): Buffer => {
-	if (!isMultipleOfGroupOrder(sk)) {
+	if (isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
 
@@ -98,7 +93,7 @@ export const blsAggregate = (signatures: Buffer[]): Buffer | false => {
 
 // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.6
 export const blsSign = (sk: Buffer, message: Buffer): Buffer => {
-	if (!isMultipleOfGroupOrder(sk)) {
+	if (isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
 
@@ -161,7 +156,7 @@ export const blsPopProve = (sk: Buffer): Buffer => {
 	const message = blsSkToPk(sk);
 	const sig = new blst.P2();
 
-	if (!isMultipleOfGroupOrder(sk)) {
+	if (isMultipleOfGroupOrder(sk)) {
 		throw new Error('Secret key is not valid.');
 	}
 

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -60,36 +60,36 @@ interface EthFastAggrVerifySpec {
 
 describe('bls_lib', () => {
 	describe('isMultipleOfGroupOrder', () => {
-		it('should return true if sk is not equal to groupOrder or groupOrderDouble', () => {
+		it('should return false if sk is not equal to groupOrder or groupOrderDouble', () => {
 			const sk = Buffer.from(
 				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000003',
 				'hex',
 			);
-			expect(isMultipleOfGroupOrder(sk)).toBe(true);
+			expect(isMultipleOfGroupOrder(sk)).toBe(false);
 		});
 
-		it('should return true when the buffer is not a multiple of the group order that is 32 bytes long', () => {
+		it('should return false when the buffer is not a multiple of the group order that is 32 bytes long', () => {
 			const sk = Buffer.from(
 				'0000000000000000000000000000000000000000000000000000000000000001',
 				'hex',
 			);
-			expect(isMultipleOfGroupOrder(sk)).toBe(true);
+			expect(isMultipleOfGroupOrder(sk)).toBe(false);
 		});
 
-		it('should return false when the buffer is equal to the group order', () => {
+		it('should return true when the buffer is equal to the group order', () => {
 			const sk = Buffer.from(
 				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
 				'hex',
 			);
-			expect(isMultipleOfGroupOrder(sk)).toBe(false);
+			expect(isMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
-		it('should return false if sk is equal to 2 times the group order', () => {
+		it('should return true if sk is equal to 2 times the group order', () => {
 			const sk = Buffer.from(
 				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
 				'hex',
 			);
-			expect(isMultipleOfGroupOrder(sk)).toBe(false);
+			expect(isMultipleOfGroupOrder(sk)).toBe(true);
 		});
 	});
 
@@ -145,12 +145,12 @@ describe('bls_lib', () => {
 			expect(() => blsSkToPk(sk)).toThrow('Secret key is not valid.');
 		});
 
-		it('should pass if sk is equal to 3 times the group order', () => {
+		it('should throw error if sk is equal to 3 times the group order', () => {
 			const sk = Buffer.from(
-				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'015bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
 				'hex',
 			);
-			expect(() => blsSkToPk(sk)).not.toThrow();
+			expect(() => blsSkToPk(sk)).toThrow('Input buffers must have the same byte length');
 		});
 	});
 
@@ -201,10 +201,12 @@ describe('bls_lib', () => {
 
 		it('should pass if sk is equal to 3 times the group order', () => {
 			const sk = Buffer.from(
-				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'015bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
 				'hex',
 			);
-			expect(() => blsSign(sk, Buffer.alloc(32, 1))).not.toThrow();
+			expect(() => blsSign(sk, Buffer.alloc(32, 1))).toThrow(
+				'Input buffers must have the same byte length',
+			);
 		});
 	});
 
@@ -336,10 +338,10 @@ describe('bls_lib', () => {
 
 		it('should pass if sk is equal to 3 times the group order', () => {
 			const sk = Buffer.from(
-				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'015bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
 				'hex',
 			);
-			expect(() => blsPopProve(sk)).not.toThrow();
+			expect(() => blsPopProve(sk)).toThrow('Input buffers must have the same byte length');
 		});
 	});
 

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -336,7 +336,7 @@ describe('bls_lib', () => {
 			expect(() => blsPopProve(sk)).toThrow('Secret key is not valid.');
 		});
 
-		it('should pass if sk is equal to 3 times the group order', () => {
+		it('should throw if sk is equal to 3 times the group order', () => {
 			const sk = Buffer.from(
 				'015bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
 				'hex',

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -13,8 +13,7 @@
  *
  */
 
-import { ErrorBLST, SecretKey } from '@chainsafe/blst';
-import { isSecretKeyNonZeroModOrder } from '../../src/bls_lib/lib';
+import { isMultipleOfGroupOrder } from '../../src/bls_lib/lib';
 import {
 	blsAggregate,
 	blsAggregateVerify,
@@ -60,231 +59,299 @@ interface EthFastAggrVerifySpec {
 }
 
 describe('bls_lib', () => {
-	const groupOrder = '0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001';
-
-	describe('isSecretKeyNonZeroModOrder', () => {
-		it('should return true when given a valid secret key', () => {
-			const secretKey = SecretKey.fromBytes(Buffer.alloc(32, 1));
-			expect(isSecretKeyNonZeroModOrder(secretKey)).toBe(true);
-		});
-
-		it('should throw error when given a zero secret key', () => {
-			expect(() => isSecretKeyNonZeroModOrder(SecretKey.fromBytes(Buffer.alloc(32, 0)))).toThrow(
-				'ZERO_SECRET_KEY',
+	describe('isMultipleOfGroupOrder', () => {
+		it('should return true if sk is not equal to groupOrder or groupOrderDouble', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000003',
+				'hex',
 			);
+			expect(isMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
-		it('should return false for a secret key that is a multiple of the order of the group', () => {
-			const secretKey = SecretKey.fromBytes(
-				Buffer.from('73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001', 'hex'),
+		it('should return true when the buffer is not a multiple of the group order that is 32 bytes long', () => {
+			const sk = Buffer.from(
+				'0000000000000000000000000000000000000000000000000000000000000001',
+				'hex',
 			);
-			expect(isSecretKeyNonZeroModOrder(secretKey)).toBe(false);
+			expect(isMultipleOfGroupOrder(sk)).toBe(true);
 		});
 
-		describe('blsSkToPk', () => {
-			describe.each(getAllFiles(['bls_specs/sk_to_pk']))('%s', ({ path }) => {
-				it('should convert to valid pk', () => {
-					const { input, output } = loadSpecFile<{ input: string; output: string }>(path);
-
-					expect(blsSkToPk(hexToBuffer(input)).toString('hex')).toEqual(
-						hexToBuffer(output).toString('hex'),
-					);
-				});
-			});
-
-			it('should return a non-empty buffer when given a valid input buffer', () => {
-				const sk = Buffer.alloc(32, 1);
-				const pk = blsSkToPk(sk);
-
-				expect(pk).toBeDefined();
-				expect(pk.length).toBeGreaterThan(0);
-			});
-
-			it('should throw an error when given an input buffer with value equal to the group order', () => {
-				const sk = Buffer.from(groupOrder.slice(2), 'hex');
-
-				expect(() => blsSkToPk(sk)).toThrow('Secret key is not valid.');
-			});
-
-			it('should throw an error if the input buffer is zero', () => {
-				const sk = Buffer.alloc(32, 0);
-				expect(() => blsSkToPk(sk)).toThrow('ZERO_SECRET_KEY');
-			});
-
-			it('should throw an error if the input buffer is not 32 bytes long', () => {
-				const sk = Buffer.alloc(31, 1);
-				expect(() => blsSkToPk(sk)).toThrow(ErrorBLST);
-			});
+		it('should return false when the buffer is equal to the group order', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+				'hex',
+			);
+			expect(isMultipleOfGroupOrder(sk)).toBe(false);
 		});
 
-		describe('blsSign', () => {
-			describe.each(getAllFiles(['eth2_bls_specs/sign', 'bls_specs/sign']))('%s', ({ path }) => {
-				const {
-					input: { privkey, message },
-					output,
-				} = loadSpecFile<EthSignSpec>(path);
+		it('should return false if sk is equal to 2 times the group order', () => {
+			const sk = Buffer.from(
+				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+				'hex',
+			);
+			expect(isMultipleOfGroupOrder(sk)).toBe(false);
+		});
+	});
 
-				if (privkey !== `0x${'00'.repeat(32)}`) {
-					it('should generate valid signature if private key is non zero', () => {
-						const signature = blsSign(hexToBuffer(privkey), hexToBuffer(message));
-						expect(signature.toString('hex')).toEqual(hexToBuffer(output).toString('hex'));
-					});
-				} else {
-					it('should throw an error if the private key is all zeros', () => {
-						expect(() => blsSign(hexToBuffer(privkey), hexToBuffer(message))).toThrow(
-							'ZERO_SECRET_KEY',
-						);
-					});
-				}
-			});
+	describe('blsSkToPk', () => {
+		describe.each(getAllFiles(['bls_specs/sk_to_pk']))('%s', ({ path }) => {
+			it('should convert to valid pk', () => {
+				const { input, output } = loadSpecFile<{ input: string; output: string }>(path);
 
-			it('should throw an error when given an input buffer with value equal to the group order', () => {
-				const sk = Buffer.from(groupOrder.slice(2), 'hex');
-				const message = Buffer.from('hello world');
-
-				expect(() => blsSign(sk, message)).toThrow('Secret key is not valid.');
-			});
-
-			it('should throw an error when a secret key that is non-zero but zero modulo the group order', () => {
-				// sk equals 2*r where r is order of the groups G1 and G2
-				const sk = Buffer.from(
-					'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
-					'hex',
+				expect(blsSkToPk(hexToBuffer(input)).toString('hex')).toEqual(
+					hexToBuffer(output).toString('hex'),
 				);
-				const message = Buffer.from('hello world', 'hex');
-
-				expect(() => blsSign(sk, message)).toThrow('Secret key is not valid.');
 			});
 		});
 
-		describe('blsVerify', () => {
-			describe.each(getAllFiles(['eth2_bls_specs/verify', 'bls_specs/verify']))(
-				'%s',
-				({ path }) => {
-					it('should verify signatures', () => {
-						const {
-							input: { pubkey, message, signature },
-							output,
-						} = loadSpecFile<EthVerifySpec>(path);
+		it('should return a non-empty buffer when given a valid input buffer', () => {
+			const sk = Buffer.alloc(32, 1);
+			const pk = blsSkToPk(sk);
 
-						const verify = blsVerify(
-							hexToBuffer(pubkey),
-							hexToBuffer(message),
-							hexToBuffer(signature),
-						);
+			expect(pk).toBeDefined();
+			expect(pk.length).toBeGreaterThan(0);
+		});
 
-						expect(verify).toEqual(output);
-					});
-				},
+		it('should throw an error if the input buffer is zero', () => {
+			const sk = Buffer.alloc(32, 0);
+			expect(() => blsSkToPk(sk)).toThrow('ZERO_SECRET_KEY');
+		});
+
+		it('should throw an error if the input buffer is not 32 bytes long', () => {
+			const sk = Buffer.alloc(31, 1);
+			expect(() => blsSkToPk(sk)).toThrow('Input buffers must have the same byte length');
+		});
+
+		it('should throw an error when given a secret key that is not a 32-byte Buffer', () => {
+			const sk = Buffer.from('0123456789abcdef0123456789abcdef0123456789abcdef0123456789', 'hex');
+			expect(() => {
+				blsSkToPk(sk);
+			}).toThrow();
+		});
+
+		it('should throw error when sk is equal to the group order', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+				'hex',
 			);
+			expect(() => blsSkToPk(sk)).toThrow('Secret key is not valid.');
 		});
 
-		describe('blsAggregate', () => {
-			describe.each(getAllFiles(['eth2_bls_specs/aggregate', 'bls_specs/aggregate']))(
-				'%s',
-				({ path }) => {
-					it('should aggregate signatures', () => {
-						const { input, output } = loadSpecFile<EthAggrSpec>(path);
-
-						const signature = blsAggregate(input.map(hexToBuffer));
-
-						if (signature) {
-							expect(signature.toString('hex')).toEqual(hexToBuffer(output).toString('hex'));
-						} else {
-							// In one of eth2 specs, they refer null as INVALID case
-							const expectedOutput = output ?? false;
-							expect(signature).toEqual(expectedOutput);
-						}
-					});
-				},
+		it('should throw error if sk is equal to 2 times the group order', () => {
+			const sk = Buffer.from(
+				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+				'hex',
 			);
+			expect(() => blsSkToPk(sk)).toThrow('Secret key is not valid.');
 		});
 
-		describe('blsAggregateVerify', () => {
-			describe.each(getAllFiles(['eth2_bls_specs/aggregate_verify']))('%s', ({ path }) => {
-				it('should verify messages', () => {
-					const {
-						input: { pubkeys, messages, signature },
-						output,
-					} = loadSpecFile<EthAggrVerifySpec>(path);
+		it('should pass if sk is equal to 3 times the group order', () => {
+			const sk = Buffer.from(
+				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'hex',
+			);
+			expect(() => blsSkToPk(sk)).not.toThrow();
+		});
+	});
 
-					const verify = blsAggregateVerify(
-						pubkeys.map(hexToBuffer),
-						messages.map(hexToBuffer),
-						hexToBuffer(signature),
-					);
+	describe('blsSign', () => {
+		describe.each(getAllFiles(['eth2_bls_specs/sign', 'bls_specs/sign']))('%s', ({ path }) => {
+			const {
+				input: { privkey, message },
+				output,
+			} = loadSpecFile<EthSignSpec>(path);
 
-					expect(verify).toEqual(output);
+			if (privkey !== `0x${'00'.repeat(32)}`) {
+				it('should generate valid signature if private key is non zero', () => {
+					const signature = blsSign(hexToBuffer(privkey), hexToBuffer(message));
+					expect(signature.toString('hex')).toEqual(hexToBuffer(output).toString('hex'));
 				});
-			});
-		});
-
-		describe('blsFastAggregateVerify', () => {
-			// The ignored test case "fast_aggregate_verify_infinity_pubkey" contains pk at infinity (identify point)
-			// Since implementation standard https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-3.3.4
-			// specifies to not validate public keys in "FastAggregateVerify"
-			// so we why our implementation returns "true" and eth2 specs mentioned it as "false"
-			describe.each(
-				getAllFiles(
-					['eth2_bls_specs/fast_aggregate_verify', 'bls_specs/fast_aggregate_verify'],
-					/fast_aggregate_verify_infinity_pubkey/,
-				),
-			)('%s', ({ path }) => {
-				it('should verify message', () => {
-					const {
-						input: { pubkeys, message, signature },
-						output,
-					} = loadSpecFile<EthFastAggrVerifySpec>(path);
-
-					const verify = blsFastAggregateVerify(
-						pubkeys.map(hexToBuffer),
-						hexToBuffer(message),
-						hexToBuffer(signature),
-					);
-
-					expect(verify).toEqual(output);
-				});
-			});
-		});
-
-		describe('blsPopProve', () => {
-			describe.each(getAllFiles(['bls_specs/pop_prove']))('%s', ({ path }) => {
-				it('should create valid proof of possession', () => {
-					const { input, output } = loadSpecFile<{ input: string; output: string }>(path);
-
-					expect(blsPopProve(hexToBuffer(input)).toString('hex')).toEqual(
-						hexToBuffer(output).toString('hex'),
+			} else {
+				it('should throw an error if the private key is all zeros', () => {
+					expect(() => blsSign(hexToBuffer(privkey), hexToBuffer(message))).toThrow(
+						'ZERO_SECRET_KEY',
 					);
 				});
+			}
+		});
+
+		it('should throw an error when given a secret key Buffer of length other than 32', () => {
+			const sk = Buffer.from('0123456789abcdef0123456789abcdef0123456789abcdef', 'hex');
+
+			expect(() => {
+				blsSign(sk, Buffer.alloc(32, 1));
+			}).toThrow();
+		});
+
+		it('should throw error when sk is equal to the group order', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+				'hex',
+			);
+			expect(() => blsSign(sk, Buffer.alloc(32, 1))).toThrow('Secret key is not valid.');
+		});
+
+		it('should throw error if sk is equal to 2 times the group order', () => {
+			const sk = Buffer.from(
+				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+				'hex',
+			);
+			expect(() => blsSign(sk, Buffer.alloc(32, 1))).toThrow('Secret key is not valid.');
+		});
+
+		it('should pass if sk is equal to 3 times the group order', () => {
+			const sk = Buffer.from(
+				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'hex',
+			);
+			expect(() => blsSign(sk, Buffer.alloc(32, 1))).not.toThrow();
+		});
+	});
+
+	describe('blsVerify', () => {
+		describe.each(getAllFiles(['eth2_bls_specs/verify', 'bls_specs/verify']))('%s', ({ path }) => {
+			it('should verify signatures', () => {
+				const {
+					input: { pubkey, message, signature },
+					output,
+				} = loadSpecFile<EthVerifySpec>(path);
+
+				const verify = blsVerify(hexToBuffer(pubkey), hexToBuffer(message), hexToBuffer(signature));
+
+				expect(verify).toEqual(output);
 			});
+		});
+	});
 
-			it('should throw an error when given an input buffer with value equal to the group order', () => {
-				const sk = Buffer.from(groupOrder.slice(2), 'hex');
+	describe('blsAggregate', () => {
+		describe.each(getAllFiles(['eth2_bls_specs/aggregate', 'bls_specs/aggregate']))(
+			'%s',
+			({ path }) => {
+				it('should aggregate signatures', () => {
+					const { input, output } = loadSpecFile<EthAggrSpec>(path);
 
-				expect(() => {
-					blsPopProve(sk);
-				}).toThrow('Secret key is not valid.');
+					const signature = blsAggregate(input.map(hexToBuffer));
+
+					if (signature) {
+						expect(signature.toString('hex')).toEqual(hexToBuffer(output).toString('hex'));
+					} else {
+						// In one of eth2 specs, they refer null as INVALID case
+						const expectedOutput = output ?? false;
+						expect(signature).toEqual(expectedOutput);
+					}
+				});
+			},
+		);
+	});
+
+	describe('blsAggregateVerify', () => {
+		describe.each(getAllFiles(['eth2_bls_specs/aggregate_verify']))('%s', ({ path }) => {
+			it('should verify messages', () => {
+				const {
+					input: { pubkeys, messages, signature },
+					output,
+				} = loadSpecFile<EthAggrVerifySpec>(path);
+
+				const verify = blsAggregateVerify(
+					pubkeys.map(hexToBuffer),
+					messages.map(hexToBuffer),
+					hexToBuffer(signature),
+				);
+
+				expect(verify).toEqual(output);
 			});
+		});
+	});
 
-			it('should throw an error when a secret key is zero', () => {
-				const sk = Buffer.alloc(32, 0);
+	describe('blsFastAggregateVerify', () => {
+		// The ignored test case "fast_aggregate_verify_infinity_pubkey" contains pk at infinity (identify point)
+		// Since implementation standard https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-3.3.4
+		// specifies to not validate public keys in "FastAggregateVerify"
+		// so we why our implementation returns "true" and eth2 specs mentioned it as "false"
+		describe.each(
+			getAllFiles(
+				['eth2_bls_specs/fast_aggregate_verify', 'bls_specs/fast_aggregate_verify'],
+				/fast_aggregate_verify_infinity_pubkey/,
+			),
+		)('%s', ({ path }) => {
+			it('should verify message', () => {
+				const {
+					input: { pubkeys, message, signature },
+					output,
+				} = loadSpecFile<EthFastAggrVerifySpec>(path);
 
-				expect(() => {
-					blsPopProve(sk);
-				}).toThrow('ZERO_SECRET_KEY');
+				const verify = blsFastAggregateVerify(
+					pubkeys.map(hexToBuffer),
+					hexToBuffer(message),
+					hexToBuffer(signature),
+				);
+
+				expect(verify).toEqual(output);
+			});
+		});
+	});
+
+	describe('blsPopProve', () => {
+		describe.each(getAllFiles(['bls_specs/pop_prove']))('%s', ({ path }) => {
+			it('should create valid proof of possession', () => {
+				const { input, output } = loadSpecFile<{ input: string; output: string }>(path);
+
+				expect(blsPopProve(hexToBuffer(input)).toString('hex')).toEqual(
+					hexToBuffer(output).toString('hex'),
+				);
 			});
 		});
 
-		describe('blsPopVerify', () => {
-			describe.each(getAllFiles(['bls_specs/pop_verify']))('%s', ({ path }) => {
-				it('should verify proof of possession', () => {
-					const {
-						input: { pk, proof },
-						output,
-					} = loadSpecFile<{ input: { pk: string; proof: string }; output: boolean }>(path);
+		it('should throw an error when a secret key is zero', () => {
+			const sk = Buffer.alloc(32, 0);
 
-					expect(blsPopVerify(hexToBuffer(pk), hexToBuffer(proof))).toEqual(output);
-				});
+			expect(() => {
+				blsPopProve(sk);
+			}).toThrow('ZERO_SECRET_KEY');
+		});
+
+		it('should throw an error when given a secret key Buffer of length other than 32', () => {
+			const sk = Buffer.from('0123456789abcdef0123456789abcdef0123456789abcdef', 'hex');
+
+			expect(() => {
+				blsPopProve(sk);
+			}).toThrow();
+		});
+
+		it('should throw error when sk is equal to the group order', () => {
+			const sk = Buffer.from(
+				'73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001',
+				'hex',
+			);
+			expect(() => blsPopProve(sk)).toThrow('Secret key is not valid.');
+		});
+
+		it('should throw error if sk is equal to 2 times the group order', () => {
+			const sk = Buffer.from(
+				'e7db4ea6533afa906673b0101343b00aa77b4805fffcb7fdfffffffe00000002',
+				'hex',
+			);
+			expect(() => blsPopProve(sk)).toThrow('Secret key is not valid.');
+		});
+
+		it('should pass if sk is equal to 3 times the group order', () => {
+			const sk = Buffer.from(
+				'15bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
+				'hex',
+			);
+			expect(() => blsPopProve(sk)).not.toThrow();
+		});
+	});
+
+	describe('blsPopVerify', () => {
+		describe.each(getAllFiles(['bls_specs/pop_verify']))('%s', ({ path }) => {
+			it('should verify proof of possession', () => {
+				const {
+					input: { pk, proof },
+					output,
+				} = loadSpecFile<{ input: { pk: string; proof: string }; output: boolean }>(path);
+
+				expect(blsPopVerify(hexToBuffer(pk), hexToBuffer(proof))).toEqual(output);
 			});
 		});
 	});

--- a/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
+++ b/elements/lisk-cryptography/test/bls_lib/lib.spec.ts
@@ -199,7 +199,7 @@ describe('bls_lib', () => {
 			expect(() => blsSign(sk, Buffer.alloc(32, 1))).toThrow('Secret key is not valid.');
 		});
 
-		it('should pass if sk is equal to 3 times the group order', () => {
+		it('should throw error if sk is equal to 3 times the group order', () => {
 			const sk = Buffer.from(
 				'015bc8f5f97cd877d899ad88181ce5880ffb38ec08fffb13fcfffffffd00000003',
 				'hex',


### PR DESCRIPTION
### What was the problem?

This PR resolves #8449 and continues #8877

The test expectation was wrong for 3 * r. bls function should throw in this case but it was expecting not to throw

### How was it solved?

Fix the test fixture and refactor the function name and content to be aligned

### How was it tested?

- Test is fixed to align with what is expected
