### PR TITLE
:fire: messageFeeTokenID from TransferCrossChainCommand of NFT Module

### DIFF
--- a/framework/src/modules/nft/commands/transfer_cross_chain.ts
+++ b/framework/src/modules/nft/commands/transfer_cross_chain.ts
@@ -33,7 +33,6 @@ export interface Params {
 	recipientAddress: Buffer;
 	data: string;
 	messageFee: bigint;
-	messageFeeTokenID: Buffer;
 	includeAttributes: boolean;
 }
 
@@ -90,10 +89,6 @@ export class TransferCrossChainCommand extends BaseCommand {
 			params.receivingChainID,
 		);
 
-		if (!params.messageFeeTokenID.equals(messageFeeTokenID)) {
-			throw new Error('Mismatching message fee Token ID');
-		}
-
 		if (!owner.equals(context.transaction.senderAddress)) {
 			throw new Error('Transfer not initiated by the NFT owner');
 		}
@@ -110,7 +105,7 @@ export class TransferCrossChainCommand extends BaseCommand {
 		const availableBalance = await this._tokenMethod.getAvailableBalance(
 			context.getMethodContext(),
 			context.transaction.senderAddress,
-			params.messageFeeTokenID,
+			messageFeeTokenID,
 		);
 
 		if (availableBalance < params.messageFee) {

--- a/framework/src/modules/nft/schemas.ts
+++ b/framework/src/modules/nft/schemas.ts
@@ -16,7 +16,6 @@ import {
 	LENGTH_CHAIN_ID,
 	LENGTH_COLLECTION_ID,
 	LENGTH_NFT_ID,
-	LENGTH_TOKEN_ID,
 	MAX_LENGTH_MODULE_NAME,
 	MIN_LENGTH_MODULE_NAME,
 	MAX_LENGTH_DATA,
@@ -114,7 +113,6 @@ export const crossChainTransferParamsSchema = {
 		'recipientAddress',
 		'data',
 		'messageFee',
-		'messageFeeTokenID',
 		'includeAttributes',
 	],
 	properties: {
@@ -145,15 +143,9 @@ export const crossChainTransferParamsSchema = {
 			dataType: 'uint64',
 			fieldNumber: 5,
 		},
-		messageFeeTokenID: {
-			dataType: 'bytes',
-			minLength: LENGTH_TOKEN_ID,
-			maxLength: LENGTH_TOKEN_ID,
-			fieldNumber: 6,
-		},
 		includeAttributes: {
 			dataType: 'boolean',
-			fieldNumber: 7,
+			fieldNumber: 6,
 		},
 	},
 };

--- a/framework/test/unit/modules/nft/commands/transfer_cross_chain.spec.ts
+++ b/framework/test/unit/modules/nft/commands/transfer_cross_chain.spec.ts
@@ -82,7 +82,6 @@ describe('TransferCrossChainComand', () => {
 		recipientAddress: utils.getRandomBytes(LENGTH_ADDRESS),
 		data: '',
 		messageFee: BigInt(100000),
-		messageFeeTokenID,
 		includeAttributes: false,
 	};
 
@@ -302,32 +301,6 @@ describe('TransferCrossChainComand', () => {
 			).rejects.toThrow("'.data' must NOT have more than 64 characters");
 		});
 
-		it('should fail if messageFeeTokenID does not have valid length', async () => {
-			const messageFeeTokenIDMinLengthContext = createTransactionContextWithOverridingParams({
-				messageFeeTokenID: utils.getRandomBytes(LENGTH_TOKEN_ID - 1),
-			});
-
-			const messageFeeTokenIDMaxLengthContext = createTransactionContextWithOverridingParams({
-				messageFeeTokenID: utils.getRandomBytes(LENGTH_TOKEN_ID + 1),
-			});
-
-			await expect(
-				command.verify(
-					messageFeeTokenIDMinLengthContext.createCommandVerifyContext(
-						crossChainTransferParamsSchema,
-					),
-				),
-			).rejects.toThrow("'.messageFeeTokenID' minLength not satisfied");
-
-			await expect(
-				command.verify(
-					messageFeeTokenIDMaxLengthContext.createCommandVerifyContext(
-						crossChainTransferParamsSchema,
-					),
-				),
-			).rejects.toThrow("'.messageFeeTokenID' maxLength exceeded");
-		});
-
 		it('should fail if NFT does not exist', async () => {
 			const context = createTransactionContextWithOverridingParams({
 				nftID: utils.getRandomBytes(LENGTH_NFT_ID),
@@ -363,17 +336,6 @@ describe('TransferCrossChainComand', () => {
 			await expect(
 				command.verify(context.createCommandVerifyContext(crossChainTransferParamsSchema)),
 			).rejects.toThrow('');
-		});
-
-		it('should fail if messageFeeTokenID for receiving chain differs from the messageFeeTokenID of parameters', async () => {
-			const context = createTransactionContextWithOverridingParams({
-				nftID: existingNFT.nftID,
-				messageFeeTokenID: utils.getRandomBytes(LENGTH_TOKEN_ID),
-			});
-
-			await expect(
-				command.verify(context.createCommandVerifyContext(crossChainTransferParamsSchema)),
-			).rejects.toThrow('Mismatching message fee Token ID');
 		});
 
 		it('should fail if the owner of the NFT is not the sender', async () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8957 

### How was it solved?

Removes `messageFeeTokenID` from `TransferCrossChainCommand`'s schema of NFT Module, updated relevant type definitions and removed tests for validation.

### How was it tested?
Ensuring existing tests pass.
