### PR TITLE
Revert #9048 to fix the testnet genesis block issue

### DIFF
--- a/elements/lisk-chain/src/block_header.ts
+++ b/elements/lisk-chain/src/block_header.ts
@@ -261,13 +261,13 @@ export class BlockHeader {
 			});
 		}
 
-		if (header.aggregateCommit.height !== header.height) {
+		if (header.aggregateCommit.height !== 0) {
 			errors.push({
-				message: 'Genesis block header aggregateCommit.height must equal to the genesis height',
+				message: 'Genesis block header aggregateCommit.height must equal 0',
 				keyword: 'const',
 				dataPath: 'aggregateCommit.height',
 				schemaPath: 'properties.aggregateCommit.height',
-				params: { allowedValue: header.height },
+				params: { allowedValue: 0 },
 			});
 		}
 

--- a/elements/lisk-chain/test/unit/block.spec.ts
+++ b/elements/lisk-chain/test/unit/block.spec.ts
@@ -124,7 +124,7 @@ describe('block', () => {
 			maxHeightGenerated: 0,
 			validatorsHash: utils.hash(Buffer.alloc(0)),
 			aggregateCommit: {
-				height: 1009988,
+				height: 0,
 				aggregationBits: Buffer.alloc(0),
 				certificateSignature: EMPTY_BUFFER,
 			},

--- a/elements/lisk-chain/test/unit/block_header.spec.ts
+++ b/elements/lisk-chain/test/unit/block_header.spec.ts
@@ -257,7 +257,7 @@ describe('block_header', () => {
 				);
 			});
 
-			it('should throw error if aggregateCommit.height is not equal to the height', () => {
+			it('should throw error if aggregateCommit.height is not equal to 0', () => {
 				const block = getGenesisBlockAttrs();
 				const blockHeader = new BlockHeader({
 					...block,
@@ -265,7 +265,7 @@ describe('block_header', () => {
 				});
 
 				expect(() => blockHeader.validateGenesis()).toThrow(
-					'Genesis block header aggregateCommit.height must equal to the genesis height',
+					'Genesis block header aggregateCommit.height must equal 0',
 				);
 			});
 

--- a/framework/src/genesis_block.ts
+++ b/framework/src/genesis_block.ts
@@ -68,7 +68,7 @@ export const generateGenesisBlock = async (
 		impliesMaxPrevotes: true,
 		assetRoot,
 		aggregateCommit: {
-			height,
+			height: 0,
 			aggregationBits: EMPTY_BUFFER,
 			certificateSignature: EMPTY_BUFFER,
 		},

--- a/framework/test/unit/genesis_block.spec.ts
+++ b/framework/test/unit/genesis_block.spec.ts
@@ -33,7 +33,6 @@ describe('generateGenesisBlock', () => {
 		expect(result.header.validatorsHash).toHaveLength(32);
 		expect(result.header.eventRoot).toHaveLength(32);
 		expect(result.header.version).toBe(0);
-		expect(result.header.aggregateCommit.height).toBe(30);
 
 		expect(stateMachine.executeGenesisBlock).toHaveBeenCalledTimes(1);
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #9070

### How was it solved?

Revert the PR #9048 

### How was it tested?

Try to run Lisk testnet node from genesis block without data
