### PR TITLE
NFT module can not lock an NFT

### DIFF
--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -329,6 +329,10 @@ export class NFTMethod extends BaseMethod {
 	}
 
 	public async lock(methodContext: MethodContext, module: string, nftID: Buffer): Promise<void> {
+		if (module === NFT_NOT_LOCKED) {
+			throw new Error('Cannot be locked by NFT module');
+		}
+
 		const nftStore = this.stores.get(NFTStore);
 
 		const nftExists = await nftStore.has(methodContext, nftID);
@@ -364,10 +368,6 @@ export class NFTMethod extends BaseMethod {
 		const userStore = this.stores.get(UserStore);
 		const userKey = userStore.getKey(owner, nftID);
 		const userData = await userStore.get(methodContext, userKey);
-
-		if (module === NFT_NOT_LOCKED) {
-			throw new Error('Cannot be locked by NFT module');
-		}
 
 		if (userData.lockingModule !== NFT_NOT_LOCKED) {
 			this.events.get(LockEvent).error(

--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -365,6 +365,10 @@ export class NFTMethod extends BaseMethod {
 		const userKey = userStore.getKey(owner, nftID);
 		const userData = await userStore.get(methodContext, userKey);
 
+		if (module === NFT_NOT_LOCKED) {
+			throw new Error('Cannot be locked by NFT module');
+		}
+
 		if (userData.lockingModule !== NFT_NOT_LOCKED) {
 			this.events.get(LockEvent).error(
 				methodContext,

--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -184,16 +184,8 @@ export class NFTMethod extends BaseMethod {
 		});
 	}
 
-	public async getCollectionID(
-		methodContext: ImmutableMethodContext,
-		nftID: Buffer,
-	): Promise<Buffer> {
-		const nftStore = this.stores.get(NFTStore);
-		const nftExists = await nftStore.has(methodContext, nftID);
-		if (!nftExists) {
-			throw new Error('NFT substore entry does not exist');
-		}
-		return nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
+	public getCollectionID(nftID: Buffer): Buffer {
+		return nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
 	}
 
 	public async isNFTSupported(
@@ -220,7 +212,7 @@ export class NFTMethod extends BaseMethod {
 			if (supportedNFTsStoreData.supportedCollectionIDArray.length === 0) {
 				return true;
 			}
-			const collectionID = await this.getCollectionID(methodContext, nftID);
+			const collectionID = this.getCollectionID(nftID);
 			if (
 				supportedNFTsStoreData.supportedCollectionIDArray.some(id =>
 					collectionID.equals(id.collectionID),

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -253,8 +253,6 @@ describe('NFTMethod', () => {
 		});
 
 		it('should return the lockingModule for the owner of the NFT', async () => {
-			// const lockingModule = 'nft';
-
 			await nftStore.save(methodContext, nftID, {
 				owner,
 				attributesArray: [],

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -362,19 +362,13 @@ describe('NFTMethod', () => {
 	});
 
 	describe('getCollectionID', () => {
-		it('should throw if entry does not exist in the nft substore for the nft id', async () => {
-			await expect(method.getCollectionID(methodContext, nftID)).rejects.toThrow(
-				'NFT substore entry does not exist',
-			);
-		});
-
 		it('should return the first bytes of length LENGTH_CHAIN_ID from provided nftID', async () => {
 			await nftStore.save(methodContext, nftID, {
 				owner: utils.getRandomBytes(LENGTH_CHAIN_ID),
 				attributesArray: [],
 			});
-			const expectedValue = nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
-			const receivedValue = await method.getCollectionID(methodContext, nftID);
+			const expectedValue = nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
+			const receivedValue = method.getCollectionID(nftID);
 			expect(receivedValue).toEqual(expectedValue);
 		});
 	});
@@ -395,7 +389,7 @@ describe('NFTMethod', () => {
 		});
 
 		it('should return true if nft chain id does not equal own chain id but nft chain id is supported and corresponding supported collection id array is empty', async () => {
-			await supportedNFTsStore.set(methodContext, nftID.slice(0, LENGTH_CHAIN_ID), {
+			await supportedNFTsStore.set(methodContext, nftID.subarray(0, LENGTH_CHAIN_ID), {
 				supportedCollectionIDArray: [],
 			});
 
@@ -404,9 +398,9 @@ describe('NFTMethod', () => {
 		});
 
 		it('should return true if nft chain id does not equal own chain id but nft chain id is supported and corresponding supported collection id array includes collection id for nft id', async () => {
-			await supportedNFTsStore.set(methodContext, nftID.slice(0, LENGTH_CHAIN_ID), {
+			await supportedNFTsStore.set(methodContext, nftID.subarray(0, LENGTH_CHAIN_ID), {
 				supportedCollectionIDArray: [
-					{ collectionID: nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID) },
+					{ collectionID: nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID) },
 					{ collectionID: utils.getRandomBytes(LENGTH_COLLECTION_ID) },
 				],
 			});

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -92,6 +92,7 @@ describe('NFTMethod', () => {
 
 	let methodContext!: MethodContext;
 
+	const lockingModule = 'token';
 	const nftStore = module.stores.get(NFTStore);
 	const userStore = module.stores.get(UserStore);
 	const supportedNFTsStore = module.stores.get(SupportedNFTsStore);
@@ -252,7 +253,7 @@ describe('NFTMethod', () => {
 		});
 
 		it('should return the lockingModule for the owner of the NFT', async () => {
-			const lockingModule = 'nft';
+			// const lockingModule = 'nft';
 
 			await nftStore.save(methodContext, nftID, {
 				owner,
@@ -627,7 +628,7 @@ describe('NFTMethod', () => {
 
 	describe('lock', () => {
 		it('should throw and log LockEvent if NFT does not exist', async () => {
-			await expect(method.lock(methodContext, module.name, nftID)).rejects.toThrow(
+			await expect(method.lock(methodContext, lockingModule, nftID)).rejects.toThrow(
 				'NFT substore entry does not exist',
 			);
 
@@ -637,7 +638,7 @@ describe('NFTMethod', () => {
 				LockEvent,
 				0,
 				{
-					module: module.name,
+					module: lockingModule,
 					nftID,
 				},
 				NftEventResult.RESULT_NFT_DOES_NOT_EXIST,
@@ -645,7 +646,7 @@ describe('NFTMethod', () => {
 		});
 
 		it('should throw and log LockEvent if NFT is escrowed', async () => {
-			await expect(method.lock(methodContext, module.name, escrowedNFT.nftID)).rejects.toThrow(
+			await expect(method.lock(methodContext, lockingModule, escrowedNFT.nftID)).rejects.toThrow(
 				'NFT is escrowed to another chain',
 			);
 
@@ -655,7 +656,7 @@ describe('NFTMethod', () => {
 				LockEvent,
 				0,
 				{
-					module: module.name,
+					module: lockingModule,
 					nftID: escrowedNFT.nftID,
 				},
 				NftEventResult.RESULT_NFT_ESCROWED,
@@ -664,7 +665,7 @@ describe('NFTMethod', () => {
 
 		it('should throw and log LockEvent if NFT is locked', async () => {
 			await expect(
-				method.lock(methodContext, module.name, lockedExistingNFT.nftID),
+				method.lock(methodContext, lockingModule, lockedExistingNFT.nftID),
 			).rejects.toThrow('NFT is already locked');
 
 			checkEventResult<LockEventData>(
@@ -673,10 +674,16 @@ describe('NFTMethod', () => {
 				LockEvent,
 				0,
 				{
-					module: module.name,
+					module: lockingModule,
 					nftID: lockedExistingNFT.nftID,
 				},
 				NftEventResult.RESULT_NFT_LOCKED,
+			);
+		});
+
+		it('should throw if provided locking module is "nft"', async () => {
+			await expect(method.lock(methodContext, NFT_NOT_LOCKED, existingNFT.nftID)).rejects.toThrow(
+				'Cannot be locked by NFT module',
 			);
 		});
 
@@ -698,12 +705,12 @@ describe('NFTMethod', () => {
 				NftEventResult.RESULT_SUCCESSFUL,
 			);
 
-			const { lockingModule } = await userStore.get(
+			const { lockingModule: actualLockingModule } = await userStore.get(
 				methodContext,
 				userStore.getKey(existingNFT.owner, existingNFT.nftID),
 			);
 
-			expect(lockingModule).toEqual(expectedLockingModule);
+			expect(actualLockingModule).toEqual(expectedLockingModule);
 		});
 	});
 
@@ -785,12 +792,12 @@ describe('NFTMethod', () => {
 				NftEventResult.RESULT_SUCCESSFUL,
 			);
 
-			const { lockingModule } = await userStore.get(
+			const { lockingModule: expectedLockingModule } = await userStore.get(
 				methodContext,
 				userStore.getKey(lockedExistingNFT.owner, lockedExistingNFT.nftID),
 			);
 
-			expect(lockingModule).toEqual(NFT_NOT_LOCKED);
+			expect(expectedLockingModule).toEqual(NFT_NOT_LOCKED);
 		});
 	});
 

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -625,6 +625,12 @@ describe('NFTMethod', () => {
 	});
 
 	describe('lock', () => {
+		it('should throw if provided locking module is "nft"', async () => {
+			await expect(method.lock(methodContext, NFT_NOT_LOCKED, existingNFT.nftID)).rejects.toThrow(
+				'Cannot be locked by NFT module',
+			);
+		});
+
 		it('should throw and log LockEvent if NFT does not exist', async () => {
 			await expect(method.lock(methodContext, lockingModule, nftID)).rejects.toThrow(
 				'NFT substore entry does not exist',
@@ -676,12 +682,6 @@ describe('NFTMethod', () => {
 					nftID: lockedExistingNFT.nftID,
 				},
 				NftEventResult.RESULT_NFT_LOCKED,
-			);
-		});
-
-		it('should throw if provided locking module is "nft"', async () => {
-			await expect(method.lock(methodContext, NFT_NOT_LOCKED, existingNFT.nftID)).rejects.toThrow(
-				'Cannot be locked by NFT module',
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #8956 

### How was it solved?

Updated `NFTModule.lock` to throw if locking module is `nft`.

### How was it tested?

Implemented unit tests.
