### PR TITLE
Fix validator unshuffling

### DIFF
--- a/framework/src/engine/bft/method.ts
+++ b/framework/src/engine/bft/method.ts
@@ -40,6 +40,7 @@ import {
 import { BFTHeights } from './types';
 import { BFTParameterNotFoundError } from './errors';
 import { Validator } from '../../abi';
+import { ActiveValidator } from '../consensus/types';
 
 export interface BlockHeaderAsset {
 	maxHeightPrevoted: number;
@@ -218,11 +219,12 @@ export class BFTMethod {
 			throw new Error('Invalid certificateThreshold input.');
 		}
 
-		sortValidatorsByBLSKey(validators);
+		const validatorsWithBFTWeight = validators
+			.filter(validator => validator.bftWeight > BigInt(0))
+			.map(validator => ({ bftWeight: validator.bftWeight, blsKey: validator.blsKey }));
+
 		const validatorsHash = computeValidatorsHash(
-			validators
-				.filter(v => v.bftWeight > BigInt(0))
-				.map(v => ({ bftWeight: v.bftWeight, blsKey: v.blsKey })),
+			sortValidatorsByBLSKey(validatorsWithBFTWeight) as ActiveValidator[],
 			certificateThreshold,
 		);
 		const bftParams: BFTParameters = {

--- a/framework/src/engine/bft/module.ts
+++ b/framework/src/engine/bft/module.ts
@@ -38,9 +38,13 @@ export class BFTModule {
 	private _maxLengthBlockBFTInfos!: number;
 
 	// eslint-disable-next-line @typescript-eslint/require-await
-	public async init(batchSize: number, blockTime: number): Promise<void> {
+	public async init(
+		batchSize: number,
+		blockTime: number,
+		shuffleValidatorsFromHeight: number,
+	): Promise<void> {
 		this._batchSize = batchSize;
-		this.method.init(this._batchSize, blockTime);
+		this.method.init(this._batchSize, blockTime, shuffleValidatorsFromHeight);
 		this._maxLengthBlockBFTInfos = 3 * this._batchSize;
 	}
 

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -186,7 +186,7 @@ export class Consensus {
 		await this._bft.init(
 			this._genesisConfig.bftBatchSize,
 			this._genesisConfig.blockTime,
-			this._genesisConfig.shuffleValidatorsFromHeight,
+			this._genesisConfig.exceptions.shuffleValidatorsFromHeight,
 		);
 
 		this._network.registerEndpoint(NETWORK_LEGACY_GET_BLOCKS_FROM_ID, async ({ data, peerId }) =>

--- a/framework/src/engine/consensus/consensus.ts
+++ b/framework/src/engine/consensus/consensus.ts
@@ -183,7 +183,11 @@ export class Consensus {
 			blockExecutor,
 			mechanisms: [blockSyncMechanism, fastChainSwitchMechanism],
 		});
-		await this._bft.init(this._genesisConfig.bftBatchSize, this._genesisConfig.blockTime);
+		await this._bft.init(
+			this._genesisConfig.bftBatchSize,
+			this._genesisConfig.blockTime,
+			this._genesisConfig.shuffleValidatorsFromHeight,
+		);
 
 		this._network.registerEndpoint(NETWORK_LEGACY_GET_BLOCKS_FROM_ID, async ({ data, peerId }) =>
 			this._legacyEndpoint.handleRPCGetLegacyBlocksFromID(data, peerId),
@@ -1028,6 +1032,7 @@ export class Consensus {
 					afterResult.preCommitThreshold,
 					afterResult.certificateThreshold,
 					afterResult.nextValidators,
+					block.header.height,
 				);
 				this.events.emit(CONSENSUS_EVENT_VALIDATORS_CHANGED, {
 					preCommitThreshold: afterResult.preCommitThreshold,
@@ -1081,6 +1086,7 @@ export class Consensus {
 				result.preCommitThreshold,
 				result.certificateThreshold,
 				result.nextValidators,
+				genesisBlock.header.height,
 			);
 			this.events.emit(CONSENSUS_EVENT_VALIDATORS_CHANGED, {
 				preCommitThreshold: result.preCommitThreshold,

--- a/framework/src/engine/generator/generator.ts
+++ b/framework/src/engine/generator/generator.ts
@@ -596,6 +596,7 @@ export class Generator {
 				afterResult.preCommitThreshold,
 				afterResult.certificateThreshold,
 				afterResult.nextValidators,
+				height,
 			);
 		}
 

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -279,6 +279,11 @@ export const applicationConfigSchema = {
 					minimum: 1,
 					description: 'Minimum block height which can be certified',
 				},
+				shuffleValidatorsFromHeight: {
+					type: 'integer',
+					minimum: 0,
+					description: 'Block height from which the validator list will be shuffled',
+				},
 			},
 			additionalProperties: false,
 		},
@@ -351,6 +356,7 @@ export const applicationConfigSchema = {
 			bftBatchSize: BFT_BATCH_SIZE,
 			maxTransactionsSize: MAX_TRANSACTIONS_SIZE,
 			minimumCertifyHeight: 1,
+			shuffleValidatorsFromHeight: 0,
 		},
 		generator: {
 			keys: {},

--- a/framework/src/schema/application_config_schema.ts
+++ b/framework/src/schema/application_config_schema.ts
@@ -279,10 +279,16 @@ export const applicationConfigSchema = {
 					minimum: 1,
 					description: 'Minimum block height which can be certified',
 				},
-				shuffleValidatorsFromHeight: {
-					type: 'integer',
-					minimum: 0,
-					description: 'Block height from which the validator list will be shuffled',
+				exceptions: {
+					type: 'object',
+					required: ['shuffleValidatorsFromHeight'],
+					properties: {
+						shuffleValidatorsFromHeight: {
+							type: 'integer',
+							minimum: 0,
+							description: 'Block height from which the validator list will be shuffled',
+						},
+					},
 				},
 			},
 			additionalProperties: false,
@@ -356,7 +362,9 @@ export const applicationConfigSchema = {
 			bftBatchSize: BFT_BATCH_SIZE,
 			maxTransactionsSize: MAX_TRANSACTIONS_SIZE,
 			minimumCertifyHeight: 1,
-			shuffleValidatorsFromHeight: 0,
+			exceptions: {
+				shuffleValidatorsFromHeight: 0,
+			},
 		},
 		generator: {
 			keys: {},

--- a/framework/src/testing/fixtures/config.ts
+++ b/framework/src/testing/fixtures/config.ts
@@ -34,7 +34,9 @@ export const defaultConfig: ApplicationConfig = {
 		blockTime: 10,
 		chainID: '10000000',
 		maxTransactionsSize: 15 * 1024, // Kilo Bytes
-		shuffleValidatorsFromHeight: 0,
+		exceptions: {
+			shuffleValidatorsFromHeight: 0,
+		},
 	},
 	network: {
 		version: '1.0',

--- a/framework/src/testing/fixtures/config.ts
+++ b/framework/src/testing/fixtures/config.ts
@@ -34,6 +34,7 @@ export const defaultConfig: ApplicationConfig = {
 		blockTime: 10,
 		chainID: '10000000',
 		maxTransactionsSize: 15 * 1024, // Kilo Bytes
+		shuffleValidatorsFromHeight: 0,
 	},
 	network: {
 		version: '1.0',

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -65,7 +65,7 @@ export interface GenesisConfig {
 	blockTime: number;
 	bftBatchSize: number;
 	minimumCertifyHeight: number;
-	shuffleValidatorsFromHeight: number;
+	exceptions: { shuffleValidatorsFromHeight: number };
 }
 
 export interface TransactionPoolConfig {

--- a/framework/src/types.ts
+++ b/framework/src/types.ts
@@ -65,6 +65,7 @@ export interface GenesisConfig {
 	blockTime: number;
 	bftBatchSize: number;
 	minimumCertifyHeight: number;
+	shuffleValidatorsFromHeight: number;
 }
 
 export interface TransactionPoolConfig {

--- a/framework/test/unit/__snapshots__/application.spec.ts.snap
+++ b/framework/test/unit/__snapshots__/application.spec.ts.snap
@@ -12,6 +12,9 @@ exports[`Application #constructor should set internal variables 1`] = `
     },
     "blockTime": 10,
     "chainID": "10000000",
+    "exceptions": {
+      "shuffleValidatorsFromHeight": 0,
+    },
     "maxTransactionsSize": 15360,
     "minimumCertifyHeight": 1,
   },

--- a/framework/test/unit/engine/bft/bft_processing.spec.ts
+++ b/framework/test/unit/engine/bft/bft_processing.spec.ts
@@ -39,6 +39,7 @@ describe('BFT processing', () => {
 		scenario11ValidatorsPartialSwitch,
 	];
 	const blockTime = 10;
+	const shuffleValidatorsFromHeight = 0;
 
 	for (const scenario of bftScenarios) {
 		// eslint-disable-next-line no-loop-func
@@ -49,7 +50,11 @@ describe('BFT processing', () => {
 
 			beforeAll(async () => {
 				bftModule = new BFTModule();
-				await bftModule.init(scenario.config.activeValidators, blockTime);
+				await bftModule.init(
+					scenario.config.activeValidators,
+					blockTime,
+					shuffleValidatorsFromHeight,
+				);
 				db = new InMemoryDatabase();
 				stateStore = new StateStore(db);
 

--- a/framework/test/unit/engine/bft/method.spec.ts
+++ b/framework/test/unit/engine/bft/method.spec.ts
@@ -940,9 +940,7 @@ describe('BFT Method', () => {
 				);
 
 				expect(bftParams.validators).toHaveLength(3);
-				expect(bftParams.validators[0].address).toEqual(shuffledValidators[0].address);
-				expect(bftParams.validators[1].address).toEqual(shuffledValidators[1].address);
-				expect(bftParams.validators[2].address).toEqual(shuffledValidators[2].address);
+expect(bftParams.validators).toEqual(shuffledValidators);
 			});
 
 			it('should store BFT parameters with height maxHeightPrevoted + 1 if blockBFTInfo does not exist', async () => {

--- a/framework/test/unit/engine/bft/module.spec.ts
+++ b/framework/test/unit/engine/bft/module.spec.ts
@@ -32,7 +32,7 @@ describe('bft module', () => {
 
 	describe('init', () => {
 		it('should initialize config with given value', async () => {
-			await expect(bftModule.init(20, 10)).toResolve();
+			await expect(bftModule.init(20, 10, 0)).toResolve();
 
 			expect(bftModule['_batchSize']).toBe(20);
 		});

--- a/framework/test/unit/engine/consensus/consensus.spec.ts
+++ b/framework/test/unit/engine/consensus/consensus.spec.ts
@@ -127,6 +127,9 @@ describe('consensus', () => {
 			bft,
 			genesisConfig: {
 				blockTime: 10,
+				exceptions: {
+					shuffleValidatorsFromHeight: 0,
+				},
 			} as any,
 		});
 		dbMock = {

--- a/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
+++ b/framework/test/unit/schema/__snapshots__/application_config_schema.spec.ts.snap
@@ -14,6 +14,9 @@ exports[`schema/application_config_schema.js application config schema must matc
         "fromFile": "./config/genesis_block.blob",
       },
       "blockTime": 10,
+      "exceptions": {
+        "shuffleValidatorsFromHeight": 0,
+      },
       "maxTransactionsSize": 15360,
       "minimumCertifyHeight": 1,
     },
@@ -124,6 +127,19 @@ exports[`schema/application_config_schema.js application config schema must matc
           "description": "The unique name of the chain as a string encoded in Hex format",
           "format": "hex",
           "type": "string",
+        },
+        "exceptions": {
+          "properties": {
+            "shuffleValidatorsFromHeight": {
+              "description": "Block height from which the validator list will be shuffled",
+              "minimum": 0,
+              "type": "integer",
+            },
+          },
+          "required": [
+            "shuffleValidatorsFromHeight",
+          ],
+          "type": "object",
         },
         "maxTransactionsSize": {
           "description": "Maximum number of transactions allowed per block",


### PR DESCRIPTION
### What was the problem?

This PR resolves #9040, resolves #9075 and resolves #9080 

### How was it solved?

- Fixed the bug in the engine where the original validator list array was sorted and then saved in sorted order to BFT Params Store
- Added config option [default to 0] to prevent validator shuffling before the configured block height, to ensure that the the new version can sync
- BONUS: Cleaned up and simplified BFT Method unit tests 😎 

### How was it tested?

- When running the app, validator's consecutive missed blocks now show correct value
- When running the app, the validators are shuffled after each round
- All tests are passing 👌🏻 
