### PR TITLE
Incorrect MIN_SINT32 constant in lisk validator

### DIFF
--- a/elements/lisk-validator/src/constants.ts
+++ b/elements/lisk-validator/src/constants.ts
@@ -13,9 +13,9 @@
  *
  */
 
-export const MAX_SINT32 = 2147483647; // (2 ** (32 - 1)) + 1 * -1
-export const MIN_SINT32 = MAX_SINT32 * -1; // ((2 ** (32 - 1)) - 1) * -1
+export const MAX_SINT32 = 2147483647; // (2 ** (32 - 1)) - 1
+export const MIN_SINT32 = MAX_SINT32 * -1 - 1; // (2 ** (32 - 1)) * -1
 export const MAX_UINT32 = 4294967295; // (2 ** 32) - 1
-export const MAX_UINT64 = BigInt('18446744073709551615'); // BigInt((2 ** 64) - 1) - 1
-export const MAX_SINT64 = BigInt('9223372036854775807'); // BigInt(2 ** (64 - 1) - 1) -1
-export const MIN_SINT64 = MAX_SINT64 * BigInt(-1) - BigInt(1); // (BigInt(2 ** (64 - 1) - 1) -1) * BigInt(-1)
+export const MAX_UINT64 = BigInt('18446744073709551615'); // BigInt((2 ** 64) - 1) - BigInt(1)
+export const MAX_SINT64 = BigInt('9223372036854775807'); // BigInt(2 ** (64 - 1) - 1) - BigInt(1)
+export const MIN_SINT64 = MAX_SINT64 * BigInt(-1) - BigInt(1); // BigInt(2 ** (64 - 1)) * BigInt(-1)

--- a/elements/lisk-validator/test/validation.spec.ts
+++ b/elements/lisk-validator/test/validation.spec.ts
@@ -327,8 +327,8 @@ describe('validation', () => {
 			return expect(isSInt32(2147483648)).toBeFalse();
 		});
 
-		it('should return false when a number "-2147483648" which is just below the limit of sint32', () => {
-			return expect(isSInt32(-2147483648)).toBeFalse();
+		it('should return false when a number "-2147483649" which is just below the limit of sint32', () => {
+			return expect(isSInt32(-2147483649)).toBeFalse();
 		});
 
 		it('should return true when a valid number was provided', () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8975 

### How was it solved?

- Update incorrect constant
- Update incorrect comments

### How was it tested?

Update unit test
