### PR TITLE
Updates type parameter for StateStore.getStore

### DIFF
--- a/elements/lisk-chain/src/state_store/state_store.ts
+++ b/elements/lisk-chain/src/state_store/state_store.ts
@@ -47,19 +47,10 @@ export class StateStore {
 		this._latestSnapshotId = -1;
 	}
 
-	// TODO: Remove accepting number for subStorePrefix
-	public getStore(storePrefix: Buffer, subStorePrefix: Buffer | number): StateStore {
-		let storePrefixBuffer: Buffer;
-		if (typeof subStorePrefix === 'number') {
-			storePrefixBuffer = Buffer.alloc(2);
-			storePrefixBuffer.writeUInt16BE(subStorePrefix, 0);
-		} else {
-			storePrefixBuffer = subStorePrefix;
-		}
-
+	public getStore(storePrefix: Buffer, subStorePrefix: Buffer): StateStore {
 		const subStore = new StateStore(
 			this._db,
-			Buffer.concat([DB_KEY_STATE_STORE, storePrefix, storePrefixBuffer]),
+			Buffer.concat([DB_KEY_STATE_STORE, storePrefix, subStorePrefix]),
 			this._cache,
 		);
 

--- a/elements/lisk-chain/test/unit/chain.spec.ts
+++ b/elements/lisk-chain/test/unit/chain.spec.ts
@@ -201,7 +201,7 @@ describe('chain', () => {
 		beforeEach(async () => {
 			stateStore = new StateStore(db);
 			jest.spyOn(stateStore, 'finalize');
-			const subStore = stateStore.getStore(utils.intToBuffer(2, 4), 0);
+			const subStore = stateStore.getStore(utils.intToBuffer(2, 4), Buffer.from([0, 0]));
 			await subStore.set(utils.getRandomBytes(20), utils.getRandomBytes(100));
 			batch = new Batch();
 			jest.spyOn(batch, 'set');

--- a/framework/src/engine/bft/constants.ts
+++ b/framework/src/engine/bft/constants.ts
@@ -19,8 +19,8 @@ export const MODULE_STORE_PREFIX_BFT = Buffer.from([0, 0, 0, 0]);
 export const ED25519_PUBLIC_KEY_LENGTH = 32;
 export const BLS_PUBLIC_KEY_LENGTH = 48;
 export const EMPTY_BLS_KEY = Buffer.alloc(BLS_PUBLIC_KEY_LENGTH, 0);
-export const STORE_PREFIX_BFT_PARAMETERS = 0x0000;
-export const STORE_PREFIX_BFT_VOTES = 0x8000;
+export const STORE_PREFIX_BFT_PARAMETERS = Buffer.from([0x00, 0x00]);
+export const STORE_PREFIX_BFT_VOTES = Buffer.from([0x80, 0x00]);
 export const EMPTY_KEY = Buffer.alloc(0);
 export const MAX_UINT32 = 2 ** 32 - 1;
 

--- a/framework/src/state_machine/generator_context.ts
+++ b/framework/src/state_machine/generator_context.ts
@@ -68,7 +68,7 @@ export class GenerationContext {
 				this._stateStore.getStore(moduleID, storePrefix),
 			stateStore: this._stateStore,
 			getOffchainStore: (moduleID: Buffer, subStorePrefix: Buffer) =>
-				this._generatorStore.getStore(moduleID, subStorePrefix.readUInt16BE(0)),
+				this._generatorStore.getStore(moduleID, subStorePrefix),
 			header: this._header,
 			assets: this._assets,
 			chainID: this._chainID,


### PR DESCRIPTION
### What was the problem?

This PR resolves #9045 

### How was it solved?

Updated type for `subStorePrefix` parameter of `StateStore.getStore`.

### How was it tested?

Updated unit tests.
