### PR TITLE
Update getChildQueue to replace default topic

### DIFF
--- a/examples/interop/pos-sidechain-example-one/src/app/modules/hello/schema.ts
+++ b/examples/interop/pos-sidechain-example-one/src/app/modules/hello/schema.ts
@@ -82,7 +82,7 @@ export const getHelloRequestSchema = {
  */
 export const crossChainReactParamsSchema = {
 	/** The unique identifier of the schema. */
-	$id: '/lisk/ccReactParams',
+	$id: '/lisk/hello/ccReactParams',
 	type: 'object',
 	/** The required parameters for the command. */
 	required: ['reactionType', 'helloMessageID', 'data'],

--- a/examples/interop/pos-sidechain-example-two/src/app/modules/react/schemas.ts
+++ b/examples/interop/pos-sidechain-example-two/src/app/modules/react/schemas.ts
@@ -3,7 +3,7 @@
  */
 export const crossChainReactParamsSchema = {
 	/** The unique identifier of the schema. */
-	$id: '/lisk/ccReactParams',
+	$id: '/lisk/react/ccReactParams',
 	type: 'object',
 	/** The required parameters for the command. */
 	required: [

--- a/framework/src/modules/interoperability/base_cross_chain_update_command.ts
+++ b/framework/src/modules/interoperability/base_cross_chain_update_command.ts
@@ -19,7 +19,7 @@ import { CommandExecuteContext, CommandVerifyContext } from '../../state_machine
 import { BaseInteroperabilityCommand } from './base_interoperability_command';
 import { BaseInteroperabilityInternalMethod } from './base_interoperability_internal_methods';
 import { BaseInteroperabilityMethod } from './base_interoperability_method';
-import { CCMStatusCode, EMPTY_BYTES, EmptyCCM } from './constants';
+import { CCMStatusCode, EMPTY_BYTES, EVENT_TOPIC_CCM_EXECUTION, EmptyCCM } from './constants';
 import { CCMProcessedCode, CcmProcessedEvent, CCMProcessedResult } from './events/ccm_processed';
 import { CcmSendSuccessEvent } from './events/ccm_send_success';
 import { ccmSchema, crossChainUpdateTransactionParams } from './schemas';
@@ -34,6 +34,7 @@ import { ChainAccountStore, ChainStatus } from './stores/chain_account';
 import {
 	emptyActiveValidatorsUpdate,
 	getEncodedCCMAndID,
+	getIDFromCCMBytes,
 	getMainchainID,
 	isInboxUpdateEmpty,
 	validateFormat,
@@ -122,39 +123,12 @@ export abstract class BaseCrossChainUpdateCommand<
 		}
 	}
 
-	protected async executeCommon(
+	protected async beforeCrossChainMessagesExecution(
 		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
 		isMainchain: boolean,
 	): Promise<[CCMsg[], boolean]> {
-		const { params, transaction } = context;
+		const { params } = context;
 		const { inboxUpdate } = params;
-
-		// Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
-		await this.internalMethod.verifyCertificateSignature(context, params);
-
-		if (!isInboxUpdateEmpty(inboxUpdate)) {
-			// This check is expensive. Therefore, it is done in the execute step instead of the verify
-			// step. Otherwise, a malicious relayer could spam the transaction pool with computationally
-			// costly CCU verifications without paying fees.
-			try {
-				await this.internalMethod.verifyPartnerChainOutboxRoot(context, params);
-			} catch (error) {
-				return [[], false];
-			}
-
-			// Initialize the relayer account for the message fee token.
-			// This is necessary to ensure that the relayer can receive the CCM fees
-			// If the account already exists, nothing is done.
-			const messageFeeTokenID = await this._interopsMethod.getMessageFeeTokenID(
-				context,
-				params.sendingChainID,
-			);
-			await this._tokenMethod.initializeUserAccount(
-				context,
-				transaction.senderAddress,
-				messageFeeTokenID,
-			);
-		}
 
 		const ccms: CCMsg[] = [];
 		let ccm: CCMsg;
@@ -162,16 +136,25 @@ export abstract class BaseCrossChainUpdateCommand<
 		// Process cross-chain messages in inbox update.
 		// First process basic checks for all CCMs.
 		for (const ccmBytes of inboxUpdate.crossChainMessages) {
+			const ccmID = getIDFromCCMBytes(ccmBytes);
+			const ccmContext = {
+				...context,
+				eventQueue: context.eventQueue.getChildQueue(
+					Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, ccmID]),
+				),
+			};
 			try {
 				// Verify general format. Past this point, we can access ccm root properties.
 				ccm = codec.decode<CCMsg>(ccmSchema, ccmBytes);
 			} catch (error) {
-				await this.internalMethod.terminateChainInternal(context, params.sendingChainID);
-				this.events.get(CcmProcessedEvent).log(context, params.sendingChainID, context.chainID, {
-					ccm: EmptyCCM,
-					result: CCMProcessedResult.DISCARDED,
-					code: CCMProcessedCode.INVALID_CCM_DECODING_EXCEPTION,
-				});
+				await this.internalMethod.terminateChainInternal(ccmContext, params.sendingChainID);
+				this.events
+					.get(CcmProcessedEvent)
+					.log(ccmContext, params.sendingChainID, ccmContext.chainID, {
+						ccm: EmptyCCM,
+						result: CCMProcessedResult.DISCARDED,
+						code: CCMProcessedCode.INVALID_CCM_DECODING_EXCEPTION,
+					});
 				// In this case, we do not even update the chain account with the new certificate.
 				return [[], false];
 			}
@@ -179,11 +162,11 @@ export abstract class BaseCrossChainUpdateCommand<
 			try {
 				validateFormat(ccm);
 			} catch (error) {
-				await this.internalMethod.terminateChainInternal(context, params.sendingChainID);
+				await this.internalMethod.terminateChainInternal(ccmContext, params.sendingChainID);
 				ccm = { ...ccm, params: EMPTY_BYTES };
 				this.events
 					.get(CcmProcessedEvent)
-					.log(context, params.sendingChainID, ccm.receivingChainID, {
+					.log(ccmContext, params.sendingChainID, ccm.receivingChainID, {
 						ccm,
 						result: CCMProcessedResult.DISCARDED,
 						code: CCMProcessedCode.INVALID_CCM_VALIDATION_EXCEPTION,
@@ -193,27 +176,13 @@ export abstract class BaseCrossChainUpdateCommand<
 			}
 
 			try {
-				// The CCM must come from the sending chain.
-				if (isMainchain && !ccm.sendingChainID.equals(params.sendingChainID)) {
-					throw new Error('CCM is not from the sending chain.');
-				}
-				// Sending and receiving chains must differ.
-				if (ccm.receivingChainID.equals(ccm.sendingChainID)) {
-					throw new Error('Sending and receiving chains must differ.');
-				}
-				// The CCM must come be directed to the sidechain, unless it was bounced on the mainchain.
-				if (!isMainchain && !context.chainID.equals(ccm.receivingChainID)) {
-					throw new Error('CCM is not directed to the sidechain.');
-				}
-				if (isMainchain && ccm.status === CCMStatusCode.CHANNEL_UNAVAILABLE) {
-					throw new Error('CCM status channel unavailable can only be set on the mainchain.');
-				}
+				this.verifyRoutingRules(ccm, params, ccmContext.chainID, isMainchain);
 				ccms.push(ccm);
 			} catch (error) {
-				await this.internalMethod.terminateChainInternal(context, params.sendingChainID);
+				await this.internalMethod.terminateChainInternal(ccmContext, params.sendingChainID);
 				this.events
 					.get(CcmProcessedEvent)
-					.log(context, params.sendingChainID, ccm.receivingChainID, {
+					.log(ccmContext, params.sendingChainID, ccm.receivingChainID, {
 						ccm,
 						result: CCMProcessedResult.DISCARDED,
 						code: CCMProcessedCode.INVALID_CCM_ROUTING_EXCEPTION,
@@ -224,6 +193,29 @@ export abstract class BaseCrossChainUpdateCommand<
 		}
 
 		return [ccms, true];
+	}
+
+	protected verifyRoutingRules(
+		ccm: CCMsg,
+		ccuParams: CrossChainUpdateTransactionParams,
+		ownChainID: Buffer,
+		isMainchain: boolean,
+	) {
+		// The CCM must come from the sending chain.
+		if (isMainchain && !ccm.sendingChainID.equals(ccuParams.sendingChainID)) {
+			throw new Error('CCM is not from the sending chain.');
+		}
+		// Sending and receiving chains must differ.
+		if (ccm.receivingChainID.equals(ccm.sendingChainID)) {
+			throw new Error('Sending and receiving chains must differ.');
+		}
+		// The CCM must come be directed to the sidechain, unless it was bounced on the mainchain.
+		if (!isMainchain && !ownChainID.equals(ccm.receivingChainID)) {
+			throw new Error('CCM is not directed to the sidechain.');
+		}
+		if (isMainchain && ccm.status === CCMStatusCode.CHANNEL_UNAVAILABLE) {
+			throw new Error('CCM status channel unavailable can only be set on the mainchain.');
+		}
 	}
 
 	protected async afterExecuteCommon(

--- a/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
+++ b/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
@@ -696,15 +696,10 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 
 		if (params.certificate.length === 0) {
 			if (!newInboxRoot.equals(channel.partnerChainOutboxRoot)) {
-				this.events.get(InvalidOutboxRootverification).error(
-					context,
-					params.sendingChainID,
-					{
-						inboxRoot: newInboxRoot,
-						partnerChainOutboxRoot: channel.partnerChainOutboxRoot,
-					},
-					true,
-				);
+				this.events.get(InvalidOutboxRootverification).error(context, params.sendingChainID, {
+					inboxRoot: newInboxRoot,
+					partnerChainOutboxRoot: channel.partnerChainOutboxRoot,
+				});
 				throw new Error('Inbox root does not match partner chain outbox root.');
 			}
 			return;

--- a/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
+++ b/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
@@ -65,8 +65,8 @@ import { TerminatedOutboxCreatedEvent } from './events/terminated_outbox_created
 import { BaseCCMethod } from './base_cc_method';
 import { verifyAggregateCertificateSignature } from '../../engine/consensus/certificate_generation/utils';
 import { InvalidCertificateSignatureEvent } from './events/invalid_certificate_signature';
-import { InvalidSMTVerification } from './events/invalid_smt_verification';
-import { InvalidOutboxRootverification } from './events/invalid_outbox_root_verification';
+import { InvalidSMTVerificationEvent } from './events/invalid_smt_verification';
+import { InvalidOutboxRootVerificationEvent } from './events/invalid_outbox_root_verification';
 
 export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMethod {
 	protected readonly interoperableModuleMethods = new Map<string, BaseCCMethod>();
@@ -696,7 +696,7 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 
 		if (params.certificate.length === 0) {
 			if (!newInboxRoot.equals(channel.partnerChainOutboxRoot)) {
-				this.events.get(InvalidOutboxRootverification).error(context, params.sendingChainID, {
+				this.events.get(InvalidOutboxRootVerificationEvent).error(context, params.sendingChainID, {
 					inboxRoot: newInboxRoot,
 					partnerChainOutboxRoot: channel.partnerChainOutboxRoot,
 				});
@@ -724,7 +724,7 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 		const smt = new SparseMerkleTree();
 		const valid = await smt.verifyInclusionProof(certificate.stateRoot, [outboxKey], proof);
 		if (!valid) {
-			this.events.get(InvalidSMTVerification).error(context);
+			this.events.get(InvalidSMTVerificationEvent).error(context);
 			throw new Error('Invalid inclusion proof for inbox update.');
 		}
 	}

--- a/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
+++ b/framework/src/modules/interoperability/base_interoperability_internal_methods.ts
@@ -48,7 +48,12 @@ import { TerminatedOutboxAccount, TerminatedOutboxStore } from './stores/termina
 import { ChainAccountUpdatedEvent } from './events/chain_account_updated';
 import { TerminatedStateCreatedEvent } from './events/terminated_state_created';
 import { BaseInternalMethod } from '../BaseInternalMethod';
-import { MethodContext, ImmutableMethodContext, NotFoundError } from '../../state_machine';
+import {
+	MethodContext,
+	ImmutableMethodContext,
+	NotFoundError,
+	CommandExecuteContext,
+} from '../../state_machine';
 import { ChainValidatorsStore } from './stores/chain_validators';
 import { certificateSchema } from '../../engine/consensus/certificate_generation/schema';
 import { Certificate } from '../../engine/consensus/certificate_generation/types';
@@ -60,6 +65,8 @@ import { TerminatedOutboxCreatedEvent } from './events/terminated_outbox_created
 import { BaseCCMethod } from './base_cc_method';
 import { verifyAggregateCertificateSignature } from '../../engine/consensus/certificate_generation/utils';
 import { InvalidCertificateSignatureEvent } from './events/invalid_certificate_signature';
+import { InvalidSMTVerification } from './events/invalid_smt_verification';
+import { InvalidOutboxRootverification } from './events/invalid_outbox_root_verification';
 
 export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMethod {
 	protected readonly interoperableModuleMethods = new Map<string, BaseCCMethod>();
@@ -665,7 +672,7 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 	 * @see https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#verifypartnerchainoutboxroot
 	 */
 	public async verifyPartnerChainOutboxRoot(
-		context: ImmutableMethodContext,
+		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
 		params: CrossChainUpdateTransactionParams,
 	): Promise<void> {
 		const channel = await this.stores.get(ChannelDataStore).get(context, params.sendingChainID);
@@ -689,6 +696,15 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 
 		if (params.certificate.length === 0) {
 			if (!newInboxRoot.equals(channel.partnerChainOutboxRoot)) {
+				this.events.get(InvalidOutboxRootverification).error(
+					context,
+					params.sendingChainID,
+					{
+						inboxRoot: newInboxRoot,
+						partnerChainOutboxRoot: channel.partnerChainOutboxRoot,
+					},
+					true,
+				);
 				throw new Error('Inbox root does not match partner chain outbox root.');
 			}
 			return;
@@ -713,6 +729,7 @@ export abstract class BaseInteroperabilityInternalMethod extends BaseInternalMet
 		const smt = new SparseMerkleTree();
 		const valid = await smt.verifyInclusionProof(certificate.stateRoot, [outboxKey], proof);
 		if (!valid) {
+			this.events.get(InvalidSMTVerification).error(context);
 			throw new Error('Invalid inclusion proof for inbox update.');
 		}
 	}

--- a/framework/src/modules/interoperability/base_interoperability_module.ts
+++ b/framework/src/modules/interoperability/base_interoperability_module.ts
@@ -48,6 +48,7 @@ import { TerminatedOutboxCreatedEvent } from './events/terminated_outbox_created
 import { TerminatedStateCreatedEvent } from './events/terminated_state_created';
 import { InvalidSMTVerification } from './events/invalid_smt_verification';
 import { InvalidRMTVerification } from './events/invalid_rmt_verification';
+import { InvalidOutboxRootverification } from './events/invalid_outbox_root_verification';
 
 export abstract class BaseInteroperabilityModule extends BaseInteroperableModule {
 	protected interoperableCCCommands = new Map<string, BaseCCCommand[]>();
@@ -82,6 +83,10 @@ export abstract class BaseInteroperabilityModule extends BaseInteroperableModule
 		this.events.register(
 			InvalidCertificateSignatureEvent,
 			new InvalidCertificateSignatureEvent(this.name),
+		);
+		this.events.register(
+			InvalidOutboxRootverification,
+			new InvalidOutboxRootverification(this.name),
 		);
 	}
 

--- a/framework/src/modules/interoperability/base_interoperability_module.ts
+++ b/framework/src/modules/interoperability/base_interoperability_module.ts
@@ -46,9 +46,9 @@ import { InvalidCertificateSignatureEvent } from './events/invalid_certificate_s
 import { InvalidRegistrationSignatureEvent } from './events/invalid_registration_signature';
 import { TerminatedOutboxCreatedEvent } from './events/terminated_outbox_created';
 import { TerminatedStateCreatedEvent } from './events/terminated_state_created';
-import { InvalidSMTVerification } from './events/invalid_smt_verification';
-import { InvalidRMTVerification } from './events/invalid_rmt_verification';
-import { InvalidOutboxRootverification } from './events/invalid_outbox_root_verification';
+import { InvalidSMTVerificationEvent } from './events/invalid_smt_verification';
+import { InvalidRMTVerificationEvent } from './events/invalid_rmt_verification';
+import { InvalidOutboxRootVerificationEvent } from './events/invalid_outbox_root_verification';
 
 export abstract class BaseInteroperabilityModule extends BaseInteroperableModule {
 	protected interoperableCCCommands = new Map<string, BaseCCCommand[]>();
@@ -78,15 +78,15 @@ export abstract class BaseInteroperabilityModule extends BaseInteroperableModule
 		);
 		this.events.register(TerminatedStateCreatedEvent, new TerminatedStateCreatedEvent(this.name));
 		this.events.register(TerminatedOutboxCreatedEvent, new TerminatedOutboxCreatedEvent(this.name));
-		this.events.register(InvalidSMTVerification, new InvalidSMTVerification(this.name));
-		this.events.register(InvalidRMTVerification, new InvalidRMTVerification(this.name));
+		this.events.register(InvalidSMTVerificationEvent, new InvalidSMTVerificationEvent(this.name));
+		this.events.register(InvalidRMTVerificationEvent, new InvalidRMTVerificationEvent(this.name));
 		this.events.register(
 			InvalidCertificateSignatureEvent,
 			new InvalidCertificateSignatureEvent(this.name),
 		);
 		this.events.register(
-			InvalidOutboxRootverification,
-			new InvalidOutboxRootverification(this.name),
+			InvalidOutboxRootVerificationEvent,
+			new InvalidOutboxRootVerificationEvent(this.name),
 		);
 	}
 

--- a/framework/src/modules/interoperability/base_state_recovery.ts
+++ b/framework/src/modules/interoperability/base_state_recovery.ts
@@ -29,7 +29,7 @@ import { TerminatedStateStore } from './stores/terminated_state';
 import { computeStorePrefix } from '../base_store';
 import { BaseCCMethod } from './base_cc_method';
 import { BaseInteroperabilityInternalMethod } from './base_interoperability_internal_methods';
-import { InvalidSMTVerification } from './events/invalid_smt_verification';
+import { InvalidSMTVerificationEvent } from './events/invalid_smt_verification';
 
 // LIP: https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#state-recovery-command
 export class BaseStateRecoveryCommand<
@@ -138,7 +138,7 @@ export class BaseStateRecoveryCommand<
 		);
 
 		if (!smtVerified) {
-			this.events.get(InvalidSMTVerification).error(context);
+			this.events.get(InvalidSMTVerificationEvent).error(context);
 			throw new Error('State recovery proof of inclusion is not valid.');
 		}
 

--- a/framework/src/modules/interoperability/constants.ts
+++ b/framework/src/modules/interoperability/constants.ts
@@ -90,8 +90,10 @@ export const EVENT_NAME_CHAIN_ACCOUNT_UPDATED = 'chainAccountUpdated';
 export const EVENT_NAME_CCM_PROCESSED = 'ccmProcessed';
 export const EVENT_NAME_CCM_SEND_SUCCESS = 'ccmSendSucess';
 export const EVENT_NAME_INVALID_CERTIFICATE_SIGNATURE = 'invalidCertificateSignature';
+export const EVENT_NAME_INVALID_OUTBOX_ROOT_VERIFICATION = 'invalidOutboxRootVerification';
 
 export const CONTEXT_STORE_KEY_CCM_PROCESSING = 'CONTEXT_STORE_KEY_CCM_PROCESSING';
+export const EVENT_TOPIC_CCM_EXECUTION = Buffer.from([5]);
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0045.md#empty-cross-chain-message
 export const EmptyCCM = {

--- a/framework/src/modules/interoperability/events/invalid_outbox_root_verification.ts
+++ b/framework/src/modules/interoperability/events/invalid_outbox_root_verification.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ */
+import { BaseEvent, EventQueuer } from '../../base_event';
+import { HASH_LENGTH } from '../constants';
+
+export interface InvalidOutboxRootVerificationData {
+	inboxRoot: Buffer;
+	partnerChainOutboxRoot: Buffer;
+}
+
+export const invalidOutboxRootVerificationSchema = {
+	$id: '/interoperability/events/invalidOutboxRootVerification',
+	type: 'object',
+	required: ['inboxRoot', 'partnerChainOutboxRoot'],
+	properties: {
+		inboxRoot: {
+			dataType: 'bytes',
+			fieldNumber: 1,
+			minLength: HASH_LENGTH,
+			maxLength: HASH_LENGTH,
+		},
+		partnerChainOutboxRoot: {
+			dataType: 'bytes',
+			fieldNumber: 2,
+			minLength: HASH_LENGTH,
+			maxLength: HASH_LENGTH,
+		},
+	},
+};
+
+export class InvalidOutboxRootverification extends BaseEvent<InvalidOutboxRootVerificationData> {
+	public schema = invalidOutboxRootVerificationSchema;
+
+	public error(
+		ctx: EventQueuer,
+		chainID: Buffer,
+		data: InvalidOutboxRootVerificationData,
+		noRevert: boolean,
+	): void {
+		this.add(ctx, data, [chainID], noRevert);
+	}
+}

--- a/framework/src/modules/interoperability/events/invalid_outbox_root_verification.ts
+++ b/framework/src/modules/interoperability/events/invalid_outbox_root_verification.ts
@@ -42,12 +42,7 @@ export const invalidOutboxRootVerificationSchema = {
 export class InvalidOutboxRootverification extends BaseEvent<InvalidOutboxRootVerificationData> {
 	public schema = invalidOutboxRootVerificationSchema;
 
-	public error(
-		ctx: EventQueuer,
-		chainID: Buffer,
-		data: InvalidOutboxRootVerificationData,
-		noRevert: boolean,
-	): void {
-		this.add(ctx, data, [chainID], noRevert);
+	public error(ctx: EventQueuer, chainID: Buffer, data: InvalidOutboxRootVerificationData): void {
+		this.add(ctx, data, [chainID], true);
 	}
 }

--- a/framework/src/modules/interoperability/events/invalid_outbox_root_verification.ts
+++ b/framework/src/modules/interoperability/events/invalid_outbox_root_verification.ts
@@ -39,7 +39,7 @@ export const invalidOutboxRootVerificationSchema = {
 	},
 };
 
-export class InvalidOutboxRootverification extends BaseEvent<InvalidOutboxRootVerificationData> {
+export class InvalidOutboxRootVerificationEvent extends BaseEvent<InvalidOutboxRootVerificationData> {
 	public schema = invalidOutboxRootVerificationSchema;
 
 	public error(ctx: EventQueuer, chainID: Buffer, data: InvalidOutboxRootVerificationData): void {

--- a/framework/src/modules/interoperability/events/invalid_rmt_verification.ts
+++ b/framework/src/modules/interoperability/events/invalid_rmt_verification.ts
@@ -13,7 +13,7 @@
  */
 import { BaseEvent, EventQueuer } from '../../base_event';
 
-export class InvalidRMTVerification extends BaseEvent<undefined> {
+export class InvalidRMTVerificationEvent extends BaseEvent<undefined> {
 	public error(ctx: EventQueuer): void {
 		this.add(ctx, undefined);
 	}

--- a/framework/src/modules/interoperability/events/invalid_smt_verification.ts
+++ b/framework/src/modules/interoperability/events/invalid_smt_verification.ts
@@ -13,7 +13,7 @@
  */
 import { BaseEvent, EventQueuer } from '../../base_event';
 
-export class InvalidSMTVerification extends BaseEvent<undefined> {
+export class InvalidSMTVerificationEvent extends BaseEvent<undefined> {
 	public error(ctx: EventQueuer): void {
 		this.add(ctx, undefined);
 	}

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -43,7 +43,7 @@ import {
 	CcmProcessedEvent,
 	CCMProcessedResult,
 } from '../../events/ccm_processed';
-import { InvalidRMTVerification } from '../../events/invalid_rmt_verification';
+import { InvalidRMTVerificationEvent } from '../../events/invalid_rmt_verification';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#message-recovery-command
 export class RecoverMessageCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
@@ -192,7 +192,7 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 		);
 
 		if (!isVerified) {
-			this.events.get(InvalidRMTVerification).error(context);
+			this.events.get(InvalidRMTVerificationEvent).error(context);
 
 			throw new Error('Message recovery proof of inclusion is not valid.');
 		}

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -31,7 +31,11 @@ import {
 	getEncodedCCMAndID,
 	getDecodedCCMAndID,
 } from '../../utils';
-import { CCMStatusCode, CONTEXT_STORE_KEY_CCM_PROCESSING } from '../../constants';
+import {
+	CCMStatusCode,
+	CONTEXT_STORE_KEY_CCM_PROCESSING,
+	EVENT_TOPIC_CCM_EXECUTION,
+} from '../../constants';
 import { ccmSchema, messageRecoveryParamsSchema } from '../../schemas';
 import { TerminatedOutboxAccount, TerminatedOutboxStore } from '../../stores/terminated_outbox';
 import {
@@ -40,7 +44,6 @@ import {
 	CCMProcessedResult,
 } from '../../events/ccm_processed';
 import { InvalidRMTVerification } from '../../events/invalid_rmt_verification';
-import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../state_machine/constants';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#message-recovery-command
 export class RecoverMessageCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {

--- a/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/recover_message.ts
@@ -40,6 +40,7 @@ import {
 	CCMProcessedResult,
 } from '../../events/ccm_processed';
 import { InvalidRMTVerification } from '../../events/invalid_rmt_verification';
+import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../state_machine/constants';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0054.md#message-recovery-command
 export class RecoverMessageCommand extends BaseInteroperabilityCommand<MainchainInteroperabilityInternalMethod> {
@@ -203,7 +204,9 @@ export class RecoverMessageCommand extends BaseInteroperabilityCommand<Mainchain
 			const ctx: CrossChainMessageContext = {
 				...context,
 				ccm,
-				eventQueue: context.eventQueue.getChildQueue(ccmID),
+				eventQueue: context.eventQueue.getChildQueue(
+					Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, ccmID]),
+				),
 			};
 			let recoveredCCM: CCMsg;
 			// If the sending chain is the mainchain, recover the CCM.

--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -85,6 +85,7 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 	): Promise<void> {
 		const { params } = context;
 
+		// This call can throw error and fails a transaction
 		await this.verifyCertificateSignatureAndPartnerChainOutboxRoot(context);
 		const [decodedCCMs, ok] = await this.beforeCrossChainMessagesExecution(context, true);
 		if (!ok) {
@@ -127,7 +128,7 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 			context.contextStore.delete(CONTEXT_STORE_KEY_CCM_PROCESSING);
 		}
 
-		await this.afterExecuteCommon(context);
+		await this.afterCrossChainMessagesExecute(context);
 	}
 
 	private async _beforeCrossChainMessageForwarding(

--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -47,6 +47,7 @@ import {
 	getIDFromCCMBytes,
 } from '../../utils';
 import { MainchainInteroperabilityInternalMethod } from '../internal_method';
+import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../state_machine/constants';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#commands
 export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdateCommand<MainchainInteroperabilityInternalMethod> {
@@ -98,7 +99,9 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 				const ccmContext = {
 					...context,
 					ccm,
-					eventQueue: context.eventQueue.getChildQueue(ccmID),
+					eventQueue: context.eventQueue.getChildQueue(
+						Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, ccmID]),
+					),
 				};
 
 				// If the receiving chain is the mainchain, apply the CCM

--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -83,31 +83,9 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 	public async execute(
 		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
 	): Promise<void> {
-		const { params, transaction } = context;
-		const { inboxUpdate } = params;
-		// Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
-		await this.internalMethod.verifyCertificateSignature(context, params);
+		const { params } = context;
 
-		if (!isInboxUpdateEmpty(inboxUpdate)) {
-			// This check is expensive. Therefore, it is done in the execute step instead of the verify
-			// step. Otherwise, a malicious relayer could spam the transaction pool with computationally
-			// costly CCU verifications without paying fees.
-			await this.internalMethod.verifyPartnerChainOutboxRoot(context, params);
-
-			// Initialize the relayer account for the message fee token.
-			// This is necessary to ensure that the relayer can receive the CCM fees
-			// If the account already exists, nothing is done.
-			const messageFeeTokenID = await this._interopsMethod.getMessageFeeTokenID(
-				context,
-				params.sendingChainID,
-			);
-			await this._tokenMethod.initializeUserAccount(
-				context,
-				transaction.senderAddress,
-				messageFeeTokenID,
-			);
-		}
-
+		await this.verifyCertificateSignatureAndPartnerChainOutboxRoot(context);
 		const [decodedCCMs, ok] = await this.beforeCrossChainMessagesExecution(context, true);
 		if (!ok) {
 			return;

--- a/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/initialize_state_recovery.ts
@@ -31,7 +31,7 @@ import { TerminatedStateAccount, TerminatedStateStore } from '../../stores/termi
 import { ChainAccount, StateRecoveryInitParams } from '../../types';
 import { getMainchainID } from '../../utils';
 import { SidechainInteroperabilityInternalMethod } from '../internal_method';
-import { InvalidSMTVerification } from '../../events/invalid_smt_verification';
+import { InvalidSMTVerificationEvent } from '../../events/invalid_smt_verification';
 
 export class InitializeStateRecoveryCommand extends BaseInteroperabilityCommand<SidechainInteroperabilityInternalMethod> {
 	public schema = stateRecoveryInitParamsSchema;
@@ -117,7 +117,7 @@ export class InitializeStateRecoveryCommand extends BaseInteroperabilityCommand<
 
 		const verified = await smt.verifyInclusionProof(stateRoot, [queryKey], proofOfInclusion);
 		if (!verified) {
-			this.events.get(InvalidSMTVerification).error(context);
+			this.events.get(InvalidSMTVerificationEvent).error(context);
 			throw new Error('State recovery initialization proof of inclusion is not valid.');
 		}
 

--- a/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
@@ -18,6 +18,7 @@ import {
 	VerificationResult,
 	VerifyStatus,
 } from '../../../../state_machine';
+import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../state_machine/constants';
 import { BaseCrossChainUpdateCommand } from '../../base_cross_chain_update_command';
 import { CONTEXT_STORE_KEY_CCM_PROCESSING } from '../../constants';
 import { CrossChainUpdateTransactionParams } from '../../types';
@@ -57,7 +58,9 @@ export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdate
 				const ccmContext = {
 					...context,
 					ccm,
-					eventQueue: context.eventQueue.getChildQueue(ccmID),
+					eventQueue: context.eventQueue.getChildQueue(
+						Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, ccmID]),
+					),
 				};
 
 				await this.apply(ccmContext);

--- a/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
@@ -18,11 +18,11 @@ import {
 	VerificationResult,
 	VerifyStatus,
 } from '../../../../state_machine';
-import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../state_machine/constants';
+import { panic } from '../../../../utils/panic';
 import { BaseCrossChainUpdateCommand } from '../../base_cross_chain_update_command';
-import { CONTEXT_STORE_KEY_CCM_PROCESSING } from '../../constants';
+import { CONTEXT_STORE_KEY_CCM_PROCESSING, EVENT_TOPIC_CCM_EXECUTION } from '../../constants';
 import { CrossChainUpdateTransactionParams } from '../../types';
-import { getIDFromCCMBytes } from '../../utils';
+import { getIDFromCCMBytes, isInboxUpdateEmpty } from '../../utils';
 import { SidechainInteroperabilityInternalMethod } from '../internal_method';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#sidechaincrosschainupdate
@@ -41,11 +41,35 @@ export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdate
 	public async execute(
 		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
 	): Promise<void> {
-		const [decodedCCMs, ok] = await this.executeCommon(context, false);
+		const { params, transaction } = context;
+		const { inboxUpdate } = params;
+		// Verify certificate signature. We do it here because if it fails, the transaction fails rather than being invalid.
+		await this.internalMethod.verifyCertificateSignature(context, params);
+
+		if (!isInboxUpdateEmpty(inboxUpdate)) {
+			// This check is expensive. Therefore, it is done in the execute step instead of the verify
+			// step. Otherwise, a malicious relayer could spam the transaction pool with computationally
+			// costly CCU verifications without paying fees.
+			await this.internalMethod.verifyPartnerChainOutboxRoot(context, params);
+
+			// Initialize the relayer account for the message fee token.
+			// This is necessary to ensure that the relayer can receive the CCM fees
+			// If the account already exists, nothing is done.
+			const messageFeeTokenID = await this._interopsMethod.getMessageFeeTokenID(
+				context,
+				params.sendingChainID,
+			);
+			await this._tokenMethod.initializeUserAccount(
+				context,
+				transaction.senderAddress,
+				messageFeeTokenID,
+			);
+		}
+
+		const [decodedCCMs, ok] = await this.beforeCrossChainMessagesExecution(context, false);
 		if (!ok) {
 			return;
 		}
-		const { params } = context;
 
 		try {
 			// Update the context to indicate that now we start the CCM processing.
@@ -70,6 +94,8 @@ export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdate
 				// would refer to an inbox where the message has not been appended yet).
 				await this.internalMethod.appendToInboxTree(context, params.sendingChainID, ccmBytes);
 			}
+		} catch (error) {
+			panic(context.logger, error as Error);
 		} finally {
 			// Update the context to indicate that now we stop the CCM processing.
 			context.contextStore.delete(CONTEXT_STORE_KEY_CCM_PROCESSING);

--- a/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
@@ -43,6 +43,7 @@ export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdate
 	): Promise<void> {
 		const { params } = context;
 
+		// This call can throw error and fails a transaction
 		await this.verifyCertificateSignatureAndPartnerChainOutboxRoot(context);
 
 		const [decodedCCMs, ok] = await this.beforeCrossChainMessagesExecution(context, false);
@@ -80,6 +81,6 @@ export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdate
 			context.contextStore.delete(CONTEXT_STORE_KEY_CCM_PROCESSING);
 		}
 
-		await this.afterExecuteCommon(context);
+		await this.afterCrossChainMessagesExecute(context);
 	}
 }

--- a/framework/src/state_machine/constants.ts
+++ b/framework/src/state_machine/constants.ts
@@ -19,3 +19,5 @@ export const EVENT_INDEX_BEFORE_TRANSACTIONS = Buffer.from([2]);
 export const EVENT_INDEX_AFTER_TRANSACTIONS = Buffer.from([3]);
 
 export const EVENT_TRANSACTION_NAME = 'commandExecutionResult';
+export const EVENT_TOPIC_TRANSACTION_EXECUTION = Buffer.from([4]);
+export const EVENT_TOPIC_CCM_EXECUTION = Buffer.from([5]);

--- a/framework/src/state_machine/event_queue.ts
+++ b/framework/src/state_machine/event_queue.ts
@@ -76,8 +76,7 @@ export class EventQueue {
 	}
 
 	public getChildQueue(topicID: Buffer): EventQueue {
-		const allTopics = [...this._defaultTopics, topicID];
-		return new EventQueue(this._height, this._events, allTopics);
+		return new EventQueue(this._height, this._events, [topicID]);
 	}
 
 	public createSnapshot(): number {

--- a/framework/src/state_machine/state_machine.ts
+++ b/framework/src/state_machine/state_machine.ts
@@ -24,7 +24,7 @@ import { GenerationContext } from './generator_context';
 import { GenesisBlockContext } from './genesis_block_context';
 import { TransactionContext } from './transaction_context';
 import { VerifyStatus, VerificationResult } from './types';
-import { EVENT_TRANSACTION_NAME } from './constants';
+import { EVENT_TOPIC_TRANSACTION_EXECUTION, EVENT_TRANSACTION_NAME } from './constants';
 
 export class StateMachine {
 	private readonly _modules: BaseModule[] = [];
@@ -218,7 +218,7 @@ export class StateMachine {
 			ctx.transaction.module,
 			EVENT_TRANSACTION_NAME,
 			codec.encode(standardEventDataSchema, { success: status === TransactionExecutionResult.OK }),
-			[ctx.transaction.id],
+			[Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, ctx.transaction.id])],
 		);
 
 		return status;

--- a/framework/src/state_machine/transaction_context.ts
+++ b/framework/src/state_machine/transaction_context.ts
@@ -26,6 +26,7 @@ import {
 	BlockHeader,
 	BlockAssets,
 } from './types';
+import { EVENT_TOPIC_TRANSACTION_EXECUTION } from './constants';
 
 interface ContextParams {
 	chainID: Buffer;
@@ -77,7 +78,9 @@ export class TransactionContext {
 		if (!this._assets) {
 			throw new Error('Transaction Execution requires block assets in the context.');
 		}
-		const childQueue = this._eventQueue.getChildQueue(this._transaction.id);
+		const childQueue = this._eventQueue.getChildQueue(
+			Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, this._transaction.id]),
+		);
 		return {
 			logger: this._logger,
 			chainID: this._chainID,
@@ -132,7 +135,9 @@ export class TransactionContext {
 		if (!this._assets) {
 			throw new Error('Transaction Execution requires block assets in the context.');
 		}
-		const childQueue = this._eventQueue.getChildQueue(this._transaction.id);
+		const childQueue = this._eventQueue.getChildQueue(
+			Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, this._transaction.id]),
+		);
 		return {
 			logger: this._logger,
 			chainID: this._chainID,

--- a/framework/src/utils/panic.ts
+++ b/framework/src/utils/panic.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Lisk Foundation
+ * Copyright © 2023 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -12,11 +12,12 @@
  * Removal or modification of this copyright notice is prohibited.
  */
 
-export const EVENT_INDEX_INIT_GENESIS_STATE = Buffer.from([0]);
-export const EVENT_INDEX_FINALIZE_GENESIS_STATE = Buffer.from([1]);
+import { Logger } from '../logger';
 
-export const EVENT_INDEX_BEFORE_TRANSACTIONS = Buffer.from([2]);
-export const EVENT_INDEX_AFTER_TRANSACTIONS = Buffer.from([3]);
-
-export const EVENT_TRANSACTION_NAME = 'commandExecutionResult';
-export const EVENT_TOPIC_TRANSACTION_EXECUTION = Buffer.from([4]);
+export const panic = (logger: Logger, error?: Error): void => {
+	logger.fatal(
+		{ error: error ?? new Error('Something unexpected happened') },
+		'Raising panic and shutting down the application',
+	);
+	process.exit(1);
+};

--- a/framework/test/integration/node/processor/pos.spec.ts
+++ b/framework/test/integration/node/processor/pos.spec.ts
@@ -26,6 +26,7 @@ import * as testing from '../../../../src/testing';
 import { defaultConfig } from '../../../../src/modules/token/constants';
 import { ValidatorAccountJSON } from '../../../../src/modules/pos/stores/validator';
 import { StakerDataJSON } from '../../../../src/modules/pos/types';
+import { EVENT_TOPIC_TRANSACTION_EXECUTION } from '../../../../src/state_machine/constants';
 
 describe('PoS and reward', () => {
 	let processEnv: testing.BlockProcessingEnv;
@@ -96,10 +97,10 @@ describe('PoS and reward', () => {
 
 			const events = await processEnv.getEvents(newBlock.header.height);
 			expect(events.find(e => e.name === 'generatorKeyRegistration')?.topics[0]).toEqual(
-				registrationTx.id.toString('hex'),
+				Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, registrationTx.id]).toString('hex'),
 			);
 			expect(events.find(e => e.name === 'blsKeyRegistration')?.topics[0]).toEqual(
-				registrationTx.id.toString('hex'),
+				Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, registrationTx.id]).toString('hex'),
 			);
 			expect(events.find(e => e.name === 'commandExecutionResult')).toHaveProperty('data', '0801');
 
@@ -140,10 +141,10 @@ describe('PoS and reward', () => {
 
 			const events = await processEnv.getEvents(newBlock.header.height);
 			expect(events.find(e => e.name === 'generatorKeyRegistration')?.topics[0]).toEqual(
-				registrationTx.id.toString('hex'),
+				Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, registrationTx.id]).toString('hex'),
 			);
 			expect(events.find(e => e.name === 'blsKeyRegistration')?.topics[0]).toEqual(
-				registrationTx.id.toString('hex'),
+				Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, registrationTx.id]).toString('hex'),
 			);
 			expect(events.find(e => e.name === 'commandExecutionResult')).toHaveProperty('data', '0801');
 

--- a/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
@@ -998,7 +998,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 		});
 	});
 
-	describe('afterExecuteCommon', () => {
+	describe('afterCrossChainMessagesExecute', () => {
 		let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
 		let chainValidatorsStore: ChainValidatorsStore;
 
@@ -1042,7 +1042,9 @@ describe('BaseCrossChainUpdateCommand', () => {
 				certificateThreshold: BigInt(20),
 			} as any);
 
-			await expect(command['afterExecuteCommon'](executeContext)).resolves.toBeUndefined();
+			await expect(
+				command['afterCrossChainMessagesExecute'](executeContext),
+			).resolves.toBeUndefined();
 			expect(command['internalMethod'].updateValidators).toHaveBeenCalledWith(
 				expect.anything(),
 				executeContext.params,
@@ -1051,7 +1053,9 @@ describe('BaseCrossChainUpdateCommand', () => {
 
 		it('should update validators if activeValidatorsUpdate is empty but params.certificateThreshold !== sendingChainValidators.certificateThreshold', async () => {
 			executeContext.params.activeValidatorsUpdate.bftWeightsUpdateBitmap = EMPTY_BUFFER;
-			await expect(command['afterExecuteCommon'](executeContext)).resolves.toBeUndefined();
+			await expect(
+				command['afterCrossChainMessagesExecute'](executeContext),
+			).resolves.toBeUndefined();
 
 			expect(command['internalMethod'].updateValidators).toHaveBeenCalledWith(
 				expect.anything(),
@@ -1061,7 +1065,9 @@ describe('BaseCrossChainUpdateCommand', () => {
 
 		it('should not update certificate and updatePartnerChainOutboxRoot if certificate is empty', async () => {
 			executeContext.params.certificate = EMPTY_BYTES;
-			await expect(command['afterExecuteCommon'](executeContext)).resolves.toBeUndefined();
+			await expect(
+				command['afterCrossChainMessagesExecute'](executeContext),
+			).resolves.toBeUndefined();
 			expect(command['internalMethod'].updateCertificate).not.toHaveBeenCalled();
 			expect(command['internalMethod'].updatePartnerChainOutboxRoot).not.toHaveBeenCalled();
 		});
@@ -1075,7 +1081,9 @@ describe('BaseCrossChainUpdateCommand', () => {
 					bitmap: EMPTY_BUFFER,
 				},
 			};
-			await expect(command['afterExecuteCommon'](executeContext)).resolves.toBeUndefined();
+			await expect(
+				command['afterCrossChainMessagesExecute'](executeContext),
+			).resolves.toBeUndefined();
 
 			expect(command['internalMethod'].updatePartnerChainOutboxRoot).not.toHaveBeenCalled();
 		});

--- a/framework/test/unit/modules/interoperability/base_interoperability_module.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_interoperability_module.spec.ts
@@ -41,8 +41,8 @@ import { InvalidCertificateSignatureEvent } from '../../../../src/modules/intero
 import { InvalidRegistrationSignatureEvent } from '../../../../src/modules/interoperability/events/invalid_registration_signature';
 import { TerminatedOutboxCreatedEvent } from '../../../../src/modules/interoperability/events/terminated_outbox_created';
 import { TerminatedStateCreatedEvent } from '../../../../src/modules/interoperability/events/terminated_state_created';
-import { InvalidRMTVerification } from '../../../../src/modules/interoperability/events/invalid_rmt_verification';
-import { InvalidSMTVerification } from '../../../../src/modules/interoperability/events/invalid_smt_verification';
+import { InvalidRMTVerificationEvent } from '../../../../src/modules/interoperability/events/invalid_rmt_verification';
+import { InvalidSMTVerificationEvent } from '../../../../src/modules/interoperability/events/invalid_smt_verification';
 
 describe('initGenesisState Common Tests', () => {
 	const chainID = Buffer.from([0, 0, 0, 0]);
@@ -94,8 +94,8 @@ describe('initGenesisState Common Tests', () => {
 			expect(interopMod.events.get(TerminatedStateCreatedEvent)).toBeDefined();
 			expect(interopMod.events.get(TerminatedOutboxCreatedEvent)).toBeDefined();
 			expect(interopMod.events.get(InvalidCertificateSignatureEvent)).toBeDefined();
-			expect(interopMod.events.get(InvalidRMTVerification)).toBeDefined();
-			expect(interopMod.events.get(InvalidSMTVerification)).toBeDefined();
+			expect(interopMod.events.get(InvalidRMTVerificationEvent)).toBeDefined();
+			expect(interopMod.events.get(InvalidSMTVerificationEvent)).toBeDefined();
 		});
 	});
 

--- a/framework/test/unit/modules/interoperability/base_state_recovery.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_state_recovery.spec.ts
@@ -40,7 +40,7 @@ import { PrefixedStateReadWriter } from '../../../../src/state_machine/prefixed_
 import { createTransactionContext } from '../../../../src/testing';
 import { InMemoryPrefixedStateDB } from '../../../../src/testing/in_memory_prefixed_state';
 import { createStoreGetter } from '../../../../src/testing/utils';
-import { InvalidSMTVerification } from '../../../../src/modules/interoperability/events/invalid_smt_verification';
+import { InvalidSMTVerificationEvent } from '../../../../src/modules/interoperability/events/invalid_smt_verification';
 import { computeStorePrefix } from '../../../../src/modules/base_store';
 
 describe('RecoverStateCommand', () => {
@@ -190,7 +190,7 @@ describe('RecoverStateCommand', () => {
 		});
 
 		it('should return error if proof of inclusion is not valid', async () => {
-			const invalidSMTVerificationEvent = interopMod.events.get(InvalidSMTVerification);
+			const invalidSMTVerificationEvent = interopMod.events.get(InvalidSMTVerificationEvent);
 			jest.spyOn(SparseMerkleTree.prototype, 'verify').mockResolvedValue(false);
 			jest.spyOn(invalidSMTVerificationEvent, 'error');
 

--- a/framework/test/unit/modules/interoperability/internal_method.spec.ts
+++ b/framework/test/unit/modules/interoperability/internal_method.spec.ts
@@ -70,12 +70,12 @@ import { TerminatedOutboxCreatedEvent } from '../../../../src/modules/interopera
 import { createStoreGetter } from '../../../../src/testing/utils';
 import { InvalidCertificateSignatureEvent } from '../../../../src/modules/interoperability/events/invalid_certificate_signature';
 import { EVENT_TOPIC_TRANSACTION_EXECUTION } from '../../../../src/state_machine/constants';
-import { InvalidOutboxRootverification } from '../../../../src/modules/interoperability/events/invalid_outbox_root_verification';
+import { InvalidOutboxRootVerificationEvent } from '../../../../src/modules/interoperability/events/invalid_outbox_root_verification';
 import {
 	ccmSchema,
 	crossChainUpdateTransactionParams,
 } from '../../../../src/modules/interoperability/schemas';
-import { InvalidSMTVerification } from '../../../../src/modules/interoperability/events/invalid_smt_verification';
+import { InvalidSMTVerificationEvent } from '../../../../src/modules/interoperability/events/invalid_smt_verification';
 
 describe('Base interoperability internal method', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -1570,8 +1570,8 @@ describe('Base interoperability internal method', () => {
 				.set(commandExecuteContext, crossChainUpdateParams.sendingChainID, {
 					...channelData,
 				});
-			jest.spyOn(interopMod.events.get(InvalidOutboxRootverification), 'error');
-			jest.spyOn(interopMod.events.get(InvalidSMTVerification), 'error');
+			jest.spyOn(interopMod.events.get(InvalidOutboxRootVerificationEvent), 'error');
+			jest.spyOn(interopMod.events.get(InvalidSMTVerificationEvent), 'error');
 		});
 
 		it('should reject when outboxRootWitness is empty but partnerchain outbox root does not match inboxRoot', async () => {
@@ -1592,14 +1592,12 @@ describe('Base interoperability internal method', () => {
 				),
 			).rejects.toThrow('Inbox root does not match partner chain outbox root');
 
-			expect(interopMod['events'].get(InvalidOutboxRootverification).error).toHaveBeenCalledWith(
-				commandExecuteContext,
-				crossChainUpdateParams.sendingChainID,
-				{
-					inboxRoot: expect.anything(),
-					partnerChainOutboxRoot: channelData.partnerChainOutboxRoot,
-				},
-			);
+			expect(
+				interopMod['events'].get(InvalidOutboxRootVerificationEvent).error,
+			).toHaveBeenCalledWith(commandExecuteContext, crossChainUpdateParams.sendingChainID, {
+				inboxRoot: expect.anything(),
+				partnerChainOutboxRoot: channelData.partnerChainOutboxRoot,
+			});
 		});
 
 		it('should reject when certificate state root does not contain valid inclusion proof for inbox update', async () => {
@@ -1614,7 +1612,7 @@ describe('Base interoperability internal method', () => {
 				),
 			).rejects.toThrow('Invalid inclusion proof for inbox update');
 
-			expect(interopMod['events'].get(InvalidSMTVerification).error).toHaveBeenCalledWith(
+			expect(interopMod['events'].get(InvalidSMTVerificationEvent).error).toHaveBeenCalledWith(
 				commandExecuteContext,
 			);
 		});

--- a/framework/test/unit/modules/interoperability/internal_method.spec.ts
+++ b/framework/test/unit/modules/interoperability/internal_method.spec.ts
@@ -21,20 +21,26 @@ import { validator } from '@liskhq/lisk-validator';
 import {
 	BLS_PUBLIC_KEY_LENGTH,
 	BLS_SIGNATURE_LENGTH,
+	CCMStatusCode,
+	CROSS_CHAIN_COMMAND_REGISTRATION,
 	EMPTY_BYTES,
 	EMPTY_HASH,
 	HASH_LENGTH,
 	MAX_UINT64,
 	MESSAGE_TAG_CERTIFICATE,
 	MIN_RETURN_FEE_PER_BYTE_BEDDOWS,
+	MODULE_NAME_INTEROPERABILITY,
 } from '../../../../src/modules/interoperability/constants';
 import { MainchainInteroperabilityInternalMethod } from '../../../../src/modules/interoperability/mainchain/internal_method';
 import * as utils from '../../../../src/modules/interoperability/utils';
-import { MainchainInteroperabilityModule, testing } from '../../../../src';
 import {
 	CrossChainUpdateTransactionParams,
+	MainchainInteroperabilityModule,
+	Transaction,
+	testing,
+	CCMsg,
 	OwnChainAccount,
-} from '../../../../src/modules/interoperability/types';
+} from '../../../../src';
 import { PrefixedStateReadWriter } from '../../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../../src/testing/in_memory_prefixed_state';
 import { ChannelDataStore } from '../../../../src/modules/interoperability/stores/channel_data';
@@ -49,10 +55,10 @@ import {
 import { ChainAccountStore } from '../../../../src/modules/interoperability/stores/chain_account';
 import { TerminatedStateStore } from '../../../../src/modules/interoperability/stores/terminated_state';
 import { StoreGetter } from '../../../../src/modules/base_store';
-import { MethodContext } from '../../../../src/state_machine';
+import { CommandExecuteContext, EventQueue, MethodContext } from '../../../../src/state_machine';
 import { ChainAccountUpdatedEvent } from '../../../../src/modules/interoperability/events/chain_account_updated';
 import { TerminatedStateCreatedEvent } from '../../../../src/modules/interoperability/events/terminated_state_created';
-import { createTransientMethodContext } from '../../../../src/testing';
+import { createTransactionContext, createTransientMethodContext } from '../../../../src/testing';
 import { ChainValidatorsStore } from '../../../../src/modules/interoperability/stores/chain_validators';
 import {
 	certificateSchema,
@@ -63,6 +69,13 @@ import { Certificate } from '../../../../src/engine/consensus/certificate_genera
 import { TerminatedOutboxCreatedEvent } from '../../../../src/modules/interoperability/events/terminated_outbox_created';
 import { createStoreGetter } from '../../../../src/testing/utils';
 import { InvalidCertificateSignatureEvent } from '../../../../src/modules/interoperability/events/invalid_certificate_signature';
+import { EVENT_TOPIC_TRANSACTION_EXECUTION } from '../../../../src/state_machine/constants';
+import { InvalidOutboxRootverification } from '../../../../src/modules/interoperability/events/invalid_outbox_root_verification';
+import {
+	ccmSchema,
+	crossChainUpdateTransactionParams,
+} from '../../../../src/modules/interoperability/schemas';
+import { InvalidSMTVerification } from '../../../../src/modules/interoperability/events/invalid_smt_verification';
 
 describe('Base interoperability internal method', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -190,7 +203,15 @@ describe('Base interoperability internal method', () => {
 			interopMod.events,
 			new Map(),
 		);
-		methodContext = createTransientMethodContext({ stateStore });
+		const defaultTopic = Buffer.concat([
+			EVENT_TOPIC_TRANSACTION_EXECUTION,
+			cryptoUtils.hash(cryptoUtils.getRandomBytes(1)),
+		]);
+		methodContext = createTransientMethodContext({
+			stateStore,
+			eventQueue: new EventQueue(0, [], [defaultTopic]),
+		});
+		// Adding transaction ID as default topic
 		storeContext = createStoreGetter(stateStore);
 		await channelDataSubstore.set(methodContext, chainID, channelData);
 		await ownChainAccountSubstore.set(methodContext, EMPTY_BYTES, ownChainAccount);
@@ -1456,56 +1477,146 @@ describe('Base interoperability internal method', () => {
 	});
 
 	describe('verifyPartnerChainOutboxRoot', () => {
-		const encodedCertificate = codec.encode(certificateSchema, defaultCertificate);
-		const txParams: CrossChainUpdateTransactionParams = {
-			certificate: encodedCertificate,
-			activeValidatorsUpdate: {
-				blsKeysUpdate: [],
-				bftWeightsUpdate: [],
-				bftWeightsUpdateBitmap: Buffer.from([]),
+		const certificate: Certificate = {
+			blockID: cryptography.utils.getRandomBytes(HASH_LENGTH),
+			height: 21,
+			timestamp: Math.floor(Date.now() / 1000),
+			stateRoot: cryptoUtils.getRandomBytes(HASH_LENGTH),
+			validatorsHash: cryptography.utils.getRandomBytes(HASH_LENGTH),
+			aggregationBits: cryptography.utils.getRandomBytes(1),
+			signature: cryptography.utils.getRandomBytes(BLS_SIGNATURE_LENGTH),
+		};
+		const encodedDefaultCertificate = codec.encode(certificateSchema, {
+			...certificate,
+		});
+		// const txParams: CrossChainUpdateTransactionParams = {
+		// 	certificate: encodedDefaultCertificate,
+		// 	activeValidatorsUpdate: {
+		// 		blsKeysUpdate: [],
+		// 		bftWeightsUpdate: [],
+		// 		bftWeightsUpdateBitmap: Buffer.from([]),
+		// 	},
+		// 	certificateThreshold: BigInt(10),
+		// 	sendingChainID: cryptoUtils.getRandomBytes(4),
+		// 	inboxUpdate: {
+		// 		crossChainMessages: [],
+		// 		messageWitnessHashes: [],
+		// 		outboxRootWitness: {
+		// 			bitmap: cryptoUtils.getRandomBytes(4),
+		// 			siblingHashes: [cryptoUtils.getRandomBytes(32)],
+		// 		},
+		// 	},
+		// };
+		// const chainID = Buffer.alloc(4, 0);
+		const senderPublicKey = cryptoUtils.getRandomBytes(32);
+		const defaultTransaction = {
+			fee: BigInt(0),
+			module: interopMod.name,
+			nonce: BigInt(1),
+			senderPublicKey,
+			signatures: [],
+		};
+
+		const defaultSendingChainID = 20;
+		const defaultSendingChainIDBuffer = cryptoUtils.intToBuffer(defaultSendingChainID, 4);
+		const defaultCCMs: CCMsg[] = [
+			{
+				crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,
+				fee: BigInt(0),
+				module: MODULE_NAME_INTEROPERABILITY,
+				nonce: BigInt(1),
+				params: Buffer.alloc(2),
+				receivingChainID: Buffer.from([0, 0, 0, 2]),
+				sendingChainID: defaultSendingChainIDBuffer,
+				status: CCMStatusCode.OK,
 			},
-			certificateThreshold: BigInt(10),
-			sendingChainID: cryptoUtils.getRandomBytes(4),
-			inboxUpdate: {
-				crossChainMessages: [],
-				messageWitnessHashes: [],
-				outboxRootWitness: {
-					bitmap: cryptoUtils.getRandomBytes(4),
-					siblingHashes: [cryptoUtils.getRandomBytes(32)],
-				},
+		];
+		const defaultCCMsEncoded = defaultCCMs.map(ccMsg => codec.encode(ccmSchema, ccMsg));
+		const defaultInboxUpdateValue = {
+			crossChainMessages: defaultCCMsEncoded,
+			messageWitnessHashes: [Buffer.alloc(32)],
+			outboxRootWitness: {
+				bitmap: Buffer.alloc(1),
+				siblingHashes: [Buffer.alloc(32)],
 			},
 		};
 
+		let commandExecuteContext: CommandExecuteContext;
+		let crossChainUpdateParams: CrossChainUpdateTransactionParams;
+
 		beforeEach(async () => {
-			await interopMod.stores.get(ChannelDataStore).set(methodContext, txParams.sendingChainID, {
-				...channelData,
-			});
+			crossChainUpdateParams = {
+				activeValidatorsUpdate: {
+					blsKeysUpdate: [],
+					bftWeightsUpdate: [],
+					bftWeightsUpdateBitmap: Buffer.alloc(0),
+				},
+				certificate: encodedDefaultCertificate,
+				inboxUpdate: { ...defaultInboxUpdateValue },
+				certificateThreshold: BigInt(20),
+				sendingChainID: cryptoUtils.intToBuffer(defaultSendingChainID, 4),
+			};
+			commandExecuteContext = createTransactionContext({
+				chainID,
+				stateStore,
+				transaction: new Transaction({
+					...defaultTransaction,
+					command: '',
+					params: codec.encode(crossChainUpdateTransactionParams, crossChainUpdateParams),
+				}),
+			}).createCommandExecuteContext(crossChainUpdateTransactionParams);
+			await interopMod.stores
+				.get(ChannelDataStore)
+				.set(commandExecuteContext, crossChainUpdateParams.sendingChainID, {
+					...channelData,
+				});
+			jest.spyOn(interopMod.events.get(InvalidOutboxRootverification), 'error');
+			jest.spyOn(interopMod.events.get(InvalidSMTVerification), 'error');
 		});
 
 		it('should reject when outboxRootWitness is empty but partnerchain outbox root does not match inboxRoot', async () => {
 			await expect(
-				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(methodContext, {
-					...txParams,
-					inboxUpdate: {
-						...txParams.inboxUpdate,
-						outboxRootWitness: {
-							bitmap: Buffer.alloc(0),
-							siblingHashes: [],
+				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(
+					commandExecuteContext as any,
+					{
+						...crossChainUpdateParams,
+						inboxUpdate: {
+							...crossChainUpdateParams.inboxUpdate,
+							outboxRootWitness: {
+								bitmap: Buffer.alloc(0),
+								siblingHashes: [],
+							},
 						},
+						certificate: Buffer.alloc(0),
 					},
-					certificate: Buffer.alloc(0),
-				}),
+				),
 			).rejects.toThrow('Inbox root does not match partner chain outbox root');
+
+			expect(interopMod['events'].get(InvalidOutboxRootverification).error).toHaveBeenCalledWith(
+				commandExecuteContext,
+				crossChainUpdateParams.sendingChainID,
+				{
+					inboxRoot: expect.anything(),
+					partnerChainOutboxRoot: channelData.partnerChainOutboxRoot,
+				},
+			);
 		});
 
 		it('should reject when certificate state root does not contain valid inclusion proof for inbox update', async () => {
 			jest.spyOn(SparseMerkleTree.prototype, 'verify').mockResolvedValue(false);
 
 			await expect(
-				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(methodContext, {
-					...txParams,
-				}),
+				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(
+					commandExecuteContext as any,
+					{
+						...crossChainUpdateParams,
+					},
+				),
 			).rejects.toThrow('Invalid inclusion proof for inbox update');
+
+			expect(interopMod['events'].get(InvalidSMTVerification).error).toHaveBeenCalledWith(
+				commandExecuteContext,
+			);
 		});
 
 		it('should resolve when certificate is empty and inbox root matches partner outbox root', async () => {
@@ -1515,17 +1626,21 @@ describe('Base interoperability internal method', () => {
 				.mockReturnValue(channelData.partnerChainOutboxRoot);
 
 			await expect(
-				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(methodContext, {
-					...txParams,
-					inboxUpdate: {
-						...txParams.inboxUpdate,
-						outboxRootWitness: {
-							bitmap: Buffer.alloc(0),
-							siblingHashes: [],
+				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(
+					commandExecuteContext as any,
+					{
+						...crossChainUpdateParams,
+						inboxUpdate: {
+							crossChainMessages: [],
+							messageWitnessHashes: [],
+							outboxRootWitness: {
+								bitmap: Buffer.alloc(0),
+								siblingHashes: [],
+							},
 						},
+						certificate: Buffer.alloc(0),
 					},
-					certificate: Buffer.alloc(0),
-				}),
+				),
 			).resolves.toBeUndefined();
 		});
 
@@ -1535,9 +1650,12 @@ describe('Base interoperability internal method', () => {
 			jest.spyOn(regularMerkleTree, 'calculateRootFromRightWitness').mockReturnValue(nextRoot);
 
 			await expect(
-				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(methodContext, {
-					...txParams,
-				}),
+				mainchainInteroperabilityInternalMethod.verifyPartnerChainOutboxRoot(
+					commandExecuteContext as any,
+					{
+						...crossChainUpdateParams,
+					},
+				),
 			).resolves.toBeUndefined();
 
 			const outboxKey = Buffer.concat([
@@ -1545,15 +1663,15 @@ describe('Base interoperability internal method', () => {
 				cryptoUtils.hash(ownChainAccount.chainID),
 			]);
 			expect(SparseMerkleTree.prototype.verify).toHaveBeenCalledWith(
-				defaultCertificate.stateRoot,
+				certificate.stateRoot,
 				[outboxKey],
 				{
-					siblingHashes: txParams.inboxUpdate.outboxRootWitness.siblingHashes,
+					siblingHashes: crossChainUpdateParams.inboxUpdate.outboxRootWitness.siblingHashes,
 					queries: [
 						{
 							key: outboxKey,
 							value: cryptoUtils.hash(codec.encode(outboxRootSchema, { root: nextRoot })),
-							bitmap: txParams.inboxUpdate.outboxRootWitness.bitmap,
+							bitmap: crossChainUpdateParams.inboxUpdate.outboxRootWitness.bitmap,
 						},
 					],
 				},

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -31,6 +31,7 @@ import {
 	CONTEXT_STORE_KEY_CCM_PROCESSING,
 	CROSS_CHAIN_COMMAND_CHANNEL_TERMINATED,
 	CROSS_CHAIN_COMMAND_REGISTRATION,
+	EVENT_TOPIC_CCM_EXECUTION,
 	MODULE_NAME_INTEROPERABILITY,
 } from '../../../../../../src/modules/interoperability/constants';
 import { RecoverMessageCommand } from '../../../../../../src/modules/interoperability/mainchain/commands/recover_message';
@@ -58,7 +59,6 @@ import {
 } from '../../../../../../src/modules/interoperability/events/ccm_processed';
 import { CcmSendSuccessEvent } from '../../../../../../src/modules/interoperability/events/ccm_send_success';
 import { InvalidRMTVerification } from '../../../../../../src/modules/interoperability/events/invalid_rmt_verification';
-import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../../../src/state_machine/constants';
 
 describe('MessageRecoveryCommand', () => {
 	const interopModule = new MainchainInteroperabilityModule();

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -58,6 +58,7 @@ import {
 } from '../../../../../../src/modules/interoperability/events/ccm_processed';
 import { CcmSendSuccessEvent } from '../../../../../../src/modules/interoperability/events/ccm_send_success';
 import { InvalidRMTVerification } from '../../../../../../src/modules/interoperability/events/invalid_rmt_verification';
+import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../../../src/state_machine/constants';
 
 describe('MessageRecoveryCommand', () => {
 	const interopModule = new MainchainInteroperabilityModule();
@@ -540,7 +541,9 @@ describe('MessageRecoveryCommand', () => {
 				const ctx: CrossChainMessageContext = {
 					...commandExecuteContext,
 					ccm,
-					eventQueue: commandExecuteContext.eventQueue.getChildQueue(utils.hash(crossChainMessage)),
+					eventQueue: commandExecuteContext.eventQueue.getChildQueue(
+						Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, utils.hash(crossChainMessage)]),
+					),
 				};
 
 				expect(command['_applyRecovery']).toHaveBeenCalledWith(ctx);
@@ -567,7 +570,9 @@ describe('MessageRecoveryCommand', () => {
 				const ctx: CrossChainMessageContext = {
 					...commandExecuteContext,
 					ccm,
-					eventQueue: commandExecuteContext.eventQueue.getChildQueue(utils.hash(crossChainMessage)),
+					eventQueue: commandExecuteContext.eventQueue.getChildQueue(
+						Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, utils.hash(crossChainMessage)]),
+					),
 				};
 
 				expect(command['_forwardRecovery']).toHaveBeenCalledWith(ctx);

--- a/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/recover_message.spec.ts
@@ -58,7 +58,7 @@ import {
 	CCMProcessedResult,
 } from '../../../../../../src/modules/interoperability/events/ccm_processed';
 import { CcmSendSuccessEvent } from '../../../../../../src/modules/interoperability/events/ccm_send_success';
-import { InvalidRMTVerification } from '../../../../../../src/modules/interoperability/events/invalid_rmt_verification';
+import { InvalidRMTVerificationEvent } from '../../../../../../src/modules/interoperability/events/invalid_rmt_verification';
 
 describe('MessageRecoveryCommand', () => {
 	const interopModule = new MainchainInteroperabilityModule();
@@ -492,7 +492,7 @@ describe('MessageRecoveryCommand', () => {
 			jest.spyOn(command, '_forwardRecovery' as never);
 			jest.spyOn(interopModule.stores.get(TerminatedOutboxStore), 'set');
 			jest.spyOn(commandExecuteContext['contextStore'], 'set');
-			jest.spyOn(command['events'].get(InvalidRMTVerification), 'error');
+			jest.spyOn(command['events'].get(InvalidRMTVerificationEvent), 'error');
 		});
 
 		it('should return error if message recovery proof of inclusion is not valid', async () => {
@@ -526,7 +526,7 @@ describe('MessageRecoveryCommand', () => {
 			await expect(command.execute(commandExecuteContext)).rejects.toThrow(
 				'Message recovery proof of inclusion is not valid.',
 			);
-			expect(command['events'].get(InvalidRMTVerification).error).toHaveBeenCalledWith(
+			expect(command['events'].get(InvalidRMTVerificationEvent).error).toHaveBeenCalledWith(
 				commandExecuteContext,
 			);
 		});

--- a/framework/test/unit/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.spec.ts
@@ -88,6 +88,7 @@ import {
 	OwnChainAccountStore,
 	OwnChainAccount,
 } from '../../../../../../src/modules/interoperability/stores/own_chain_account';
+import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../../../src/state_machine/constants';
 
 describe('SubmitMainchainCrossChainUpdateCommand', () => {
 	const interopMod = new MainchainInteroperabilityModule();
@@ -538,7 +539,9 @@ describe('SubmitMainchainCrossChainUpdateCommand', () => {
 			expect(mainchainCCUUpdateCommand['apply']).toHaveBeenCalledWith({
 				...executeContext,
 				ccm: decodedCCM,
-				eventQueue: executeContext.eventQueue.getChildQueue(ccmID),
+				eventQueue: executeContext.eventQueue.getChildQueue(
+					Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, ccmID]),
+				),
 			});
 			expect(mainchainCCUUpdateCommand['internalMethod'].appendToInboxTree).toHaveBeenCalledTimes(
 				3,
@@ -567,7 +570,9 @@ describe('SubmitMainchainCrossChainUpdateCommand', () => {
 			expect(mainchainCCUUpdateCommand['_forward']).toHaveBeenCalledWith({
 				...executeContext,
 				ccm: firstDecodedCCM,
-				eventQueue: executeContext.eventQueue.getChildQueue(firstCCMID),
+				eventQueue: executeContext.eventQueue.getChildQueue(
+					Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, firstCCMID]),
+				),
 			});
 			const { ccmID: thirdCCMID, decodedCCM: thirdDecodedCCM } = getDecodedCCMAndID(
 				params.inboxUpdate.crossChainMessages[2],
@@ -575,7 +580,9 @@ describe('SubmitMainchainCrossChainUpdateCommand', () => {
 			expect(mainchainCCUUpdateCommand['_forward']).toHaveBeenCalledWith({
 				...executeContext,
 				ccm: thirdDecodedCCM,
-				eventQueue: executeContext.eventQueue.getChildQueue(thirdCCMID),
+				eventQueue: executeContext.eventQueue.getChildQueue(
+					Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, thirdCCMID]),
+				),
 			});
 			expect(mainchainCCUUpdateCommand['internalMethod'].appendToInboxTree).toHaveBeenCalledTimes(
 				3,

--- a/framework/test/unit/modules/interoperability/sidechain/commands/initialize_state_recovery.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/initialize_state_recovery.spec.ts
@@ -50,7 +50,7 @@ import {
 import { createStoreGetter } from '../../../../../../src/testing/utils';
 import { OwnChainAccountStore } from '../../../../../../src/modules/interoperability/stores/own_chain_account';
 import { getMainchainID } from '../../../../../../src/modules/interoperability/utils';
-import { InvalidSMTVerification } from '../../../../../../src/modules/interoperability/events/invalid_smt_verification';
+import { InvalidSMTVerificationEvent } from '../../../../../../src/modules/interoperability/events/invalid_smt_verification';
 
 describe('Sidechain InitializeStateRecoveryCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
@@ -368,7 +368,7 @@ describe('Sidechain InitializeStateRecoveryCommand', () => {
 	});
 
 	describe('execute', () => {
-		let invalidSMTVerificationEvent: InvalidSMTVerification;
+		let invalidSMTVerificationEvent: InvalidSMTVerificationEvent;
 		beforeEach(() => {
 			mainchainAccount = {
 				name: 'mainchain',
@@ -380,9 +380,9 @@ describe('Sidechain InitializeStateRecoveryCommand', () => {
 				},
 				status: ChainStatus.ACTIVE,
 			};
-			invalidSMTVerificationEvent = new InvalidSMTVerification(interopMod.name);
+			invalidSMTVerificationEvent = new InvalidSMTVerificationEvent(interopMod.name);
 			stateRecoveryInitCommand['events'].register(
-				InvalidSMTVerification,
+				InvalidSMTVerificationEvent,
 				invalidSMTVerificationEvent,
 			);
 		});

--- a/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
@@ -47,6 +47,7 @@ import {
 	CCMStatusCode,
 	CROSS_CHAIN_COMMAND_REGISTRATION,
 	CROSS_CHAIN_COMMAND_SIDECHAIN_TERMINATED,
+	EVENT_TOPIC_CCM_EXECUTION,
 	MIN_RETURN_FEE_PER_BYTE_BEDDOWS,
 	MODULE_NAME_INTEROPERABILITY,
 } from '../../../../../../src/modules/interoperability/constants';
@@ -66,7 +67,6 @@ import {
 	OwnChainAccountStore,
 	OwnChainAccount,
 } from '../../../../../../src/modules/interoperability/stores/own_chain_account';
-import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../../../src/state_machine/constants';
 
 describe('SubmitSidechainCrossChainUpdateCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
@@ -363,7 +363,7 @@ describe('SubmitSidechainCrossChainUpdateCommand', () => {
 			jest.spyOn(sidechainCCUUpdateCommand, 'apply' as never).mockResolvedValue(undefined as never);
 		});
 
-		it('should call executeCommon', async () => {
+		it('should call beforeCrossChainMessagesExecution', async () => {
 			executeContext = createTransactionContext({
 				chainID,
 				stateStore,
@@ -376,15 +376,40 @@ describe('SubmitSidechainCrossChainUpdateCommand', () => {
 				}),
 			}).createCommandExecuteContext(sidechainCCUUpdateCommand.schema);
 			jest
-				.spyOn(sidechainCCUUpdateCommand, 'executeCommon' as never)
+				.spyOn(sidechainCCUUpdateCommand, 'beforeCrossChainMessagesExecution' as never)
 				.mockResolvedValue([[], true] as never);
 
 			await expect(sidechainCCUUpdateCommand.execute(executeContext)).resolves.toBeUndefined();
-			expect(sidechainCCUUpdateCommand['executeCommon']).toHaveBeenCalledTimes(1);
-			expect(sidechainCCUUpdateCommand['executeCommon']).toHaveBeenCalledWith(
+			expect(sidechainCCUUpdateCommand['beforeCrossChainMessagesExecution']).toHaveBeenCalledTimes(
+				1,
+			);
+			expect(sidechainCCUUpdateCommand['beforeCrossChainMessagesExecution']).toHaveBeenCalledWith(
 				expect.anything(),
 				false,
 			);
+		});
+
+		it('should call panic which shutdown the application when apply fails', async () => {
+			const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {
+				return undefined as never;
+			});
+			executeContext = createTransactionContext({
+				chainID,
+				stateStore,
+				transaction: new Transaction({
+					...defaultTransaction,
+					command: sidechainCCUUpdateCommand.name,
+					params: codec.encode(crossChainUpdateTransactionParams, {
+						...params,
+					}),
+				}),
+			}).createCommandExecuteContext(sidechainCCUUpdateCommand.schema);
+			jest
+				.spyOn(sidechainCCUUpdateCommand, 'apply' as never)
+				.mockRejectedValue(new Error('Something went wrong.') as never);
+			await expect(sidechainCCUUpdateCommand.execute(executeContext)).resolves.toBeUndefined();
+			expect(mockExit).toHaveBeenCalledWith(1);
+			expect(sidechainCCUUpdateCommand['apply']).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call apply for ccm and add to the inbox where receiving chain is the main chain', async () => {

--- a/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
@@ -66,6 +66,7 @@ import {
 	OwnChainAccountStore,
 	OwnChainAccount,
 } from '../../../../../../src/modules/interoperability/stores/own_chain_account';
+import { EVENT_TOPIC_CCM_EXECUTION } from '../../../../../../src/state_machine/constants';
 
 describe('SubmitSidechainCrossChainUpdateCommand', () => {
 	const interopMod = new SidechainInteroperabilityModule();
@@ -406,7 +407,9 @@ describe('SubmitSidechainCrossChainUpdateCommand', () => {
 				expect(sidechainCCUUpdateCommand['apply']).toHaveBeenCalledWith({
 					...executeContext,
 					ccm: decodedCCM,
-					eventQueue: executeContext.eventQueue.getChildQueue(ccmID),
+					eventQueue: executeContext.eventQueue.getChildQueue(
+						Buffer.concat([EVENT_TOPIC_CCM_EXECUTION, ccmID]),
+					),
 				});
 			}
 			expect(sidechainCCUUpdateCommand['internalMethod'].appendToInboxTree).toHaveBeenCalledTimes(

--- a/framework/test/unit/state_machine/state_machine.spec.ts
+++ b/framework/test/unit/state_machine/state_machine.spec.ts
@@ -36,7 +36,7 @@ import {
 	EVENT_INDEX_BEFORE_TRANSACTIONS,
 	EVENT_INDEX_FINALIZE_GENESIS_STATE,
 	EVENT_INDEX_INIT_GENESIS_STATE,
-	// EVENT_TOPIC_TRANSACTION_EXECUTION,
+	EVENT_TOPIC_TRANSACTION_EXECUTION,
 } from '../../../src/state_machine/constants';
 import { PrefixedStateReadWriter } from '../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../src/testing/in_memory_prefixed_state';
@@ -206,7 +206,9 @@ describe('state_machine', () => {
 			const events = ctx.eventQueue.getEvents();
 			const dataDecoded = codec.decode(standardEventDataSchema, events[0].toObject().data);
 			expect(events).toHaveLength(1);
-			expect(events[0].toObject().topics[0]).toEqual(transaction.id);
+			expect(events[0].toObject().topics[0]).toEqual(
+				Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, transaction.id]),
+			);
 			expect(dataDecoded).toStrictEqual({ success: true });
 		});
 
@@ -233,10 +235,13 @@ describe('state_machine', () => {
 			await stateMachine.executeTransaction(ctx);
 
 			const events = ctx.eventQueue.getEvents();
+
 			const dataDecoded = codec.decode(standardEventDataSchema, events[0].toObject().data);
 			expect(events).toHaveLength(1);
 
-			expect(events[0].toObject().topics[0]).toEqual(transactionWithInvalidCommand.id);
+			expect(events[0].toObject().topics[0]).toEqual(
+				Buffer.concat([EVENT_TOPIC_TRANSACTION_EXECUTION, transactionWithInvalidCommand.id]),
+			);
 			expect(dataDecoded).toStrictEqual({ success: false });
 		});
 

--- a/framework/test/unit/state_machine/state_machine.spec.ts
+++ b/framework/test/unit/state_machine/state_machine.spec.ts
@@ -36,6 +36,7 @@ import {
 	EVENT_INDEX_BEFORE_TRANSACTIONS,
 	EVENT_INDEX_FINALIZE_GENESIS_STATE,
 	EVENT_INDEX_INIT_GENESIS_STATE,
+	// EVENT_TOPIC_TRANSACTION_EXECUTION,
 } from '../../../src/state_machine/constants';
 import { PrefixedStateReadWriter } from '../../../src/state_machine/prefixed_state_read_writer';
 import { InMemoryPrefixedStateDB } from '../../../src/testing/in_memory_prefixed_state';
@@ -58,6 +59,7 @@ describe('state_machine', () => {
 		params: codec.encode(new CustomCommand0(new NamedRegistry(), new NamedRegistry()).schema, {
 			data: 'some info',
 		}),
+		id: utils.hash(utils.getRandomBytes(2)),
 	} as Transaction;
 
 	let stateMachine: StateMachine;
@@ -215,6 +217,7 @@ describe('state_machine', () => {
 				params: codec.encode(new CustomCommand3(new NamedRegistry(), new NamedRegistry()).schema, {
 					data: 'some info',
 				}),
+				id: utils.hash(utils.getRandomBytes(2)),
 			} as Transaction;
 			stateMachine.registerModule(new CustomModule3());
 			const ctx = new TransactionContext({
@@ -232,7 +235,8 @@ describe('state_machine', () => {
 			const events = ctx.eventQueue.getEvents();
 			const dataDecoded = codec.decode(standardEventDataSchema, events[0].toObject().data);
 			expect(events).toHaveLength(1);
-			expect(events[0].toObject().topics[0]).toEqual(transaction.id);
+
+			expect(events[0].toObject().topics[0]).toEqual(transactionWithInvalidCommand.id);
 			expect(dataDecoded).toStrictEqual({ success: false });
 		});
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #9099 #9100 #9111 #9112

### How was it solved?

- getChildQueue is updated to replace default topic
- Transaction execution to have a transactionID with prefix as default topic
- CCM execution to have a ccmID with prefix as default topic

### How was it tested?

Setup 2 sidechains and 2 mainchain nodes using interop examples and try to send invalid CCM from sidechainTwo to sidechainOne using React Module.
