### PR TITLE
Fix unintended removal of element

### DIFF
--- a/framework/src/engine/consensus/certificate_generation/commit_list.ts
+++ b/framework/src/engine/consensus/certificate_generation/commit_list.ts
@@ -71,6 +71,10 @@ export class CommitList {
 		const index = commitList.findIndex(
 			c => c.blockID.equals(commit.blockID) && c.validatorAddress.equals(commit.validatorAddress),
 		);
+		// if the commit does not exist, do nothing
+		if (index < 0) {
+			return;
+		}
 
 		commitList.splice(index, 1);
 

--- a/framework/test/unit/engine/consensus/certificate_generation/commit_list.spec.ts
+++ b/framework/test/unit/engine/consensus/certificate_generation/commit_list.spec.ts
@@ -223,5 +223,25 @@ describe('CommitList', () => {
 			// Assert
 			expect(commitList.exists(singleSampleCommit)).toBeFalse();
 		});
+
+		it('should not delete anything if the height does not exist', () => {
+			const originalSize = commitList.size();
+
+			commitList.deleteSingle({
+				...singleSampleCommit,
+				height: 9999,
+			});
+			expect(commitList.size()).toBe(originalSize);
+		});
+
+		it('should not delete anything if commit does not exist', () => {
+			const originalSize = commitList.size();
+
+			commitList.deleteSingle({
+				...singleSampleCommit,
+				validatorAddress: utils.getRandomBytes(20),
+			});
+			expect(commitList.size()).toBe(originalSize);
+		});
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #9086

### How was it solved?

- Add check if the commit does not exist, it will not delete anything

### How was it tested?

- Added unit test, and without this fix, unit test will fail
- Asked several validators from the community to add this patch and observed fix on testnet. (caught up now)
