### PR TITLE
Update terminate liveness command

### DIFF
--- a/framework/src/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.ts
@@ -11,7 +11,6 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
-import { validator } from '@liskhq/lisk-validator';
 import {
 	CommandExecuteContext,
 	CommandVerifyContext,
@@ -32,7 +31,6 @@ export class TerminateSidechainForLivenessCommand extends BaseInteroperabilityCo
 		context: CommandVerifyContext<TerminateSidechainForLivenessParams>,
 	): Promise<VerificationResult> {
 		const { params } = context;
-		validator.validate(terminateSidechainForLivenessParamsSchema, params);
 
 		const chainAccount = await this.stores
 			.get(ChainAccountStore)

--- a/framework/src/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.ts
@@ -11,6 +11,7 @@
  *
  * Removal or modification of this copyright notice is prohibited.
  */
+import { validator } from '@liskhq/lisk-validator';
 import {
 	CommandExecuteContext,
 	CommandVerifyContext,
@@ -31,6 +32,7 @@ export class TerminateSidechainForLivenessCommand extends BaseInteroperabilityCo
 		context: CommandVerifyContext<TerminateSidechainForLivenessParams>,
 	): Promise<VerificationResult> {
 		const { params } = context;
+		validator.validate(terminateSidechainForLivenessParamsSchema, params);
 
 		const chainAccount = await this.stores
 			.get(ChainAccountStore)

--- a/framework/src/modules/interoperability/schemas.ts
+++ b/framework/src/modules/interoperability/schemas.ts
@@ -545,6 +545,7 @@ export const stateRecoveryInitParamsSchema = {
 	},
 };
 
+// https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#parameters-2
 export const terminateSidechainForLivenessParamsSchema = {
 	$id: '/modules/interoperability/mainchain/terminateSidechainForLiveness',
 	type: 'object',

--- a/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
@@ -100,7 +100,7 @@ describe('TerminateSidechainForLivenessCommand', () => {
 			jest.spyOn(interopMod['internalMethod'], 'isLive').mockResolvedValue(true);
 		});
 
-		it('should return error validation fails', async () => {
+		it('should return error when validation fails', async () => {
 			await expect(
 				livenessTerminationCommand.verify({
 					...commandVerifyContext,

--- a/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
@@ -192,7 +192,7 @@ describe('TerminateSidechainForLivenessCommand', () => {
 		it('should successfully terminate chain', async () => {
 			await livenessTerminationCommand.execute(commandExecuteContext);
 			expect(interopMod['internalMethod'].terminateChainInternal).toHaveBeenCalledWith(
-				expect.anything(),
+				commandExecuteContext,
 				transactionParams.chainID,
 			);
 		});

--- a/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/terminate_sidechain_for_liveness.spec.ts
@@ -100,6 +100,18 @@ describe('TerminateSidechainForLivenessCommand', () => {
 			jest.spyOn(interopMod['internalMethod'], 'isLive').mockResolvedValue(true);
 		});
 
+		it('should return error validation fails', async () => {
+			await expect(
+				livenessTerminationCommand.verify({
+					...commandVerifyContext,
+					params: {
+						...commandVerifyContext.params,
+						chainID: Buffer.alloc(0),
+					},
+				}),
+			).rejects.toThrow("Property '.chainID' minLength not satisfied");
+		});
+
 		it('should return error when chain account does not exist', async () => {
 			await interopMod.stores
 				.get(ChainAccountStore)


### PR DESCRIPTION
### What was the problem?

This PR resolves #8193

Regarding this point:
> Line 126: This test should be reverted. The verify() function throws error when the chain is Live; when it is not live, verification is successful. So, the description should be "should return error if the chain is live" and in line 127 call mockResolvedValue(true).

- line 126: Test title is already updated
- line 127: Already set
```
describe('verify', () => {
   ...
   beforeEach(async () => {
   ...
       jest.spyOn(interopMod['internalMethod'], 'isLive').mockResolvedValue(true);
       ...
   ....
   });
});
   ```
  



### How was it solved?
- Source code updated with latest code changes
- `validator.validate` check applied

### How was it tested?
Relevant test added
