### PR TITLE
Remove redundant call to verifyTransfer in method of NFT module

### DIFF
--- a/framework/src/modules/nft/method.ts
+++ b/framework/src/modules/nft/method.ts
@@ -432,8 +432,6 @@ export class NFTMethod extends BaseMethod {
 		includeAttributes: boolean,
 	): Promise<void> {
 		try {
-			await this._internalMethod.verifyTransfer(methodContext, senderAddress, nftID);
-
 			await this._internalMethod.verifyTransferCrossChain(
 				methodContext,
 				senderAddress,


### PR DESCRIPTION
### What was the problem?

This PR resolves #9101 

### How was it solved?

Remove the check as specified

### How was it tested?

All tests pass already
