### PR TITLE
Adds getKey option to passphrase encryption

### DIFF
--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -91,6 +91,7 @@ export const encryptAES128GCMWithPassword = async (
 			iterations: number;
 			parallelism: number;
 			memorySize: number;
+			hashLength: number;
 		}) => Promise<Buffer>;
 	},
 ): Promise<EncryptedMessageObject> => {
@@ -112,6 +113,7 @@ export const encryptAES128GCMWithPassword = async (
 			iterations,
 			parallelism,
 			memorySize,
+			hashLength: HASH_LENGTH,
 		});
 	} else if (kdf === KDF.ARGON2) {
 		key = await getKeyFromPasswordWithArgon2({
@@ -191,6 +193,7 @@ export async function decryptAES128GCMWithPassword(
 			iterations: number;
 			parallelism: number;
 			memorySize: number;
+			hashLength: number;
 		}) => Promise<Buffer>;
 	},
 ): Promise<string | Buffer> {
@@ -211,6 +214,7 @@ export async function decryptAES128GCMWithPassword(
 			iterations,
 			parallelism,
 			memorySize,
+			hashLength: HASH_LENGTH,
 		});
 	} else if (kdf === KDF.ARGON2) {
 		key = await getKeyFromPasswordWithArgon2({

--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -85,6 +85,13 @@ export const encryptAES128GCMWithPassword = async (
 			iterations?: number;
 			memorySize?: number;
 		};
+		getKey?: (options: {
+			password: string;
+			salt: Buffer;
+			iterations: number;
+			parallelism: number;
+			memorySize: number;
+		}) => Promise<Buffer>;
 	},
 ): Promise<EncryptedMessageObject> => {
 	const kdf = options?.kdf ?? KDF.ARGON2;
@@ -96,16 +103,28 @@ export const encryptAES128GCMWithPassword = async (
 		kdf === KDF.ARGON2 ? ARGON2_ITERATIONS : options?.kdfparams?.iterations ?? PBKDF2_ITERATIONS;
 	const parallelism = options?.kdfparams?.parallelism ?? ARGON2_PARALLELISM;
 	const memorySize = options?.kdfparams?.memorySize ?? ARGON2_MEMORY;
-	const key =
-		kdf === KDF.ARGON2
-			? await getKeyFromPasswordWithArgon2({
-					password,
-					salt,
-					iterations,
-					parallelism,
-					memorySize,
-			  })
-			: getKeyFromPassword(password, salt, iterations);
+	let key: Buffer;
+
+	if (options?.getKey !== undefined) {
+		key = await options.getKey({
+			password,
+			salt,
+			iterations,
+			parallelism,
+			memorySize,
+		});
+	} else if (kdf === KDF.ARGON2) {
+		key = await getKeyFromPasswordWithArgon2({
+			password,
+			salt,
+			iterations,
+			parallelism,
+			memorySize,
+		});
+	} else {
+		key = getKeyFromPassword(password, salt, iterations);
+	}
+
 	const cipher = crypto.createCipheriv('aes-128-gcm', key.slice(0, 16), iv);
 	const firstBlock = Buffer.isBuffer(plainText)
 		? cipher.update(plainText)
@@ -151,11 +170,29 @@ export async function decryptAES128GCMWithPassword(
 	encryptedMessage: EncryptedMessageObject,
 	password: string,
 	encoding: 'utf8' | 'utf-8',
+	options?: {
+		getKey?: (options: {
+			password: string;
+			salt: Buffer;
+			iterations: number;
+			parallelism: number;
+			memorySize: number;
+		}) => Promise<Buffer>;
+	},
 ): Promise<string>;
 export async function decryptAES128GCMWithPassword(
 	encryptedMessage: EncryptedMessageObject,
 	password: string,
 	encoding?: 'utf8' | 'utf-8',
+	options?: {
+		getKey?: (options: {
+			password: string;
+			salt: Buffer;
+			iterations: number;
+			parallelism: number;
+			memorySize: number;
+		}) => Promise<Buffer>;
+	},
 ): Promise<string | Buffer> {
 	const {
 		kdf,
@@ -165,17 +202,27 @@ export async function decryptAES128GCMWithPassword(
 	} = encryptedMessage;
 
 	const tagBuffer = getTagBuffer(tag);
-	const key =
-		kdf === KDF.ARGON2
-			? await getKeyFromPasswordWithArgon2({
-					password,
-					salt: hexToBuffer(salt, 'Salt'),
-					iterations,
-					parallelism,
-					memorySize,
-			  })
-			: getKeyFromPassword(password, hexToBuffer(salt, 'Salt'), iterations);
+	let key: Buffer;
 
+	if (options?.getKey !== undefined) {
+		key = await options.getKey({
+			password,
+			salt: hexToBuffer(salt, 'Salt'),
+			iterations,
+			parallelism,
+			memorySize,
+		});
+	} else if (kdf === KDF.ARGON2) {
+		key = await getKeyFromPasswordWithArgon2({
+			password,
+			salt: hexToBuffer(salt, 'Salt'),
+			iterations,
+			parallelism,
+			memorySize,
+		});
+	} else {
+		key = getKeyFromPassword(password, hexToBuffer(salt, 'Salt'), iterations);
+	}
 	const decipher = crypto.createDecipheriv('aes-128-gcm', key.slice(0, 16), hexToBuffer(iv, 'IV'));
 	decipher.setAuthTag(tagBuffer);
 	const firstBlock = decipher.update(hexToBuffer(ciphertext, 'Cipher text'));

--- a/elements/lisk-cryptography/test/encrypt.spec.ts
+++ b/elements/lisk-cryptography/test/encrypt.spec.ts
@@ -11,6 +11,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import { HASH_LENGTH } from '../src/constants';
 import {
 	EncryptedMessageObject,
 	encryptMessageWithPassword,
@@ -117,7 +118,14 @@ describe('encrypt', () => {
 					getKey: mockGetKey,
 				});
 
-				expect(mockGetKey).toHaveBeenCalledOnce();
+				expect(mockGetKey).toHaveBeenCalledOnceWith({
+					password: expect.anything(),
+					salt: expect.anything(),
+					iterations: expect.anything(),
+					parallelism: expect.anything(),
+					memorySize: expect.anything(),
+					hashLength: HASH_LENGTH,
+				});
 			});
 		});
 
@@ -241,6 +249,14 @@ describe('encrypt', () => {
 				});
 
 				expect(mockGetKey).toHaveBeenCalledTimes(2);
+				expect(mockGetKey).toHaveBeenNthCalledWith(2, {
+					password: expect.anything(),
+					salt: expect.anything(),
+					iterations: expect.anything(),
+					parallelism: expect.anything(),
+					memorySize: expect.anything(),
+					hashLength: HASH_LENGTH,
+				});
 			});
 		});
 

--- a/elements/lisk-cryptography/test/encrypt.spec.ts
+++ b/elements/lisk-cryptography/test/encrypt.spec.ts
@@ -108,6 +108,17 @@ describe('encrypt', () => {
 
 				expect(encryptedMessage.kdfparams.iterations).toBe(customIterations);
 			});
+
+			it('should call options.getKey if provided', async () => {
+				const mockKey = utils.getRandomBytes(32);
+				const mockGetKey = jest.fn().mockResolvedValue(mockKey);
+				encryptedMessage = await encryptMessageWithPassword(passphrase, password, {
+					kdf: KDF.ARGON2,
+					getKey: mockGetKey,
+				});
+
+				expect(mockGetKey).toHaveBeenCalledOnce();
+			});
 		});
 
 		describe('#decryptMessageWithPassword', () => {
@@ -215,6 +226,21 @@ describe('encrypt', () => {
 				await expect(
 					decryptMessageWithPassword(encryptedMessage, defaultPassword, 'utf-8'),
 				).rejects.toThrow('Unsupported state or unable to authenticate data');
+			});
+
+			it('should call options.getKey if provided', async () => {
+				const mockKey = utils.getRandomBytes(32);
+				const mockGetKey = jest.fn().mockResolvedValue(mockKey);
+				encryptedMessage = await encryptMessageWithPassword(passphrase, password, {
+					kdf: KDF.ARGON2,
+					getKey: mockGetKey,
+				});
+
+				await decryptMessageWithPassword(encryptedMessage, passphrase, 'utf-8', {
+					getKey: mockGetKey,
+				});
+
+				expect(mockGetKey).toHaveBeenCalledTimes(2);
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8928 

### How was it solved?

Added a new optional `getKey` parameters to encrypt and decrypt methods to take precedence for key retrieval.

### How was it tested?

Implemented unit tests.
