### PR TITLE
Validate lengths of arguments used in Validator module methods and endpoints

### DIFF
--- a/framework/src/modules/validators/schemas.ts
+++ b/framework/src/modules/validators/schemas.ts
@@ -12,6 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
+import { BLS_POP_LENGTH, BLS_PUBLIC_KEY_LENGTH } from './constants';
+
 export interface ValidateBLSKeyRequest {
 	proofOfPossession: string;
 	blsKey: string;
@@ -25,10 +27,14 @@ export const validateBLSKeyRequestSchema = {
 		proofOfPossession: {
 			type: 'string',
 			format: 'hex',
+			minLength: BLS_POP_LENGTH * 2,
+			maxLength: BLS_POP_LENGTH * 2,
 		},
 		blsKey: {
 			type: 'string',
 			format: 'hex',
+			minLength: BLS_PUBLIC_KEY_LENGTH * 2,
+			maxLength: BLS_PUBLIC_KEY_LENGTH * 2,
 		},
 	},
 	required: ['proofOfPossession', 'blsKey'],

--- a/framework/test/unit/modules/validators/endpoint.spec.ts
+++ b/framework/test/unit/modules/validators/endpoint.spec.ts
@@ -54,11 +54,9 @@ describe('ValidatorsModuleEndpoint', () => {
 					},
 				});
 
-				await validatorsModule.stores
-					.get(BLSKeyStore)
-					.set(createStoreGetter(stateStore), blsKey, {
-						address: utils.getRandomBytes(ADDRESS_LENGTH),
-					});
+				await validatorsModule.stores.get(BLSKeyStore).set(createStoreGetter(stateStore), blsKey, {
+					address: utils.getRandomBytes(ADDRESS_LENGTH),
+				});
 
 				await expect(validatorsModule.endpoint.validateBLSKey(context)).resolves.toStrictEqual({
 					valid: false,

--- a/framework/test/unit/modules/validators/endpoint.spec.ts
+++ b/framework/test/unit/modules/validators/endpoint.spec.ts
@@ -21,16 +21,20 @@ import { PrefixedStateReadWriter } from '../../../../src/state_machine/prefixed_
 import { createTransientModuleEndpointContext } from '../../../../src/testing';
 import { InMemoryPrefixedStateDB } from '../../../../src/testing/in_memory_prefixed_state';
 import { createStoreGetter } from '../../../../src/testing/utils';
+import {
+	ADDRESS_LENGTH,
+	BLS_POP_LENGTH,
+	BLS_PUBLIC_KEY_LENGTH,
+	ED25519_PUBLIC_KEY_LENGTH,
+} from '../../../../src/modules/validators/constants';
 
 describe('ValidatorsModuleEndpoint', () => {
 	let validatorsModule: ValidatorsModule;
 	let stateStore: PrefixedStateReadWriter;
-	const pk = utils.getRandomBytes(48);
-	const address = utils.getRandomBytes(48);
-	const proof = utils.getRandomBytes(96);
-	const validatorAddress = utils.getRandomBytes(20);
-	const blsKey = utils.getRandomBytes(48);
-	const generatorKey = utils.getRandomBytes(32);
+	const proof = utils.getRandomBytes(BLS_POP_LENGTH);
+	const validatorAddress = utils.getRandomBytes(ADDRESS_LENGTH);
+	const blsKey = utils.getRandomBytes(BLS_PUBLIC_KEY_LENGTH);
+	const generatorKey = utils.getRandomBytes(ED25519_PUBLIC_KEY_LENGTH);
 	const validProof =
 		'88bb31b27eae23038e14f9d9d1b628a39f5881b5278c3c6f0249f81ba0deb1f68aa5f8847854d6554051aa810fdf1cdb02df4af7a5647b1aa4afb60ec6d446ee17af24a8a50876ffdaf9bf475038ec5f8ebeda1c1c6a3220293e23b13a9a5d26';
 
@@ -46,13 +50,15 @@ describe('ValidatorsModuleEndpoint', () => {
 					stateStore,
 					params: {
 						proofOfPossession: proof.toString('hex'),
-						blsKey: pk.toString('hex'),
+						blsKey: blsKey.toString('hex'),
 					},
 				});
 
 				await validatorsModule.stores
 					.get(BLSKeyStore)
-					.set(createStoreGetter(stateStore), pk, { address });
+					.set(createStoreGetter(stateStore), blsKey, {
+						address: utils.getRandomBytes(ADDRESS_LENGTH),
+					});
 
 				await expect(validatorsModule.endpoint.validateBLSKey(context)).resolves.toStrictEqual({
 					valid: false,
@@ -64,7 +70,7 @@ describe('ValidatorsModuleEndpoint', () => {
 					stateStore,
 					params: {
 						proofOfPossession: proof.toString('hex'),
-						blsKey: pk.toString('hex'),
+						blsKey: blsKey.toString('hex'),
 					},
 				});
 				await expect(validatorsModule.endpoint.validateBLSKey(context)).resolves.toStrictEqual({
@@ -87,7 +93,7 @@ describe('ValidatorsModuleEndpoint', () => {
 			});
 
 			it('should resolve with false when proof of possession is invalid but bls key has a valid length', async () => {
-				const validPk =
+				const validBLSKey =
 					'a491d1b0ecd9bb917989f0e74f0dea0422eac4a873e5e2644f368dffb9a6e20fd6e10c1b77654d067c0618f6e5a7f79a';
 				const invalidProof =
 					'b803eb0ed93ea10224a73b6b9c725796be9f5fefd215ef7a5b97234cc956cf6870db6127b7e4d824ec62276078e787db05584ce1adbf076bc0808ca0f15b73d59060254b25393d95dfc7abe3cda566842aaedf50bbb062aae1bbb6ef3b1fffff';
@@ -95,7 +101,7 @@ describe('ValidatorsModuleEndpoint', () => {
 					stateStore,
 					params: {
 						proofOfPossession: invalidProof,
-						blsKey: validPk,
+						blsKey: validBLSKey,
 					},
 				});
 				await expect(validatorsModule.endpoint.validateBLSKey(context)).resolves.toStrictEqual({
@@ -103,32 +109,32 @@ describe('ValidatorsModuleEndpoint', () => {
 				});
 			});
 
-			it('should resolve with false when bls key length is less than 48 bytes and proof of possession has valid length', async () => {
-				const invalidPk = utils.getRandomBytes(47).toString('hex');
+			it('should throw when BLS key length is too short and proof of possession has valid length', async () => {
+				const shortBLSKey = utils.getRandomBytes(BLS_PUBLIC_KEY_LENGTH - 1).toString('hex');
 				const context = createTransientModuleEndpointContext({
 					stateStore,
 					params: {
 						proofOfPossession: validProof,
-						blsKey: invalidPk,
+						blsKey: shortBLSKey,
 					},
 				});
-				await expect(validatorsModule.endpoint.validateBLSKey(context)).resolves.toStrictEqual({
-					valid: false,
-				});
+				await expect(validatorsModule.endpoint.validateBLSKey(context)).rejects.toThrow(
+					`Property '.blsKey' must NOT have fewer than ${BLS_PUBLIC_KEY_LENGTH * 2} characters`,
+				);
 			});
 
-			it('should resolve with false when bls key length is greater than 48 bytes and proof of possession has valid length', async () => {
-				const invalidPk = utils.getRandomBytes(49).toString('hex');
+			it('should throw when BLS key length is too long and proof of possession has valid length', async () => {
+				const longBLSKey = utils.getRandomBytes(BLS_PUBLIC_KEY_LENGTH + 1).toString('hex');
 				const context = createTransientModuleEndpointContext({
 					stateStore,
 					params: {
 						proofOfPossession: validProof,
-						blsKey: invalidPk,
+						blsKey: longBLSKey,
 					},
 				});
-				await expect(validatorsModule.endpoint.validateBLSKey(context)).resolves.toStrictEqual({
-					valid: false,
-				});
+				await expect(validatorsModule.endpoint.validateBLSKey(context)).rejects.toThrow(
+					`Property '.blsKey' must NOT have more than ${BLS_PUBLIC_KEY_LENGTH * 2} characters`,
+				);
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8914

### How was it solved?

- All relevant Validator methods now validate argument lengths using the new private method `_validateLengths()`
- Updated `validateBLSKey` endpoint request schema to validate lengths of BLS key and proof of possession.
- BONUS: improved tests to use constants for lengths instead of specifying number literals 😎 

### How was it tested?

- Implemented additional tests for `_validateLengths()` method
- All tests OK 👌🏻 
