### PR TITLE
Add missing chainID to offline transaction signing

### DIFF
--- a/commander/src/bootstrapping/commands/transaction/sign.ts
+++ b/commander/src/bootstrapping/commands/transaction/sign.ts
@@ -203,7 +203,7 @@ export abstract class SignCommand extends Command {
 		let signedTransaction: Record<string, unknown>;
 
 		if (flags.offline) {
-			const app = this.getApplication({}, {});
+			const app = this.getApplication({ genesis: { chainID: flags['chain-id'] } });
 			this._metadata = app.getMetadata();
 			this._schema = {
 				header: blockHeaderSchema,
@@ -266,8 +266,5 @@ export abstract class SignCommand extends Command {
 		}
 	}
 
-	abstract getApplication(
-		genesisBlock: Record<string, unknown>,
-		config: PartialApplicationConfig,
-	): Application;
+	abstract getApplication(config: PartialApplicationConfig): Application;
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves #9037

### How was it solved?

- Offline signing now uses `chainID` value provided in command flag.
- Aligned outdated `abstract getApplication()` method with other commands.

### How was it tested?

Signing using `--offline` flag no longer returns schema validator error.

```bash
./bin/run transaction:sign 0a05746f6b656e12087472616e7366657218002080c2d72f2a20bab2de16d9d9c409f19befc529542927cc45fb05ae52d39af95b3ebefb15005e322a0a0803000001000000001095d8970b1a14a90e238ec53202fafc2f3f2db89530ec1ff0159922036a6b273a40904c9ae644499de872ee0f9ff65ba879ca07bf7f30cb381894b284e69ba7f52f56118d637f49abddf6d95c8bf824d49a42c198d71682566d28287ae61cd5640a --mandatory-keys "['dfda7c78310bcda455b258084bb43283168271d3bae5cf5a560013918cf7f21d', '47ef4e36c52968f27cc1aefb003b344319ad08672120494b31e7c13450dc710e']" --optional-keys "['55c3fc3afaa5d717b8bba76e5e621f536f6544e7dcd7362b0a7953e8dfd79f33', '12c440d0c9e6fb1cb96921b6e788e9dda4b1e1f6aec338a7cfd0af761e6f2458']" --key-derivation-path 'm/44'/134'/1' --json --chain-id 03000001 --offline --pretty
```