### PR TITLE
:necktie: NFTMethod.getCollectionID

### DIFF
--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -184,16 +184,8 @@ export class NFTMethod extends BaseMethod {
 		});
 	}
 
-	public async getCollectionID(
-		methodContext: ImmutableMethodContext,
-		nftID: Buffer,
-	): Promise<Buffer> {
-		const nftStore = this.stores.get(NFTStore);
-		const nftExists = await nftStore.has(methodContext, nftID);
-		if (!nftExists) {
-			throw new Error('NFT substore entry does not exist');
-		}
-		return nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
+	public getCollectionID(nftID: Buffer): Buffer {
+		return nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
 	}
 
 	public async isNFTSupported(
@@ -220,7 +212,7 @@ export class NFTMethod extends BaseMethod {
 			if (supportedNFTsStoreData.supportedCollectionIDArray.length === 0) {
 				return true;
 			}
-			const collectionID = await this.getCollectionID(methodContext, nftID);
+			const collectionID = this.getCollectionID(nftID);
 			if (
 				supportedNFTsStoreData.supportedCollectionIDArray.some(id =>
 					collectionID.equals(id.collectionID),

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -362,19 +362,13 @@ describe('NFTMethod', () => {
 	});
 
 	describe('getCollectionID', () => {
-		it('should throw if entry does not exist in the nft substore for the nft id', async () => {
-			await expect(method.getCollectionID(methodContext, nftID)).rejects.toThrow(
-				'NFT substore entry does not exist',
-			);
-		});
-
 		it('should return the first bytes of length LENGTH_CHAIN_ID from provided nftID', async () => {
 			await nftStore.save(methodContext, nftID, {
 				owner: utils.getRandomBytes(LENGTH_CHAIN_ID),
 				attributesArray: [],
 			});
-			const expectedValue = nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
-			const receivedValue = await method.getCollectionID(methodContext, nftID);
+			const expectedValue = nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
+			const receivedValue = method.getCollectionID(nftID);
 			expect(receivedValue).toEqual(expectedValue);
 		});
 	});
@@ -395,7 +389,7 @@ describe('NFTMethod', () => {
 		});
 
 		it('should return true if nft chain id does not equal own chain id but nft chain id is supported and corresponding supported collection id array is empty', async () => {
-			await supportedNFTsStore.set(methodContext, nftID.slice(0, LENGTH_CHAIN_ID), {
+			await supportedNFTsStore.set(methodContext, nftID.subarray(0, LENGTH_CHAIN_ID), {
 				supportedCollectionIDArray: [],
 			});
 
@@ -404,9 +398,9 @@ describe('NFTMethod', () => {
 		});
 
 		it('should return true if nft chain id does not equal own chain id but nft chain id is supported and corresponding supported collection id array includes collection id for nft id', async () => {
-			await supportedNFTsStore.set(methodContext, nftID.slice(0, LENGTH_CHAIN_ID), {
+			await supportedNFTsStore.set(methodContext, nftID.subarray(0, LENGTH_CHAIN_ID), {
 				supportedCollectionIDArray: [
-					{ collectionID: nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID) },
+					{ collectionID: nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID) },
 					{ collectionID: utils.getRandomBytes(LENGTH_COLLECTION_ID) },
 				],
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8955  

### How was it solved?

Removed validation logic from `NFTMethod.getCollectionID` and replaced calls to `Buffer.slice` with `Buffer.subarray` in `NFTMethod.getCollectionID` and `NFTMethod.isNFTSupported`.

### How was it tested?

Updated unit tests.
