### PR TITLE
Remove deprecated slice function

### DIFF
--- a/commander/test/bootstrapping/commands/hash-onion.spec.ts
+++ b/commander/test/bootstrapping/commands/hash-onion.spec.ts
@@ -44,7 +44,7 @@ describe('hash-onion command', () => {
 			for (let i = 0; i < result.hashes.length - 1; i += 1) {
 				let nextHash = Buffer.from(result.hashes[i + 1], 'hex');
 				for (let j = 0; j < result.distance; j += 1) {
-					nextHash = cryptography.utils.hash(nextHash).slice(0, 16);
+					nextHash = cryptography.utils.hash(nextHash).subarray(0, 16);
 				}
 				expect(result.hashes[i]).toBe(nextHash.toString('hex'));
 			}

--- a/elements/lisk-chain/src/data_access/storage.ts
+++ b/elements/lisk-chain/src/data_access/storage.ts
@@ -506,7 +506,7 @@ export class Storage {
 			const ids = await this._db.get(concatDBKeys(DB_KEY_TRANSACTIONS_BLOCK_ID, blockID));
 			const idLength = 32;
 			for (let i = 0; i < ids.length; i += idLength) {
-				txIDs.push(ids.slice(i, i + idLength));
+				txIDs.push(ids.subarray(i, i + idLength));
 			}
 		} catch (error) {
 			if (!(error instanceof NotFoundError)) {

--- a/elements/lisk-chain/src/state_store/state_store.ts
+++ b/elements/lisk-chain/src/state_store/state_store.ts
@@ -186,14 +186,14 @@ export class StateStore {
 		for (const data of cachedValues) {
 			existingKey[data.key.toString('binary')] = true;
 			result.push({
-				key: data.key.slice(this._prefix.length),
+				key: data.key.subarray(this._prefix.length),
 				value: data.value,
 			});
 		}
 		for (const data of storedData) {
 			if (existingKey[data.key.toString('binary')] === undefined) {
 				result.push({
-					key: data.key.slice(this._prefix.length),
+					key: data.key.subarray(this._prefix.length),
 					value: data.value,
 				});
 			}

--- a/elements/lisk-chain/src/state_store/utils.ts
+++ b/elements/lisk-chain/src/state_store/utils.ts
@@ -24,6 +24,6 @@ export const copyBuffer = (value: Buffer): Buffer => {
 export const toSMTKey = (value: Buffer): Buffer =>
 	// First byte is the DB prefix
 	Buffer.concat([
-		value.slice(1, SMT_PREFIX_SIZE + 1),
-		utils.hash(value.slice(SMT_PREFIX_SIZE + 1)),
+		value.subarray(1, SMT_PREFIX_SIZE + 1),
+		utils.hash(value.subarray(SMT_PREFIX_SIZE + 1)),
 	]);

--- a/elements/lisk-chain/test/unit/event.spec.ts
+++ b/elements/lisk-chain/test/unit/event.spec.ts
@@ -71,7 +71,7 @@ describe('event', () => {
 				const { key } = pairs[i];
 				expect(key).toHaveLength(EVENT_TOPIC_HASH_LENGTH_BYTES + EVENT_TOTAL_INDEX_LENGTH_BYTES);
 
-				const index = key.slice(EVENT_TOPIC_HASH_LENGTH_BYTES);
+				const index = key.subarray(EVENT_TOPIC_HASH_LENGTH_BYTES);
 
 				// Check index
 				const indexNum = index.readUInt32BE(0);

--- a/elements/lisk-client/test/lisk-cryptography/utils.spec.ts
+++ b/elements/lisk-client/test/lisk-cryptography/utils.spec.ts
@@ -214,7 +214,7 @@ describe('buffer', () => {
 			});
 
 			it('should be able to calculate the checkpoint from another checkpoint', () => {
-				const firstDistanceHashes = hashOnion(hashOnionBuffers[1].slice(), 1000, 1);
+				const firstDistanceHashes = hashOnion(hashOnionBuffers[1].subarray(), 1000, 1);
 				expect(firstDistanceHashes[0]).toEqual(hashOnionBuffers[0]);
 				expect(firstDistanceHashes[1000]).toEqual(hashOnionBuffers[1]);
 			});

--- a/elements/lisk-codec/fuzz/round_trip.js
+++ b/elements/lisk-codec/fuzz/round_trip.js
@@ -72,7 +72,7 @@ function mutateRandomByte(buffer) {
 	else if (mutationType < 0.66) {
 		const index = Math.floor(Math.random() * (buffer.length + 1));
 		const mutation = utils.getRandomBytes(1);
-		buffer = Buffer.concat([buffer.slice(0, index), mutation, buffer.slice(index)]);
+		buffer = Buffer.concat([buffer.subarray(0, index), mutation, buffer.subarray(index)]);
 	}
 	// Remove a byte
 	else {
@@ -80,7 +80,7 @@ function mutateRandomByte(buffer) {
 			return buffer; // Can't remove byte from buffer of length 1
 		}
 		const index = Math.floor(Math.random() * buffer.length);
-		buffer = Buffer.concat([buffer.slice(0, index), buffer.slice(index + 1)]);
+		buffer = Buffer.concat([buffer.subarray(0, index), buffer.subarray(index + 1)]);
 	}
 
 	return buffer;

--- a/elements/lisk-cryptography/src/address.ts
+++ b/elements/lisk-cryptography/src/address.ts
@@ -54,7 +54,7 @@ const convertUInt5ToBase32 = (uint5Array: number[]): string =>
 
 export const getAddressFromPublicKey = (publicKey: Buffer): Buffer => {
 	const buffer = hash(publicKey);
-	const truncatedBuffer = buffer.slice(0, BINARY_ADDRESS_LENGTH);
+	const truncatedBuffer = buffer.subarray(0, BINARY_ADDRESS_LENGTH);
 
 	if (truncatedBuffer.length !== BINARY_ADDRESS_LENGTH) {
 		throw new Error(`Lisk address must contain exactly ${BINARY_ADDRESS_LENGTH} bytes`);

--- a/elements/lisk-cryptography/src/bls.ts
+++ b/elements/lisk-cryptography/src/bls.ts
@@ -181,7 +181,7 @@ const hkdfSHA256 = (ikm: Buffer, length: number, salt: Buffer, info: Buffer) => 
 		t = hmacSHA256(PRK, Buffer.concat([t, info, Buffer.from([1 + i])]), SHA256);
 		OKM = Buffer.concat([OKM, t]);
 	}
-	return OKM.slice(0, length);
+	return OKM.subarray(0, length);
 };
 
 const toLamportSK = (IKM: Buffer, salt: Buffer) => {
@@ -190,7 +190,7 @@ const toLamportSK = (IKM: Buffer, salt: Buffer) => {
 
 	const lamportSK = [];
 	for (let i = 0; i < 255; i += 1) {
-		lamportSK.push(OKM.slice(i * 32, (i + 1) * 32));
+		lamportSK.push(OKM.subarray(i * 32, (i + 1) * 32));
 	}
 	return lamportSK;
 };

--- a/elements/lisk-cryptography/src/ed.ts
+++ b/elements/lisk-cryptography/src/ed.ts
@@ -37,8 +37,8 @@ export const getPublicKeyFromPrivateKey = (pk: Buffer): Buffer => getPublicKey(p
 const getMasterKeyFromSeed = (seed: Buffer) => {
 	const hmac = crypto.createHmac('sha512', ED25519_CURVE);
 	const digest = hmac.update(seed).digest();
-	const leftBytes = digest.slice(0, 32);
-	const rightBytes = digest.slice(32);
+	const leftBytes = digest.subarray(0, 32);
+	const rightBytes = digest.subarray(32);
 	return {
 		key: leftBytes,
 		chainCode: rightBytes,
@@ -50,8 +50,8 @@ const getChildKey = (node: { key: Buffer; chainCode: Buffer }, index: number) =>
 	indexBuffer.writeUInt32BE(index, 0);
 	const data = Buffer.concat([Buffer.alloc(1, 0), node.key, indexBuffer]);
 	const digest = crypto.createHmac('sha512', node.chainCode).update(data).digest();
-	const leftBytes = digest.slice(0, 32);
-	const rightBytes = digest.slice(32);
+	const leftBytes = digest.subarray(0, 32);
+	const rightBytes = digest.subarray(32);
 
 	return {
 		key: leftBytes,

--- a/elements/lisk-cryptography/src/encrypt.ts
+++ b/elements/lisk-cryptography/src/encrypt.ts
@@ -127,7 +127,7 @@ export const encryptAES128GCMWithPassword = async (
 		key = getKeyFromPassword(password, salt, iterations);
 	}
 
-	const cipher = crypto.createCipheriv('aes-128-gcm', key.slice(0, 16), iv);
+	const cipher = crypto.createCipheriv('aes-128-gcm', key.subarray(0, 16), iv);
 	const firstBlock = Buffer.isBuffer(plainText)
 		? cipher.update(plainText)
 		: cipher.update(plainText, 'utf8');
@@ -136,7 +136,7 @@ export const encryptAES128GCMWithPassword = async (
 
 	return {
 		ciphertext: encrypted.toString('hex'),
-		mac: crypto.createHash('sha256').update(key.slice(16, 32)).update(encrypted).digest('hex'),
+		mac: crypto.createHash('sha256').update(key.subarray(16, 32)).update(encrypted).digest('hex'),
 		kdf,
 		kdfparams: {
 			parallelism,
@@ -227,7 +227,11 @@ export async function decryptAES128GCMWithPassword(
 	} else {
 		key = getKeyFromPassword(password, hexToBuffer(salt, 'Salt'), iterations);
 	}
-	const decipher = crypto.createDecipheriv('aes-128-gcm', key.slice(0, 16), hexToBuffer(iv, 'IV'));
+	const decipher = crypto.createDecipheriv(
+		'aes-128-gcm',
+		key.subarray(0, 16),
+		hexToBuffer(iv, 'IV'),
+	);
 	decipher.setAuthTag(tagBuffer);
 	const firstBlock = decipher.update(hexToBuffer(ciphertext, 'Cipher text'));
 	const decrypted = Buffer.concat([firstBlock, decipher.final()]);

--- a/elements/lisk-cryptography/src/legacy_address.ts
+++ b/elements/lisk-cryptography/src/legacy_address.ts
@@ -25,10 +25,10 @@ export const getFirstEightBytesReversed = (input: string | Buffer): Buffer => {
 	// Union type arguments on overloaded functions do not work in typescript.
 	// Relevant discussion: https://github.com/Microsoft/TypeScript/issues/23155
 	if (typeof input === 'string') {
-		return reverse(Buffer.from(input).slice(0, BUFFER_SIZE));
+		return reverse(Buffer.from(input).subarray(0, BUFFER_SIZE));
 	}
 
-	return reverse(Buffer.from(input).slice(0, BUFFER_SIZE));
+	return reverse(Buffer.from(input).subarray(0, BUFFER_SIZE));
 };
 
 export const getLegacyAddressFromPublicKey = (publicKey: Buffer): string => {

--- a/elements/lisk-cryptography/src/nacl/slow.ts
+++ b/elements/lisk-cryptography/src/nacl/slow.ts
@@ -83,7 +83,7 @@ const PRIVATE_KEY_LENGTH = 32;
 
 export const getPublicKey: NaclInterface['getPublicKey'] = privateKey => {
 	const { publicKey } = tweetnacl.sign.keyPair.fromSeed(
-		Uint8Array.from(privateKey.slice(0, PRIVATE_KEY_LENGTH)),
+		Uint8Array.from(privateKey.subarray(0, PRIVATE_KEY_LENGTH)),
 	);
 
 	return Buffer.from(publicKey);

--- a/elements/lisk-cryptography/src/utils.ts
+++ b/elements/lisk-cryptography/src/utils.ts
@@ -176,7 +176,7 @@ const defaultCount = 1000000;
 const defaultDistance = 1000;
 
 export const generateHashOnionSeed = (): Buffer =>
-	hash(getRandomBytes(INPUT_SIZE)).slice(0, HASH_SIZE);
+	hash(getRandomBytes(INPUT_SIZE)).subarray(0, HASH_SIZE);
 
 export const hashOnion = (
 	seed: Buffer,
@@ -195,7 +195,7 @@ export const hashOnion = (
 	const hashes = [seed];
 
 	for (let i = 1; i <= count; i += 1) {
-		const nextHash = hash(previousHash).slice(0, HASH_SIZE);
+		const nextHash = hash(previousHash).subarray(0, HASH_SIZE);
 		if (i % distance === 0) {
 			hashes.push(nextHash);
 		}

--- a/elements/lisk-cryptography/test/address.spec.ts
+++ b/elements/lisk-cryptography/test/address.spec.ts
@@ -45,7 +45,7 @@ describe('address', () => {
 
 	describe('#getAddressFromPrivateKey', () => {
 		it('should create correct address', () => {
-			expect(getAddressFromPrivateKey(defaultPrivateKey.slice(0, 64))).toEqual(defaultAddress);
+			expect(getAddressFromPrivateKey(defaultPrivateKey.subarray(0, 64))).toEqual(defaultAddress);
 		});
 	});
 

--- a/elements/lisk-tree/src/merkle_tree/merkle_tree.ts
+++ b/elements/lisk-tree/src/merkle_tree/merkle_tree.ts
@@ -452,10 +452,11 @@ export class MerkleTree {
 			type === NodeType.BRANCH
 				? value.readInt32BE(BRANCH_PREFIX.length + LAYER_INDEX_SIZE)
 				: value.readInt32BE(LEAF_PREFIX.length);
-		const rightHash = type === NodeType.BRANCH ? value.slice(-1 * NODE_HASH_SIZE) : Buffer.alloc(0);
+		const rightHash =
+			type === NodeType.BRANCH ? value.subarray(-1 * NODE_HASH_SIZE) : Buffer.alloc(0);
 		const leftHash =
 			type === NodeType.BRANCH
-				? value.slice(-2 * NODE_HASH_SIZE, -1 * NODE_HASH_SIZE)
+				? value.subarray(-2 * NODE_HASH_SIZE, -1 * NODE_HASH_SIZE)
 				: Buffer.alloc(0);
 
 		return {

--- a/framework-plugins/lisk-framework-chain-connector-plugin/src/utils.ts
+++ b/framework-plugins/lisk-framework-chain-connector-plugin/src/utils.ts
@@ -45,7 +45,7 @@ interface BFTParametersWithoutGeneratorKey extends Omit<BFTParameters, 'validato
 }
 
 export const getMainchainID = (chainID: Buffer): Buffer => {
-	const networkID = chainID.slice(0, 1);
+	const networkID = chainID.subarray(0, 1);
 	// 3 bytes for remaining chainID bytes
 	return Buffer.concat([networkID, Buffer.alloc(CHAIN_ID_LENGTH - 1, 0)]);
 };

--- a/framework/src/engine/generator/generator_store.ts
+++ b/framework/src/engine/generator/generator_store.ts
@@ -71,7 +71,7 @@ export class GeneratorStore {
 			const pairs: KeyValue[] = [];
 			stream
 				.on('data', ({ key, value }: { key: Buffer; value: Buffer }) => {
-					pairs.push({ key: key.slice(this._prefix.length), value });
+					pairs.push({ key: key.subarray(this._prefix.length), value });
 				})
 				.on('error', error => {
 					reject(error);

--- a/framework/src/modules/base_offchain_store.ts
+++ b/framework/src/modules/base_offchain_store.ts
@@ -42,14 +42,14 @@ export abstract class BaseOffchainStore<T> {
 
 	public constructor(moduleName: string, version = 0) {
 		this._version = version;
-		this._storePrefix = utils.hash(Buffer.from(moduleName, 'utf-8')).slice(0, 4);
+		this._storePrefix = utils.hash(Buffer.from(moduleName, 'utf-8')).subarray(0, 4);
 		// eslint-disable-next-line no-bitwise
 		this._storePrefix[0] &= 0x7f;
 		const versionBuffer = Buffer.alloc(2);
 		versionBuffer.writeUInt16BE(this._version, 0);
 		this._subStorePrefix = utils
 			.hash(Buffer.concat([Buffer.from(this.name, 'utf-8'), versionBuffer]))
-			.slice(0, 2);
+			.subarray(0, 2);
 	}
 
 	public async get(ctx: ImmutableOffchainStoreGetter, key: Buffer): Promise<T> {

--- a/framework/src/modules/base_store.ts
+++ b/framework/src/modules/base_store.ts
@@ -26,7 +26,7 @@ export interface StoreGetter {
 
 // LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0040.md#module-store-prefix-1
 export const computeStorePrefix = (name: string): Buffer => {
-	const prefix = utils.hash(Buffer.from(name, 'utf-8')).slice(0, 4);
+	const prefix = utils.hash(Buffer.from(name, 'utf-8')).subarray(0, 4);
 	// eslint-disable-next-line no-bitwise
 	prefix[0] &= 0x7f;
 	return prefix;

--- a/framework/src/modules/interoperability/mainchain/endpoint.ts
+++ b/framework/src/modules/interoperability/mainchain/endpoint.ts
@@ -42,8 +42,8 @@ export class MainchainInteroperabilityEndpoint extends BaseInteroperabilityEndpo
 		validator.validate(isChainIDAvailableRequestSchema, context.params);
 		const chainID = Buffer.from(context.params.chainID as string, 'hex');
 		const ownChainAccount = await this.stores.get(OwnChainAccountStore).get(context, EMPTY_BYTES);
-		const networkID = chainID.slice(0, 1);
-		const ownChainNetworkID = ownChainAccount.chainID.slice(0, 1);
+		const networkID = chainID.subarray(0, 1);
+		const ownChainNetworkID = ownChainAccount.chainID.subarray(0, 1);
 		// Only mainchain network IDs are available
 		if (!networkID.equals(ownChainNetworkID)) {
 			return {

--- a/framework/src/modules/interoperability/utils.ts
+++ b/framework/src/modules/interoperability/utils.ts
@@ -270,14 +270,14 @@ export const verifyLivenessConditionForRegisteredChains = (
 };
 
 export const getMainchainID = (chainID: Buffer): Buffer => {
-	const networkID = chainID.slice(0, 1);
+	const networkID = chainID.subarray(0, 1);
 	// 3 bytes for remaining chainID bytes
 	return Buffer.concat([networkID, Buffer.alloc(CHAIN_ID_LENGTH - 1, 0)]);
 };
 
 // TODO: Update to use Token method after merging development
 export const getTokenIDLSK = (chainID: Buffer): Buffer => {
-	const networkID = chainID.slice(0, 1);
+	const networkID = chainID.subarray(0, 1);
 	// 3 bytes for remaining chainID bytes
 	return Buffer.concat([networkID, Buffer.alloc(7, 0)]);
 };

--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -75,7 +75,7 @@ export class NFTMethod extends BaseMethod {
 			throw new Error(`NFT ID must have length ${LENGTH_NFT_ID}`);
 		}
 
-		return nftID.slice(0, LENGTH_CHAIN_ID);
+		return nftID.subarray(0, LENGTH_CHAIN_ID);
 	}
 
 	public async getNFTOwner(methodContext: ImmutableMethodContext, nftID: Buffer): Promise<Buffer> {
@@ -278,7 +278,7 @@ export class NFTMethod extends BaseMethod {
 		}
 
 		const latestKey = nftStoreData[nftStoreData.length - 1].key;
-		const indexBytes = latestKey.slice(LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID, LENGTH_NFT_ID);
+		const indexBytes = latestKey.subarray(LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID, LENGTH_NFT_ID);
 		const index = indexBytes.readBigUInt64BE();
 		const largestIndex = BigInt(BigInt(2 ** 64) - BigInt(1));
 

--- a/framework/src/modules/pos/stores/eligible_validators.ts
+++ b/framework/src/modules/pos/stores/eligible_validators.ts
@@ -69,8 +69,8 @@ export class EligibleValidatorsStore extends BaseStore<EligibleValidator> {
 	}
 
 	public splitKey(key: Buffer): [Buffer, bigint] {
-		const weightBytes = key.slice(0, 8);
-		const address = key.slice(8);
+		const weightBytes = key.subarray(0, 8);
+		const address = key.subarray(8);
 		return [address, weightBytes.readBigUInt64BE()];
 	}
 

--- a/framework/src/modules/random/utils.ts
+++ b/framework/src/modules/random/utils.ts
@@ -35,7 +35,7 @@ export const isSeedValidInput = (
 	if (!lastSeed) {
 		return !previousSeedRequired;
 	}
-	return lastSeed.seedReveal.equals(utils.hash(seedReveal).slice(0, SEED_LENGTH));
+	return lastSeed.seedReveal.equals(utils.hash(seedReveal).subarray(0, SEED_LENGTH));
 };
 
 export const getRandomSeed = (
@@ -51,7 +51,7 @@ export const getRandomSeed = (
 	}
 
 	const initRandomBuffer = utils.intToBuffer(height + numberOfSeeds, 4);
-	const currentSeeds = [utils.hash(initRandomBuffer).slice(0, 16)];
+	const currentSeeds = [utils.hash(initRandomBuffer).subarray(0, 16)];
 	let isInFuture = true;
 
 	for (const validatorReveal of validatorsReveal) {

--- a/framework/src/modules/token/cc_method.ts
+++ b/framework/src/modules/token/cc_method.ts
@@ -179,7 +179,7 @@ export class TokenInteroperableMethod extends BaseCCMethod {
 	public async recover(ctx: RecoverContext): Promise<void> {
 		const methodContext = ctx.getMethodContext();
 		const userStore = this.stores.get(UserStore);
-		const address = ctx.storeKey.slice(0, ADDRESS_LENGTH);
+		const address = ctx.storeKey.subarray(0, ADDRESS_LENGTH);
 		let account: UserStoreData;
 
 		if (
@@ -213,8 +213,8 @@ export class TokenInteroperableMethod extends BaseCCMethod {
 			throw new Error('Invalid arguments.');
 		}
 
-		const chainID = ctx.storeKey.slice(ADDRESS_LENGTH, ADDRESS_LENGTH + CHAIN_ID_LENGTH);
-		const tokenID = ctx.storeKey.slice(ADDRESS_LENGTH, ADDRESS_LENGTH + TOKEN_ID_LENGTH);
+		const chainID = ctx.storeKey.subarray(ADDRESS_LENGTH, ADDRESS_LENGTH + CHAIN_ID_LENGTH);
+		const tokenID = ctx.storeKey.subarray(ADDRESS_LENGTH, ADDRESS_LENGTH + TOKEN_ID_LENGTH);
 		const totalAmount =
 			account.availableBalance +
 			account.lockedBalances.reduce((prev, curr) => prev + curr.amount, BigInt(0));

--- a/framework/src/modules/token/endpoint.ts
+++ b/framework/src/modules/token/endpoint.ts
@@ -52,7 +52,7 @@ export class TokenEndpoint extends BaseEndpoint {
 
 		return {
 			balances: userData.map(({ key, value: user }) => ({
-				tokenID: key.slice(20).toString('hex'),
+				tokenID: key.subarray(20).toString('hex'),
 				availableBalance: user.availableBalance.toString(),
 				lockedBalances: user.lockedBalances.map(b => ({
 					amount: b.amount.toString(),
@@ -120,7 +120,7 @@ export class TokenEndpoint extends BaseEndpoint {
 
 		// main chain token
 		const mainchainTokenID = Buffer.concat([
-			context.chainID.slice(0, 1),
+			context.chainID.subarray(0, 1),
 			Buffer.alloc(TOKEN_ID_LENGTH - 1, 0),
 		]);
 		supportedTokens.push(mainchainTokenID.toString('hex'));
@@ -168,8 +168,8 @@ export class TokenEndpoint extends BaseEndpoint {
 		});
 		return {
 			escrowedAmounts: escrowData.map(({ key, value: escrow }) => {
-				const escrowChainID = key.slice(0, CHAIN_ID_LENGTH);
-				const tokenID = key.slice(CHAIN_ID_LENGTH);
+				const escrowChainID = key.subarray(0, CHAIN_ID_LENGTH);
+				const tokenID = key.subarray(CHAIN_ID_LENGTH);
 				return {
 					escrowChainID: escrowChainID.toString('hex'),
 					amount: escrow.amount.toString(),

--- a/framework/src/modules/token/method.ts
+++ b/framework/src/modules/token/method.ts
@@ -79,7 +79,7 @@ export class TokenMethod extends BaseMethod {
 	}
 
 	public getTokenIDLSK(): Buffer {
-		const networkID = this._config.ownChainID.slice(0, 1);
+		const networkID = this._config.ownChainID.subarray(0, 1);
 		// 3 bytes for remaining chainID bytes
 		return Buffer.concat([networkID, Buffer.alloc(3 + LOCAL_ID_LENGTH, 0)]);
 	}

--- a/framework/src/modules/token/module.ts
+++ b/framework/src/modules/token/module.ts
@@ -399,7 +399,7 @@ export class TokenModule extends BaseInteroperableModule {
 						);
 					}
 					for (const tokenID of supportedTokenIDsData.supportedTokenIDs) {
-						if (!tokenID.slice(0, CHAIN_ID_LENGTH).equals(supportedTokenIDsData.chainID)) {
+						if (!tokenID.subarray(0, CHAIN_ID_LENGTH).equals(supportedTokenIDsData.chainID)) {
 							throw new Error('supportedTokensSubstore tokenIDs must match the chainID.');
 						}
 					}
@@ -418,7 +418,7 @@ export class TokenModule extends BaseInteroperableModule {
 			lte: Buffer.alloc(ADDRESS_LENGTH + TOKEN_ID_LENGTH, 255),
 		});
 		for (const { key, value: user } of allUsers) {
-			const tokenID = key.slice(ADDRESS_LENGTH);
+			const tokenID = key.subarray(ADDRESS_LENGTH);
 			const [chainID] = splitTokenID(tokenID);
 			if (chainID.equals(context.chainID)) {
 				const existingSupply = computedSupply.get(tokenID) ?? BigInt(0);
@@ -435,7 +435,7 @@ export class TokenModule extends BaseInteroperableModule {
 			lte: Buffer.alloc(CHAIN_ID_LENGTH + TOKEN_ID_LENGTH, 255),
 		});
 		for (const { key, value } of allEscrows) {
-			const tokenID = key.slice(CHAIN_ID_LENGTH);
+			const tokenID = key.subarray(CHAIN_ID_LENGTH);
 			const existingSupply = computedSupply.get(tokenID) ?? BigInt(0);
 			computedSupply.set(tokenID, existingSupply + value.amount);
 		}

--- a/framework/src/modules/token/utils.ts
+++ b/framework/src/modules/token/utils.ts
@@ -19,8 +19,8 @@ export const splitTokenID = (tokenID: TokenID): [Buffer, Buffer] => {
 	if (tokenID.length !== TOKEN_ID_LENGTH) {
 		throw new Error(`Token ID must have length ${TOKEN_ID_LENGTH}`);
 	}
-	const chainID = tokenID.slice(0, CHAIN_ID_LENGTH);
-	const localID = tokenID.slice(CHAIN_ID_LENGTH);
+	const chainID = tokenID.subarray(0, CHAIN_ID_LENGTH);
+	const localID = tokenID.subarray(CHAIN_ID_LENGTH);
 
 	return [chainID, localID];
 };

--- a/framework/src/state_machine/prefixed_state_read_writer.ts
+++ b/framework/src/state_machine/prefixed_state_read_writer.ts
@@ -95,7 +95,7 @@ export class PrefixedStateReadWriter {
 		};
 		const result = await this._readWriter.range(optionsWithKey);
 		return result.map(kv => ({
-			key: kv.key.slice(this._prefix.length),
+			key: kv.key.subarray(this._prefix.length),
 			value: kv.value,
 		}));
 	}
@@ -111,7 +111,7 @@ export class PrefixedStateReadWriter {
 		};
 		const result = await this._readWriter.range(optionsWithKey);
 		return result.map(kv => ({
-			key: kv.key.slice(this._prefix.length),
+			key: kv.key.subarray(this._prefix.length),
 			value: codec.decode<T>(schema, kv.value),
 		}));
 	}

--- a/framework/test/unit/engine/legacy/codec.spec.ts
+++ b/framework/test/unit/engine/legacy/codec.spec.ts
@@ -36,7 +36,7 @@ describe('Legacy codec', () => {
 			});
 
 			it('should fail to decode invalid block', () => {
-				expect(() => decodeBlock(encodedBlock.slice(2))).toThrow();
+				expect(() => decodeBlock(encodedBlock.subarray(2))).toThrow();
 			});
 		});
 

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -210,7 +210,7 @@ describe('NFTMethod', () => {
 		});
 
 		it('should return the first bytes of length LENGTH_CHAIN_ID from provided nftID', () => {
-			expect(method.getChainID(nftID)).toEqual(nftID.slice(0, LENGTH_CHAIN_ID));
+			expect(method.getChainID(nftID)).toEqual(nftID.subarray(0, LENGTH_CHAIN_ID));
 		});
 	});
 
@@ -416,7 +416,7 @@ describe('NFTMethod', () => {
 				attributesArray: [],
 			});
 
-			await supportedNFTsStore.set(methodContext, foreignNFT.slice(0, LENGTH_CHAIN_ID), {
+			await supportedNFTsStore.set(methodContext, foreignNFT.subarray(0, LENGTH_CHAIN_ID), {
 				supportedCollectionIDArray: [
 					{ collectionID: utils.getRandomBytes(LENGTH_COLLECTION_ID) },
 					{ collectionID: utils.getRandomBytes(LENGTH_COLLECTION_ID) },
@@ -490,7 +490,7 @@ describe('NFTMethod', () => {
 			{ module: 'customMod1', attributes: Buffer.alloc(5) },
 			{ module: 'customMod2', attributes: Buffer.alloc(2) },
 		];
-		const collectionID = nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
+		const collectionID = nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
 
 		beforeEach(async () => {
 			await nftStore.save(methodContext, nftID, {
@@ -544,7 +544,7 @@ describe('NFTMethod', () => {
 	describe('create', () => {
 		const attributesArray1 = [{ module: 'customMod3', attributes: Buffer.alloc(7) }];
 		const attributesArray2 = [{ module: 'customMod3', attributes: Buffer.alloc(9) }];
-		const collectionID = nftID.slice(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
+		const collectionID = nftID.subarray(LENGTH_CHAIN_ID, LENGTH_CHAIN_ID + LENGTH_COLLECTION_ID);
 		const address = utils.getRandomBytes(LENGTH_ADDRESS);
 
 		beforeEach(() => {
@@ -933,7 +933,7 @@ describe('NFTMethod', () => {
 
 		it('should throw and emit error transfer cross chain event if nft does not exist', async () => {
 			const nonExistingNFTID = utils.getRandomBytes(LENGTH_NFT_ID);
-			receivingChainID = nonExistingNFTID.slice(0, LENGTH_CHAIN_ID);
+			receivingChainID = nonExistingNFTID.subarray(0, LENGTH_CHAIN_ID);
 			await expect(
 				method.transferCrossChain(
 					methodContext,

--- a/framework/test/unit/modules/pos/method.spec.ts
+++ b/framework/test/unit/modules/pos/method.spec.ts
@@ -374,7 +374,7 @@ describe('PoSMethod', () => {
 			const eligibleValidators = await pos.stores
 				.get(EligibleValidatorsStore)
 				.getAll(methodContext);
-			expect(eligibleValidators.find(v => v.key.slice(8).equals(address))).toBeDefined();
+			expect(eligibleValidators.find(v => v.key.subarray(8).equals(address))).toBeDefined();
 		});
 
 		it('should reject changing status if the validator does not exist', async () => {

--- a/framework/test/unit/modules/random/method.spec.ts
+++ b/framework/test/unit/modules/random/method.spec.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../../src/modules/random/stores/validator_reveals';
 
 const strippedHashOfIntegerBuffer = (num: number) =>
-	cryptography.utils.hash(cryptography.utils.intToBuffer(num, 4)).slice(0, SEED_LENGTH);
+	cryptography.utils.hash(cryptography.utils.intToBuffer(num, 4)).subarray(0, SEED_LENGTH);
 
 describe('RandomModuleMethod', () => {
 	let randomMethod: RandomMethod;

--- a/framework/test/unit/modules/random/module.spec.ts
+++ b/framework/test/unit/modules/random/module.spec.ts
@@ -756,7 +756,7 @@ describe('RandomModule', () => {
 		const seedHash = (seed: Buffer, times: number) => {
 			let res = seed;
 			for (let i = 0; i < times; i += 1) {
-				res = utils.hash(res).slice(0, 16);
+				res = utils.hash(res).subarray(0, 16);
 			}
 			return res;
 		};

--- a/framework/test/unit/modules/random/utils.spec.ts
+++ b/framework/test/unit/modules/random/utils.spec.ts
@@ -47,7 +47,7 @@ describe('Random module utils', () => {
 	describe('isSeedValidInput', () => {
 		const generatorAddress = utils.getRandomBytes(ADDRESS_LENGTH);
 		const seed = utils.getRandomBytes(SEED_LENGTH);
-		const previousSeed = utils.hash(seed).slice(0, SEED_LENGTH);
+		const previousSeed = utils.hash(seed).subarray(0, SEED_LENGTH);
 		let validatorSeedReveals: ValidatorSeedReveal[];
 
 		beforeEach(() => {

--- a/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
+++ b/framework/test/unit/modules/token/cc_commands/cc_transfer.spec.ts
@@ -186,7 +186,7 @@ describe('CrossChain Transfer Command', () => {
 		escrowStore = tokenModule.stores.get(EscrowStore);
 		await escrowStore.set(
 			methodContext,
-			Buffer.concat([defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH), defaultTokenID]),
+			Buffer.concat([defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH), defaultTokenID]),
 			{ amount: defaultEscrowAmount },
 		);
 		await escrowStore.set(

--- a/framework/test/unit/modules/token/cc_method.spec.ts
+++ b/framework/test/unit/modules/token/cc_method.spec.ts
@@ -144,7 +144,7 @@ describe('TokenInteroperableMethod', () => {
 		escrowStore = tokenModule.stores.get(EscrowStore);
 		await escrowStore.set(
 			methodContext,
-			Buffer.concat([defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH), defaultTokenID]),
+			Buffer.concat([defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH), defaultTokenID]),
 			{ amount: defaultEscrowAmount },
 		);
 		await escrowStore.set(

--- a/framework/test/unit/modules/token/method.spec.ts
+++ b/framework/test/unit/modules/token/method.spec.ts
@@ -131,7 +131,7 @@ describe('token module', () => {
 		const escrowStore = tokenModule.stores.get(EscrowStore);
 		await escrowStore.set(
 			methodContext,
-			Buffer.concat([defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH), defaultTokenID]),
+			Buffer.concat([defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH), defaultTokenID]),
 			{ amount: defaultEscrowAmount },
 		);
 	});
@@ -202,7 +202,7 @@ describe('token module', () => {
 			await expect(
 				method.getEscrowedAmount(
 					methodContext,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					defaultForeignTokenID,
 				),
 			).rejects.toThrow('Only native token can have escrow amount');
@@ -218,7 +218,7 @@ describe('token module', () => {
 			await expect(
 				method.getEscrowedAmount(
 					methodContext,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					Buffer.from([0, 0, 0, 1, 0, 0, 0, 1]),
 				),
 			).resolves.toBe(BigInt(0));
@@ -228,7 +228,7 @@ describe('token module', () => {
 			await expect(
 				method.getEscrowedAmount(
 					methodContext,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					defaultTokenID,
 				),
 			).resolves.toEqual(defaultEscrowAmount);
@@ -511,7 +511,7 @@ describe('token module', () => {
 			await expect(
 				method.initializeEscrowAccount(
 					methodContext,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					defaultTokenID,
 				),
 			).resolves.toBeUndefined();
@@ -678,7 +678,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt('100'),
@@ -744,7 +744,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					newAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt('100'),
@@ -783,7 +783,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					newAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt('100'),
@@ -812,7 +812,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					newAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt('100'),
@@ -847,7 +847,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					unknownToken,
 					BigInt(100000),
@@ -887,7 +887,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt('100000'),
@@ -901,7 +901,7 @@ describe('token module', () => {
 			const escrowStore = tokenModule.stores.get(EscrowStore);
 			const { amount } = await escrowStore.get(
 				methodContext,
-				escrowStore.getKey(defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH), defaultTokenID),
+				escrowStore.getKey(defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH), defaultTokenID),
 			);
 			expect(amount).toEqual(defaultEscrowAmount + BigInt('100000'));
 			checkEventResult(
@@ -917,7 +917,7 @@ describe('token module', () => {
 			await method.transferCrossChain(
 				methodContext,
 				defaultAddress,
-				defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+				defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 				recipient,
 				defaultTokenID,
 				BigInt('100000'),
@@ -930,7 +930,7 @@ describe('token module', () => {
 				defaultAddress,
 				'token',
 				CROSS_CHAIN_COMMAND_NAME_TRANSFER,
-				defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+				defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 				BigInt('10000'),
 				codec.encode(crossChainTransferMessageParams, {
 					tokenID: defaultTokenID,
@@ -952,7 +952,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt(0),
@@ -967,7 +967,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt(-1),
@@ -982,7 +982,7 @@ describe('token module', () => {
 				method.transferCrossChain(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					utils.getRandomBytes(20),
 					defaultTokenID,
 					BigInt('100000'),
@@ -1193,7 +1193,7 @@ describe('token module', () => {
 				method.payMessageFee(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					BigInt(-1),
 				),
 			).rejects.toThrow('Invalid Message Fee');
@@ -1204,7 +1204,7 @@ describe('token module', () => {
 				method.payMessageFee(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					defaultAccount.availableBalance + BigInt(1),
 				),
 			).rejects.toThrow('does not have sufficient balance');
@@ -1215,14 +1215,14 @@ describe('token module', () => {
 				method.payMessageFee(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					BigInt(100),
 				),
 			).resolves.toBeUndefined();
 			const escrowStore = tokenModule.stores.get(EscrowStore);
 			const { amount } = await escrowStore.get(
 				methodContext,
-				escrowStore.getKey(defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH), defaultTokenID),
+				escrowStore.getKey(defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH), defaultTokenID),
 			);
 			expect(amount).toEqual(defaultEscrowAmount + BigInt('100'));
 		});
@@ -1232,7 +1232,7 @@ describe('token module', () => {
 				method.payMessageFee(
 					methodContext,
 					defaultAddress,
-					defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH),
+					defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH),
 					BigInt(100),
 				),
 			).resolves.toBeUndefined();
@@ -1506,7 +1506,7 @@ describe('token module', () => {
 	});
 
 	describe('escrowSubstoreExists', () => {
-		const escrowChainID = defaultForeignTokenID.slice(0, CHAIN_ID_LENGTH);
+		const escrowChainID = defaultForeignTokenID.subarray(0, CHAIN_ID_LENGTH);
 
 		it('should return false if escrow subStore does not exist for the given chain id and token id', async () => {
 			const escrowStore = tokenModule.stores.get(EscrowStore);

--- a/protocol-specs/generators/address_generation/index.js
+++ b/protocol-specs/generators/address_generation/index.js
@@ -35,7 +35,7 @@ const GENERATOR = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
 
 const getBinaryAddress = publicKey => {
 	const publicKeyBuffer = Buffer.from(publicKey, 'hex');
-	return utils.hash(publicKeyBuffer).slice(0, 20);
+	return utils.hash(publicKeyBuffer).subarray(0, 20);
 };
 
 const polymod = uint5Array => {

--- a/protocol-specs/generators/pos_generator_selection/sample_generator.js
+++ b/protocol-specs/generators/pos_generator_selection/sample_generator.js
@@ -26,7 +26,7 @@ const generateValidators = (num, fixedNum) => {
 	for (let i = 0; i < num; i += 1) {
 		const passphrase = Mnemonic.generateMnemonic();
 		const { publicKey } = ed.getKeys(passphrase);
-		const address = utils.hash(Buffer.from(publicKey, 'hex')).slice(0, 20);
+		const address = utils.hash(Buffer.from(publicKey, 'hex')).subarray(0, 20);
 		const buf = crypto.randomBytes(8);
 		const randomNumber = buf.readBigUInt64BE() / BigInt(10) ** BigInt(8);
 		const validatorWeight = fixedValue

--- a/protocol-specs/generators/pos_random_seed_generation/index.js
+++ b/protocol-specs/generators/pos_random_seed_generation/index.js
@@ -35,7 +35,7 @@ const strippedHash = data => {
 		throw new Error('Hash input is not a valid type');
 	}
 
-	return utils.hash(data).slice(0, 16);
+	return utils.hash(data).subarray(0, 16);
 };
 
 const bitwiseXOR = bufferArray => {

--- a/protocol-specs/generators/pos_validator_shuffling/sample_generator.js
+++ b/protocol-specs/generators/pos_validator_shuffling/sample_generator.js
@@ -25,7 +25,7 @@ const generateValidators = num => {
 	for (let i = 0; i < num; i += 1) {
 		const passphrase = Mnemonic.generateMnemonic();
 		const { publicKey } = ed.getKeys(passphrase);
-		const address = utils.hash(Buffer.from(publicKey, 'hex')).slice(0, 20);
+		const address = utils.hash(Buffer.from(publicKey, 'hex')).subarray(0, 20);
 
 		validatorList.push({
 			address,


### PR DESCRIPTION
### What was the problem?

This PR resolves #8984

### How was it solved?

Replaced all instances of the deprecated `Buffer.slice` function with `Buffer.subarray`

### How was it tested?

All tests pass
