### PR TITLE
Fix validation of int64 and uint64 formats

### DIFF
--- a/elements/lisk-validator/src/formats.ts
+++ b/elements/lisk-validator/src/formats.ts
@@ -13,17 +13,28 @@
  *
  */
 import { address as cryptoAddress } from '@liskhq/lisk-cryptography';
-import { isHexString, isBytes, isIP, isIPV4, isEncryptedPassphrase, isSemVer } from './validation';
-import { MAX_UINT32, MAX_UINT64 } from './constants';
+import {
+	isHexString,
+	isBytes,
+	isIP,
+	isIPV4,
+	isEncryptedPassphrase,
+	isSemVer,
+	isNumberString,
+	isUInt64,
+	isSInt64,
+} from './validation';
+import { MAX_UINT32 } from './constants';
 
 export const hex = isHexString;
 export const bytes = isBytes;
 
-export const uint64 = {
-	type: 'number',
-	validate: (value: number) => Number.isInteger(value) && value >= 0 && value <= MAX_UINT64,
-};
+// uint64 and int64 are always type string, while uint32 and int32 are type integer
+export const int64 = (data: string): boolean => isNumberString(data) && isSInt64(BigInt(data));
 
+export const uint64 = (data: string): boolean => isNumberString(data) && isUInt64(BigInt(data));
+
+// int32 is appropriately defined in ajv-format plugin, no need to create a custom format
 export const uint32 = {
 	type: 'number',
 	validate: (value: number) => Number.isInteger(value) && value >= 0 && value <= MAX_UINT32,

--- a/elements/lisk-validator/test/lisk_validator_formats.spec.ts
+++ b/elements/lisk-validator/test/lisk_validator_formats.spec.ts
@@ -22,7 +22,7 @@ describe('validator formats', () => {
 	};
 
 	describe('uint32', () => {
-		const uint32IntegerSchema = {
+		const uint32Schema = {
 			...baseSchema,
 			properties: {
 				height: {
@@ -33,20 +33,20 @@ describe('validator formats', () => {
 		};
 
 		it('should validate a correct uint32', () => {
-			expect(() => validator.validate(uint32IntegerSchema, { height: 8 })).not.toThrow();
+			expect(() => validator.validate(uint32Schema, { height: 8 })).not.toThrow();
 		});
 
 		it('should throw for a negative number', () => {
-			expect(() => validator.validate(uint32IntegerSchema, { height: -1 })).toThrow();
+			expect(() => validator.validate(uint32Schema, { height: -1 })).toThrow();
 		});
 
 		it('should throw when the number is too big', () => {
-			expect(() => validator.validate(uint32IntegerSchema, { height: MAX_UINT32 + 1 })).toThrow();
+			expect(() => validator.validate(uint32Schema, { height: MAX_UINT32 + 1 })).toThrow();
 		});
 	});
 
 	describe('int32', () => {
-		const int32IntegerSchema = {
+		const int32Schema = {
 			...baseSchema,
 			properties: {
 				height: {
@@ -57,59 +57,65 @@ describe('validator formats', () => {
 		};
 
 		it('should validate a correct int32', () => {
-			expect(() => validator.validate(int32IntegerSchema, { height: 8 })).not.toThrow();
+			expect(() => validator.validate(int32Schema, { height: 8 })).not.toThrow();
+		});
+
+		it('should NOT throw for a negative number', () => {
+			expect(() => validator.validate(int32Schema, { height: -1 })).not.toThrow();
 		});
 
 		it('should throw when the number is too big', () => {
-			expect(() => validator.validate(int32IntegerSchema, { height: MAX_SINT32 + 1 })).toThrow();
+			expect(() => validator.validate(int32Schema, { height: MAX_SINT32 + 1 })).toThrow();
 		});
 	});
 
 	describe('uint64', () => {
-		const uint32IntegerSchema = {
+		const uint64Schema = {
 			...baseSchema,
 			properties: {
 				height: {
-					type: 'integer',
+					type: 'string',
 					format: 'uint64',
 				},
 			},
 		};
 
 		it('should validate a correct uint64', () => {
-			expect(() => validator.validate(uint32IntegerSchema, { height: 8 })).not.toThrow();
+			expect(() => validator.validate(uint64Schema, { height: '8' })).not.toThrow();
 		});
 
 		it('should throw for a negative number', () => {
-			expect(() => validator.validate(uint32IntegerSchema, { height: -1 })).toThrow();
+			expect(() => validator.validate(uint64Schema, { height: '-1' })).toThrow();
 		});
 
 		it('should throw when the number is too big', () => {
 			expect(() =>
-				validator.validate(uint32IntegerSchema, { height: MAX_UINT64 + BigInt(1) }),
+				validator.validate(uint64Schema, { height: (MAX_UINT64 + BigInt(1)).toString() }),
 			).toThrow();
 		});
 	});
 
 	describe('int64', () => {
-		const int32IntegerSchema = {
+		const int64Schema = {
 			...baseSchema,
 			properties: {
 				height: {
-					type: 'integer',
+					type: 'string',
 					format: 'int64',
 				},
 			},
 		};
 
 		it('should validate a correct int64', () => {
-			expect(() => validator.validate(int32IntegerSchema, { height: 8 })).not.toThrow();
+			expect(() => validator.validate(int64Schema, { height: '8' })).not.toThrow();
+		});
+
+		it('should NOT throw for a negative number', () => {
+			expect(() => validator.validate(int64Schema, { height: '-1' })).not.toThrow();
 		});
 
 		it('should throw when the number is too big', () => {
-			expect(() =>
-				validator.validate(int32IntegerSchema, { height: MAX_SINT64 + BigInt(1) }),
-			).toThrow();
+			expect(() => validator.validate(int64Schema, { height: MAX_SINT64 + BigInt(1) })).toThrow();
 		});
 	});
 

--- a/elements/lisk-validator/test/lisk_validator_formats.spec.ts
+++ b/elements/lisk-validator/test/lisk_validator_formats.spec.ts
@@ -40,6 +40,10 @@ describe('validator formats', () => {
 			expect(() => validator.validate(uint32Schema, { height: -1 })).toThrow();
 		});
 
+		it('should throw when a number is a correct uint32, but is provided as string type', () => {
+			expect(() => validator.validate(uint32Schema, { height: '8' })).toThrow();
+		});
+
 		it('should throw when the number is too big', () => {
 			expect(() => validator.validate(uint32Schema, { height: MAX_UINT32 + 1 })).toThrow();
 		});
@@ -62,6 +66,10 @@ describe('validator formats', () => {
 
 		it('should NOT throw for a negative number', () => {
 			expect(() => validator.validate(int32Schema, { height: -1 })).not.toThrow();
+		});
+
+		it('should throw when a number is a correct int32, but is provided as string type', () => {
+			expect(() => validator.validate(int32Schema, { height: '8' })).toThrow();
 		});
 
 		it('should throw when the number is too big', () => {
@@ -88,6 +96,10 @@ describe('validator formats', () => {
 			expect(() => validator.validate(uint64Schema, { height: '-1' })).toThrow();
 		});
 
+		it('should throw when a number is a correct uint64, but is provided as number type', () => {
+			expect(() => validator.validate(uint64Schema, { height: 8 })).toThrow();
+		});
+
 		it('should throw when the number is too big', () => {
 			expect(() =>
 				validator.validate(uint64Schema, { height: (MAX_UINT64 + BigInt(1)).toString() }),
@@ -112,6 +124,10 @@ describe('validator formats', () => {
 
 		it('should NOT throw for a negative number', () => {
 			expect(() => validator.validate(int64Schema, { height: '-1' })).not.toThrow();
+		});
+
+		it('should throw when a number is a correct int64, but is provided as number type', () => {
+			expect(() => validator.validate(int64Schema, { height: 8 })).toThrow();
 		});
 
 		it('should throw when the number is too big', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8915 

### How was it solved?

- Changed `uint64` format to accept `string` type instead of `integer`
- Reinstated previous `int64` format which overrides default `int64` format from `ajv-formats` plugin, which handles the format as `integer`

### How was it tested?

Updated existing test cases. Added new ones.
