### PR TITLE
Save relevant data & then add endpoints to retrieve legacy transactions by ID and block

### DIFF
--- a/framework/src/engine/legacy/codec.ts
+++ b/framework/src/engine/legacy/codec.ts
@@ -18,7 +18,7 @@ import {
 	blockHeaderSchemaV2,
 	blockSchemaV2,
 	legacyChainBracketInfoSchema,
-	transactionSchema,
+	transactionSchemaV2,
 } from './schemas';
 import {
 	LegacyBlock,
@@ -87,15 +87,15 @@ export const decodeBlockJSON = (
 export const getLegacyTransactionJSONWithSchema = (
 	data: Buffer,
 ): { transaction: LegacyTransactionJSON; schema: Schema } => {
-	const legacyTransaction = codec.decode<LegacyTransaction>(transactionSchema, data);
+	const legacyTransaction = codec.decode<LegacyTransaction>(transactionSchemaV2, data);
 	const id = utils.hash(data);
 
 	return {
 		transaction: {
-			...codec.toJSON(transactionSchema, legacyTransaction),
+			...codec.toJSON(transactionSchemaV2, legacyTransaction),
 			id: id.toString('hex'),
 		},
-		schema: transactionSchema,
+		schema: transactionSchemaV2,
 	};
 };
 

--- a/framework/src/engine/legacy/codec.ts
+++ b/framework/src/engine/legacy/codec.ts
@@ -14,7 +14,12 @@
 
 import { codec, Schema } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
-import { blockHeaderSchemaV2, blockSchemaV2, legacyChainBracketInfoSchema } from './schemas';
+import {
+	blockHeaderSchemaV2,
+	blockSchemaV2,
+	legacyChainBracketInfoSchema,
+	transactionSchema,
+} from './schemas';
 import {
 	LegacyBlock,
 	LegacyBlockJSON,
@@ -22,6 +27,8 @@ import {
 	RawLegacyBlock,
 	LegacyBlockWithID,
 	LegacyBlockHeaderWithID,
+	LegacyTransaction,
+	LegacyTransactionJSON,
 } from './types';
 
 interface LegacyBlockSchema {
@@ -74,6 +81,21 @@ export const decodeBlockJSON = (
 			payload: block.payload.map(tx => tx.toString('hex')),
 		},
 		schema,
+	};
+};
+
+export const getLegacyTransactionJSONWithSchema = (
+	data: Buffer,
+): { transaction: LegacyTransactionJSON; schema: Schema } => {
+	const legacyTransaction = codec.decode<LegacyTransaction>(transactionSchema, data);
+	const id = utils.hash(data);
+
+	return {
+		transaction: {
+			...codec.toJSON(transactionSchema, legacyTransaction),
+			id: id.toString('hex'),
+		},
+		schema: transactionSchema,
 	};
 };
 

--- a/framework/src/engine/legacy/constants.ts
+++ b/framework/src/engine/legacy/constants.ts
@@ -11,6 +11,8 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+
+export const BYTE_LENGTH = 4;
 export const DB_KEY_BLOCKS_ID = Buffer.from('blocks:id');
 export const DB_KEY_BLOCKS_HEIGHT = Buffer.from('blocks:height');
 export const DB_KEY_TRANSACTIONS_BLOCK_ID = Buffer.from('transactions:blockID');

--- a/framework/src/engine/legacy/constants.ts
+++ b/framework/src/engine/legacy/constants.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export const BYTE_LENGTH = 4;
 export const DB_KEY_BLOCKS_ID = Buffer.from('blocks:id');
 export const DB_KEY_BLOCKS_HEIGHT = Buffer.from('blocks:height');
 export const DB_KEY_TRANSACTIONS_BLOCK_ID = Buffer.from('transactions:blockID');

--- a/framework/src/engine/legacy/endpoint.ts
+++ b/framework/src/engine/legacy/endpoint.ts
@@ -15,9 +15,9 @@
 import { Database } from '@liskhq/lisk-db';
 import { isHexString } from '@liskhq/lisk-validator';
 import { RequestContext } from '../rpc/rpc_server';
-import { LegacyBlockJSON } from './types';
+import { LegacyBlockJSON, LegacyTransactionJSON } from './types';
 import { Storage } from './storage';
-import { decodeBlockJSON } from './codec';
+import { decodeBlockJSON, getLegacyTransactionJSONWithSchema } from './codec';
 
 interface EndpointArgs {
 	db: Database;
@@ -25,10 +25,39 @@ interface EndpointArgs {
 
 export class LegacyEndpoint {
 	[key: string]: unknown;
+
 	public readonly storage: Storage;
 
 	public constructor(args: EndpointArgs) {
 		this.storage = new Storage(args.db);
+	}
+
+	public async getTransactionByID(context: RequestContext): Promise<LegacyTransactionJSON> {
+		const { id } = context.params;
+		if (!isHexString(id)) {
+			throw new Error('Invalid parameters. `id` must be a valid hex string.');
+		}
+
+		const tx = await this.storage.getTransactionByID(
+			// Here `id` is hashed value
+			Buffer.from(id as string, 'hex'),
+		);
+
+		return getLegacyTransactionJSONWithSchema(tx).transaction;
+	}
+
+	public async getTransactionsByBlockID(context: RequestContext): Promise<LegacyTransactionJSON[]> {
+		const { id } = context.params;
+		if (!isHexString(id)) {
+			throw new Error('Invalid parameters. `id` must be a valid hex string.');
+		}
+
+		const transactions = await this.storage.getTransactionsByBlockID(
+			// Here `id` is hashed value
+			Buffer.from(id as string, 'hex'),
+		);
+
+		return transactions.map(tx => getLegacyTransactionJSONWithSchema(tx).transaction);
 	}
 
 	public async getBlockByID(context: RequestContext): Promise<LegacyBlockJSON> {

--- a/framework/src/engine/legacy/legacy_chain_handler.ts
+++ b/framework/src/engine/legacy/legacy_chain_handler.ts
@@ -187,10 +187,15 @@ export class LegacyChainHandler {
 		// @ts-expect-error Variable 'legacyBlocks' is used before being assigned.
 		for (const block of legacyBlocks) {
 			if (block.header.height > bracket.startHeight) {
+				let payload: Buffer[] = [];
+				if (block.payload.length) {
+					payload = block.payload;
+				}
 				await this._storage.saveBlock(
 					block.header.id as Buffer,
 					block.header.height,
 					encodeBlock(block),
+					payload,
 				);
 			}
 		}

--- a/framework/src/engine/legacy/legacy_chain_handler.ts
+++ b/framework/src/engine/legacy/legacy_chain_handler.ts
@@ -187,10 +187,7 @@ export class LegacyChainHandler {
 		// @ts-expect-error Variable 'legacyBlocks' is used before being assigned.
 		for (const block of legacyBlocks) {
 			if (block.header.height > bracket.startHeight) {
-				let payload: Buffer[] = [];
-				if (block.payload.length) {
-					payload = block.payload;
-				}
+				const payload = block.payload.length ? block.payload : [];
 				await this._storage.saveBlock(
 					block.header.id as Buffer,
 					block.header.height,

--- a/framework/src/engine/legacy/schemas.ts
+++ b/framework/src/engine/legacy/schemas.ts
@@ -83,8 +83,8 @@ export const blockHeaderSchemaV2 = {
 };
 
 // https://github.com/LiskHQ/lisk-sdk/blob/release/5.3.0/elements/lisk-chain/src/transaction.ts
-export const transactionSchema = {
-	$id: 'lisk/transaction',
+export const transactionSchemaV2 = {
+	$id: '/block/v2/transaction',
 	type: 'object',
 	required: ['moduleID', 'assetID', 'nonce', 'fee', 'senderPublicKey', 'asset'],
 	properties: {

--- a/framework/src/engine/legacy/schemas.ts
+++ b/framework/src/engine/legacy/schemas.ts
@@ -82,6 +82,49 @@ export const blockHeaderSchemaV2 = {
 	],
 };
 
+// https://github.com/LiskHQ/lisk-sdk/blob/release/5.3.0/elements/lisk-chain/src/transaction.ts
+export const transactionSchema = {
+	$id: 'lisk/transaction',
+	type: 'object',
+	required: ['moduleID', 'assetID', 'nonce', 'fee', 'senderPublicKey', 'asset'],
+	properties: {
+		moduleID: {
+			dataType: 'uint32',
+			fieldNumber: 1,
+			minimum: 2,
+		},
+		assetID: {
+			dataType: 'uint32',
+			fieldNumber: 2,
+		},
+		nonce: {
+			dataType: 'uint64',
+			fieldNumber: 3,
+		},
+		fee: {
+			dataType: 'uint64',
+			fieldNumber: 4,
+		},
+		senderPublicKey: {
+			dataType: 'bytes',
+			fieldNumber: 5,
+			minLength: 32,
+			maxLength: 32,
+		},
+		asset: {
+			dataType: 'bytes',
+			fieldNumber: 6,
+		},
+		signatures: {
+			type: 'array',
+			items: {
+				dataType: 'bytes',
+			},
+			fieldNumber: 7,
+		},
+	},
+};
+
 export const legacyChainBracketInfoSchema = {
 	$id: '/legacy/legacyChainBracketInfo',
 	type: 'object',

--- a/framework/src/engine/legacy/storage.ts
+++ b/framework/src/engine/legacy/storage.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { Batch, Database, NotFoundError } from '@liskhq/lisk-db';
+import { Batch, Database } from '@liskhq/lisk-db';
 import { utils } from '@liskhq/lisk-cryptography';
 import { encodeLegacyChainBracketInfo } from './codec';
 import { LegacyChainBracketInfo } from './types';
@@ -65,17 +65,12 @@ export class Storage {
 		}
 
 		const txIDs: Buffer[] = [];
-		try {
-			// each txID is hashed value of 32 length
-			const idLength = 32;
-			for (let i = 0; i < txIDsBuffer.length; i += idLength) {
-				const txID = txIDsBuffer.subarray(i, (i += idLength));
-				txIDs.push(txID);
-			}
-		} catch (error) {
-			if (!(error instanceof NotFoundError)) {
-				throw error;
-			}
+
+		// each txID is hashed value of 32 length
+		const idLength = 32;
+		for (let i = 0; i < txIDsBuffer.length; i += idLength) {
+			const txID = txIDsBuffer.subarray(i, (i += idLength));
+			txIDs.push(txID);
 		}
 
 		return Promise.all(txIDs.map(async ID => this.getTransactionByID(ID)));

--- a/framework/src/engine/legacy/storage.ts
+++ b/framework/src/engine/legacy/storage.ts
@@ -96,8 +96,8 @@ export class Storage {
 			batch.set(buildTxIDDbKey(txIds[index]), payload[index]);
 		}
 
-		// each transaction's key is saved without concatenating the DB_KEY_TX_ID
-		// since DB_KEY_TX_ID is used inside getTransactionByID(ID: Buffer)
+		// each transaction's key is saved without concatenating the DB_KEY_TRANSACTIONS_ID
+		// since DB_KEY_TRANSACTIONS_ID is used inside getTransactionByID(ID: Buffer)
 		batch.set(buildTxsBlockIDDbKey(blockID), Buffer.concat(txIds));
 		await this._db.write(batch);
 	}

--- a/framework/src/engine/legacy/types.ts
+++ b/framework/src/engine/legacy/types.ts
@@ -51,6 +51,22 @@ export interface LegacyBlockWithID extends LegacyBlock {
 
 export type LegacyBlockJSON = JSONObject<LegacyBlock>;
 
+export interface LegacyTransaction {
+	moduleID: number;
+	assetID: number;
+	nonce: bigint;
+	fee: bigint;
+	senderPublicKey: Buffer;
+	asset: Buffer;
+	signatures: Buffer[];
+}
+
+export interface LegacyTransactionWithID extends LegacyTransaction {
+	id: Buffer;
+}
+
+export type LegacyTransactionJSON = JSONObject<LegacyTransactionWithID>;
+
 export interface LegacyChainBracketInfo {
 	startHeight: number;
 	snapshotBlockHeight: number;

--- a/framework/src/engine/legacy/utils.ts
+++ b/framework/src/engine/legacy/utils.ts
@@ -1,6 +1,20 @@
-import { intToBuffer } from '@liskhq/lisk-cryptography/dist-node/utils';
+/*
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+// import { utils } from '@liskhq/lisk-cryptography';
+
+import { utils } from '@liskhq/lisk-cryptography';
 import {
-	BYTE_LENGTH,
 	DB_KEY_LEGACY_BRACKET,
 	DB_KEY_TRANSACTIONS_BLOCK_ID,
 	DB_KEY_TRANSACTIONS_ID,
@@ -17,7 +31,7 @@ export const buildTxsBlockIDDbKey = (ID: Buffer): Buffer =>
 
 // INFO: Generated Buffer is further used as `ID` for ```getBlockByID (ID:Buffer)```
 export const buildBlockHeightDbKey = (height: number): Buffer =>
-	Buffer.concat([DB_KEY_BLOCKS_HEIGHT, intToBuffer(height, BYTE_LENGTH)]);
+	Buffer.concat([DB_KEY_BLOCKS_HEIGHT, utils.intToBuffer(height, 4)]);
 
 export const buildLegacyBracketDBKey = (snapshotBlockID: Buffer): Buffer =>
 	Buffer.concat([DB_KEY_LEGACY_BRACKET, snapshotBlockID]);

--- a/framework/src/engine/legacy/utils.ts
+++ b/framework/src/engine/legacy/utils.ts
@@ -21,11 +21,11 @@ import {
 } from './constants';
 
 // INFO: Here ID refers to hashed value of 32 length
-export const buildTxIDDbKey = (ID: Buffer): Buffer => Buffer.concat([DB_KEY_TRANSACTIONS_ID, ID]);
+export const buildTxIDDbKey = (id: Buffer): Buffer => Buffer.concat([DB_KEY_TRANSACTIONS_ID, id]);
 
-export const buildBlockIDDbKey = (ID: Buffer): Buffer => Buffer.concat([DB_KEY_BLOCKS_ID, ID]);
-export const buildTxsBlockIDDbKey = (ID: Buffer): Buffer =>
-	Buffer.concat([DB_KEY_TRANSACTIONS_BLOCK_ID, ID]);
+export const buildBlockIDDbKey = (id: Buffer): Buffer => Buffer.concat([DB_KEY_BLOCKS_ID, id]);
+export const buildTxsBlockIDDbKey = (id: Buffer): Buffer =>
+	Buffer.concat([DB_KEY_TRANSACTIONS_BLOCK_ID, id]);
 
 // INFO: Generated Buffer is further used as `ID` for ```getBlockByID (ID:Buffer)```
 export const buildBlockHeightDbKey = (height: number): Buffer =>

--- a/framework/src/engine/legacy/utils.ts
+++ b/framework/src/engine/legacy/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Lisk Foundation
+ * Copyright © 2023 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -11,8 +11,6 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-// import { utils } from '@liskhq/lisk-cryptography';
-
 import { utils } from '@liskhq/lisk-cryptography';
 import {
 	DB_KEY_LEGACY_BRACKET,

--- a/framework/src/engine/legacy/utils.ts
+++ b/framework/src/engine/legacy/utils.ts
@@ -1,0 +1,23 @@
+import { intToBuffer } from '@liskhq/lisk-cryptography/dist-node/utils';
+import {
+	BYTE_LENGTH,
+	DB_KEY_LEGACY_BRACKET,
+	DB_KEY_TRANSACTIONS_BLOCK_ID,
+	DB_KEY_TRANSACTIONS_ID,
+	DB_KEY_BLOCKS_ID,
+	DB_KEY_BLOCKS_HEIGHT,
+} from './constants';
+
+// INFO: Here ID refers to hashed value of 32 length
+export const buildTxIDDbKey = (ID: Buffer): Buffer => Buffer.concat([DB_KEY_TRANSACTIONS_ID, ID]);
+
+export const buildBlockIDDbKey = (ID: Buffer): Buffer => Buffer.concat([DB_KEY_BLOCKS_ID, ID]);
+export const buildTxsBlockIDDbKey = (ID: Buffer): Buffer =>
+	Buffer.concat([DB_KEY_TRANSACTIONS_BLOCK_ID, ID]);
+
+// INFO: Generated Buffer is further used as `ID` for ```getBlockByID (ID:Buffer)```
+export const buildBlockHeightDbKey = (height: number): Buffer =>
+	Buffer.concat([DB_KEY_BLOCKS_HEIGHT, intToBuffer(height, BYTE_LENGTH)]);
+
+export const buildLegacyBracketDBKey = (snapshotBlockID: Buffer): Buffer =>
+	Buffer.concat([DB_KEY_LEGACY_BRACKET, snapshotBlockID]);

--- a/framework/test/unit/engine/legacy/endpoint.spec.ts
+++ b/framework/test/unit/engine/legacy/endpoint.spec.ts
@@ -21,7 +21,7 @@ import { blockFixtures } from './fixtures';
 import {
 	blockSchemaV2,
 	blockHeaderSchemaV2,
-	transactionSchema,
+	transactionSchemaV2,
 } from '../../../../src/engine/legacy/schemas';
 import { LegacyBlockJSON, LegacyTransactionJSON } from '../../../../src/engine/legacy/types';
 
@@ -71,10 +71,10 @@ describe('Legacy endpoint', () => {
 			inputTxID: string,
 		): void => {
 			expect(transaction.id).toEqual(inputTxID);
-			expect(codec.encodeJSON(transactionSchema, transaction)).toEqual(inputTx);
+			expect(codec.encodeJSON(transactionSchemaV2, transaction)).toEqual(inputTx);
 
 			expect(
-				codec.encodeJSON(transactionSchema, {
+				codec.encodeJSON(transactionSchemaV2, {
 					...transaction,
 					moduleID: transaction.moduleID - 1,
 				} as LegacyTransactionJSON),

--- a/framework/test/unit/engine/legacy/endpoint.spec.ts
+++ b/framework/test/unit/engine/legacy/endpoint.spec.ts
@@ -68,9 +68,9 @@ describe('Legacy endpoint', () => {
 		const matchTxExpectations = (
 			transaction: LegacyTransactionJSON,
 			inputTx: Buffer,
-			inputTxID: string,
+			inputTxId: string,
 		): void => {
-			expect(transaction.id).toEqual(inputTxID);
+			expect(transaction.id).toEqual(inputTxId);
 			expect(codec.encodeJSON(transactionSchemaV2, transaction)).toEqual(inputTx);
 
 			expect(
@@ -101,27 +101,27 @@ describe('Legacy endpoint', () => {
 			const tx = blockFixtures[0].payload[0];
 			jest.spyOn(legacyEndpoint['storage'], 'getTransactionByID').mockResolvedValue(tx);
 
-			const txID = utils.hash(tx).toString('hex');
+			const txId = utils.hash(tx).toString('hex');
 			const transaction = await legacyEndpoint.getTransactionByID({
-				params: { id: txID },
+				params: { id: txId },
 			} as any);
 
-			matchTxExpectations(transaction, tx, txID);
+			matchTxExpectations(transaction, tx, txId);
 		});
 
 		it('getTransactionsByBlockID', async () => {
-			const blockID = blockFixtures[0].header.id;
+			const blockId = blockFixtures[0].header.id;
 			const tx = blockFixtures[0].payload[0];
-			const txID = utils.hash(tx).toString('hex');
+			const txId = utils.hash(tx).toString('hex');
 
 			jest.spyOn(legacyEndpoint['storage'], 'getTransactionsByBlockID').mockResolvedValue([tx]);
 
 			const transactions = await legacyEndpoint.getTransactionsByBlockID({
-				params: { id: blockID.toString('hex') },
+				params: { id: blockId.toString('hex') },
 			} as any);
 
 			expect(transactions).toBeArray();
-			matchTxExpectations(transactions[0], tx, txID);
+			matchTxExpectations(transactions[0], tx, txId);
 		});
 	});
 });

--- a/framework/test/unit/engine/legacy/network_endpoint.spec.ts
+++ b/framework/test/unit/engine/legacy/network_endpoint.spec.ts
@@ -93,7 +93,7 @@ describe('Legacy P2P network endpoint', () => {
 			// Save blocks to the database
 			for (let i = 0; i < blocks.length; i += 1) {
 				const block = blocks[i];
-				await endpoint['_storage'].saveBlock(utils.hash(block), startHeight + i, block);
+				await endpoint['_storage'].saveBlock(utils.hash(block), startHeight + i, block, []);
 			}
 
 			const encodedRequest = codec.encode(getBlocksFromIdRequestSchema, {

--- a/framework/test/unit/engine/legacy/storage.spec.ts
+++ b/framework/test/unit/engine/legacy/storage.spec.ts
@@ -135,6 +135,26 @@ describe('Legacy storage', () => {
 			const transactions = await storage.getTransactionsByBlockID(header.id);
 			expect(transactions[0]).toEqual(payload[0]);
 		});
+
+		it("should save the block without it's transactions", async () => {
+			const { header, payload } = blockFixtures[0];
+			await storage.saveBlock(header.id, header.height, encodeBlock({ header, payload }), []);
+
+			const result = await storage.getBlockByID(header.id);
+			expect(result).toEqual(encodeBlock({ header, payload }));
+
+			try {
+				await storage.getTransactionByID(utils.hash(payload[0]));
+			} catch (error: any) {
+				expect(error.message).toInclude('does not exist');
+			}
+
+			try {
+				await storage.getTransactionsByBlockID(header.id);
+			} catch (error: any) {
+				expect(error.message).toInclude('does not exist');
+			}
+		});
 	});
 
 	describe('getLegacyChainBracketInfo', () => {

--- a/framework/test/unit/engine/legacy/storage.spec.ts
+++ b/framework/test/unit/engine/legacy/storage.spec.ts
@@ -13,12 +13,12 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-import { intToBuffer } from '@liskhq/lisk-cryptography/dist-node/utils';
 import { Batch, Database, InMemoryDatabase } from '@liskhq/lisk-db';
+import { utils } from '@liskhq/lisk-cryptography';
 import { encodeBlock, encodeLegacyChainBracketInfo } from '../../../../src/engine/legacy/codec';
-import { DB_KEY_BLOCKS_HEIGHT, DB_KEY_BLOCKS_ID } from '../../../../src/engine/legacy/constants';
 import { Storage } from '../../../../src/engine/legacy/storage';
 import { blockFixtures } from './fixtures';
+import { buildBlockHeightDbKey, buildBlockIDDbKey } from '../../../../src/engine/legacy/utils';
 
 describe('Legacy storage', () => {
 	let db: InMemoryDatabase;
@@ -36,8 +36,8 @@ describe('Legacy storage', () => {
 		for (const block of blocks) {
 			const { header, payload } = block;
 
-			batch.set(Buffer.concat([DB_KEY_BLOCKS_ID, header.id]), encodeBlock({ header, payload }));
-			batch.set(Buffer.concat([DB_KEY_BLOCKS_HEIGHT, intToBuffer(header.height, 4)]), header.id);
+			batch.set(buildBlockIDDbKey(header.id), encodeBlock({ header, payload }));
+			batch.set(buildBlockHeightDbKey(header.height), header.id);
 		}
 
 		await db.write(batch);
@@ -122,13 +122,18 @@ describe('Legacy storage', () => {
 	});
 
 	describe('saveBlock', () => {
-		it('should save the block', async () => {
+		it("should save the block along with it's transactions", async () => {
 			const { header, payload } = blockFixtures[0];
-			await storage.saveBlock(header.id, header.height, encodeBlock({ header, payload }));
+			await storage.saveBlock(header.id, header.height, encodeBlock({ header, payload }), payload);
 
 			const result = await storage.getBlockByID(header.id);
-
 			expect(result).toEqual(encodeBlock({ header, payload }));
+
+			const tx = await storage.getTransactionByID(utils.hash(payload[0]));
+			expect(tx).toEqual(payload[0]);
+
+			const transactions = await storage.getTransactionsByBlockID(header.id);
+			expect(transactions[0]).toEqual(payload[0]);
 		});
 	});
 

--- a/framework/test/unit/engine/legacy/validate.spec.ts
+++ b/framework/test/unit/engine/legacy/validate.spec.ts
@@ -17,7 +17,7 @@ import { encodeBlock } from '../../../../src/engine/legacy/codec';
 import { validateLegacyBlock } from '../../../../src/engine/legacy/validate';
 import { blockFixtures } from './fixtures';
 
-describe('Legacy valdate', () => {
+describe('Legacy validate', () => {
 	let encodedBlock: Buffer;
 
 	beforeEach(() => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8900

### How was it solved?
Block is saving transactions on `saveBlock(...)`

### How was it tested?
Test cases added