### PR TITLE
Expose NamedRegistry directly from lisk-sdk

### DIFF
--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -143,6 +143,7 @@ export { RewardMethod, RewardModule } from './modules/reward';
 export { DynamicRewardMethod, DynamicRewardModule } from './modules/dynamic_rewards';
 export { FeeMethod, FeeModule } from './modules/fee';
 export { RandomMethod, RandomModule } from './modules/random';
+export { NamedRegistry } from './modules/named_registry';
 export {
 	GenesisBlockExecuteContext,
 	InsertAssetContext,


### PR DESCRIPTION
### What was the problem?

This PR resolves #8938

### How was it solved?

Exposed `NamedRegistry` from framework index, which will make it available also from `lisk-sdk` package.

### How was it tested?

Did a sanity check that I can import `NamedRegistry` from `lisk-sdk` in mainchain app.
