### PR TITLE
Add missing BaseStore unit test

### DIFF
--- a/framework/src/modules/base_store.ts
+++ b/framework/src/modules/base_store.ts
@@ -11,8 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { emptySchema } from '@liskhq/lisk-codec';
-import { Schema } from '@liskhq/lisk-codec';
+import { Schema, emptySchema } from '@liskhq/lisk-codec';
 import { utils } from '@liskhq/lisk-cryptography';
 import { IterateOptions } from '@liskhq/lisk-db';
 import { ImmutableSubStore, SubStore } from '../state_machine/types';

--- a/framework/test/unit/modules/base_store.spec.ts
+++ b/framework/test/unit/modules/base_store.spec.ts
@@ -85,6 +85,10 @@ describe('BaseStore', () => {
 
 			await expect(store.has(context, key)).resolves.toBeTrue();
 		});
+
+		it('should return false when key does not exist', async () => {
+			await expect(store.has(context, key)).resolves.toBeFalse();
+		});
 	});
 
 	describe('set', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8950

### How was it solved?

- Added missing unit test
- BONUS: Both `@liskhq/lisk-codec` dependencies are now imported in the same line 😎 

### How was it tested?

The newly created test works as expected 👌🏻 