### PR TITLE
Adds test for getPrivateKeyFromPhraseAndPath

### DIFF
--- a/elements/lisk-cryptography/test/ed.spec.ts
+++ b/elements/lisk-cryptography/test/ed.spec.ts
@@ -166,6 +166,20 @@ describe('getPrivateKeyFromPhraseAndPath', () => {
 		);
 	});
 
+	it('should derive distinct keys from same valid phrase but distinct paths', async () => {
+		const privateKeyFromPassphrase = await getPrivateKeyFromPhraseAndPath(
+			passphrase,
+			`m/44'/134'/0'`,
+		);
+
+		const anotherPrivateKeyFromPassphrase = await getPrivateKeyFromPhraseAndPath(
+			passphrase,
+			`m/44'/134'/1'`,
+		);
+
+		expect(privateKeyFromPassphrase).not.toEqual(anotherPrivateKeyFromPassphrase);
+	});
+
 	it('should fail for empty string path', async () => {
 		await expect(getPrivateKeyFromPhraseAndPath(passphrase, '')).rejects.toThrow(
 			'Invalid path format',


### PR DESCRIPTION
### What was the problem?

This PR resolves #8104 

### How was it solved?

Adds a test case validating generation of distinct private key using similar passphrase but distinct paths.

### How was it tested?

`release/6.1.0`
