### PR TITLE
Update getMaxRemovalHeight to start from minCerifyHeight - 1

### DIFF
--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -399,7 +399,10 @@ export class Consensus {
 		const finalizedBlockHeader = await this._chain.dataAccess.getBlockHeaderByHeight(
 			this._chain.finalizedHeight,
 		);
-		return Math.max(finalizedBlockHeader.aggregateCommit.height, this._chain.genesisHeight);
+		return Math.max(
+			finalizedBlockHeader.aggregateCommit.height,
+			this._genesisConfig.minimumCertifyHeight - 1,
+		);
 	}
 
 	private async _execute(block: Block, peerID: string): Promise<void> {

--- a/framework/src/engine/generator/generator.ts
+++ b/framework/src/engine/generator/generator.ts
@@ -258,9 +258,12 @@ export class Generator {
 		this._consensus.events.on(
 			CONSENSUS_EVENT_FINALIZED_HEIGHT_CHANGED,
 			({ from, to }: { from: number; to: number }) => {
-				Promise.all(this._handleFinalizedHeightChanged(from, to)).catch((err: Error) =>
-					this._logger.error({ err }, 'Fail to certify single commit'),
-				);
+				this._consensus
+					.getMaxRemovalHeight()
+					.then(async maxRemovalHeight =>
+						Promise.all(this._handleFinalizedHeightChanged(Math.max(maxRemovalHeight, from), to)),
+					)
+					.catch((err: Error) => this._logger.error({ err }, 'Fail to certify single commit'));
 			},
 		);
 	}

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -237,10 +237,10 @@ describe('consensus', () => {
 			(chain.dataAccess.getBlockHeaderByHeight as jest.Mock).mockResolvedValue(
 				finalizedBlock.header,
 			);
-			const genesisHeight = 25519;
-			(chain as any).genesisHeight = genesisHeight;
+			const minimumCertifyHeight = 25519;
+			consensus['_genesisConfig'].minimumCertifyHeight = minimumCertifyHeight;
 
-			await expect(consensus.getMaxRemovalHeight()).resolves.toEqual(genesisHeight);
+			await expect(consensus.getMaxRemovalHeight()).resolves.toEqual(minimumCertifyHeight - 1);
 		});
 
 		it('should return finalizedBlock.aggregateCommit.height if the genesis height is smaller', async () => {
@@ -257,8 +257,7 @@ describe('consensus', () => {
 			(chain.dataAccess.getBlockHeaderByHeight as jest.Mock).mockResolvedValue(
 				finalizedBlock.header,
 			);
-			const genesisHeight = 25519;
-			(chain as any).genesisHeight = genesisHeight;
+			consensus['_genesisConfig'].minimumCertifyHeight = 25519;
 
 			await expect(consensus.getMaxRemovalHeight()).resolves.toEqual(
 				finalizedBlock.header.aggregateCommit.height,

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -223,7 +223,7 @@ describe('consensus', () => {
 	});
 
 	describe('getMaxRemovalHeight', () => {
-		it('should return genesis height if the finalizedBlock.aggregateCommit.height is smaller', async () => {
+		it('should return minCertifyHeight if the finalizedBlock.aggregateCommit.height is smaller', async () => {
 			const finalizedBlock = await createValidDefaultBlock({
 				header: {
 					height: 1,
@@ -243,7 +243,7 @@ describe('consensus', () => {
 			await expect(consensus.getMaxRemovalHeight()).resolves.toEqual(minimumCertifyHeight - 1);
 		});
 
-		it('should return finalizedBlock.aggregateCommit.height if the genesis height is smaller', async () => {
+		it('should return finalizedBlock.aggregateCommit.height if the minCertifyHeight is smaller', async () => {
 			const finalizedBlock = await createValidDefaultBlock({
 				header: {
 					height: 1,

--- a/framework/test/unit/engine/generator/generator.spec.ts
+++ b/framework/test/unit/engine/generator/generator.spec.ts
@@ -812,15 +812,10 @@ describe('generator', () => {
 
 		describe('when previous finalized height change and maxRemovalHeight is non zero', () => {
 			beforeEach(async () => {
-				await generator.init({
-					blockchainDB,
-					generatorDB,
-					logger,
-					genesisHeight: 0,
-				});
 				await generator.start();
 				jest.spyOn(generator, '_handleFinalizedHeightChanged' as never);
 				jest.spyOn(generator, '_certifySingleCommitForChangedHeight' as never);
+				jest.spyOn(generator, '_certifySingleCommit' as never);
 			});
 
 			afterEach(async () => {
@@ -833,10 +828,11 @@ describe('generator', () => {
 					from: 0,
 					to: 25520,
 				});
-				await new Promise(process.nextTick);
+				await Promise.resolve();
 
 				expect(generator['_handleFinalizedHeightChanged']).toHaveBeenCalledWith(30000, 25520);
 				expect(generator['_certifySingleCommitForChangedHeight']).not.toHaveBeenCalled();
+				expect(generator['_certifySingleCommit']).not.toHaveBeenCalled();
 			});
 
 			it('should call certifySingleCommit when getMaxRemovalHeight is lower than next finalized height', async () => {
@@ -845,10 +841,13 @@ describe('generator', () => {
 					from: 30001,
 					to: 30003,
 				});
-				await new Promise(process.nextTick);
+				await Promise.resolve();
 
 				expect(generator['_handleFinalizedHeightChanged']).toHaveBeenCalledWith(30001, 30003);
 				expect(generator['_certifySingleCommitForChangedHeight']).toHaveBeenCalledTimes(
+					1 * generator['_keypairs'].size,
+				);
+				expect(generator['_certifySingleCommit']).toHaveBeenCalledTimes(
 					1 * generator['_keypairs'].size,
 				);
 			});


### PR DESCRIPTION
### What was the problem?

This PR resolves #9057 

### How was it solved?

Update to use `minCertifyHeight` to be used instead of genesis height

### How was it tested?

- Update unit test
