### PR TITLE
NFT recover method now checks if NFT exists

### DIFF
--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -935,6 +935,20 @@ export class NFTMethod extends BaseMethod {
 			throw new Error('Recovery called by a foreign chain');
 		}
 
+		const nftExists = await nftStore.has(methodContext, nftID);
+		if (!nftExists) {
+			this.events.get(RecoverEvent).error(
+				methodContext,
+				{
+					terminatedChainID,
+					nftID,
+				},
+				NftEventResult.RESULT_NFT_DOES_NOT_EXIST,
+			);
+
+			throw new Error('NFT substore entry does not exist');
+		}
+
 		const nftData = await nftStore.get(methodContext, nftID);
 		if (!nftData.owner.equals(terminatedChainID)) {
 			this.events.get(RecoverEvent).error(

--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -891,15 +891,14 @@ export class NFTMethod extends BaseMethod {
 		methodContext: MethodContext,
 		terminatedChainID: Buffer,
 		substorePrefix: Buffer,
-		storeKey: Buffer,
-		storeValue: Buffer,
+		nftID: Buffer,
+		nft: Buffer,
 	): Promise<void> {
 		const nftStore = this.stores.get(NFTStore);
-		const nftID = storeKey;
 		let isValidInput = true;
 		let decodedValue: NFTStoreData;
 		try {
-			decodedValue = codec.decode<NFTStoreData>(nftStoreSchema, storeValue);
+			decodedValue = codec.decode<NFTStoreData>(nftStoreSchema, nft);
 			validator.validate(nftStoreSchema, decodedValue);
 		} catch (error) {
 			isValidInput = false;
@@ -907,7 +906,7 @@ export class NFTMethod extends BaseMethod {
 
 		if (
 			!substorePrefix.equals(nftStore.subStorePrefix) ||
-			storeKey.length !== LENGTH_NFT_ID ||
+			nftID.length !== LENGTH_NFT_ID ||
 			!isValidInput
 		) {
 			this.events.get(RecoverEvent).error(

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -1601,17 +1601,17 @@ describe('NFTMethod', () => {
 	});
 
 	describe('recover', () => {
-		const terminatedChainID = utils.getRandomBytes(LENGTH_CHAIN_ID);
+		const terminatedChainID = Buffer.alloc(LENGTH_CHAIN_ID, 8);
 		const substorePrefix = Buffer.from('0000', 'hex');
-		const storeKey = utils.getRandomBytes(LENGTH_NFT_ID);
-		const storeValue = codec.encode(nftStoreSchema, {
+		const newNftID = Buffer.alloc(LENGTH_NFT_ID, 1);
+		const nft = codec.encode(nftStoreSchema, {
 			owner: utils.getRandomBytes(LENGTH_CHAIN_ID),
 			attributesArray: [],
 		});
 
 		it('should throw and emit error recover event if substore prefix is not valid', async () => {
 			await expect(
-				method.recover(methodContext, terminatedChainID, Buffer.alloc(2, 2), storeKey, storeValue),
+				method.recover(methodContext, terminatedChainID, Buffer.alloc(2, 2), nftID, nft),
 			).rejects.toThrow('Invalid inputs');
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1620,17 +1620,17 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: storeKey,
+					nftID,
 				},
 				NftEventResult.RESULT_RECOVER_FAIL_INVALID_INPUTS,
 			);
 		});
 
-		it('should throw and emit error recover event if store key length is not valid', async () => {
-			const newStoreKey = utils.getRandomBytes(LENGTH_NFT_ID + 1);
+		it('should throw and emit error recover event if NFT ID length is not valid', async () => {
+			const invalidNftID = utils.getRandomBytes(LENGTH_NFT_ID + 1);
 
 			await expect(
-				method.recover(methodContext, terminatedChainID, substorePrefix, newStoreKey, storeValue),
+				method.recover(methodContext, terminatedChainID, substorePrefix, invalidNftID, nft),
 			).rejects.toThrow('Invalid inputs');
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1639,19 +1639,19 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: newStoreKey,
+					nftID: invalidNftID,
 				},
 				NftEventResult.RESULT_RECOVER_FAIL_INVALID_INPUTS,
 			);
 		});
 
-		it('should throw and emit error recover event if store value is not valid', async () => {
+		it('should throw and emit error recover event if NFT is not valid', async () => {
 			await expect(
 				method.recover(
 					methodContext,
 					terminatedChainID,
 					substorePrefix,
-					storeKey,
+					nftID,
 					Buffer.from('asfas'),
 				),
 			).rejects.toThrow('Invalid inputs');
@@ -1662,7 +1662,7 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: storeKey,
+					nftID,
 				},
 				NftEventResult.RESULT_RECOVER_FAIL_INVALID_INPUTS,
 			);
@@ -1678,7 +1678,7 @@ describe('NFTMethod', () => {
 			});
 
 			await expect(
-				method.recover(methodContext, terminatedChainID, substorePrefix, storeKey, newStoreValue),
+				method.recover(methodContext, terminatedChainID, substorePrefix, nftID, newStoreValue),
 			).rejects.toThrow('Invalid inputs');
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1687,15 +1687,25 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: storeKey,
+					nftID,
 				},
 				NftEventResult.RESULT_RECOVER_FAIL_INVALID_INPUTS,
 			);
 		});
 
 		it('should throw and emit error recover event if nft chain id is not same as own chain id', async () => {
+			// ensure that random NFT is on a different chain than ownChainID
+			const randomNftID = Buffer.concat([
+				Buffer.alloc(LENGTH_CHAIN_ID, 9),
+				utils.getRandomBytes(LENGTH_NFT_ID - LENGTH_CHAIN_ID),
+			]);
+			await nftStore.save(methodContext, randomNftID, {
+				owner: utils.getRandomBytes(LENGTH_ADDRESS),
+				attributesArray: [],
+			});
+
 			await expect(
-				method.recover(methodContext, terminatedChainID, substorePrefix, storeKey, storeValue),
+				method.recover(methodContext, terminatedChainID, substorePrefix, randomNftID, nft),
 			).rejects.toThrow('Recovery called by a foreign chain');
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1704,7 +1714,7 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: storeKey,
+					nftID: randomNftID,
 				},
 				NftEventResult.RESULT_INITIATED_BY_NONNATIVE_CHAIN,
 			);
@@ -1717,7 +1727,7 @@ describe('NFTMethod', () => {
 			]);
 
 			await expect(
-				method.recover(methodContext, terminatedChainID, substorePrefix, unknownNftID, storeValue),
+				method.recover(methodContext, terminatedChainID, substorePrefix, unknownNftID, nft),
 			).rejects.toThrow('NFT substore entry does not exist');
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1733,14 +1743,13 @@ describe('NFTMethod', () => {
 		});
 
 		it('should throw and emit error recover event if nft is not escrowed to terminated chain', async () => {
-			const newStoreKey = Buffer.alloc(LENGTH_NFT_ID, 1);
-			await nftStore.save(methodContext, newStoreKey, {
+			await nftStore.save(methodContext, newNftID, {
 				owner: utils.getRandomBytes(LENGTH_CHAIN_ID),
 				attributesArray: [],
 			});
 
 			await expect(
-				method.recover(methodContext, terminatedChainID, substorePrefix, newStoreKey, storeValue),
+				method.recover(methodContext, terminatedChainID, substorePrefix, newNftID, nft),
 			).rejects.toThrow('NFT was not escrowed to terminated chain');
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1749,21 +1758,20 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: newStoreKey,
+					nftID: newNftID,
 				},
 				NftEventResult.RESULT_NFT_NOT_ESCROWED,
 			);
 		});
 
-		it('should throw and emit error recover event if store value owner length is invalid', async () => {
-			const newStoreKey = Buffer.alloc(LENGTH_NFT_ID, 1);
-			await nftStore.save(methodContext, newStoreKey, {
+		it('should throw and emit error recover event if NFT owner length is invalid', async () => {
+			await nftStore.save(methodContext, newNftID, {
 				owner: terminatedChainID,
 				attributesArray: [],
 			});
 
 			await expect(
-				method.recover(methodContext, terminatedChainID, substorePrefix, newStoreKey, storeValue),
+				method.recover(methodContext, terminatedChainID, substorePrefix, newNftID, nft),
 			).rejects.toThrow('Invalid account information');
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1772,33 +1780,26 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: newStoreKey,
+					nftID: newNftID,
 				},
 				NftEventResult.RESULT_INVALID_ACCOUNT,
 			);
 		});
 
 		it('should set appropriate values to stores and resolve with emitting success recover event if params are valid', async () => {
-			const newStoreKey = Buffer.alloc(LENGTH_NFT_ID, 1);
-			const storeValueOwner = utils.getRandomBytes(LENGTH_ADDRESS);
-			const newStoreValue = codec.encode(nftStoreSchema, {
-				owner: storeValueOwner,
+			const nftOwner = utils.getRandomBytes(LENGTH_ADDRESS);
+			const newNft = codec.encode(nftStoreSchema, {
+				owner: nftOwner,
 				attributesArray: [],
 			});
-			await nftStore.save(methodContext, newStoreKey, {
+			await nftStore.save(methodContext, newNftID, {
 				owner: terminatedChainID,
 				attributesArray: [],
 			});
 			jest.spyOn(internalMethod, 'createUserEntry');
 
 			await expect(
-				method.recover(
-					methodContext,
-					terminatedChainID,
-					substorePrefix,
-					newStoreKey,
-					newStoreValue,
-				),
+				method.recover(methodContext, terminatedChainID, substorePrefix, newNftID, newNft),
 			).resolves.toBeUndefined();
 			checkEventResult<RecoverEventData>(
 				methodContext.eventQueue,
@@ -1807,22 +1808,22 @@ describe('NFTMethod', () => {
 				0,
 				{
 					terminatedChainID,
-					nftID: newStoreKey,
+					nftID: newNftID,
 				},
 				NftEventResult.RESULT_SUCCESSFUL,
 			);
-			const nftStoreData = await nftStore.get(methodContext, newStoreKey);
+			const retrievedNft = await nftStore.get(methodContext, newNftID);
 			const escrowStore = module.stores.get(EscrowStore);
 			const escrowAccountExists = await escrowStore.has(
 				methodContext,
-				escrowStore.getKey(terminatedChainID, newStoreKey),
+				escrowStore.getKey(terminatedChainID, newNftID),
 			);
-			expect(nftStoreData.owner).toStrictEqual(storeValueOwner);
-			expect(nftStoreData.attributesArray).toEqual([]);
+			expect(retrievedNft.owner).toStrictEqual(nftOwner);
+			expect(retrievedNft.attributesArray).toEqual([]);
 			expect(internalMethod['createUserEntry']).toHaveBeenCalledWith(
 				methodContext,
-				storeValueOwner,
-				newStoreKey,
+				nftOwner,
+				newNftID,
 			);
 			expect(escrowAccountExists).toBe(false);
 		});

--- a/framework/test/unit/modules/nft/method.spec.ts
+++ b/framework/test/unit/modules/nft/method.spec.ts
@@ -1710,6 +1710,28 @@ describe('NFTMethod', () => {
 			);
 		});
 
+		it('should throw and emit error recover event if nft does not exist', async () => {
+			const unknownNftID = Buffer.concat([
+				config.ownChainID,
+				utils.getRandomBytes(LENGTH_NFT_ID - LENGTH_CHAIN_ID),
+			]);
+
+			await expect(
+				method.recover(methodContext, terminatedChainID, substorePrefix, unknownNftID, storeValue),
+			).rejects.toThrow('NFT substore entry does not exist');
+			checkEventResult<RecoverEventData>(
+				methodContext.eventQueue,
+				1,
+				RecoverEvent,
+				0,
+				{
+					terminatedChainID,
+					nftID: unknownNftID,
+				},
+				NftEventResult.RESULT_NFT_DOES_NOT_EXIST,
+			);
+		});
+
 		it('should throw and emit error recover event if nft is not escrowed to terminated chain', async () => {
 			const newStoreKey = Buffer.alloc(LENGTH_NFT_ID, 1);
 			await nftStore.save(methodContext, newStoreKey, {


### PR DESCRIPTION
### What was the problem?

This PR resolves #8970

### How was it solved?

- Added check to `recover()` method
- Added unit test for the new functionality
- BONUS: Renamed `storeKey` and `storeValue` concepts into `nftID` and `nft` 😎 

### How was it tested?

All tests are passing 👌🏻 
