### PR TITLE
Consumes iterations when encrypting with passphrase

### DIFF
--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -101,7 +101,9 @@ export const encryptAES128GCMWithPassword = async (
 	const salt = crypto.randomBytes(SALT_BUFFER_SIZE);
 	const iv = crypto.randomBytes(IV_BUFFER_SIZE);
 	const iterations =
-		kdf === KDF.ARGON2 ? ARGON2_ITERATIONS : options?.kdfparams?.iterations ?? PBKDF2_ITERATIONS;
+		options?.kdfparams?.iterations ??
+		(kdf === KDF.ARGON2 ? ARGON2_ITERATIONS : options?.kdfparams?.iterations ?? PBKDF2_ITERATIONS);
+
 	const parallelism = options?.kdfparams?.parallelism ?? ARGON2_PARALLELISM;
 	const memorySize = options?.kdfparams?.memorySize ?? ARGON2_MEMORY;
 	let key: Buffer;

--- a/elements/lisk-cryptography/test/encrypt.spec.ts
+++ b/elements/lisk-cryptography/test/encrypt.spec.ts
@@ -110,21 +110,45 @@ describe('encrypt', () => {
 				expect(encryptedMessage.kdfparams.iterations).toBe(customIterations);
 			});
 
-			it('should call options.getKey if provided', async () => {
-				const mockKey = utils.getRandomBytes(32);
-				const mockGetKey = jest.fn().mockResolvedValue(mockKey);
-				encryptedMessage = await encryptMessageWithPassword(passphrase, password, {
-					kdf: KDF.ARGON2,
-					getKey: mockGetKey,
+			describe('if options.getKey is provided', () => {
+				it('should call options.getKey', async () => {
+					const mockKey = utils.getRandomBytes(32);
+					const mockGetKey = jest.fn().mockResolvedValue(mockKey);
+					encryptedMessage = await encryptMessageWithPassword(passphrase, password, {
+						kdf: KDF.ARGON2,
+						getKey: mockGetKey,
+					});
+
+					expect(mockGetKey).toHaveBeenCalledOnceWith({
+						password: expect.anything(),
+						salt: expect.anything(),
+						iterations: expect.anything(),
+						parallelism: expect.anything(),
+						memorySize: expect.anything(),
+						hashLength: HASH_LENGTH,
+					});
 				});
 
-				expect(mockGetKey).toHaveBeenCalledOnceWith({
-					password: expect.anything(),
-					salt: expect.anything(),
-					iterations: expect.anything(),
-					parallelism: expect.anything(),
-					memorySize: expect.anything(),
-					hashLength: HASH_LENGTH,
+				it('should call options.getKey with provided iterations', async () => {
+					const iterations = 10;
+					const mockKey = utils.getRandomBytes(32);
+					const mockGetKey = jest.fn().mockResolvedValue(mockKey);
+					encryptedMessage = await encryptMessageWithPassword(passphrase, password, {
+						kdf: KDF.ARGON2,
+						getKey: mockGetKey,
+						kdfparams: {
+							iterations: 10,
+						},
+					});
+
+					expect(mockGetKey).toHaveBeenCalledOnceWith({
+						password: expect.anything(),
+						salt: expect.anything(),
+						iterations,
+						parallelism: expect.anything(),
+						memorySize: expect.anything(),
+						hashLength: HASH_LENGTH,
+					});
 				});
 			});
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8943 

### How was it solved?

If provided, passes `options.kdfparams.iterations` to `options.getKey`.

### How was it tested?

Updated unit tests.
