### PR TITLE
Fix config on application bootstrap

### DIFF
--- a/commander/src/bootstrapping/commands/config/create.ts
+++ b/commander/src/bootstrapping/commands/config/create.ts
@@ -14,7 +14,6 @@
  *
  */
 import { Command, Flags as flagParser } from '@oclif/core';
-import { homedir } from 'os';
 import * as fs from 'fs-extra';
 import { join, resolve } from 'path';
 import * as inquirer from 'inquirer';
@@ -68,7 +67,7 @@ export class CreateCommand extends Command {
 		const configPath = resolve(output);
 		const filePath = join(configPath, 'config');
 
-		defaultConfig.system.dataPath = join(homedir(), '.lisk', label);
+		defaultConfig.system.dataPath = join('~', '.lisk', label);
 		(defaultConfig.genesis as Record<string, unknown>).chainID = chainID;
 
 		// check for existing file at given location & ask the user before overwriting

--- a/commander/src/bootstrapping/commands/config/create.ts
+++ b/commander/src/bootstrapping/commands/config/create.ts
@@ -14,6 +14,7 @@
  *
  */
 import { Command, Flags as flagParser } from '@oclif/core';
+import { homedir } from 'os';
 import * as fs from 'fs-extra';
 import { join, resolve } from 'path';
 import * as inquirer from 'inquirer';
@@ -67,7 +68,7 @@ export class CreateCommand extends Command {
 		const configPath = resolve(output);
 		const filePath = join(configPath, 'config');
 
-		defaultConfig.system.dataPath = join('~', '.lisk', label);
+		defaultConfig.system.dataPath = join(homedir(), '.lisk', label);
 		(defaultConfig.genesis as Record<string, unknown>).chainID = chainID;
 
 		// check for existing file at given location & ask the user before overwriting

--- a/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
+++ b/commander/src/bootstrapping/templates/lisk-template-ts/generators/init_generator.ts
@@ -102,6 +102,8 @@ export default class InitGenerator extends Generator {
 			this.answers.chainID,
 			'--output',
 			'config/default',
+			'--label',
+			this.answers.name,
 		]);
 		// create passphrase to generate all the keys
 		const passphrase = Mnemonic.generateMnemonic(256);

--- a/commander/src/utils/config.ts
+++ b/commander/src/utils/config.ts
@@ -8,6 +8,7 @@ export const defaultConfig = {
 		modes: ['ipc'],
 		port: 7887,
 		host: '127.0.0.1',
+		allowedMethods: [],
 	},
 	network: {
 		version: '1.0',


### PR DESCRIPTION
### What was the problem?

This PR resolves #9151 

### How was it solved?

- Update `config.json` to have `allowedMethods` in `rpc`
- Update `dataPath` to have a format `~/.lisk/<app_name>`

### How was it tested?

In order to test locally, 
1. build `commander`
2. `yarn link`
3. `npm i -g`
4. `./bin/run init ~/Desktop/testapp`
5. `cd ~/Desktop/testapp`
6. `yarn link lisk-commander`
7. `./bin/run config:create --chain-id 02000001 --label 'testapp'`
8. check the `config.json` file for `dataPath` and `rpc` values
