### PR TITLE
Update tests for interop cross chain updates

### DIFF
--- a/framework/src/modules/interoperability/base_cross_chain_update_command.ts
+++ b/framework/src/modules/interoperability/base_cross_chain_update_command.ts
@@ -196,6 +196,7 @@ export abstract class BaseCrossChainUpdateCommand<
 		return [ccms, true];
 	}
 
+	// https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#verifyroutingrules
 	protected verifyRoutingRules(
 		ccm: CCMsg,
 		ccuParams: CrossChainUpdateTransactionParams,

--- a/framework/src/modules/interoperability/base_cross_chain_update_command.ts
+++ b/framework/src/modules/interoperability/base_cross_chain_update_command.ts
@@ -123,6 +123,7 @@ export abstract class BaseCrossChainUpdateCommand<
 		}
 	}
 
+	// https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#beforecrosschainmessagesexecution
 	protected async beforeCrossChainMessagesExecution(
 		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
 		isMainchain: boolean,
@@ -219,7 +220,8 @@ export abstract class BaseCrossChainUpdateCommand<
 		}
 	}
 
-	protected async afterCrossChainMessagesExecute(
+	// https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#aftercrosschainmessagesexecution
+	protected async afterCrossChainMessagesExecution(
 		context: CommandExecuteContext<CrossChainUpdateTransactionParams>,
 	) {
 		const { params } = context;

--- a/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/mainchain/commands/submit_mainchain_cross_chain_update.ts
@@ -128,7 +128,7 @@ export class SubmitMainchainCrossChainUpdateCommand extends BaseCrossChainUpdate
 			context.contextStore.delete(CONTEXT_STORE_KEY_CCM_PROCESSING);
 		}
 
-		await this.afterCrossChainMessagesExecute(context);
+		await this.afterCrossChainMessagesExecution(context);
 	}
 
 	private async _beforeCrossChainMessageForwarding(

--- a/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
+++ b/framework/src/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.ts
@@ -26,7 +26,6 @@ import { getIDFromCCMBytes } from '../../utils';
 import { SidechainInteroperabilityInternalMethod } from '../internal_method';
 
 // https://github.com/LiskHQ/lips/blob/main/proposals/lip-0053.md#sidechaincrosschainupdate
-
 export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdateCommand<SidechainInteroperabilityInternalMethod> {
 	public async verify(
 		context: CommandVerifyContext<CrossChainUpdateTransactionParams>,
@@ -81,6 +80,6 @@ export class SubmitSidechainCrossChainUpdateCommand extends BaseCrossChainUpdate
 			context.contextStore.delete(CONTEXT_STORE_KEY_CCM_PROCESSING);
 		}
 
-		await this.afterCrossChainMessagesExecute(context);
+		await this.afterCrossChainMessagesExecution(context);
 	}
 }

--- a/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
@@ -83,6 +83,8 @@ class CrossChainUpdateCommand extends BaseCrossChainUpdateCommand<MainchainInter
 }
 
 describe('BaseCrossChainUpdateCommand', () => {
+	let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
+	let stateStore: PrefixedStateReadWriter;
 	const interopsModule = new MainchainInteroperabilityModule();
 	const senderPublicKey = utils.getRandomBytes(32);
 	const messageFeeTokenID = Buffer.alloc(8, 0);
@@ -212,6 +214,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 
 	beforeEach(() => {
 		const interopModule = new MainchainInteroperabilityModule();
+		stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 		ccMethods = new Map();
 		ccMethods.set(
 			'token',
@@ -268,7 +271,6 @@ describe('BaseCrossChainUpdateCommand', () => {
 	});
 
 	describe('verifyCommon', () => {
-		let stateStore: PrefixedStateReadWriter;
 		let verifyContext: CommandVerifyContext<CrossChainUpdateTransactionParams>;
 
 		const ownChainAccount: OwnChainAccount = {
@@ -296,7 +298,6 @@ describe('BaseCrossChainUpdateCommand', () => {
 		].sort((v1, v2) => v2.blsKey.compare(v1.blsKey)); // unsorted list
 
 		beforeEach(async () => {
-			stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 			verifyContext = createTransactionContext({
 				chainID,
 				stateStore,
@@ -530,12 +531,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 	});
 
 	describe('verifyCertificateSignatureAndPartnerChainOutboxRoot', () => {
-		let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
-		let stateStore: PrefixedStateReadWriter;
-
 		beforeEach(async () => {
-			stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
-
 			executeContext = createTransactionContext({
 				chainID,
 				stateStore,
@@ -635,12 +631,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 	// otherwise, they can fail due to some other check
 	// also, we can simplify test cases by giving only one CCM to params.inboxUpdate.crossChainMessages array
 	describe('beforeCrossChainMessagesExecution', () => {
-		let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
-		let stateStore: PrefixedStateReadWriter;
-
 		beforeEach(async () => {
-			stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
-
 			executeContext = createTransactionContext({
 				chainID,
 				stateStore,
@@ -840,11 +831,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 	});
 
 	describe('verifyRoutingRules', () => {
-		let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
-		let stateStore: PrefixedStateReadWriter;
-
 		beforeEach(async () => {
-			stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 			executeContext = createTransactionContext({
 				chainID,
 				stateStore,
@@ -1029,7 +1016,6 @@ describe('BaseCrossChainUpdateCommand', () => {
 	});
 
 	describe('afterCrossChainMessagesExecution', () => {
-		let executeContext: CommandExecuteContext<CrossChainUpdateTransactionParams>;
 		let chainValidatorsStore: ChainValidatorsStore;
 
 		beforeEach(() => {
@@ -1602,10 +1588,8 @@ describe('BaseCrossChainUpdateCommand', () => {
 		const ccmStatus = CCMStatusCode.MODULE_NOT_SUPPORTED;
 		const ccmProcessedEventCode = CCMProcessedCode.MODULE_NOT_SUPPORTED;
 		const ccmSize = 100;
-		let stateStore: PrefixedStateReadWriter;
 
 		beforeEach(async () => {
-			stateStore = new PrefixedStateReadWriter(new InMemoryPrefixedStateDB());
 			await interopsModule.stores.get(OwnChainAccountStore).set(stateStore, EMPTY_BYTES, {
 				chainID: Buffer.from('11111111', 'hex'),
 				name: 'ownChain',

--- a/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
@@ -706,7 +706,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 				{
 					ccm: EmptyCCM,
 					result: CCMProcessedResult.DISCARDED,
-					code: CCMProcessedCode.INVALID_CCM_DECODING_EXCEPTION, // ***
+					code: CCMProcessedCode.INVALID_CCM_DECODING_EXCEPTION,
 				},
 			);
 		});
@@ -752,7 +752,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 				{
 					ccm: { ...EmptyCCM, params: EMPTY_BYTES },
 					result: CCMProcessedResult.DISCARDED,
-					code: CCMProcessedCode.INVALID_CCM_VALIDATION_EXCEPTION, // ***
+					code: CCMProcessedCode.INVALID_CCM_VALIDATION_EXCEPTION,
 				},
 			);
 		});
@@ -802,7 +802,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 				executeContext.params,
 				executeContext.chainID,
 				true,
-			); // ***
+			);
 
 			// let's make sure it indeed throws expected error
 			expect(() => {
@@ -830,7 +830,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 				{
 					ccm,
 					result: CCMProcessedResult.DISCARDED,
-					code: CCMProcessedCode.INVALID_CCM_ROUTING_EXCEPTION, // ***
+					code: CCMProcessedCode.INVALID_CCM_ROUTING_EXCEPTION,
 				},
 			);
 
@@ -919,7 +919,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 					// must be same as defaultSendingChainID to pass `!ccm.sendingChainID.equals(params.sendingChainID)`
 					sendingChainID: defaultSendingChainID,
 					// will fail for `CCMStatusCode.CHANNEL_UNAVAILABLE`
-					status: CCMStatusCode.CHANNEL_UNAVAILABLE, // ***
+					status: CCMStatusCode.CHANNEL_UNAVAILABLE,
 				};
 
 				executeContext = createTransactionContext({

--- a/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
@@ -868,84 +868,82 @@ describe('BaseCrossChainUpdateCommand', () => {
 				.set(stateStore, defaultSendingChainID, partnerChannel);
 		});
 
-		describe('isMainchain', () => {
-			it('should return error when CCM sending chain and ccu sending chain is not the same', () => {
-				const ccm = {
-					crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,
-					fee: BigInt(0),
-					module: MODULE_NAME_INTEROPERABILITY,
-					nonce: BigInt(1),
-					params: utils.getRandomBytes(10),
-					// must be same as `context.chainID` to pass `!context.chainID.equals(ccm.receivingChainID)` check
-					receivingChainID: chainID,
-					// this will fail for `!ccm.sendingChainID.equals(params.sendingChainID)`
-					// params.sendingChainID is `defaultSendingChainID` (line 158)
-					sendingChainID: Buffer.from([1, 2, 3, 4]),
-					status: CCMStatusCode.OK,
-				};
+		it('should return error when CCM sending chain and ccu sending chain is not the same', () => {
+			const ccm = {
+				crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,
+				fee: BigInt(0),
+				module: MODULE_NAME_INTEROPERABILITY,
+				nonce: BigInt(1),
+				params: utils.getRandomBytes(10),
+				// must be same as `context.chainID` to pass `!context.chainID.equals(ccm.receivingChainID)` check
+				receivingChainID: chainID,
+				// this will fail for `!ccm.sendingChainID.equals(params.sendingChainID)`
+				// params.sendingChainID is `defaultSendingChainID` (line 158)
+				sendingChainID: Buffer.from([1, 2, 3, 4]),
+				status: CCMStatusCode.OK,
+			};
 
-				executeContext = createTransactionContext({
-					chainID,
-					stateStore,
-					transaction: new Transaction({
-						...defaultTransaction,
-						command: command.name,
-						params: codec.encode(crossChainUpdateTransactionParams, {
-							...params,
-							inboxUpdate: {
-								...params.inboxUpdate,
-								crossChainMessages: [codec.encode(ccmSchema, ccm)],
-							},
-						}),
+			executeContext = createTransactionContext({
+				chainID,
+				stateStore,
+				transaction: new Transaction({
+					...defaultTransaction,
+					command: command.name,
+					params: codec.encode(crossChainUpdateTransactionParams, {
+						...params,
+						inboxUpdate: {
+							...params.inboxUpdate,
+							crossChainMessages: [codec.encode(ccmSchema, ccm)],
+						},
 					}),
-				}).createCommandExecuteContext(command.schema);
+				}),
+			}).createCommandExecuteContext(command.schema);
 
-				try {
-					command['verifyRoutingRules'](ccm, executeContext.params, executeContext.chainID, true);
-				} catch (err: any) {
-					expect((err as Error).message).toBe('CCM is not from the sending chain.');
-				}
-			});
+			try {
+				command['verifyRoutingRules'](ccm, executeContext.params, executeContext.chainID, true);
+			} catch (err: any) {
+				expect((err as Error).message).toBe('CCM is not from the sending chain.');
+			}
+		});
 
-			it('should return error when ccm status is CCMStatusCode.CHANNEL_UNAVAILABLE', () => {
-				const ccm = {
-					crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,
-					fee: BigInt(0),
-					module: MODULE_NAME_INTEROPERABILITY,
-					nonce: BigInt(1),
-					params: utils.getRandomBytes(10),
-					// must be same as `context.chainID` to pass `!context.chainID.equals(ccm.receivingChainID)`
-					receivingChainID: chainID,
-					// must be same as defaultSendingChainID to pass `!ccm.sendingChainID.equals(params.sendingChainID)`
-					sendingChainID: defaultSendingChainID,
-					// will fail for `CCMStatusCode.CHANNEL_UNAVAILABLE`
-					status: CCMStatusCode.CHANNEL_UNAVAILABLE,
-				};
+		it('should return error when ccm status is CCMStatusCode.CHANNEL_UNAVAILABLE', () => {
+			const ccm = {
+				crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,
+				fee: BigInt(0),
+				module: MODULE_NAME_INTEROPERABILITY,
+				nonce: BigInt(1),
+				params: utils.getRandomBytes(10),
+				// must be same as `context.chainID` to pass `!context.chainID.equals(ccm.receivingChainID)`
+				receivingChainID: chainID,
+				// must be same as defaultSendingChainID to pass `!ccm.sendingChainID.equals(params.sendingChainID)`
+				sendingChainID: defaultSendingChainID,
+				// will fail for `CCMStatusCode.CHANNEL_UNAVAILABLE`
+				status: CCMStatusCode.CHANNEL_UNAVAILABLE,
+			};
 
-				executeContext = createTransactionContext({
-					chainID,
-					stateStore,
-					transaction: new Transaction({
-						...defaultTransaction,
-						command: command.name,
-						params: codec.encode(crossChainUpdateTransactionParams, {
-							...params,
-							inboxUpdate: {
-								...params.inboxUpdate,
-								crossChainMessages: [codec.encode(ccmSchema, ccm)],
-							},
-						}),
+			executeContext = createTransactionContext({
+				chainID,
+				stateStore,
+				transaction: new Transaction({
+					...defaultTransaction,
+					command: command.name,
+					params: codec.encode(crossChainUpdateTransactionParams, {
+						...params,
+						inboxUpdate: {
+							...params.inboxUpdate,
+							crossChainMessages: [codec.encode(ccmSchema, ccm)],
+						},
 					}),
-				}).createCommandExecuteContext(command.schema);
+				}),
+			}).createCommandExecuteContext(command.schema);
 
-				try {
-					command['verifyRoutingRules'](ccm, executeContext.params, executeContext.chainID, true);
-				} catch (err: any) {
-					expect((err as Error).message).toBe(
-						'CCM status channel unavailable can only be set on the mainchain.',
-					);
-				}
-			});
+			try {
+				command['verifyRoutingRules'](ccm, executeContext.params, executeContext.chainID, true);
+			} catch (err: any) {
+				expect((err as Error).message).toBe(
+					'CCM status channel unavailable can only be set on the mainchain.',
+				);
+			}
 		});
 
 		it('should return error when CCM is not directed to the sidechain', () => {
@@ -1018,7 +1016,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 			}).createCommandExecuteContext(command.schema);
 
 			try {
-				command['verifyRoutingRules'](ccm, executeContext.params, executeContext.chainID, true);
+				command['verifyRoutingRules'](ccm, executeContext.params, executeContext.chainID, false);
 			} catch (err: any) {
 				expect((err as Error).message).toBe('Sending and receiving chains must differ.');
 			}

--- a/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
@@ -947,6 +947,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 		});
 
 		it('should return error when CCM is not directed to the sidechain', () => {
+			const sidechainID = Buffer.from([1, 2, 3, 4]);
 			const ccm = {
 				crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,
 				fee: BigInt(0),
@@ -960,7 +961,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 			};
 
 			executeContext = createTransactionContext({
-				chainID,
+				chainID: sidechainID,
 				stateStore,
 				transaction: new Transaction({
 					...defaultTransaction,
@@ -982,7 +983,7 @@ describe('BaseCrossChainUpdateCommand', () => {
 			}
 		});
 
-		it('should return error  when receiving chain is the same as sending chain', () => {
+		it('should return error when receiving chain is the same as sending chain', () => {
 			const sendingChainID = chainID;
 			const ccm = {
 				crossChainCommand: CROSS_CHAIN_COMMAND_REGISTRATION,

--- a/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
+++ b/framework/test/unit/modules/interoperability/base_cross_chain_update_command.spec.ts
@@ -798,11 +798,6 @@ describe('BaseCrossChainUpdateCommand', () => {
 				true,
 			);
 
-			// let's make sure it indeed throws expected error
-			expect(() => {
-				command['verifyRoutingRules'](ccm, executeContext.params, executeContext.chainID, true);
-			}).toThrow('blah');
-
 			const ccmBytes = executeContext.params.inboxUpdate.crossChainMessages[0];
 			const ccmID = getIDFromCCMBytes(ccmBytes);
 			const ccmContext = {

--- a/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
+++ b/framework/test/unit/modules/interoperability/sidechain/commands/submit_sidechain_cross_chain_update.spec.ts
@@ -311,7 +311,7 @@ describe('SubmitSidechainCrossChainUpdateCommand', () => {
 				status: VerifyStatus.OK,
 			});
 
-			expect(sidechainCCUUpdateCommand['verifyCommon']).toHaveBeenCalled();
+			expect(sidechainCCUUpdateCommand['verifyCommon']).toHaveBeenCalledWith(verifyContext, false);
 		});
 
 		it('should call isLive with only 2 params', async () => {
@@ -353,6 +353,31 @@ describe('SubmitSidechainCrossChainUpdateCommand', () => {
 				.spyOn(sidechainCCUUpdateCommand['internalMethod'], 'appendToInboxTree')
 				.mockResolvedValue(undefined);
 			jest.spyOn(sidechainCCUUpdateCommand, 'apply' as never).mockResolvedValue(undefined as never);
+		});
+
+		// verifyCertificateSignatureAndPartnerChainOutboxRoot relevant checks are covered in base_cross_chain_update_command.spec.ts
+		it('should call verifyCertificateSignatureAndPartnerChainOutboxRoot', async () => {
+			jest.spyOn(
+				sidechainCCUUpdateCommand,
+				'verifyCertificateSignatureAndPartnerChainOutboxRoot' as never,
+			);
+
+			executeContext = createTransactionContext({
+				chainID,
+				stateStore,
+				transaction: new Transaction({
+					...defaultTransaction,
+					command: sidechainCCUUpdateCommand.name,
+					params: codec.encode(crossChainUpdateTransactionParams, {
+						...params,
+					}),
+				}),
+			}).createCommandExecuteContext(sidechainCCUUpdateCommand.schema);
+
+			await expect(sidechainCCUUpdateCommand.execute(executeContext)).resolves.toBeUndefined();
+			expect(
+				sidechainCCUUpdateCommand['verifyCertificateSignatureAndPartnerChainOutboxRoot'],
+			).toHaveBeenCalledTimes(1);
 		});
 
 		it('should call beforeCrossChainMessagesExecution', async () => {
@@ -404,7 +429,7 @@ describe('SubmitSidechainCrossChainUpdateCommand', () => {
 			expect(sidechainCCUUpdateCommand['apply']).toHaveBeenCalledTimes(1);
 		});
 
-		it('should call apply for ccm and add to the inbox where receiving chain is the main chain', async () => {
+		it('should call apply for ccm and add to the inbox', async () => {
 			executeContext = createTransactionContext({
 				chainID,
 				stateStore,
@@ -430,7 +455,27 @@ describe('SubmitSidechainCrossChainUpdateCommand', () => {
 				});
 			}
 			expect(sidechainCCUUpdateCommand['internalMethod'].appendToInboxTree).toHaveBeenCalledTimes(
-				3,
+				params.inboxUpdate.crossChainMessages.length,
+			);
+		});
+
+		it('should call afterCrossChainMessagesExecution', async () => {
+			jest.spyOn(sidechainCCUUpdateCommand, 'afterCrossChainMessagesExecution' as any);
+			executeContext = createTransactionContext({
+				chainID,
+				stateStore,
+				transaction: new Transaction({
+					...defaultTransaction,
+					command: sidechainCCUUpdateCommand.name,
+					params: codec.encode(crossChainUpdateTransactionParams, {
+						...params,
+					}),
+				}),
+			}).createCommandExecuteContext(sidechainCCUUpdateCommand.schema);
+
+			await expect(sidechainCCUUpdateCommand.execute(executeContext)).resolves.toBeUndefined();
+			expect(sidechainCCUUpdateCommand['afterCrossChainMessagesExecution']).toHaveBeenCalledTimes(
+				1,
 			);
 		});
 	});


### PR DESCRIPTION
### What was the problem?

This PR resolves #8193

### How was it solved?

<!--- Please describe your technical implementation -->

### How was it tested?
- Since we have a separate `verifyRoutingRules` method, relevant tests moved to a separate `describe('verifyRoutingRules')`
- Repeated `expect`s relevant to `CCMProcessedCode.INVALID_CCM_ROUTING_EXCEPTION` are now called once
