### PR TITLE
Fix genesis block aggregate commit

### DIFF
--- a/elements/lisk-chain/src/block_header.ts
+++ b/elements/lisk-chain/src/block_header.ts
@@ -261,13 +261,13 @@ export class BlockHeader {
 			});
 		}
 
-		if (header.aggregateCommit.height !== 0) {
+		if (header.aggregateCommit.height !== header.height) {
 			errors.push({
-				message: 'Genesis block header aggregateCommit.height must equal 0',
+				message: 'Genesis block header aggregateCommit.height must equal to the height',
 				keyword: 'const',
 				dataPath: 'aggregateCommit.height',
 				schemaPath: 'properties.aggregateCommit.height',
-				params: { allowedValue: 0 },
+				params: { allowedValue: header.height },
 			});
 		}
 

--- a/elements/lisk-chain/src/block_header.ts
+++ b/elements/lisk-chain/src/block_header.ts
@@ -263,7 +263,7 @@ export class BlockHeader {
 
 		if (header.aggregateCommit.height !== header.height) {
 			errors.push({
-				message: 'Genesis block header aggregateCommit.height must equal to the height',
+				message: 'Genesis block header aggregateCommit.height must equal to the genesis height',
 				keyword: 'const',
 				dataPath: 'aggregateCommit.height',
 				schemaPath: 'properties.aggregateCommit.height',

--- a/elements/lisk-chain/test/unit/block.spec.ts
+++ b/elements/lisk-chain/test/unit/block.spec.ts
@@ -124,7 +124,7 @@ describe('block', () => {
 			maxHeightGenerated: 0,
 			validatorsHash: utils.hash(Buffer.alloc(0)),
 			aggregateCommit: {
-				height: 0,
+				height: 1009988,
 				aggregationBits: Buffer.alloc(0),
 				certificateSignature: EMPTY_BUFFER,
 			},

--- a/elements/lisk-chain/test/unit/block_header.spec.ts
+++ b/elements/lisk-chain/test/unit/block_header.spec.ts
@@ -265,7 +265,7 @@ describe('block_header', () => {
 				});
 
 				expect(() => blockHeader.validateGenesis()).toThrow(
-					'Genesis block header aggregateCommit.height must equal to the height',
+					'Genesis block header aggregateCommit.height must equal to the genesis height',
 				);
 			});
 

--- a/elements/lisk-chain/test/unit/block_header.spec.ts
+++ b/elements/lisk-chain/test/unit/block_header.spec.ts
@@ -257,7 +257,7 @@ describe('block_header', () => {
 				);
 			});
 
-			it('should throw error if aggregateCommit.height is not equal to 0', () => {
+			it('should throw error if aggregateCommit.height is not equal to the height', () => {
 				const block = getGenesisBlockAttrs();
 				const blockHeader = new BlockHeader({
 					...block,
@@ -265,7 +265,7 @@ describe('block_header', () => {
 				});
 
 				expect(() => blockHeader.validateGenesis()).toThrow(
-					'Genesis block header aggregateCommit.height must equal 0',
+					'Genesis block header aggregateCommit.height must equal to the height',
 				);
 			});
 

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -399,7 +399,7 @@ export class Consensus {
 		const finalizedBlockHeader = await this._chain.dataAccess.getBlockHeaderByHeight(
 			this._chain.finalizedHeight,
 		);
-		return finalizedBlockHeader.aggregateCommit.height;
+		return Math.max(finalizedBlockHeader.aggregateCommit.height, this._chain.genesisHeight);
 	}
 
 	private async _execute(block: Block, peerID: string): Promise<void> {

--- a/framework/src/genesis_block.ts
+++ b/framework/src/genesis_block.ts
@@ -68,7 +68,7 @@ export const generateGenesisBlock = async (
 		impliesMaxPrevotes: true,
 		assetRoot,
 		aggregateCommit: {
-			height: 0,
+			height,
 			aggregationBits: EMPTY_BUFFER,
 			certificateSignature: EMPTY_BUFFER,
 		},

--- a/framework/test/unit/genesis_block.spec.ts
+++ b/framework/test/unit/genesis_block.spec.ts
@@ -33,6 +33,7 @@ describe('generateGenesisBlock', () => {
 		expect(result.header.validatorsHash).toHaveLength(32);
 		expect(result.header.eventRoot).toHaveLength(32);
 		expect(result.header.version).toBe(0);
+		expect(result.header.aggregateCommit.height).toBe(30);
 
 		expect(stateMachine.executeGenesisBlock).toHaveBeenCalledTimes(1);
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #9044 

### How was it solved?

- Update `getMaxRemovalHeight` to be at least genesis height
- Update genesis header aggregateCommit.height to be genesis height

### How was it tested?

- Update unit tests
