### PR TITLE
UX improvements for dashboard and commands

### DIFF
--- a/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/modules.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/templates/init/src/app/modules.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Application } from 'lisk-sdk';
 
-// @ts-expect-error app will have typescript error for unsued variable
-export const registerModules = (app: Application): void => {};
+export const registerModules = (_app: Application): void => {};

--- a/commander/src/commands/generate/command.ts
+++ b/commander/src/commands/generate/command.ts
@@ -22,7 +22,7 @@ interface CommandCommandArgs {
 }
 
 export default class CommandCommand extends BaseBootstrapCommand {
-	static description = 'Creates an command skeleton for the given module name and comand name.';
+	static description = 'Creates a command skeleton for the given module name and command name.';
 	static examples = ['generate:command moduleName commandName', 'generate:command nft transfer'];
 	static args = [
 		{

--- a/commander/src/commands/generate/command.ts
+++ b/commander/src/commands/generate/command.ts
@@ -22,11 +22,8 @@ interface CommandCommandArgs {
 }
 
 export default class CommandCommand extends BaseBootstrapCommand {
-	static description = 'Creates an command skeleton for the given module name, name and id.';
-	static examples = [
-		'generate:command moduleName commandName commandID',
-		'generate:command nft transfer 1',
-	];
+	static description = 'Creates an command skeleton for the given module name and comand name.';
+	static examples = ['generate:command moduleName commandName', 'generate:command nft transfer'];
 	static args = [
 		{
 			name: 'moduleName',

--- a/examples/interop/pos-mainchain-fast/src/app/modules.ts
+++ b/examples/interop/pos-mainchain-fast/src/app/modules.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Application } from 'lisk-sdk';
 
-// @ts-expect-error app will have typescript error for unsued variable
-export const registerModules = (app: Application): void => {};
+export const registerModules = (_app: Application): void => {};

--- a/examples/interop/pos-sidechain-example-one/src/app/modules.ts
+++ b/examples/interop/pos-sidechain-example-one/src/app/modules.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Application } from 'lisk-sdk';
 
-// @ts-expect-error app will have typescript error for unsued variable
-export const registerModules = (app: Application): void => {};
+export const registerModules = (_app: Application): void => {};

--- a/examples/interop/pos-sidechain-example-two/src/app/modules.ts
+++ b/examples/interop/pos-sidechain-example-two/src/app/modules.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Application } from 'lisk-sdk';
 
-// @ts-expect-error app will have typescript error for unsued variable
-export const registerModules = (app: Application): void => {};
+export const registerModules = (_app: Application): void => {};

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/CopiableText/CopiableText.module.scss
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/CopiableText/CopiableText.module.scss
@@ -5,7 +5,7 @@
 }
 
 .copyText {
-    white-space: nowrap;
+	white-space: nowrap;
 	overflow-wrap: unset !important;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/CopiableText/CopiableText.module.scss
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/CopiableText/CopiableText.module.scss
@@ -5,6 +5,7 @@
 }
 
 .copyText {
+    white-space: nowrap;
 	overflow-wrap: unset !important;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/dialogs/AccountDialog.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/dialogs/AccountDialog.tsx
@@ -40,13 +40,13 @@ const AccountDialog: React.FC<AccountDialogProps> = props => {
 								<Box mb={2} mr={1}>
 									<Text type={'h3'}>Lisk32 address</Text>
 								</Box>
-								<CopiableText text={account.address}>{account.address}</CopiableText>
+								<CopiableText text={account.address} />
 							</Grid>
 							<Grid md={6} xs={12}>
 								<Box mb={2}>
 									<Text type={'h3'}>Public Key</Text>
 								</Box>
-								<CopiableText text={account.publicKey}>{account.publicKey}</CopiableText>
+								<CopiableText text={account.publicKey} />
 							</Grid>
 						</Grid>
 						<Grid row>
@@ -54,7 +54,7 @@ const AccountDialog: React.FC<AccountDialogProps> = props => {
 								<Box mb={2}>
 									<Text type={'h3'}>Passphrase</Text>
 								</Box>
-								<CopiableText text={account.passphrase ?? ''}>{account.passphrase}</CopiableText>
+								<CopiableText text={account.passphrase ?? ''} />
 							</Grid>
 						</Grid>
 					</Grid>

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/BlockWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/BlockWidget.tsx
@@ -53,9 +53,13 @@ const BlockWidget: React.FC<WidgetProps> = props => {
 					<TableBody>
 						{blocks.map(block => (
 							<tr key={block.header.height}>
-								<td><CopiableText text={block.header.id} /></td>
-								<td><CopiableText text={block.header.generatorAddress} /></td>
-                                <td>
+								<td>
+									<CopiableText text={block.header.id} />
+								</td>
+								<td>
+									<CopiableText text={block.header.generatorAddress} />
+								</td>
+								<td>
 									<Text key={block.header.height}>{block.header.height}</Text>
 								</td>
 								<td>

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/BlockWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/BlockWidget.tsx
@@ -53,15 +53,9 @@ const BlockWidget: React.FC<WidgetProps> = props => {
 					<TableBody>
 						{blocks.map(block => (
 							<tr key={block.header.height}>
-								<td>
-									<CopiableText text={block.header.id}>{block.header.id}</CopiableText>
-								</td>
-								<td>
-									<CopiableText text={block.header.generatorAddress}>
-										{block.header.generatorAddress}
-									</CopiableText>
-								</td>
-								<td>
+								<td><CopiableText text={block.header.id} /></td>
+								<td><CopiableText text={block.header.generatorAddress} /></td>
+                                <td>
 									<Text key={block.header.height}>{block.header.height}</Text>
 								</td>
 								<td>

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/MyAccountWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/MyAccountWidget.tsx
@@ -44,10 +44,13 @@ const MyAccountWidget: React.FC<MyAccountProps> = props => {
 						<TableHeader sticky>
 							<tr>
 								<th>
-									<Text>Binary addresss</Text>
+									<Text>Lisk32 address</Text>
 								</th>
 								<th>
 									<Text>Public Key</Text>
+								</th>
+                                <th>
+									<Text>Passphrase</Text>
 								</th>
 							</tr>
 						</TableHeader>
@@ -59,6 +62,9 @@ const MyAccountWidget: React.FC<MyAccountProps> = props => {
 									</td>
 									<td>
 										<CopiableText text={account.publicKey}>{account.publicKey}</CopiableText>
+									</td>
+                                    <td>
+										<CopiableText text={account.passphrase ?? ''}></CopiableText>
 									</td>
 								</tr>
 							))}

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/MyAccountWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/MyAccountWidget.tsx
@@ -57,15 +57,9 @@ const MyAccountWidget: React.FC<MyAccountProps> = props => {
 						<TableBody>
 							{accounts.map((account: Account) => (
 								<tr onClick={() => handleClick(account)} key={account.address}>
-									<td>
-										<CopiableText text={account.address}>{account.address}</CopiableText>
-									</td>
-									<td>
-										<CopiableText text={account.publicKey}>{account.publicKey}</CopiableText>
-									</td>
-                                    <td>
-										<CopiableText text={account.passphrase ?? ''}></CopiableText>
-									</td>
+									<td><CopiableText text={account.address} /></td>
+									<td><CopiableText text={account.publicKey} /></td>
+                                    <td><CopiableText text={account.passphrase ?? ''} /></td>
 								</tr>
 							))}
 						</TableBody>

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/MyAccountWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/MyAccountWidget.tsx
@@ -49,7 +49,7 @@ const MyAccountWidget: React.FC<MyAccountProps> = props => {
 								<th>
 									<Text>Public Key</Text>
 								</th>
-                                <th>
+								<th>
 									<Text>Passphrase</Text>
 								</th>
 							</tr>
@@ -57,9 +57,15 @@ const MyAccountWidget: React.FC<MyAccountProps> = props => {
 						<TableBody>
 							{accounts.map((account: Account) => (
 								<tr onClick={() => handleClick(account)} key={account.address}>
-									<td><CopiableText text={account.address} /></td>
-									<td><CopiableText text={account.publicKey} /></td>
-                                    <td><CopiableText text={account.passphrase ?? ''} /></td>
+									<td>
+										<CopiableText text={account.address} />
+									</td>
+									<td>
+										<CopiableText text={account.publicKey} />
+									</td>
+									<td>
+										<CopiableText text={account.passphrase ?? ''} />
+									</td>
 								</tr>
 							))}
 						</TableBody>

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/TransactionWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/TransactionWidget.tsx
@@ -76,14 +76,8 @@ const TransactionWidget: React.FC<WidgetProps> = props => {
 					<TableBody>
 						{transactions.map(transaction => (
 							<tr key={transaction.id}>
-								<td>
-									<CopiableText text={transaction.id}>{transaction.id}</CopiableText>
-								</td>
-								<td>
-									<CopiableText text={transaction.senderPublicKey}>
-										{transaction.senderPublicKey}
-									</CopiableText>
-								</td>
+								<td><CopiableText text={transaction.id} /></td>
+								<td><CopiableText text={transaction.senderPublicKey} /></td>
 								<td>
 									<Text>
 										{getModuleAsset(props.metadata, transaction.module, transaction.command)}

--- a/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/TransactionWidget.tsx
+++ b/framework-plugins/lisk-framework-dashboard-plugin/src/ui/components/widgets/TransactionWidget.tsx
@@ -76,8 +76,12 @@ const TransactionWidget: React.FC<WidgetProps> = props => {
 					<TableBody>
 						{transactions.map(transaction => (
 							<tr key={transaction.id}>
-								<td><CopiableText text={transaction.id} /></td>
-								<td><CopiableText text={transaction.senderPublicKey} /></td>
+								<td>
+									<CopiableText text={transaction.id} />
+								</td>
+								<td>
+									<CopiableText text={transaction.senderPublicKey} />
+								</td>
 								<td>
 									<Text>
 										{getModuleAsset(props.metadata, transaction.module, transaction.command)}


### PR DESCRIPTION
### What was the problem?

This PR resolves #8941

### How was it solved?

- Updated description and examples of `generate:command`
- Bootstrapped modules no longer throw error at build until TS directive is removed
- Dashboard `MyAccountWidget` component now also shows passphrase
- Dashboard `MyAccountWidget` component now shows correct label for Lisk32 address
- Fixed misaligned rendering of passphrase in `AccountDialog` component
- BONUS: removed unused children from `CopiableText` component 😎

### How was it tested?

Visual checks of modified command and dashboard.
