### PR TITLE
Fix Monitor Plugin `getTransactionStats`

### DIFF
--- a/framework-plugins/lisk-framework-monitor-plugin/src/controllers/transactions.ts
+++ b/framework-plugins/lisk-framework-monitor-plugin/src/controllers/transactions.ts
@@ -37,6 +37,7 @@ export const getTransactionStats = async (
 	state: SharedState,
 ): Promise<TransactionStats> => ({
 	transactions: state.transactions,
-	connectedPeers: (await client.invoke<ReadonlyArray<PeerInfo>>('app_getConnectedPeers')).length,
+	connectedPeers: (await client.invoke<ReadonlyArray<PeerInfo>>('network_getConnectedPeers'))
+		.length,
 	averageReceivedTransactions: getAverage(state.transactions),
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #9082

### How was it solved?

Changed used endpoint from `app_getConnectedPeers` into `network_getConnectedPeers`

### How was it tested?

When invoking `monitor_getTransactionStats` endpoint, the result now includes `connectedPeers` property, e.g:

```json
{
  "transactions": {},
  "connectedPeers": 0,
  "averageReceivedTransactions": 0
}
```